### PR TITLE
Changed go build to go install in spec file

### DIFF
--- a/ar-web-api.spec
+++ b/ar-web-api.spec
@@ -23,7 +23,7 @@ Installs the A/R API.
 export GOPATH=$PWD
 cd src/github.com/argoeu/ar-web-api/
 go get
-go build
+go install
 
 %install
 %{__rm} -rf %{buildroot}


### PR DESCRIPTION
The go install command places binaries only in bin/ directory where the builder scripts expects to find them
