### PR TITLE
ARGO-124 Argo Administrators authentication mechanism

### DIFF
--- a/app/factors/factorsController.go
+++ b/app/factors/factorsController.go
@@ -23,9 +23,6 @@ func List(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) 
 
 	//STANDARD DECLARATIONS END
 
-	//TODO: change this to the actual tenantdb using a call
-	// tenantdb := get_tenant_db(r , cfg) where r is the http request
-	// that has the header x-api-key which needs to be checked
 	tenantDbConfig, err := authentication.AuthenticateTenant(r.Header, cfg)
 
 	if err != nil {

--- a/app/factors/factorsController.go
+++ b/app/factors/factorsController.go
@@ -44,7 +44,7 @@ func List(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) 
 	defer mongo.CloseSession(session)
 
 	results := []FactorsOutput{}
-	err = mongo.Find(session, tenantDbConfig.Db, "hepspec", nil, "s", &results)
+	err = mongo.Find(session, tenantDbConfig.Db, "weights", nil, "name", &results)
 
 	if err != nil {
 		code = http.StatusInternalServerError

--- a/app/factors/factorsController.go
+++ b/app/factors/factorsController.go
@@ -1,3 +1,29 @@
+/*
+ * Copyright (c) 2014 GRNET S.A., SRCE, IN2P3 CNRS Computing Centre
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS
+ * IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ *
+ * The views and conclusions contained in the software and
+ * documentation are those of the authors and should not be
+ * interpreted as representing official policies, either expressed
+ * or implied, of either GRNET S.A., SRCE or IN2P3 CNRS Computing
+ * Centre
+ *
+ * The work represented by this source file is partially funded by
+ * the EGI-InSPIRE project through the European Commission's 7th
+ * Framework Programme (contract # INFSO-RI-261323)
+ */
+
 package factors
 
 import (

--- a/app/factors/factorsModel.go
+++ b/app/factors/factorsModel.go
@@ -35,6 +35,7 @@ type root struct {
 	Factor []*Factor
 }
 
+// FactorsOutput struct to represent Name/Factor pair
 type FactorsOutput struct {
 	Site   string  `bson:"name"`
 	Weight float64 `bson:"hepspec"`

--- a/app/factors/factorsModel.go
+++ b/app/factors/factorsModel.go
@@ -36,6 +36,6 @@ type root struct {
 }
 
 type FactorsOutput struct {
-	Site   string  `bson:"s"`
-	Weight float64 `bson:"hs"`
+	Site   string  `bson:"name"`
+	Weight float64 `bson:"hepspec"`
 }

--- a/app/factors/factorsView.go
+++ b/app/factors/factorsView.go
@@ -31,6 +31,7 @@ import (
 	"fmt"
 )
 
+// createView returns an XML view of the results to the controller
 func createView(results []FactorsOutput) ([]byte, error) {
 
 	docRoot := &root{}

--- a/app/factors/factors_test.go
+++ b/app/factors/factors_test.go
@@ -61,7 +61,7 @@ func (suite *FactorsTestSuite) SetupTest() {
     [mongodb]
     host = "127.0.0.1"
     port = 27017
-    db = "argo_core_test"
+    db = "argo_core_test_factors"
 `
 	_ = gcfg.ReadStringInto(&suite.cfg, coreConfig)
 	suite.resp_nokeyprovided = "404 page not found"

--- a/app/factors/factors_test.go
+++ b/app/factors/factors_test.go
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2014 GRNET S.A., SRCE, IN2P3 CNRS Computing Centre
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS
+ * IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ *
+ * The views and conclusions contained in the software and
+ * documentation are those of the authors and should not be
+ * interpreted as representing official policies, either expressed
+ * or implied, of either GRNET S.A., SRCE or IN2P3 CNRS Computing
+ * Centre
+ *
+ * The work represented by this source file is partially funded by
+ * the EGI-InSPIRE project through the European Commission's 7th
+ * Framework Programme (contract # INFSO-RI-261323)
+ */
+
+package factors
+
+import (
+	"code.google.com/p/gcfg"
+	"github.com/argoeu/argo-web-api/utils/config"
+	"github.com/argoeu/argo-web-api/utils/mongo"
+	"github.com/stretchr/testify/suite"
+	"labix.org/v2/mgo"
+	"labix.org/v2/mgo/bson"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// This is a util. suite struct used in tests (see pkg "testify")
+type FactorsTestSuite struct {
+	suite.Suite
+	cfg                 config.Config
+	tenantcfg           config.MongoConfig
+	resp_nokeyprovided  string
+	resp_unauthorized   string
+	resp_factorsList    string
+}
+
+func (suite *FactorsTestSuite) SetupTest() {
+
+	const coreConfig = `
+    [server]
+    bindip = ""
+    port = 8080
+    maxprocs = 4
+    cache = false
+    lrucache = 700000000
+    gzip = true
+    [mongodb]
+    host = "127.0.0.1"
+    port = 27017
+    db = "argo_core_test"
+`
+	_ = gcfg.ReadStringInto(&suite.cfg, coreConfig)
+	suite.resp_nokeyprovided = "404 page not found"
+	suite.resp_unauthorized = "Unauthorized"
+	suite.resp_factorsList = `<root>
+ <Factor site="CETA-GRID" weight="5406"></Factor>
+ <Factor site="CFP-IST" weight="1019"></Factor>
+ <Factor site="CIEMAT-LCG2" weight="14595"></Factor>
+</root>`
+
+	// Connect to mongo coredb
+	session, err := mongo.OpenSession(suite.cfg.MongoDB)
+	defer session.Close()
+
+	// Add authentication token to mongo coredb
+	seed_auth := bson.M{"name" : "TEST",
+		"db_conf" : []bson.M{ bson.M{"server" : "127.0.0.1", "port" : 27017, "database" : "AR_test"} } ,
+		"users" : []bson.M{ bson.M{"name" : "Jack Doe", "email" : "jack.doe@example.com", "api_key" : "secret"} }}
+	_ = mongo.Insert(session, suite.cfg.MongoDB.Db, "tenants", seed_auth)
+
+	mongo.CloseSession(session)
+
+	// TODO: I don't like it here that I rewrite the test data. 
+	// However, this is a test for factors, not for AuthenticateTenant function. 
+	suite.tenantcfg.Host = "127.0.0.1"
+	suite.tenantcfg.Port = 27017
+	suite.tenantcfg.Db = "AR_test"
+
+	// seed tenantdb mongo
+	session, err = mgo.Dial(suite.tenantcfg.Host)
+	if err != nil {
+		panic(err)
+	}
+	defer session.Close()
+
+	// Add a few factors in collection
+	c := session.DB(suite.tenantcfg.Db).C("hepspec")
+	c.Insert(bson.M{ "hs" : 14595, "s" : "CIEMAT-LCG2" })
+	c.Insert(bson.M{ "hs" : 1019, "s" : "CFP-IST" })
+	c.Insert(bson.M{ "hs" : 5406, "s" : "CETA-GRID" })
+
+	mongo.CloseSession(session)
+
+}
+
+func (suite *FactorsTestSuite) TestListFactors() {
+
+	// Prepare the request object
+	request, _ := http.NewRequest("GET", "/api/v1/factors", strings.NewReader(""))
+	// add the authentication token which is seeded in testdb
+	request.Header.Set("x-api-key", "secret")
+	// Execute the request in the controller
+	code, _, output, _ := List(request, suite.cfg)
+	suite.Equal(200, code, "Internal Server Error")
+	suite.Equal(suite.resp_factorsList, string(output), "Response body mismatch")
+
+	// Prepare new request object
+	request, _ = http.NewRequest("GET", "/api/v1/tenants", strings.NewReader(""))
+	// add the authentication token which is seeded in testdb
+	request.Header.Set("x-api-key", "wrongkey")
+	// Execute the request in the controller
+	code, _, output, _ = List(request, suite.cfg)
+	suite.Equal(401, code, "Should have gotten return code 401 (Unauthorized)")
+	suite.Equal(suite.resp_unauthorized, string(output), "Should have gotten reply Unauthorized")
+
+	// Remove the test data from core db not to contaminate other tests
+	// Open session to core mongo
+	session, err := mgo.Dial(suite.cfg.MongoDB.Host)
+	if err != nil {
+		panic(err)
+	}
+	defer session.Close()
+	// Open collection authentication
+	c := session.DB(suite.cfg.MongoDB.Db).C("authentication")
+	// Remove the specific entries inserted during this test
+	c.Remove(bson.M{"name": "John Doe"})
+
+	// Remove the test data from tenant db not to contaminate other tests
+	// Open session to tenant mongo
+	session, err = mgo.Dial(suite.tenantcfg.Host)
+	if err != nil {
+		panic(err)
+	}
+	defer session.Close()
+	// Open collection authentication
+	c = session.DB(suite.tenantcfg.Db).C("hepspec")
+	// Remove the specific entries inserted during this test
+	c.Remove(bson.M{"s": "CIEMAT-LCG2"})
+	c.Remove(bson.M{"s": "CFP-IST"})
+	c.Remove(bson.M{"s": "CETA-GRID"})
+}
+
+//TearDownTest to tear down every test
+func (suite *FactorsTestSuite) TearDownTest() {
+
+	session, err := mgo.Dial(suite.cfg.MongoDB.Host)
+	if err != nil {
+		panic(err)
+	}
+	session.DB(suite.cfg.MongoDB.Db).DropDatabase()
+
+	session, err = mgo.Dial(suite.tenantcfg.Host)
+	if err != nil {
+		panic(err)
+	}
+	session.DB(suite.tenantcfg.Db).DropDatabase()
+
+}
+
+func TestFactorsTestSuite(t *testing.T) {
+	suite.Run(t, new(FactorsTestSuite))
+}

--- a/app/factors/factors_test.go
+++ b/app/factors/factors_test.go
@@ -98,10 +98,10 @@ func (suite *FactorsTestSuite) SetupTest() {
 	defer session.Close()
 
 	// Add a few factors in collection
-	c := session.DB(suite.tenantcfg.Db).C("hepspec")
-	c.Insert(bson.M{ "hs" : 14595, "s" : "CIEMAT-LCG2" })
-	c.Insert(bson.M{ "hs" : 1019, "s" : "CFP-IST" })
-	c.Insert(bson.M{ "hs" : 5406, "s" : "CETA-GRID" })
+	c := session.DB(suite.tenantcfg.Db).C("weights")
+	c.Insert(bson.M{ "hepspec" : 14595, "name" : "CIEMAT-LCG2" })
+	c.Insert(bson.M{ "hepspec" : 1019, "name" : "CFP-IST" })
+	c.Insert(bson.M{ "hepspec" : 5406, "name" : "CETA-GRID" })
 
 	mongo.CloseSession(session)
 
@@ -147,11 +147,11 @@ func (suite *FactorsTestSuite) TestListFactors() {
 	}
 	defer session.Close()
 	// Open collection authentication
-	c = session.DB(suite.tenantcfg.Db).C("hepspec")
+	c = session.DB(suite.tenantcfg.Db).C("weights")
 	// Remove the specific entries inserted during this test
-	c.Remove(bson.M{"s": "CIEMAT-LCG2"})
-	c.Remove(bson.M{"s": "CFP-IST"})
-	c.Remove(bson.M{"s": "CETA-GRID"})
+	c.Remove(bson.M{"name": "CIEMAT-LCG2"})
+	c.Remove(bson.M{"name": "CFP-IST"})
+	c.Remove(bson.M{"name": "CETA-GRID"})
 }
 
 //TearDownTest to tear down every test

--- a/app/factors/factors_test.go
+++ b/app/factors/factors_test.go
@@ -70,6 +70,9 @@ func (suite *FactorsTestSuite) SetupTest() {
 	// Connect to mongo coredb
 	session, err := mongo.OpenSession(suite.cfg.MongoDB)
 	defer mongo.CloseSession(session)
+	if err != nil {
+		panic(err)
+	}
 
 	// Add authentication token to mongo coredb
 	seed_auth := bson.M{"name" : "TEST",
@@ -77,20 +80,11 @@ func (suite *FactorsTestSuite) SetupTest() {
 		"users" : []bson.M{ bson.M{"name" : "Jack Doe", "email" : "jack.doe@example.com", "api_key" : "secret"} }}
 	_ = mongo.Insert(session, suite.cfg.MongoDB.Db, "tenants", seed_auth)
 
-	mongo.CloseSession(session)
-
 	// TODO: I don't like it here that I rewrite the test data. 
 	// However, this is a test for factors, not for AuthenticateTenant function. 
 	suite.tenantcfg.Host = "127.0.0.1"
 	suite.tenantcfg.Port = 27017
 	suite.tenantcfg.Db = "AR_test"
-
-	// seed tenantdb mongo
-	session, err = mgo.Dial(suite.tenantcfg.Host)
-	if err != nil {
-		panic(err)
-	}
-	defer mongo.CloseSession(session)
 
 	// Add a few factors in collection
 	c := session.DB(suite.tenantcfg.Db).C("weights")

--- a/app/factors/factors_test.go
+++ b/app/factors/factors_test.go
@@ -38,7 +38,7 @@ import (
 	"testing"
 )
 
-// This is a util. suite struct used in tests (see pkg "testify")
+// FactorsTestSuite is a utility suite struct used in tests
 type FactorsTestSuite struct {
 	suite.Suite
 	cfg                 config.Config
@@ -48,6 +48,7 @@ type FactorsTestSuite struct {
 	resp_factorsList    string
 }
 
+// SetupTest will bootstrap and provide the testing environment
 func (suite *FactorsTestSuite) SetupTest() {
 
 	const coreConfig = `
@@ -94,6 +95,7 @@ func (suite *FactorsTestSuite) SetupTest() {
 
 }
 
+// TestListFactors will run unit tests against the List function
 func (suite *FactorsTestSuite) TestListFactors() {
 
 	suite.resp_factorsList = `<root>

--- a/app/tenants/tenantsController.go
+++ b/app/tenants/tenantsController.go
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2014 GRNET S.A., SRCE, IN2P3 CNRS Computing Centre
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS
+ * IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ *
+ * The views and conclusions contained in the software and
+ * documentation are those of the authors and should not be
+ * interpreted as representing official policies, either expressed
+ * or implied, of either GRNET S.A., SRCE or IN2P3 CNRS Computing
+ * Centre
+ *
+ * The work represented by this source file is partially funded by
+ * the EGI-InSPIRE project through the European Commission's 7th
+ * Framework Programme (contract # INFSO-RI-261323)
+ */
+
+package tenants
+
+import (
+	"fmt"
+	"github.com/argoeu/argo-web-api/utils/authentication"
+	"github.com/argoeu/argo-web-api/utils/config"
+	"github.com/argoeu/argo-web-api/utils/mongo"
+	"net/http"
+)
+
+func List(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
+
+	//STANDARD DECLARATIONS START
+
+	code := http.StatusOK
+	h := http.Header{}
+	output := []byte("")
+	err := error(nil)
+	contentType := "text/xml"
+	charset := "utf-8"
+
+	//STANDARD DECLARATIONS END
+	if authentication.AuthenticateAdmin(r.Header, cfg) {
+		session, err := mongo.OpenSession(cfg.MongoDB)
+
+		if err != nil {
+			code = http.StatusInternalServerError
+			return code, h, output, err
+		}
+
+		results := []TenantsOutput{}
+		err = mongo.Find(session, cfg.MongoDB.Db, "tenants", nil, "name", &results)
+
+		if err != nil {
+			code = http.StatusInternalServerError
+			return code, h, output, err
+		}
+
+		output, err = createView(results) //Render the results into XML format
+
+		if err != nil {
+			code = http.StatusInternalServerError
+			return code, h, output, err
+		}
+
+		mongo.CloseSession(session)
+		h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+		return code, h, output, err
+	} else {
+		code = http.StatusUnauthorized
+		output = []byte(http.StatusText(http.StatusUnauthorized)) //If wrong api key is passed we return UNAUTHORIZED http status
+		h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+		return code, h, output, err
+	}
+
+}

--- a/app/tenants/tenantsController.go
+++ b/app/tenants/tenantsController.go
@@ -34,6 +34,7 @@ import (
 	"net/http"
 )
 
+// List returns a list of ARGO tenants
 func List(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
 
 	//STANDARD DECLARATIONS START

--- a/app/tenants/tenantsModel.go
+++ b/app/tenants/tenantsModel.go
@@ -26,6 +26,7 @@
 
 package tenants
 
+// Tenant is an XML respresentation of an ARGO tenant
 type Tenant struct {
 	Name    string `xml:"name,attr"`
 }
@@ -34,6 +35,7 @@ type root struct {
 	Tenant []*Tenant
 }
 
+// TenantsOutput is a JSON respresentation of an ARGO tenant name
 type TenantsOutput struct {
 	Name    string `bson:"name"`
 }

--- a/app/tenants/tenantsModel.go
+++ b/app/tenants/tenantsModel.go
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2014 GRNET S.A., SRCE, IN2P3 CNRS Computing Centre
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS
+ * IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ *
+ * The views and conclusions contained in the software and
+ * documentation are those of the authors and should not be
+ * interpreted as representing official policies, either expressed
+ * or implied, of either GRNET S.A., SRCE or IN2P3 CNRS Computing
+ * Centre
+ *
+ * The work represented by this source file is partially funded by
+ * the EGI-InSPIRE project through the European Commission's 7th
+ * Framework Programme (contract # INFSO-RI-261323)
+ */
+
+package tenants
+
+type Tenant struct {
+	Name    string `xml:"name,attr"`
+}
+
+type root struct {
+	Tenant []*Tenant
+}
+
+type TenantsOutput struct {
+	Name    string `bson:"name"`
+}

--- a/app/tenants/tenantsView.go
+++ b/app/tenants/tenantsView.go
@@ -30,6 +30,7 @@ import (
 	"encoding/xml"
 )
 
+// createView returns an XML view of the results to the controller
 func createView(results []TenantsOutput) ([]byte, error) {
 
 	docRoot := &root{}

--- a/app/tenants/tenantsView.go
+++ b/app/tenants/tenantsView.go
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2014 GRNET S.A., SRCE, IN2P3 CNRS Computing Centre
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS
+ * IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ *
+ * The views and conclusions contained in the software and
+ * documentation are those of the authors and should not be
+ * interpreted as representing official policies, either expressed
+ * or implied, of either GRNET S.A., SRCE or IN2P3 CNRS Computing
+ * Centre
+ *
+ * The work represented by this source file is partially funded by
+ * the EGI-InSPIRE project through the European Commission's 7th
+ * Framework Programme (contract # INFSO-RI-261323)
+ */
+
+package tenants
+
+import (
+	"encoding/xml"
+)
+
+func createView(results []TenantsOutput) ([]byte, error) {
+
+	docRoot := &root{}
+
+	for _, row := range results {
+		f := &Tenant{}
+		f.Name = row.Name
+		docRoot.Tenant = append(docRoot.Tenant, f)
+	}
+
+	output, err := xml.MarshalIndent(docRoot, "", " ")
+	return output, err
+
+}

--- a/app/tenants/tenants_test.go
+++ b/app/tenants/tenants_test.go
@@ -38,7 +38,7 @@ import (
 	"testing"
 )
 
-// This is a util. suite struct used in tests (see pkg "testify")
+// TenantsTestSuite is a utility suite struct used in tests
 type TenantsTestSuite struct {
 	suite.Suite
 	cfg                 config.Config
@@ -46,6 +46,7 @@ type TenantsTestSuite struct {
 	resp_tenantsList    string
 }
 
+// SetupTest will bootstrap and provide the testing environment
 func (suite *TenantsTestSuite) SetupTest() {
 
 	const testConfig = `
@@ -93,6 +94,7 @@ func (suite *TenantsTestSuite) SetupTest() {
 
 }
 
+// TestListTenants will run unit tests against the List function
 func (suite *TenantsTestSuite) TestListTenants() {
 
 	// Prepare the request object

--- a/app/tenants/tenants_test.go
+++ b/app/tenants/tenants_test.go
@@ -59,7 +59,7 @@ func (suite *TenantsTestSuite) SetupTest() {
     [mongodb]
     host = "127.0.0.1"
     port = 27017
-    db = "argo_core_test"
+    db = "argo_core_test_tenants"
 `
 	_ = gcfg.ReadStringInto(&suite.cfg, testConfig)
 	suite.resp_unauthorized = "Unauthorized"

--- a/app/tenants/tenants_test.go
+++ b/app/tenants/tenants_test.go
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2014 GRNET S.A., SRCE, IN2P3 CNRS Computing Centre
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS
+ * IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ *
+ * The views and conclusions contained in the software and
+ * documentation are those of the authors and should not be
+ * interpreted as representing official policies, either expressed
+ * or implied, of either GRNET S.A., SRCE or IN2P3 CNRS Computing
+ * Centre
+ *
+ * The work represented by this source file is partially funded by
+ * the EGI-InSPIRE project through the European Commission's 7th
+ * Framework Programme (contract # INFSO-RI-261323)
+ */
+
+package tenants
+
+import (
+	"code.google.com/p/gcfg"
+	"github.com/argoeu/argo-web-api/utils/config"
+	"github.com/argoeu/argo-web-api/utils/mongo"
+	"github.com/stretchr/testify/suite"
+	"labix.org/v2/mgo"
+	"labix.org/v2/mgo/bson"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// This is a util. suite struct used in tests (see pkg "testify")
+type TenantsTestSuite struct {
+	suite.Suite
+	cfg                 config.Config
+	resp_unauthorized   string
+	resp_tenantsList    string
+}
+
+func (suite *TenantsTestSuite) SetupTest() {
+
+	const testConfig = `
+    [server]
+    bindip = ""
+    port = 8080
+    maxprocs = 4
+    cache = false
+    lrucache = 700000000
+    gzip = true
+    [mongodb]
+    host = "127.0.0.1"
+    port = 27017
+    db = "argo_core_test"
+`
+	_ = gcfg.ReadStringInto(&suite.cfg, testConfig)
+	suite.resp_unauthorized = "Unauthorized"
+	suite.resp_tenantsList = `<root>
+ <Tenant name="PREIS"></Tenant>
+ <Tenant name="USDAT"></Tenant>
+</root>`
+
+	// Connect to mongo testdb
+	session, _ := mongo.OpenSession(suite.cfg.MongoDB)
+
+	// Add authentication token to mongo testdb
+	seed_auth := bson.M{"name" : "John Doe", "email" : "john.doe@example.com", "api_key" : "mysecretcombination"}
+	_ = mongo.Insert(session, suite.cfg.MongoDB.Db, "authentication", seed_auth)
+
+	// seed mongo
+	session, err := mgo.Dial(suite.cfg.MongoDB.Host)
+	if err != nil {
+		panic(err)
+	}
+	defer session.Close()
+
+	// Insert first seed profile
+	c := session.DB(suite.cfg.MongoDB.Db).C("tenants")
+	c.Insert(bson.M{"name" : "USDAT",
+		"db_conf" : []bson.M{ bson.M{"server" : "127.0.0.1", "port" : 27017, "database" : "USDAT_test"} } ,
+		"users" : []bson.M{ bson.M{"name" : "Jack Doe", "email" : "jack.doe@example.com", "api_key" : "anothersecret"} }})
+	c.Insert(bson.M{"name" : "PREIS",
+		"db_conf" : []bson.M{ bson.M{"server" : "127.0.0.1", "port" : 27017, "database" : "PREIS_test"} } ,
+		"users" : []bson.M{ bson.M{"name" : "Jill Doe", "email" : "jill.doe@example.com", "api_key" : "onemoresecret"} }})
+
+}
+
+func (suite *TenantsTestSuite) TestListTenants() {
+
+	// Prepare the request object
+	request, _ := http.NewRequest("GET", "/api/v1/tenants", strings.NewReader(""))
+	// add the authentication token which is seeded in testdb
+	request.Header.Set("x-api-key", "mysecretcombination")
+	// Execute the request in the controller
+	code, _, output, _ := List(request, suite.cfg)
+	suite.Equal(200, code, "Internal Server Error")
+	suite.Equal(suite.resp_tenantsList, string(output), "Response body mismatch")
+
+	// Prepare new request object
+	request, _ = http.NewRequest("GET", "/api/v1/tenants", strings.NewReader(""))
+	// add the authentication token which is seeded in testdb
+	request.Header.Set("x-api-key", "wrongkey")
+	// Execute the request in the controller
+	code, _, output, _ = List(request, suite.cfg)
+	suite.Equal(401, code, "Should have gotten return code 401 (Unauthorized)")
+	suite.Equal(suite.resp_unauthorized, string(output), "Should have gotten reply Unauthorized")
+
+	// Remove the profile not to contaminate other tests
+	// Open session to mongo
+	session, err := mgo.Dial(suite.cfg.MongoDB.Host)
+	if err != nil {
+		panic(err)
+	}
+	defer session.Close()
+	// Open collection authentication
+	c := session.DB(suite.cfg.MongoDB.Db).C("authentication")
+	// Remove the specific entries inserted during this test
+	c.Remove(bson.M{"name": "John Doe"})
+
+	// Open collection tenants
+	c = session.DB(suite.cfg.MongoDB.Db).C("tenants")
+	// Remove the specific entries inserted during this test
+	c.Remove(bson.M{"name": "USDAT"})
+	c.Remove(bson.M{"name": "PREIS"})
+
+}
+
+//TearDownTest to tear down every test
+func (suite *TenantsTestSuite) TearDownTest() {
+
+	session, err := mgo.Dial(suite.cfg.MongoDB.Host)
+	if err != nil {
+		panic(err)
+	}
+	session.DB(suite.cfg.MongoDB.Db).DropDatabase()
+
+}
+
+func TestTenantsTestSuite(t *testing.T) {
+	suite.Run(t, new(TenantsTestSuite))
+}

--- a/main.go
+++ b/main.go
@@ -44,6 +44,7 @@ import (
 	"github.com/argoeu/argo-web-api/app/statusMsg"
 	"github.com/argoeu/argo-web-api/app/statusServices"
 	"github.com/argoeu/argo-web-api/app/statusSites"
+	"github.com/argoeu/argo-web-api/app/tenants"
 	"github.com/argoeu/argo-web-api/app/voAvailability"
 	"github.com/gorilla/mux"
 )
@@ -53,7 +54,8 @@ func main() {
 	//Create the server router
 	mainRouter := mux.NewRouter()
 	//SUBROUTER DEFINITIONS
-	getSubrouter := mainRouter.Methods("GET").Subrouter()                                //Routes only GET requests
+	getSubrouter := mainRouter.Methods("GET").Subrouter()                                //Routes GET requests
+	authGetSubrouter := mainRouter.Methods("GET").Headers("x-api-key", "").Subrouter()   //Routes GET requests with auth
 	postSubrouter := mainRouter.Methods("POST").Headers("x-api-key", "").Subrouter()     //Routes only POST requests
 	deleteSubrouter := mainRouter.Methods("DELETE").Headers("x-api-key", "").Subrouter() //Routes only DELETE requests
 	putSubrouter := mainRouter.Methods("PUT").Headers("x-api-key", "").Subrouter()       //Routes only PUT requests
@@ -101,6 +103,9 @@ func main() {
 
 	//Status Sites
 	getSubrouter.HandleFunc("/api/v1/status/sites/timeline/{group}", Respond(statusSites.List))
+
+	//Tenants Operations
+	authGetSubrouter.HandleFunc("/api/v1/tenants", Respond(tenants.List))
 
 	http.Handle("/", mainRouter)
 

--- a/main.go
+++ b/main.go
@@ -87,7 +87,7 @@ func main() {
 	postSubrouter.HandleFunc("/api/v1/recomputations", Respond(recomputations.Create))
 	getSubrouter.HandleFunc("/api/v1/recomputations", Respond(recomputations.List))
 
-	getSubrouter.HandleFunc("/api/v1/factors", Respond(factors.List))
+	authGetSubrouter.HandleFunc("/api/v1/factors", Respond(factors.List))
 
 	//Status
 	getSubrouter.HandleFunc("/api/v1/status/metrics/timeline/{group}", Respond(statusDetail.List))

--- a/utils/authentication/authenticate.go
+++ b/utils/authentication/authenticate.go
@@ -104,7 +104,6 @@ func AuthenticateTenant(h http.Header, cfg config.Config) (config.MongoConfig, e
 
 	var results []map[string][]config.MongoConfig
 	mongo.FindAndProject(session, cfg.MongoDB.Db, "tenants", query, projection, "server", &results)
-	mongo.CloseSession(session)
 
 	if len(results) == 0 {
 		return config.MongoConfig{}, errors.New("Unauthorized")

--- a/utils/authentication/authenticate.go
+++ b/utils/authentication/authenticate.go
@@ -104,6 +104,7 @@ func AuthenticateTenant(h http.Header, cfg config.Config) (config.MongoConfig, e
 
 	var results []map[string][]config.MongoConfig
 	mongo.FindAndProject(session, cfg.MongoDB.Db, "tenants", query, projection, "server", &results)
+	mongo.CloseSession(session)
 
 	if len(results) == 0 {
 		return config.MongoConfig{}, errors.New("Unauthorized")

--- a/utils/authentication/authenticate_test.go
+++ b/utils/authentication/authenticate_test.go
@@ -66,7 +66,7 @@ func (suite *AuthenticationProfileTestSuite) SetupTest() {
     [mongodb]
     host = "127.0.0.1"
     port = 27017
-    db = "AR_test_Authentication"
+    db = "argo_core_test"
     `
 
 	_ = gcfg.ReadStringInto(&suite.cfg, testConfig)
@@ -147,10 +147,37 @@ func (suite *AuthenticationProfileTestSuite) SetupTest() {
 					"api_key": "itsamysterytoyou",
 				},
 			}})
+	c = session.DB(suite.cfg.MongoDB.Db).C("authentication")
+	c.Insert(
+		bson.M{
+			"name" : "Igano Kabamaru",
+			"email" : "igano@kabamaru.io",
+			"api_key" : "makaronada",
+		},
+	)
+	c.Insert(
+		bson.M{
+			"name" : "Optimus Prime",
+			"email" : "prime@autobots.com",
+			"api_key" : "megatron_sucks",
+		},
+	)
+}
+
+// Test AuthenticateAdmin function
+func (suite *AuthenticationProfileTestSuite) TestAdminAuthentication() {
+
+	request, _ := http.NewRequest("GET", "", strings.NewReader(""))
+	request.Header.Set("x-api-key", "megatron_is_a_fool")
+	suite.Equal(AuthenticateAdmin(request.Header, suite.cfg), false, "authetication problem")
+
+	request.Header.Set("x-api-key", "makaronada")
+	suite.Equal(AuthenticateAdmin(request.Header, suite.cfg), true, "authetication problem")
 
 }
 
-func (suite *AuthenticationProfileTestSuite) TestAuthentication() {
+// Test AuthenticateTenant function
+func (suite *AuthenticationProfileTestSuite) TestTenantAuthentication() {
 
 	request, _ := http.NewRequest("GET", "", strings.NewReader(""))
 	request.Header.Set("x-api-key", suite.clientkey)

--- a/utils/authentication/authenticate_test.go
+++ b/utils/authentication/authenticate_test.go
@@ -66,7 +66,7 @@ func (suite *AuthenticationProfileTestSuite) SetupTest() {
     [mongodb]
     host = "127.0.0.1"
     port = 27017
-    db = "argo_core_test"
+    db = "argo_core_test_authenticate"
     `
 
 	_ = gcfg.ReadStringInto(&suite.cfg, testConfig)

--- a/utils/authentication/authenticate_test.go
+++ b/utils/authentication/authenticate_test.go
@@ -39,7 +39,7 @@ import (
 	"labix.org/v2/mgo/bson"
 )
 
-// This is a util. suite struct used in tests (see pkg "testify")
+// AuthenticationProfileTestSuite is a utility suite struct used in tests
 type AuthenticationProfileTestSuite struct {
 	suite.Suite
 	cfg              config.Config
@@ -51,8 +51,7 @@ type AuthenticationProfileTestSuite struct {
 	respUnauthorized string
 }
 
-// Setup the Test Environment
-// This function runs before any test and setups the environment
+// SetupTest will bootstrap and provide the testing environment
 func (suite *AuthenticationProfileTestSuite) SetupTest() {
 
 	const testConfig = `
@@ -164,7 +163,7 @@ func (suite *AuthenticationProfileTestSuite) SetupTest() {
 	)
 }
 
-// Test AuthenticateAdmin function
+// TestAdminAuthentication performs unit tests against the AuthenticateAdmin function
 func (suite *AuthenticationProfileTestSuite) TestAdminAuthentication() {
 
 	request, _ := http.NewRequest("GET", "", strings.NewReader(""))
@@ -176,7 +175,7 @@ func (suite *AuthenticationProfileTestSuite) TestAdminAuthentication() {
 
 }
 
-// Test AuthenticateTenant function
+// TestTenantAuthentication performs unit tests against the AuthenticateTenant function
 func (suite *AuthenticationProfileTestSuite) TestTenantAuthentication() {
 
 	request, _ := http.NewRequest("GET", "", strings.NewReader(""))

--- a/utils/config/config.go
+++ b/utils/config/config.go
@@ -87,7 +87,7 @@ const defaultConfig = `
     [mongodb]
     host = "127.0.0.1"
     port = 27017
-    db = "AR"
+    db = "argo_core"
 `
 
 //Loads the configurations passed either by flags or by the configuration file

--- a/utils/mongo/mongo_test.go
+++ b/utils/mongo/mongo_test.go
@@ -58,7 +58,7 @@ func (suite *mongoTestSuite) SetupTest() {
     [mongodb]
     host = "127.0.0.1"
     port = 27017
-    db = "argo_core_test"
+    db = "argo_core_test_mongo"
     `
 
 	_ = gcfg.ReadStringInto(&suite.cfg, testConfig)


### PR DESCRIPTION
* Added a tenants package based on MVC
* Added a List function for providing via GET verb and x-api-key authentication the current list of tenants
* Added an `AuthenticateAdmin` function in authenticate utils package (and unit tests)
* Change in default API configuration to use `argo_core` database (instead of `AR`)
* Added a new GET subrouter via which x-api-key headers are forwarded to API methods

The changes that need to be applied per package are the ones you may find in the `factors` package. This commit was only made so as to highlight what changes. 