### PR TITLE
ARGO-105 Fix response headers on update/delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
         go get code.google.com/p/gcfg
         go get github.com/argoeu/go-lru-cache
 
-or
+        or
 
         go get
 
@@ -30,3 +30,6 @@ or
 
         go test ./...
 
+7. To generate and serve godoc (@port 6060)
+
+	`godoc -http:6060`

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ or
 
         ./ar-web-api
 
-6. To run the unit-tests
+6. To run the unit-tests:
+
         go test ./...
 

--- a/README.md
+++ b/README.md
@@ -25,3 +25,7 @@ or
 5. Run the service:
 
         ./ar-web-api
+
+6. To run the unit-tests
+        go test ./...
+

--- a/app/availabilityProfiles/availabilityProfilesController.go
+++ b/app/availabilityProfiles/availabilityProfilesController.go
@@ -79,7 +79,7 @@ func List(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) 
 		code = http.StatusInternalServerError
 		return code, h, output, err
 	}
-	
+
 	mongo.CloseSession(session)
 
 	output, err = createView(results) //Render the results into XML format
@@ -159,9 +159,9 @@ func Create(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 				code = http.StatusInternalServerError
 				return code, h, output, err
 			}
-			
+
 			mongo.CloseSession(session)
-			
+
 			//Providing with the appropriate user response
 			message = "Availability Profile record successfully created"
 			output, err := messageXML(message) //Render the response into XML
@@ -243,10 +243,10 @@ func Update(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 		}
 
 		//We update the record bassed on its unique id
-		err = mongo.IdUpdate(session, "AR", "aps", id, input)		
-		
+		err = mongo.IdUpdate(session, "AR", "aps", id, input)
+
 		mongo.CloseSession(session)
-		
+
 		if err != nil {
 			message = "No profile matching the requested id" //If not found we inform the user
 			output, err := messageXML(message)
@@ -261,12 +261,21 @@ func Update(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 			return code, h, output, err
 
 		} else {
-			code = http.StatusNoContent
+			// Everything went fine and profile was deleted
+			message = "Availability Profile was successfully updated"
+			output, err := messageXML(message) //Render the response into XML
+
+			if err != nil {
+				code = http.StatusInternalServerError
+				return code, h, output, err
+			}
+
 			h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
 			return code, h, output, err
 		}
 	} else {
 		code = http.StatusUnauthorized
+		h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
 		output = []byte(http.StatusText(http.StatusUnauthorized)) //If wrong api key is passed we return UNAUTHORIZED http status
 		return code, h, output, err
 	}
@@ -285,7 +294,6 @@ func Delete(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 	charset := "utf-8"
 
 	//STANDARD DECLARATIONS END
-
 	message := ""
 
 	//Authentication procedure
@@ -303,9 +311,8 @@ func Delete(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 
 		//We remove the record bassed on its unique id
 		err = mongo.IdRemove(session, "AR", "aps", id)
-		
 		mongo.CloseSession(session)
-		
+
 		if err != nil {
 
 			message = "No profile matching the requested id" //If not found we inform the user
@@ -320,13 +327,24 @@ func Delete(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 			h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
 			return code, h, output, err
 		} else {
-			code = http.StatusNoContent
+
+			// Everything went fine and profile was deleted
+			message = "Availability Profile was successfully deleted"
+			output, err := messageXML(message) //Render the response into XML
+
+			if err != nil {
+				code = http.StatusInternalServerError
+				return code, h, output, err
+			}
+
 			h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
 			return code, h, output, err
 		}
 	} else {
+
 		code = http.StatusUnauthorized
 		output = []byte(http.StatusText(http.StatusUnauthorized)) //If wrong api key is passed we return UNAUTHORIZED http status
+		h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
 		return code, h, output, err
 	}
 

--- a/app/availabilityProfiles/availabilityProfilesController.go
+++ b/app/availabilityProfiles/availabilityProfilesController.go
@@ -73,7 +73,7 @@ func List(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) 
 		query = nil //If no name and namespace is provided then we have to retrieve all profiles thus we send nil into db query
 	}
 
-	err = mongo.Find(session, "AR", "aps", query, "_id", &results)
+	err = mongo.Find(session, cfg.MongoDB.Db, "aps", query, "_id", &results)
 
 	if err != nil {
 		code = http.StatusInternalServerError
@@ -143,7 +143,7 @@ func Create(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 		}
 
 		query := readOne(search)
-		err = mongo.Find(session, "AR", "aps", query, "name", &results)
+		err = mongo.Find(session, cfg.MongoDB.Db, "aps", query, "name", &results)
 
 		if err != nil {
 			code = http.StatusInternalServerError
@@ -153,7 +153,7 @@ func Create(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 		if len(results) <= 0 {
 			//If name-namespace combination is unique we insert the new record into mongo
 			query := createOne(input)
-			err = mongo.Insert(session, "AR", "aps", query)
+			err = mongo.Insert(session, cfg.MongoDB.Db, "aps", query)
 
 			if err != nil {
 				code = http.StatusInternalServerError
@@ -243,7 +243,7 @@ func Update(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 		}
 
 		//We update the record bassed on its unique id
-		err = mongo.IdUpdate(session, "AR", "aps", id, input)
+		err = mongo.IdUpdate(session, cfg.MongoDB.Db, "aps", id, input)
 
 		mongo.CloseSession(session)
 
@@ -310,7 +310,7 @@ func Delete(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 		}
 
 		//We remove the record bassed on its unique id
-		err = mongo.IdRemove(session, "AR", "aps", id)
+		err = mongo.IdRemove(session, cfg.MongoDB.Db, "aps", id)
 		mongo.CloseSession(session)
 
 		if err != nil {

--- a/app/availabilityProfiles/availabilityProfilesController.go
+++ b/app/availabilityProfiles/availabilityProfilesController.go
@@ -124,15 +124,27 @@ func Create(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 		//Reading the json input
 		reqBody, err := ioutil.ReadAll(r.Body)
 
-		if err != nil {
-			code = http.StatusInternalServerError
-			return code, h, output, err
-		}
-
 		input := AvailabilityProfileInput{}
 		results := []AvailabilityProfileOutput{}
 		//Unmarshalling the json input into byte form
 		err = json.Unmarshal(reqBody, &input)
+
+		if err != nil {
+			if err != nil {
+				message = "Malformated json input data" // User provided malformed json input data
+				output, err := messageXML(message)
+
+				if err != nil {
+					code = http.StatusInternalServerError
+					return code, h, output, err
+				}
+
+				code = http.StatusBadRequest
+				h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+				return code, h, output, err
+			}
+		}
+
 		//Making sure that no profile with the requested name and namespace combination already exists in the DB
 		name = append(name, input.Name)
 		namespace = append(namespace, input.Namespace)
@@ -218,6 +230,7 @@ func Update(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 		//Extracting record id from url
 		urlValues := r.URL.Path
 		id := strings.Split(urlValues, "/")[4]
+
 		//Reading the json input
 		reqBody, err := ioutil.ReadAll(r.Body)
 
@@ -231,7 +244,16 @@ func Update(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 		err = json.Unmarshal(reqBody, &input)
 
 		if err != nil {
-			code = http.StatusInternalServerError
+			message = "Malformated json input data" // User provided malformed json input data
+			output, err := messageXML(message)
+
+			if err != nil {
+				code = http.StatusInternalServerError
+				return code, h, output, err
+			}
+
+			code = http.StatusBadRequest
+			h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
 			return code, h, output, err
 		}
 

--- a/app/availabilityProfiles/availabilityProfilesView.go
+++ b/app/availabilityProfiles/availabilityProfilesView.go
@@ -30,13 +30,23 @@ import "encoding/xml"
 
 func createView(results []AvailabilityProfileOutput) ([]byte, error) {
 
+	poem_name := ""
+
 	docRoot := &ReadRoot{}
 	for _, row := range results {
+
+		// If poem array doesn't contain items add empty string to poem attribute
+		if len(row.Poems) > 0 {
+			poem_name = row.Poems[0]
+		} else {
+			poem_name = ""
+		}
+
 		profile := &Profile{
 			ID:        row.ID.Hex(),
 			Name:      row.Name,
 			Namespace: row.Namespace,
-			Poem:      row.Poems[0],
+			Poem:      poem_name,
 		}
 		and := &And{}
 		docRoot.Profile = append(docRoot.Profile, profile)

--- a/app/availabilityProfiles/availabilityProfiles_test.go
+++ b/app/availabilityProfiles/availabilityProfiles_test.go
@@ -50,7 +50,7 @@ type AvProfileTestSuite struct {
 	resp_bad_json       string
 }
 
-// Setup the Test Enviroment
+// Setup the Test Environment
 // This function runs before any test and setups the enviroment
 // A test configuration object is instantiated using a reference
 // to testdb: AR_test. Also here is are instantiated some expected

--- a/app/availabilityProfiles/availabilityProfiles_test.go
+++ b/app/availabilityProfiles/availabilityProfiles_test.go
@@ -51,7 +51,7 @@ type AvProfileTestSuite struct {
 }
 
 // Setup the Test Environment
-// This function runs before any test and setups the enviroment
+// This function runs before any test and setups the environment
 // A test configuration object is instantiated using a reference
 // to testdb: AR_test. Also here is are instantiated some expected
 // xml response validation messages (authorization,crud responses).
@@ -121,7 +121,7 @@ func (suite *AvProfileTestSuite) SetupTest() {
 }
 
 // Testing creation of a profile  using POST request.
-// During Setup of the test enviroment the testdb is seeded with
+// During Setup of the test environment the testdb is seeded with
 // two availability profiles ("ap1","ap2"). Mongo assigns
 // two object _ids on these profiles which cannot predict so,
 // we have to read them from the database and insert them in the
@@ -176,7 +176,7 @@ func (suite *AvProfileTestSuite) TestCreateProfile() {
 }
 
 // Testing Reading of profile list using GET request.
-// During Setup of the test enviroment the testdb is seeded with
+// During Setup of the test environment the testdb is seeded with
 // two availability profiles ("ap1","ap2"). Mongo assigns
 // two object _ids on these profiles which cannot predict so,
 // we have to read them from the database and insert them in the
@@ -244,7 +244,7 @@ func (suite *AvProfileTestSuite) TestReadProfile() {
 }
 
 // Testing update of a profile  using POST request.
-// During Setup of the test enviroment the testdb is seeded with
+// During Setup of the test environment the testdb is seeded with
 // two availability profiles ("ap1","ap2"). Mongo assigns
 // two object _ids on these profiles which cannot predict so,
 // we have to read them from the database and insert them in the
@@ -309,7 +309,7 @@ func (suite *AvProfileTestSuite) TestUpdateProfile() {
 }
 
 // Testing deletion of a profile  using DELETE request.
-// During Setup of the test enviroment the testdb is seeded with
+// During Setup of the test environment the testdb is seeded with
 // two availability profiles ("ap1","ap2"). Mongo assigns
 // two object _ids on these profiles which cannot predict so,
 // we have to read them from the database and insert them in the
@@ -539,7 +539,7 @@ func (suite *AvProfileTestSuite) TestUpdateBadJson() {
 }
 
 // This function is actually called in the end of all tests
-// and clears the test enviroment.
+// and clears the test environment.
 // Mainly it's purpose is to drop the testdb
 func (suite *AvProfileTestSuite) TearDownTest() {
 

--- a/app/availabilityProfiles/availabilityProfiles_test.go
+++ b/app/availabilityProfiles/availabilityProfiles_test.go
@@ -28,7 +28,6 @@ package availabilityProfiles
 
 import (
 	"code.google.com/p/gcfg"
-	"fmt"
 	"github.com/argoeu/ar-web-api/utils/config"
 	"github.com/argoeu/ar-web-api/utils/mongo"
 	"github.com/stretchr/testify/suite"

--- a/app/availabilityProfiles/availabilityProfiles_test.go
+++ b/app/availabilityProfiles/availabilityProfiles_test.go
@@ -1,0 +1,229 @@
+/*
+ * Copyright (c) 2014 GRNET S.A., SRCE, IN2P3 CNRS Computing Centre
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS
+ * IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ *
+ * The views and conclusions contained in the software and
+ * documentation are those of the authors and should not be
+ * interpreted as representing official policies, either expressed
+ * or implied, of either GRNET S.A., SRCE or IN2P3 CNRS Computing
+ * Centre
+ *
+ * The work represented by this source file is partially funded by
+ * the EGI-InSPIRE project through the European Commission's 7th
+ * Framework Programme (contract # INFSO-RI-261323)
+ */
+
+package availabilityProfiles
+
+import (
+	"code.google.com/p/gcfg"
+	"fmt"
+	"github.com/argoeu/ar-web-api/utils/config"
+	"github.com/argoeu/ar-web-api/utils/mongo"
+	"github.com/stretchr/testify/suite"
+	"labix.org/v2/mgo/bson"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// Build a test suite as a struct with specific enviroment parameters
+type AvProfileTestSuite struct {
+	suite.Suite
+	cfg                 config.Config
+	resp_profileCreated string
+	reps_unauthorized   string
+}
+
+// Setup the test suite
+func (suite *AvProfileTestSuite) SetupTest() {
+
+	const testConfig = `
+    [server]
+    bindip = ""
+    port = 8080
+    maxprocs = 4
+    cache = false
+    lrucache = 700000000
+    gzip = true
+    [mongodb]
+    host = "127.0.0.1"
+    port = 27017
+    db = "AR_test"
+`
+
+	_ = gcfg.ReadStringInto(&suite.cfg, testConfig)
+
+	suite.resp_profileCreated = " <root>\n"
+	+"<Message>Availability Profile record successfully created</Message>\n"
+	+"</root>"
+
+	suite.reps_unauthorized = "Unauthorized"
+
+	// Connect to mongo testdb
+	session, _ := mongo.OpenSession(suite.cfg)
+
+	// Add authentication token to mongo testdb
+	seed_auth := bson.M{"apiKey": "S3CR3T"}
+	_ = mongo.Insert(session, suite.cfg.MongoDB.Db, "authentication", seed_auth)
+
+	// Ready first profile
+	prof1 := `
+    {
+        "name": "ap1",
+        "namespace": "namespace1",
+        "poems": ["poem01"],
+        "groups": [
+            [
+               "ap1-service1",
+               "ap1-service2",
+               "ap1-service3"
+            ],
+            [
+                "ap1-service4",
+                "ap1-service5",
+                "ap1-service6"
+            ]
+        ]
+    }
+    `
+	// Ready second profile
+	prof2 := `
+    {
+        "name": "ap2",
+        "namespace": "namespace2",
+        "poems": ["poem02"],
+        "groups": [
+            [
+               "ap2-service1",
+               "ap2-service2",
+               "ap2-service3"
+            ],
+            [
+                "ap2-service4",
+                "ap2-service5",
+                "ap2-service6"
+            ]
+        ]
+    }
+    `
+	//Execture requests
+	// scaffold the request object
+	request1, _ := http.NewRequest("POST", "", strings.NewReader(prof1))
+	// add the content-type header to application/json
+	request1.Header.Set("Content-Type", "application/json;")
+	// add the authentication token which is seeded in testdb
+	request1.Header.Set("x-api-key", "S3CR3T")
+	// Execute the request in the controller
+	Create(request1, suite.cfg)
+
+	// scaffold the request object
+	request2, _ := http.NewRequest("POST", "", strings.NewReader(prof2))
+	// add the content-type header to application/json
+	request2.Header.Set("Content-Type", "application/json;")
+	// add the authentication token which is seeded in testdb
+	request2.Header.Set("x-api-key", "S3CR3T")
+	// Execute the request in the controller
+	Create(request2, suite.cfg)
+
+}
+
+// Testing the insertion of profiles using POST
+func (suite *AvProfileTestSuite) TestCreateProfile() {
+
+	// create request
+	post_body := `
+    {
+        "name": "test_profile",
+        "namespace": "test_namespace",
+        "poems": ["test_poem"],
+        "groups": [
+            [
+               "service1",
+               "service2",
+               "service3"
+            ],
+            [
+                "service4",
+                "service5",
+                "service6"
+            ]
+        ]
+    }
+    `
+	// scaffold the request object
+	request, _ := http.NewRequest("POST", "", strings.NewReader(post_body))
+	// add the content-type header to application/json
+	request.Header.Set("Content-Type", "application/json;")
+	// add the authentication token which is seeded in testdb
+	request.Header.Set("x-api-key", "S3CR3T")
+
+	// Execute the request in the controller
+	code, _, output, _ := Create(request, suite.cfg)
+
+	suite.Equal(200, code, "Internal Server Error")
+	fmt.Println("testing")
+	suite.Equal(string(output), suite.resp_profileCreated, "Response body mismatch")
+}
+
+func (suite *AvProfileTestSuite) TestInsertProfile() {
+
+	// create request
+	post_body := `
+    {
+        "name": "test_profile",
+        "namespace": "test_namespace",
+        "poems": ["test_poem"],
+        "groups": [
+            [
+               "service1",
+               "service2",
+               "service3"
+            ],
+            [
+                "service4",
+                "service5",
+                "service6"
+            ]
+        ]
+    }
+    `
+	// scaffold the request object
+	request, _ := http.NewRequest("POST", "", strings.NewReader(post_body))
+	// add the content-type header to application/json
+	request.Header.Set("Content-Type", "application/json;")
+	// add the authentication token which is seeded in testdb
+	request.Header.Set("x-api-key", "S3CR3T")
+
+	// Execute the request in the controller
+	code, _, output, _ := Create(request, suite.cfg)
+
+	suite.Equal(200, code, "Internal Server Error")
+	fmt.Println("testing")
+	suite.Equal(string(output), suite.resp_profileCreated, "Response body mismatch")
+}
+
+func (suite *AvProfileTestSuite) TearDownTest() {
+
+	session, _ := mongo.OpenSession(suite.cfg)
+
+	session.DB("AR_test").DropDatabase()
+
+}
+
+// Here is the normal golang testing function that runs when
+// go test is issued
+func TestAvProfileTestSuite(t *testing.T) {
+	suite.Run(t, new(AvProfileTestSuite))
+}

--- a/app/availabilityProfiles/availabilityProfiles_test.go
+++ b/app/availabilityProfiles/availabilityProfiles_test.go
@@ -32,21 +32,32 @@ import (
 	"github.com/argoeu/ar-web-api/utils/config"
 	"github.com/argoeu/ar-web-api/utils/mongo"
 	"github.com/stretchr/testify/suite"
+	"labix.org/v2/mgo"
 	"labix.org/v2/mgo/bson"
 	"net/http"
 	"strings"
 	"testing"
 )
 
-// Build a test suite as a struct with specific enviroment parameters
+// This is a util. suite struct used in tests (see pkg "testify")
 type AvProfileTestSuite struct {
 	suite.Suite
 	cfg                 config.Config
 	resp_profileCreated string
-	reps_unauthorized   string
+	resp_profileUpdated string
+	resp_profileDeleted string
+	resp_unauthorized   string
+	resp_no_id          string
+	resp_bad_json       string
 }
 
-// Setup the test suite
+// Setup the Test Enviroment
+// This function runs before any test and setups the enviroment
+// A test configuration object is instantiated using a reference
+// to testdb: AR_test. Also here is are instantiated some expected
+// xml response validation messages (authorization,crud responses).
+// Also the testdb is seeded with two av.profiles ("ap1","ap2")
+// and with an authorization token:"S3CR3T"
 func (suite *AvProfileTestSuite) SetupTest() {
 
 	const testConfig = `
@@ -65,11 +76,22 @@ func (suite *AvProfileTestSuite) SetupTest() {
 
 	_ = gcfg.ReadStringInto(&suite.cfg, testConfig)
 
-	suite.resp_profileCreated = " <root>\n"
-	+"<Message>Availability Profile record successfully created</Message>\n"
-	+"</root>"
+	suite.resp_profileCreated = " <root>\n" +
+		"   <Message>Availability Profile record successfully created</Message>\n </root>"
 
-	suite.reps_unauthorized = "Unauthorized"
+	suite.resp_profileUpdated = " <root>\n" +
+		"   <Message>Availability Profile was successfully updated</Message>\n </root>"
+
+	suite.resp_profileDeleted = " <root>\n" +
+		"   <Message>Availability Profile was successfully deleted</Message>\n </root>"
+
+	suite.resp_unauthorized = "Unauthorized"
+
+	suite.resp_no_id = " <root>\n" +
+		"   <Message>No profile matching the requested id</Message>\n </root>"
+
+	suite.resp_bad_json = " <root>\n" +
+		"   <Message>Malformated json input data</Message>\n </root>"
 
 	// Connect to mongo testdb
 	session, _ := mongo.OpenSession(suite.cfg)
@@ -78,74 +100,39 @@ func (suite *AvProfileTestSuite) SetupTest() {
 	seed_auth := bson.M{"apiKey": "S3CR3T"}
 	_ = mongo.Insert(session, suite.cfg.MongoDB.Db, "authentication", seed_auth)
 
-	// Ready first profile
-	prof1 := `
-    {
-        "name": "ap1",
-        "namespace": "namespace1",
-        "poems": ["poem01"],
-        "groups": [
-            [
-               "ap1-service1",
-               "ap1-service2",
-               "ap1-service3"
-            ],
-            [
-                "ap1-service4",
-                "ap1-service5",
-                "ap1-service6"
-            ]
-        ]
-    }
-    `
-	// Ready second profile
-	prof2 := `
-    {
-        "name": "ap2",
-        "namespace": "namespace2",
-        "poems": ["poem02"],
-        "groups": [
-            [
-               "ap2-service1",
-               "ap2-service2",
-               "ap2-service3"
-            ],
-            [
-                "ap2-service4",
-                "ap2-service5",
-                "ap2-service6"
-            ]
-        ]
-    }
-    `
-	//Execture requests
-	// scaffold the request object
-	request1, _ := http.NewRequest("POST", "", strings.NewReader(prof1))
-	// add the content-type header to application/json
-	request1.Header.Set("Content-Type", "application/json;")
-	// add the authentication token which is seeded in testdb
-	request1.Header.Set("x-api-key", "S3CR3T")
-	// Execute the request in the controller
-	Create(request1, suite.cfg)
+	// seed mongo
+	session, err := mgo.Dial(suite.cfg.MongoDB.Host)
+	if err != nil {
+		panic(err)
+	}
+	defer session.Close()
 
-	// scaffold the request object
-	request2, _ := http.NewRequest("POST", "", strings.NewReader(prof2))
-	// add the content-type header to application/json
-	request2.Header.Set("Content-Type", "application/json;")
-	// add the authentication token which is seeded in testdb
-	request2.Header.Set("x-api-key", "S3CR3T")
-	// Execute the request in the controller
-	Create(request2, suite.cfg)
+	// Insert first seed profile
+	c := session.DB(suite.cfg.MongoDB.Db).C("aps")
+	c.Insert(bson.M{"name": "ap1", "namespace": "namespace1", "poems": []string{"poem01"},
+		"groups": [][]string{
+			[]string{"ap1-service1", "ap1-service2", "ap1-service3"},
+			[]string{"ap1-service4", "ap1-service5", "ap1-service6"}}})
+	// Insert first seed profile
+	c.Insert(bson.M{"name": "ap2", "namespace": "namespace2", "poems": []string{"poem02"},
+		"groups": [][]string{
+			[]string{"ap2-service1", "ap2-service2", "ap2-service3"},
+			[]string{"ap2-service4", "ap2-service5", "ap2-service6"}}})
 
 }
 
-// Testing the insertion of profiles using POST
+// Testing creation of a profile  using POST request.
+// During Setup of the test enviroment the testdb is seeded with
+// two availability profiles ("ap1","ap2"). Mongo assigns
+// two object _ids on these profiles which cannot predict so,
+// we have to read them from the database and insert them in the
+// expected xml response string.
 func (suite *AvProfileTestSuite) TestCreateProfile() {
 
-	// create request
-	post_body := `
+	// create json input data for the request
+	post_data := `
     {
-        "name": "test_profile",
+        "name": "fresh_test_profile",
         "namespace": "test_namespace",
         "poems": ["test_poem"],
         "groups": [
@@ -162,8 +149,8 @@ func (suite *AvProfileTestSuite) TestCreateProfile() {
         ]
     }
     `
-	// scaffold the request object
-	request, _ := http.NewRequest("POST", "", strings.NewReader(post_body))
+	// Prepare the request object
+	request, _ := http.NewRequest("POST", "", strings.NewReader(post_data))
 	// add the content-type header to application/json
 	request.Header.Set("Content-Type", "application/json;")
 	// add the authentication token which is seeded in testdb
@@ -173,34 +160,341 @@ func (suite *AvProfileTestSuite) TestCreateProfile() {
 	code, _, output, _ := Create(request, suite.cfg)
 
 	suite.Equal(200, code, "Internal Server Error")
-	fmt.Println("testing")
-	suite.Equal(string(output), suite.resp_profileCreated, "Response body mismatch")
+	suite.Equal(suite.resp_profileCreated, string(output), "Response body mismatch")
+
+	// Remove the profile not to contaminate other tests
+	// Open session to mongo
+	session, err := mgo.Dial(suite.cfg.MongoDB.Host)
+	if err != nil {
+		panic(err)
+	}
+	defer session.Close()
+	// Open collection aps
+	c := session.DB(suite.cfg.MongoDB.Db).C("aps")
+	// Remove the specific profile inserted during this test
+	c.Remove(bson.M{"name": "fresh_test_profile"})
+
 }
 
-func (suite *AvProfileTestSuite) TestInsertProfile() {
+// Testing Reading of profile list using GET request.
+// During Setup of the test enviroment the testdb is seeded with
+// two availability profiles ("ap1","ap2"). Mongo assigns
+// two object _ids on these profiles which cannot predict so,
+// we have to read them from the database and insert them in the
+// expected xml response string.
+func (suite *AvProfileTestSuite) TestReadProfile() {
 
-	// create request
-	post_body := `
+	// Open a session to mongo
+	session, err := mgo.Dial(suite.cfg.MongoDB.Host)
+	if err != nil {
+		panic(err)
+	}
+	defer session.Close()
+	// Open availability profile collection: aps
+	c := session.DB(suite.cfg.MongoDB.Db).C("aps")
+	// Instantiate a AvProfile struct to hold bson results
+	results := AvailabilityProfileOutput{}
+	// Query first seed profile - name:ap1
+	c.Find(bson.M{"name": "ap1"}).One(&results)
+	// Grab from results ObjectId and convert it to string: Hex() method
+	id1 := (results.ID.Hex())
+	// Query second seed profile - name:ap2
+	c.Find(bson.M{"name": "ap2"}).One(&results)
+	id2 := (results.ID.Hex())
+	// Hold a string multiline literal including the two profile ids retrieved
+	profile_list_xml := ` <root>
+   <profile id="` + id1 + `" name="ap1" namespace="namespace1" poems="poem01">
+     <AND>
+       <OR>
+         <Group service_flavor="ap1-service1"></Group>
+         <Group service_flavor="ap1-service2"></Group>
+         <Group service_flavor="ap1-service3"></Group>
+       </OR>
+       <OR>
+         <Group service_flavor="ap1-service4"></Group>
+         <Group service_flavor="ap1-service5"></Group>
+         <Group service_flavor="ap1-service6"></Group>
+       </OR>
+     </AND>
+   </profile>
+   <profile id="` + id2 + `" name="ap2" namespace="namespace2" poems="poem02">
+     <AND>
+       <OR>
+         <Group service_flavor="ap2-service1"></Group>
+         <Group service_flavor="ap2-service2"></Group>
+         <Group service_flavor="ap2-service3"></Group>
+       </OR>
+       <OR>
+         <Group service_flavor="ap2-service4"></Group>
+         <Group service_flavor="ap2-service5"></Group>
+         <Group service_flavor="ap2-service6"></Group>
+       </OR>
+     </AND>
+   </profile>
+ </root>`
+
+	// Prepare the request object
+	request, _ := http.NewRequest("GET", "", strings.NewReader(""))
+
+	// Pass request to controller calling List() handler method
+	code, _, output, _ := List(request, suite.cfg)
+	// Check that we must have a 200 ok code
+	suite.Equal(200, code, "Internal Server Error")
+	// Compare the expected and actual xml response
+	suite.Equal(profile_list_xml, string(output), "Response body mismatch")
+}
+
+// Testing update of a profile  using POST request.
+// During Setup of the test enviroment the testdb is seeded with
+// two availability profiles ("ap1","ap2"). Mongo assigns
+// two object _ids on these profiles which cannot predict so,
+// we have to read them from the database and insert them in the
+// expected xml response string.
+func (suite *AvProfileTestSuite) TestUpdateProfile() {
+
+	// We will make update to ap2 profile
+	put_data := `
     {
-        "name": "test_profile",
-        "namespace": "test_namespace",
-        "poems": ["test_poem"],
+        "name": "updated-ap2",
+        "namespace": "updated-ap2-namespace",
+        "poems": ["updated-ap2-poem"],
         "groups": [
             [
-               "service1",
-               "service2",
-               "service3"
+               "updated-srv1",
+               "updated-srv2"
             ],
             [
-                "service4",
-                "service5",
-                "service6"
+                "updated-srv3",
+                "updated-srv4",
+                "updated-srv5",
+                "updated-srv6"
             ]
         ]
     }
     `
-	// scaffold the request object
-	request, _ := http.NewRequest("POST", "", strings.NewReader(post_body))
+	// Read the id
+	// Open a session to mongo
+	session, err := mgo.Dial(suite.cfg.MongoDB.Host)
+	if err != nil {
+		panic(err)
+	}
+	defer session.Close()
+	// Open availability profile collection: aps
+	c := session.DB(suite.cfg.MongoDB.Db).C("aps")
+	// Instantiate a AvProfile struct to hold bson results
+	results := AvailabilityProfileOutput{}
+	// Query first seed profile - name:ap1
+	c.Find(bson.M{"name": "ap2"}).One(&results)
+	// Grab from results ObjectId and convert it to string: Hex() method
+	id2 := (results.ID.Hex())
+	// Prepare the request object (use id2 for path)
+	request, _ := http.NewRequest("PUT", "/api/v1/AP/"+id2, strings.NewReader(put_data))
+	// add the content-type header to application/json
+	request.Header.Set("Content-Type", "application/json;")
+	// add the authentication token which is seeded in testdb
+	request.Header.Set("x-api-key", "S3CR3T")
+
+	// Execute the request in the controller
+	code, _, output, _ := Update(request, suite.cfg)
+
+	suite.Equal(200, code, "Internal Server Error")
+	suite.Equal(suite.resp_profileUpdated, string(output), "Response body mismatch")
+
+	// Reestablish ap2 profile (remove and reinsert)
+	c.Remove(bson.M{"name": "ap2"})
+	c.Insert(bson.M{"name": "ap2", "namespace": "namespace2", "poems": []string{"poem02"},
+		"groups": [][]string{
+			[]string{"ap2-service1", "ap2-service2", "ap2-service3"},
+			[]string{"ap2-service4", "ap2-service5", "ap2-service6"}}})
+
+}
+
+// Testing deletion of a profile  using DELETE request.
+// During Setup of the test enviroment the testdb is seeded with
+// two availability profiles ("ap1","ap2"). Mongo assigns
+// two object _ids on these profiles which cannot predict so,
+// we have to read them from the database and insert them in the
+// expected xml response string. In this test ap2 is deleted and then
+// profile list is read again (with get request) to validate that
+// only ap1 is left present.
+func (suite *AvProfileTestSuite) TestDeleteProfile() {
+
+	// We will delete ap2 profile so we expect to find only ap1 in list
+
+	// Grab the two _ids of profiles: ap1, ap2
+	// Open a session to mongo
+	session, err := mgo.Dial(suite.cfg.MongoDB.Host)
+	if err != nil {
+		panic(err)
+	}
+	defer session.Close()
+	// Open availability profile collection: aps
+	c := session.DB(suite.cfg.MongoDB.Db).C("aps")
+	// Instantiate a AvProfile struct to hold bson results
+	results := AvailabilityProfileOutput{}
+	// Query first seed profile - name:ap1
+	c.Find(bson.M{"name": "ap1"}).One(&results)
+	// Grab from results ObjectId and convert it to string: Hex() method
+	id1 := (results.ID.Hex())
+	// Query second seed profile - name:ap2
+	c.Find(bson.M{"name": "ap2"}).One(&results)
+	id2 := (results.ID.Hex())
+
+	// Prepare the expected xml response after deleting ap2
+	profile_list_xml := ` <root>
+   <profile id="` + id1 + `" name="ap1" namespace="namespace1" poems="poem01">
+     <AND>
+       <OR>
+         <Group service_flavor="ap1-service1"></Group>
+         <Group service_flavor="ap1-service2"></Group>
+         <Group service_flavor="ap1-service3"></Group>
+       </OR>
+       <OR>
+         <Group service_flavor="ap1-service4"></Group>
+         <Group service_flavor="ap1-service5"></Group>
+         <Group service_flavor="ap1-service6"></Group>
+       </OR>
+     </AND>
+   </profile>
+ </root>`
+
+	// Prepare the request object (use id2 for path)
+	request, _ := http.NewRequest("DELETE", "/api/v1/AP/"+id2, strings.NewReader(""))
+	// add the content-type header to application/json
+	request.Header.Set("Content-Type", "application/json;")
+	// add the authentication token which is seeded in testdb
+	request.Header.Set("x-api-key", "S3CR3T")
+
+	// Execute the request in the controller
+	code, _, output, _ := Delete(request, suite.cfg)
+	// Check proper response that the profile successfully deleted
+	suite.Equal(200, code, "Internal Server Error")
+	suite.Equal(suite.resp_profileDeleted, string(output), "Response body mismatch")
+
+	// Double-check that the profile is actually missing from the profile list
+	request, _ = http.NewRequest("GET", "", strings.NewReader(""))
+
+	// Pass request to controller calling List() handler method
+	code, _, output, _ = List(request, suite.cfg)
+	// Check that we must have a 200 ok code
+	suite.Equal(200, code, "Internal Server Error")
+	// Compare the expected and actual xml response
+	suite.Equal(profile_list_xml, string(output), "Response body mismatch")
+
+	// Reestablish ap2 profile (reinsert)
+	c.Insert(bson.M{"name": "ap2", "namespace": "namespace2", "poems": []string{"poem02"},
+		"groups": [][]string{
+			[]string{"ap2-service1", "ap2-service2", "ap2-service3"},
+			[]string{"ap2-service4", "ap2-service5", "ap2-service6"}}})
+
+}
+
+// This function tests calling the create request (POST) and providing
+// a wrong api-key. The response should be unauthorized
+func (suite *AvProfileTestSuite) TestCreateUnauthorized() {
+	// Prepare the request object (use id2 for path)
+	request, _ := http.NewRequest("POST", "", strings.NewReader(""))
+	// add the content-type header to application/json
+	request.Header.Set("Content-Type", "application/json;")
+	// add the authentication token which is seeded in testdb
+	request.Header.Set("x-api-key", "F00T0K3N")
+
+	// Execute the request in the controller
+	code, _, output, _ := Create(request, suite.cfg)
+
+	suite.Equal(401, code, "Internal Server Error")
+	suite.Equal(suite.resp_unauthorized, string(output), "Response body mismatch")
+}
+
+// This function tests calling the update profile request (PUT) and providing
+// a wrong api-key. The response should be unauthorized
+func (suite *AvProfileTestSuite) TestUpdateUnauthorized() {
+	// Prepare the request object
+	request, _ := http.NewRequest("PUT", "", strings.NewReader("{}"))
+	// add the content-type header to application/json
+	request.Header.Set("Content-Type", "application/json;")
+	// add the authentication token which is seeded in testdb
+	request.Header.Set("x-api-key", "F00T0K3N")
+
+	// Execute the request in the controller
+	code, _, output, _ := Update(request, suite.cfg)
+
+	suite.Equal(401, code, "Internal Server Error")
+	suite.Equal(suite.resp_unauthorized, string(output), "Response body mismatch")
+}
+
+// This function tests calling the remove av.profile request (DELETE) and providing
+// a wrong api-key. The response should be unauthorized
+func (suite *AvProfileTestSuite) TestDeleteUnauthorized() {
+	// Prepare the request object
+	request, _ := http.NewRequest("DELETE", "", strings.NewReader("{}"))
+	// add the content-type header to application/json
+	request.Header.Set("Content-Type", "application/json;")
+	// add the authentication token which is seeded in testdb
+	request.Header.Set("x-api-key", "F00T0K3N")
+
+	// Execute the request in the controller
+	code, _, output, _ := Delete(request, suite.cfg)
+
+	suite.Equal(401, code, "Internal Server Error")
+	suite.Equal(suite.resp_unauthorized, string(output), "Response body mismatch")
+}
+
+// This function tests calling the update av.profile request (PUT) and providing
+// a wrong profile id. The response should be profile with id doesn't exist
+func (suite *AvProfileTestSuite) TestUpdateBadId() {
+	// Prepare the request object
+	request, _ := http.NewRequest("PUT", "/api/v1/AP/wrongid", strings.NewReader("{}"))
+	// add the content-type header to application/json
+	request.Header.Set("Content-Type", "application/json;")
+	// add the authentication token which is seeded in testdb
+	request.Header.Set("x-api-key", "S3CR3T")
+
+	// Execute the request in the controller
+	code, _, output, _ := Update(request, suite.cfg)
+
+	suite.Equal(400, code, "Internal Server Error")
+	suite.Equal(suite.resp_no_id, string(output), "Response body mismatch")
+}
+
+// This function tests calling the update av.profile request (DELETE) and providing
+// a wrong profile id. The response should be profile with id doesn't exist
+func (suite *AvProfileTestSuite) TestDeleteBadId() {
+	// Prepare the request object
+	request, _ := http.NewRequest("DELETE", "/api/v1/AP/wrongid", strings.NewReader("{}"))
+	// add the content-type header to application/json
+	request.Header.Set("Content-Type", "application/json;")
+	// add the authentication token which is seeded in testdb
+	request.Header.Set("x-api-key", "S3CR3T")
+
+	// Execute the request in the controller
+	code, _, output, _ := Delete(request, suite.cfg)
+
+	suite.Equal(400, code, "Internal Server Error")
+	suite.Equal(suite.resp_no_id, string(output), "Response body mismatch")
+}
+
+// This function tests calling the create av.profile request (POST) and providing
+// bad json input. The response should be malformed json
+func (suite *AvProfileTestSuite) TestCreateBadJson() {
+	// Find an existing id
+	// Open a session to mongo
+	session, err := mgo.Dial(suite.cfg.MongoDB.Host)
+	if err != nil {
+		panic(err)
+	}
+	defer session.Close()
+	// Open availability profile collection: aps
+	c := session.DB(suite.cfg.MongoDB.Db).C("aps")
+	// Instantiate a AvProfile struct to hold bson results
+	results := AvailabilityProfileOutput{}
+	// Query first seed profile - name:ap1
+	c.Find(bson.M{"name": "ap1"}).One(&results)
+	// Grab from results ObjectId and convert it to string: Hex() method
+	id1 := (results.ID.Hex())
+
+	// Prepare the request object
+	request, _ := http.NewRequest("POST", "/api/v1/AP/"+id1, strings.NewReader("{ bad json"))
 	// add the content-type header to application/json
 	request.Header.Set("Content-Type", "application/json;")
 	// add the authentication token which is seeded in testdb
@@ -209,11 +503,45 @@ func (suite *AvProfileTestSuite) TestInsertProfile() {
 	// Execute the request in the controller
 	code, _, output, _ := Create(request, suite.cfg)
 
-	suite.Equal(200, code, "Internal Server Error")
-	fmt.Println("testing")
-	suite.Equal(string(output), suite.resp_profileCreated, "Response body mismatch")
+	suite.Equal(400, code, "Internal Server Error")
+	suite.Equal(suite.resp_bad_json, string(output), "Response body mismatch")
 }
 
+// This function tests calling the update av.profile request (PUT) and providing
+// bad json input. The response should be malformed json
+func (suite *AvProfileTestSuite) TestUpdateBadJson() {
+	// Find an existing id
+	// Open a session to mongo
+	session, err := mgo.Dial(suite.cfg.MongoDB.Host)
+	if err != nil {
+		panic(err)
+	}
+	defer session.Close()
+	// Open availability profile collection: aps
+	c := session.DB(suite.cfg.MongoDB.Db).C("aps")
+	// Instantiate a AvProfile struct to hold bson results
+	results := AvailabilityProfileOutput{}
+	// Query first seed profile - name:ap1
+	c.Find(bson.M{"name": "ap1"}).One(&results)
+	// Grab from results ObjectId and convert it to string: Hex() method
+	id1 := (results.ID.Hex())
+	// Prepare the request object
+	request, _ := http.NewRequest("PUT", "/api/v1/AP/"+id1, strings.NewReader("{ bad json"))
+	// add the content-type header to application/json
+	request.Header.Set("Content-Type", "application/json;")
+	// add the authentication token which is seeded in testdb
+	request.Header.Set("x-api-key", "S3CR3T")
+
+	// Execute the request in the controller
+	code, _, output, _ := Update(request, suite.cfg)
+
+	suite.Equal(400, code, "Internal Server Error")
+	suite.Equal(suite.resp_bad_json, string(output), "Response body mismatch")
+}
+
+// This function is actually called in the end of all tests
+// and clears the test enviroment.
+// Mainly it's purpose is to drop the testdb
 func (suite *AvProfileTestSuite) TearDownTest() {
 
 	session, _ := mongo.OpenSession(suite.cfg)
@@ -222,8 +550,7 @@ func (suite *AvProfileTestSuite) TearDownTest() {
 
 }
 
-// Here is the normal golang testing function that runs when
-// go test is issued
+// This is the first function called when go test is issued
 func TestAvProfileTestSuite(t *testing.T) {
 	suite.Run(t, new(AvProfileTestSuite))
 }

--- a/ar-web-api.spec
+++ b/ar-web-api.spec
@@ -1,7 +1,7 @@
 Name: ar-web-api
 Summary: A/R API
 Version: 1.5.1
-Release: 4%{?dist}
+Release: 5%{?dist}
 License: ASL 2.0
 Buildroot: %{_tmppath}/%{name}-buildroot
 Group:     EGI/SA4
@@ -46,6 +46,8 @@ go clean
 %attr(0644,root,root) /etc/init/ar-web-api.conf
 
 %changelog
+* Wed May 6 2015 Konstantinos Kagkelidis <kaggis@gmail.com> - 1.5.1-5%{?dist}
+- Fix Av.profile update/delete responses. Add Check for valid object ids
 * Thu Jan 15 2015 Konstantinos Kagkelidis <kaggis@gmail.com> - 1.5.1-2%{?dist}
 - Add prev timestamp support at the beginning of status timelines
 * Fri Dec 19 2014 Konstantinos Kagkelidis <kaggis@gmail.com> - 1.5.1-1%{?dist}

--- a/utils/authentication/authenticate.go
+++ b/utils/authentication/authenticate.go
@@ -46,7 +46,7 @@ func Authenticate(h http.Header, cfg config.Config) bool {
 	}
 
 	results := []Auth{}
-	err = mongo.Find(session, "AR", "authentication", query, "apiKey", &results)
+	err = mongo.Find(session, cfg.MongoDB.Db, "authentication", query, "apiKey", &results)
 
 	if err != nil {
 		return false

--- a/utils/mongo/mongoQuery.go
+++ b/utils/mongo/mongoQuery.go
@@ -27,6 +27,7 @@
 package mongo
 
 import (
+	"errors"
 	"labix.org/v2/mgo"
 	"labix.org/v2/mgo/bson"
 )
@@ -70,7 +71,10 @@ func Remove(session *mgo.Session, dbName string, collectionName string, query bs
 }
 
 func IdRemove(session *mgo.Session, dbName string, collectionName string, id string) error {
-
+	// Check if given id is proper ObjectId
+	if bson.IsObjectIdHex(id) == false {
+		return errors.New("Invalid Object Id")
+	}
 	c := openCollection(session, dbName, collectionName)
 	rid := bson.ObjectIdHex(id)
 	err := c.RemoveId(rid)
@@ -78,7 +82,10 @@ func IdRemove(session *mgo.Session, dbName string, collectionName string, id str
 }
 
 func IdUpdate(session *mgo.Session, dbName string, collectionName string, id string, update interface{}) error {
-
+	// Check if given id is proper ObjectId
+	if bson.IsObjectIdHex(id) == false {
+		return errors.New("Invalid Object Id")
+	}
 	c := openCollection(session, dbName, collectionName)
 	rid := bson.ObjectIdHex(id)
 	err := c.UpdateId(rid, update)


### PR DESCRIPTION
- Issues Found: 
 - That in some cases in update/delete responses (Avail.Profiles) the response header wasn't correctly formatted (Fixed)
 - That when an id was provided for update/delete profile it was forwarded to the query before checking that the string is a valid ObjectID string. 
 - Added proper xml responses when a profile is properly deleted or updated (Were not implemented)
 - Added checks when poem definitions are missing in a profile to properly display results with an empty "poem" string 

