### PR TITLE
ARGO-121 Refactored availabilityProfiles for multitenancy

### DIFF
--- a/app/availabilityProfiles/availabilityProfilesController.go
+++ b/app/availabilityProfiles/availabilityProfilesController.go
@@ -37,6 +37,7 @@ import (
 	"strings"
 )
 
+// List an availability profile
 func List(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
 
 	//STANDARD DECLARATIONS START
@@ -93,6 +94,7 @@ func List(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) 
 	return code, h, output, err
 }
 
+// Create an availability profile
 func Create(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
 
 	//STANDARD DECLARATIONS START
@@ -209,6 +211,7 @@ func Create(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 
 }
 
+// Update an availability profile
 func Update(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
 
 	//STANDARD DECLARATIONS START
@@ -304,6 +307,7 @@ func Update(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 
 }
 
+// Delete an availability profile
 func Delete(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
 
 	//STANDARD DECLARATIONS START

--- a/app/availabilityProfiles/availabilityProfilesController.go
+++ b/app/availabilityProfiles/availabilityProfilesController.go
@@ -52,6 +52,16 @@ func List(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) 
 
 	//STANDARD DECLARATIONS END
 
+	tenantDbConfig, err := authentication.AuthenticateTenant(r.Header, cfg)
+	if err != nil {
+		if err.Error() == "Unauthorized" {
+			code = http.StatusUnauthorized
+			return code, h, output, err
+		}
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
 	//Read the search values
 	urlValues := r.URL.Query()
 
@@ -62,7 +72,8 @@ func List(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) 
 	}
 
 	results := []AvailabilityProfileOutput{}
-	session, err := mongo.OpenSession(cfg.MongoDB)
+	session, err := mongo.OpenSession(tenantDbConfig)
+	defer mongo.CloseSession(session)
 
 	if err != nil {
 		code = http.StatusInternalServerError
@@ -75,14 +86,12 @@ func List(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) 
 		query = nil //If no name and namespace is provided then we have to retrieve all profiles thus we send nil into db query
 	}
 
-	err = mongo.Find(session, cfg.MongoDB.Db, "aps", query, "_id", &results)
+	err = mongo.Find(session, tenantDbConfig.Db, "aggregation_profiles", query, "_id", &results)
 
 	if err != nil {
 		code = http.StatusInternalServerError
 		return code, h, output, err
 	}
-
-	mongo.CloseSession(session)
 
 	output, err = createView(results) //Render the results into XML format
 
@@ -109,107 +118,103 @@ func Create(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 
 	//STANDARD DECLARATIONS END
 
+	tenantDbConfig, err := authentication.AuthenticateTenant(r.Header, cfg)
+	if err != nil {
+		if err.Error() == "Unauthorized" {
+			code = http.StatusUnauthorized
+			return code, h, output, err
+		}
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
 	message := ""
 
-	//Authentication procedure
-	if authentication.Authenticate(r.Header, cfg) {
+	name := []string{}
+	namespace := []string{}
 
-		session, err := mongo.OpenSession(cfg.MongoDB)
+	//Reading the json input
+	reqBody, err := ioutil.ReadAll(r.Body)
 
-		if err != nil {
-			code = http.StatusInternalServerError
-			return code, h, output, err
-		}
+	input := AvailabilityProfileInput{}
+	results := []AvailabilityProfileOutput{}
+	//Unmarshalling the json input into byte form
+	err = json.Unmarshal(reqBody, &input)
 
-		name := []string{}
-		namespace := []string{}
-
-		//Reading the json input
-		reqBody, err := ioutil.ReadAll(r.Body)
-
-		input := AvailabilityProfileInput{}
-		results := []AvailabilityProfileOutput{}
-		//Unmarshalling the json input into byte form
-		err = json.Unmarshal(reqBody, &input)
-
-		if err != nil {
-			if err != nil {
-				message = "Malformated json input data" // User provided malformed json input data
-				output, err := messageXML(message)
-
-				if err != nil {
-					code = http.StatusInternalServerError
-					return code, h, output, err
-				}
-
-				code = http.StatusBadRequest
-				h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
-				return code, h, output, err
-			}
-		}
-
-		//Making sure that no profile with the requested name and namespace combination already exists in the DB
-		name = append(name, input.Name)
-		namespace = append(namespace, input.Namespace)
-
-		search := AvailabilityProfileSearch{
-			name,
-			namespace,
-		}
-
-		query := readOne(search)
-		err = mongo.Find(session, cfg.MongoDB.Db, "aps", query, "name", &results)
+	if err != nil {
+		message = "Malformated json input data" // User provided malformed json input data
+		output, err := messageXML(message)
 
 		if err != nil {
 			code = http.StatusInternalServerError
 			return code, h, output, err
 		}
 
-		if len(results) <= 0 {
-			//If name-namespace combination is unique we insert the new record into mongo
-			query := createOne(input)
-			err = mongo.Insert(session, cfg.MongoDB.Db, "aps", query)
-
-			if err != nil {
-				code = http.StatusInternalServerError
-				return code, h, output, err
-			}
-
-			mongo.CloseSession(session)
-
-			//Providing with the appropriate user response
-			message = "Availability Profile record successfully created"
-			output, err := messageXML(message) //Render the response into XML
-
-			if err != nil {
-				code = http.StatusInternalServerError
-				return code, h, output, err
-			}
-
-			h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
-			return code, h, output, err
-
-		} else {
-			message = "An availability profile with that name already exists"
-			output, err := messageXML(message) //Render the response into XML
-
-			if err != nil {
-				code = http.StatusInternalServerError
-				return code, h, output, err
-			}
-
-			code = http.StatusBadRequest
-			h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
-			return code, h, output, err
-		}
-
-	} else {
-		output = []byte(http.StatusText(http.StatusUnauthorized))
-		code = http.StatusUnauthorized //If wrong api key is passed we return UNAUTHORIZED http status
+		code = http.StatusBadRequest
 		h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
 		return code, h, output, err
 	}
 
+	//Making sure that no profile with the requested name and namespace combination already exists in the DB
+	name = append(name, input.Name)
+	namespace = append(namespace, input.Namespace)
+
+	search := AvailabilityProfileSearch{
+		name,
+		namespace,
+	}
+
+	session, err := mongo.OpenSession(tenantDbConfig)
+	defer mongo.CloseSession(session)
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	query := readOne(search)
+	err = mongo.Find(session, tenantDbConfig.Db, "aggregation_profiles", query, "name", &results)
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	if len(results) <= 0 {
+		//If name-namespace combination is unique we insert the new record into mongo
+		query := createOne(input)
+		err = mongo.Insert(session, tenantDbConfig.Db, "aggregation_profiles", query)
+
+		if err != nil {
+			code = http.StatusInternalServerError
+			return code, h, output, err
+		}
+
+		//Providing with the appropriate user response
+		message = "Availability Profile record successfully created"
+		output, err := messageXML(message) //Render the response into XML
+
+		if err != nil {
+			code = http.StatusInternalServerError
+			return code, h, output, err
+		}
+
+		h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+		return code, h, output, err
+
+	} else {
+		message = "An availability profile with that name already exists"
+		output, err := messageXML(message) //Render the response into XML
+
+		if err != nil {
+			code = http.StatusInternalServerError
+			return code, h, output, err
+		}
+
+		code = http.StatusBadRequest
+		h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+		return code, h, output, err
+	}
 }
 
 // Update an availability profile
@@ -226,86 +231,84 @@ func Update(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 
 	//STANDARD DECLARATIONS END
 
-	message := ""
-
-	//Authentication procedure
-	if authentication.Authenticate(r.Header, cfg) {
-
-		//Extracting record id from url
-		urlValues := r.URL.Path
-		id := strings.Split(urlValues, "/")[4]
-
-		//Reading the json input
-		reqBody, err := ioutil.ReadAll(r.Body)
-
-		if err != nil {
-			code = http.StatusInternalServerError
+	tenantDbConfig, err := authentication.AuthenticateTenant(r.Header, cfg)
+	if err != nil {
+		if err.Error() == "Unauthorized" {
+			code = http.StatusUnauthorized
 			return code, h, output, err
 		}
-
-		input := AvailabilityProfileInput{}
-		//Unmarshalling the json input into byte form
-		err = json.Unmarshal(reqBody, &input)
-
-		if err != nil {
-			message = "Malformated json input data" // User provided malformed json input data
-			output, err := messageXML(message)
-
-			if err != nil {
-				code = http.StatusInternalServerError
-				return code, h, output, err
-			}
-
-			code = http.StatusBadRequest
-			h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
-			return code, h, output, err
-		}
-
-		session, err := mongo.OpenSession(cfg.MongoDB)
-
-		if err != nil {
-			code = http.StatusInternalServerError
-			return code, h, output, err
-		}
-
-		//We update the record bassed on its unique id
-		err = mongo.IdUpdate(session, cfg.MongoDB.Db, "aps", id, input)
-
-		mongo.CloseSession(session)
-
-		if err != nil {
-			message = "No profile matching the requested id" //If not found we inform the user
-			output, err := messageXML(message)
-
-			if err != nil {
-				code = http.StatusInternalServerError
-				return code, h, output, err
-			}
-
-			code = http.StatusBadRequest
-			h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
-			return code, h, output, err
-
-		} else {
-			// Everything went fine and profile was deleted
-			message = "Availability Profile was successfully updated"
-			output, err := messageXML(message) //Render the response into XML
-
-			if err != nil {
-				code = http.StatusInternalServerError
-				return code, h, output, err
-			}
-
-			h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
-			return code, h, output, err
-		}
-	} else {
-		code = http.StatusUnauthorized
-		h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
-		output = []byte(http.StatusText(http.StatusUnauthorized)) //If wrong api key is passed we return UNAUTHORIZED http status
+		code = http.StatusInternalServerError
 		return code, h, output, err
 	}
 
+	message := ""
+	//Extracting record id from url
+	urlValues := r.URL.Path
+	id := strings.Split(urlValues, "/")[4]
+
+	//Reading the json input
+	reqBody, err := ioutil.ReadAll(r.Body)
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	input := AvailabilityProfileInput{}
+	//Unmarshalling the json input into byte form
+	err = json.Unmarshal(reqBody, &input)
+
+	if err != nil {
+		message = "Malformated json input data" // User provided malformed json input data
+		output, err := messageXML(message)
+
+		if err != nil {
+			code = http.StatusInternalServerError
+			return code, h, output, err
+		}
+
+		code = http.StatusBadRequest
+		h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+		return code, h, output, err
+	}
+
+	session, err := mongo.OpenSession(tenantDbConfig)
+	defer mongo.CloseSession(session)
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	//We update the record bassed on its unique id
+	err = mongo.IdUpdate(session, tenantDbConfig.Db, "aggregation_profiles", id, input)
+
+	if err != nil {
+		message = "No profile matching the requested id" //If not found we inform the user
+		output, err := messageXML(message)
+
+		if err != nil {
+			code = http.StatusInternalServerError
+			return code, h, output, err
+		}
+
+		code = http.StatusBadRequest
+		h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+		return code, h, output, err
+
+	} else {
+		// Everything went fine and profile was deleted
+		message = "Availability Profile was successfully updated"
+		output, err := messageXML(message) //Render the response into XML
+
+		if err != nil {
+			code = http.StatusInternalServerError
+			return code, h, output, err
+		}
+
+		h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+		return code, h, output, err
+	}
 }
 
 // Delete an availability profile
@@ -321,56 +324,54 @@ func Delete(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 	charset := "utf-8"
 
 	//STANDARD DECLARATIONS END
+	tenantDbConfig, err := authentication.AuthenticateTenant(r.Header, cfg)
+	if err != nil {
+		if err.Error() == "Unauthorized" {
+			code = http.StatusUnauthorized
+			return code, h, output, err
+		}
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
 	message := ""
+	//Extracting record id from url
+	urlValues := r.URL.Path
+	id := strings.Split(urlValues, "/")[4]
 
-	//Authentication procedure
-	if authentication.Authenticate(r.Header, cfg) {
+	session, err := mongo.OpenSession(tenantDbConfig)
+	defer mongo.CloseSession(session)
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+	//We remove the record bassed on its unique id
+	err = mongo.IdRemove(session, tenantDbConfig.Db, "aggregation_profiles", id)
 
-		//Extracting record id from url
-		urlValues := r.URL.Path
-		id := strings.Split(urlValues, "/")[4]
-		session, err := mongo.OpenSession(cfg.MongoDB)
+	if err != nil {
+
+		message = "No profile matching the requested id" //If not found we inform the user
+		output, err := messageXML(message)
 
 		if err != nil {
 			code = http.StatusInternalServerError
 			return code, h, output, err
 		}
 
-		//We remove the record bassed on its unique id
-		err = mongo.IdRemove(session, cfg.MongoDB.Db, "aps", id)
-		mongo.CloseSession(session)
-
-		if err != nil {
-
-			message = "No profile matching the requested id" //If not found we inform the user
-			output, err := messageXML(message)
-
-			if err != nil {
-				code = http.StatusInternalServerError
-				return code, h, output, err
-			}
-
-			code = http.StatusBadRequest
-			h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
-			return code, h, output, err
-		} else {
-
-			// Everything went fine and profile was deleted
-			message = "Availability Profile was successfully deleted"
-			output, err := messageXML(message) //Render the response into XML
-
-			if err != nil {
-				code = http.StatusInternalServerError
-				return code, h, output, err
-			}
-
-			h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
-			return code, h, output, err
-		}
+		code = http.StatusBadRequest
+		h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+		return code, h, output, err
 	} else {
 
-		code = http.StatusUnauthorized
-		output = []byte(http.StatusText(http.StatusUnauthorized)) //If wrong api key is passed we return UNAUTHORIZED http status
+		// Everything went fine and profile was deleted
+		message = "Availability Profile was successfully deleted"
+		output, err := messageXML(message) //Render the response into XML
+
+		if err != nil {
+			code = http.StatusInternalServerError
+			return code, h, output, err
+		}
+
 		h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
 		return code, h, output, err
 	}

--- a/app/availabilityProfiles/availabilityProfilesModel.go
+++ b/app/availabilityProfiles/availabilityProfilesModel.go
@@ -34,7 +34,7 @@ import (
 type Group struct {
 	XMLName          xml.Name
 	ServiceFlavor    string `xml:"service_flavor,attr"`
-    ServiceOperation string `xml:"operation,attr"`
+	ServiceOperation string `xml:"operation,attr"`
 }
 
 type Or struct {
@@ -48,12 +48,12 @@ type And struct {
 }
 
 type Profile struct {
-	XMLName            xml.Name `xml:"profile"`
-	ID                 string   `xml:"id,attr"`
-	Name               string   `xml:"name,attr"`
-	Namespace          string   `xml:"namespace,attr"`
-	MetricProfile      string   `xml:"metricprofiles,attr"`
-	And       *And
+	XMLName       xml.Name `xml:"profile"`
+	ID            string   `xml:"id,attr"`
+	Name          string   `xml:"name,attr"`
+	Namespace     string   `xml:"namespace,attr"`
+	MetricProfile string   `xml:"metricprofiles,attr"`
+	And           *And
 }
 
 type ReadRoot struct {
@@ -67,16 +67,16 @@ type Message struct {
 }
 
 type ServiceSetInput struct {
-    Services map[string]string `json:"services"`
-    Operation string           `json:"operation"`
+	Services  map[string]string `json:"services"`
+	Operation string            `json:"operation"`
 }
 
 //Struct for inserting data into DB
 type AvailabilityProfileInput struct {
-	Name               string                     `json:"name"`
-	Namespace          string                     `json:"namespace"`
-	Groups             map[string]ServiceSetInput `json:"groups"`
-	MetricProfiles     []string                   `json:"metricprofiles"`
+	Name           string                     `json:"name"`
+	Namespace      string                     `json:"namespace"`
+	Groups         map[string]ServiceSetInput `json:"groups"`
+	MetricProfiles []string                   `json:"metricprofiles"`
 }
 
 //Struct for searching based on name and namespace combination
@@ -86,17 +86,17 @@ type AvailabilityProfileSearch struct {
 }
 
 type ServiceSetOutput struct {
-    Services map[string]string `bson:"services"`
-    Operation string           `bson:"operation"`
+	Services  map[string]string `bson:"services"`
+	Operation string            `bson:"operation"`
 }
 
 //Struct for record retrieval
 type AvailabilityProfileOutput struct {
-	ID                 bson.ObjectId               `bson:"_id"`
-	Name               string                      `bson:"name"`
-	Namespace          string                      `bson:"namespace"`
-	Groups             map[string]ServiceSetOutput `bson:"groups"`
-	MetricProfiles     []string                    `bson:"metricprofiles"`
+	ID             bson.ObjectId               `bson:"_id"`
+	Name           string                      `bson:"name"`
+	Namespace      string                      `bson:"namespace"`
+	Groups         map[string]ServiceSetOutput `bson:"groups"`
+	MetricProfiles []string                    `bson:"metricprofiles"`
 }
 
 func prepareFilter(input AvailabilityProfileSearch) bson.M {
@@ -111,10 +111,10 @@ func prepareFilter(input AvailabilityProfileSearch) bson.M {
 
 func createOne(input AvailabilityProfileInput) bson.M {
 	query := bson.M{
-		"name":               input.Name,
-		"namespace":          input.Namespace,
-		"groups":             input.Groups,
-		"metricprofiles":     input.MetricProfiles,
+		"name":           input.Name,
+		"namespace":      input.Namespace,
+		"groups":         input.Groups,
+		"metricprofiles": input.MetricProfiles,
 	}
 	return query
 }

--- a/app/availabilityProfiles/availabilityProfilesModel.go
+++ b/app/availabilityProfiles/availabilityProfilesModel.go
@@ -52,12 +52,15 @@ type And struct {
 
 // Profile struct to hold profile basic information
 type Profile struct {
-	XMLName       xml.Name `xml:"profile"`
-	ID            string   `xml:"id,attr"`
-	Name          string   `xml:"name,attr"`
-	Namespace     string   `xml:"namespace,attr"`
-	MetricProfile string   `xml:"metricprofiles,attr"`
-	And           *And
+	XMLName          xml.Name `xml:"profile"`
+	ID               string   `xml:"id,attr"`
+	Name             string   `xml:"name,attr"`
+	Namespace        string   `xml:"namespace,attr"`
+	MetricProfile    string   `xml:"metricprofiles,attr"`
+	EndpointGroup    string   `xml:"endpointgroup,attr"`
+	MetricOperation  string   `xml:"metricoperation,attr"`
+	ProfileOperation string   `xml:"profileoperation,attr"`
+	And              *And
 }
 
 // ReadRoot to wrap profiles
@@ -80,10 +83,13 @@ type ServiceSetInput struct {
 
 // AvailabilityProfileInput struct for inserting data into DB
 type AvailabilityProfileInput struct {
-	Name           string                     `json:"name"`
-	Namespace      string                     `json:"namespace"`
-	Groups         map[string]ServiceSetInput `json:"groups"`
-	MetricProfiles []string                   `json:"metricprofiles"`
+	Name             string                     `json:"name"`
+	Namespace        string                     `json:"namespace"`
+	Groups           map[string]ServiceSetInput `json:"groups"`
+	MetricProfiles   []string                   `json:"metricprofiles"`
+	EndpointGroup    string                     `json:"endpointgroup"`
+	MetricOperation  string                     `json:"metricoperation"`
+	ProfileOperation string                     `json:"profileoperation"`
 }
 
 // AvailabilityProfileSearch struct for searching based on name and namespace combination
@@ -100,11 +106,14 @@ type ServiceSetOutput struct {
 
 // AvailabilityProfileOutput struct for record retrieval
 type AvailabilityProfileOutput struct {
-	ID             bson.ObjectId               `bson:"_id"`
-	Name           string                      `bson:"name"`
-	Namespace      string                      `bson:"namespace"`
-	Groups         map[string]ServiceSetOutput `bson:"groups"`
-	MetricProfiles []string                    `bson:"metricprofiles"`
+	ID               bson.ObjectId               `bson:"_id"`
+	Name             string                      `bson:"name"`
+	Namespace        string                      `bson:"namespace"`
+	Groups           map[string]ServiceSetOutput `bson:"groups"`
+	MetricProfiles   []string                    `bson:"metricprofiles"`
+	EndpointGroup    string                      `bson:"endpointgroup"`
+	MetricOperation  string                      `bson:"metricoperation"`
+	ProfileOperation string                      `bson:"profileoperation"`
 }
 
 func prepareFilter(input AvailabilityProfileSearch) bson.M {
@@ -119,10 +128,13 @@ func prepareFilter(input AvailabilityProfileSearch) bson.M {
 
 func createOne(input AvailabilityProfileInput) bson.M {
 	query := bson.M{
-		"name":           input.Name,
-		"namespace":      input.Namespace,
-		"groups":         input.Groups,
-		"metricprofiles": input.MetricProfiles,
+		"name":             input.Name,
+		"namespace":        input.Namespace,
+		"groups":           input.Groups,
+		"metricprofiles":   input.MetricProfiles,
+		"endpointgroup":    input.EndpointGroup,
+		"metricoperation":  input.MetricOperation,
+		"profileoperation": input.ProfileOperation,
 	}
 	return query
 }

--- a/app/availabilityProfiles/availabilityProfilesModel.go
+++ b/app/availabilityProfiles/availabilityProfilesModel.go
@@ -32,8 +32,9 @@ import (
 )
 
 type Group struct {
-	XMLName       xml.Name
-	ServiceFlavor string `xml:"service_flavor,attr"`
+	XMLName          xml.Name
+	ServiceFlavor    string `xml:"service_flavor,attr"`
+  ServiceOperation string `xml:"operation,attr"`
 }
 
 type Or struct {
@@ -65,12 +66,17 @@ type Message struct {
 	Message string
 }
 
+type ServiceSetInput struct {
+  Services map[string]string `json:"services"`
+  Operation string           `json:"operation"`
+}
+
 //Struct for inserting data into DB
 type AvailabilityProfileInput struct {
-	Name               string     `json:"name"`
-	Namespace          string     `json:"namespace"`
-	Groups             [][]string `json:"groups"`
-	MetricProfiles     []string   `json:"metricprofiles"`
+	Name               string                     `json:"name"`
+	Namespace          string                     `json:"namespace"`
+	Groups             map[string]ServiceSetInput `json:"groups"`
+	MetricProfiles     []string                   `json:"metricprofiles"`
 }
 
 //Struct for searching based on name and namespace combination
@@ -79,13 +85,18 @@ type AvailabilityProfileSearch struct {
 	Namespace []string
 }
 
+type ServiceSetOutput struct {
+  Services map[string]string `bson:"services"`
+  Operation string           `bson:"operation"`
+}
+
 //Struct for record retrieval
 type AvailabilityProfileOutput struct {
-	ID                 bson.ObjectId `bson:"_id"`
-	Name               string        `bson:"name"`
-	Namespace          string        `bson:"namespace"`
-	Groups             [][]string    `bson:"groups"`
-	MetricProfiles     []string      `bson:"metricprofiles"`
+	ID                 bson.ObjectId               `bson:"_id"`
+	Name               string                      `bson:"name"`
+	Namespace          string                      `bson:"namespace"`
+	Groups             map[string]ServiceSetOutput `bson:"groups"`
+	MetricProfiles     []string                    `bson:"metricprofiles"`
 }
 
 func prepareFilter(input AvailabilityProfileSearch) bson.M {

--- a/app/availabilityProfiles/availabilityProfilesModel.go
+++ b/app/availabilityProfiles/availabilityProfilesModel.go
@@ -31,22 +31,26 @@ import (
 	"labix.org/v2/mgo/bson"
 )
 
+// Group struct to hold service flavor and operation xml attributes
 type Group struct {
 	XMLName          xml.Name
 	ServiceFlavor    string `xml:"service_flavor,attr"`
 	ServiceOperation string `xml:"operation,attr"`
 }
 
+// Or struct to represent operation based grouping
 type Or struct {
 	XMLName xml.Name `xml:"OR"`
 	Group   []*Group
 }
 
+// And struct to represent operation based grouping
 type And struct {
 	XMLName xml.Name `xml:"AND"`
 	Or      []*Or
 }
 
+// Profile struct to hold profile basic information
 type Profile struct {
 	XMLName       xml.Name `xml:"profile"`
 	ID            string   `xml:"id,attr"`
@@ -56,22 +60,25 @@ type Profile struct {
 	And           *And
 }
 
+// ReadRoot to wrap profiles
 type ReadRoot struct {
 	XMLName xml.Name `xml:"root"`
 	Profile []*Profile
 }
 
+// Message struct to hold the xml response
 type Message struct {
 	XMLName xml.Name `xml:"root"`
 	Message string
 }
 
+// ServiceSetInput struct to represent services hash map and operation inside groups
 type ServiceSetInput struct {
 	Services  map[string]string `json:"services"`
 	Operation string            `json:"operation"`
 }
 
-//Struct for inserting data into DB
+// AvailabilityProfileInput struct for inserting data into DB
 type AvailabilityProfileInput struct {
 	Name           string                     `json:"name"`
 	Namespace      string                     `json:"namespace"`
@@ -79,18 +86,19 @@ type AvailabilityProfileInput struct {
 	MetricProfiles []string                   `json:"metricprofiles"`
 }
 
-//Struct for searching based on name and namespace combination
+// AvailabilityProfileSearch struct for searching based on name and namespace combination
 type AvailabilityProfileSearch struct {
 	Name      []string
 	Namespace []string
 }
 
+// ServiceSetOutput struct to represent services hash map in MongoDB
 type ServiceSetOutput struct {
 	Services  map[string]string `bson:"services"`
 	Operation string            `bson:"operation"`
 }
 
-//Struct for record retrieval
+// AvailabilityProfileOutput struct for record retrieval
 type AvailabilityProfileOutput struct {
 	ID             bson.ObjectId               `bson:"_id"`
 	Name           string                      `bson:"name"`

--- a/app/availabilityProfiles/availabilityProfilesModel.go
+++ b/app/availabilityProfiles/availabilityProfilesModel.go
@@ -31,6 +31,9 @@ import (
 	"labix.org/v2/mgo/bson"
 )
 
+// TODO: Merge duplicated structs into one with multiple annotations.
+// Leave it as it is for now since there would be more changes in the immediate future.
+
 // Group struct to hold service flavor and operation xml attributes
 type Group struct {
 	XMLName          xml.Name

--- a/app/availabilityProfiles/availabilityProfilesModel.go
+++ b/app/availabilityProfiles/availabilityProfilesModel.go
@@ -47,11 +47,11 @@ type And struct {
 }
 
 type Profile struct {
-	XMLName   xml.Name `xml:"profile"`
-	ID        string   `xml:"id,attr"`
-	Name      string   `xml:"name,attr"`
-	Namespace string   `xml:"namespace,attr"`
-	Poem      string   `xml:"poems,attr"`
+	XMLName            xml.Name `xml:"profile"`
+	ID                 string   `xml:"id,attr"`
+	Name               string   `xml:"name,attr"`
+	Namespace          string   `xml:"namespace,attr"`
+	MetricProfile      string   `xml:"metricprofiles,attr"`
 	And       *And
 }
 
@@ -67,10 +67,10 @@ type Message struct {
 
 //Struct for inserting data into DB
 type AvailabilityProfileInput struct {
-	Name      string     `json:"name"`
-	Namespace string     `json:"namespace"`
-	Groups    [][]string `json:"groups"`
-	Poems     []string   `json:"poems"`
+	Name               string     `json:"name"`
+	Namespace          string     `json:"namespace"`
+	Groups             [][]string `json:"groups"`
+	MetricProfiles     []string   `json:"metricprofiles"`
 }
 
 //Struct for searching based on name and namespace combination
@@ -81,11 +81,11 @@ type AvailabilityProfileSearch struct {
 
 //Struct for record retrieval
 type AvailabilityProfileOutput struct {
-	ID        bson.ObjectId `bson:"_id"`
-	Name      string        `bson:"name"`
-	Namespace string        `bson:"namespace"`
-	Groups    [][]string    `bson:"groups"`
-	Poems     []string      `bson:"poems"`
+	ID                 bson.ObjectId `bson:"_id"`
+	Name               string        `bson:"name"`
+	Namespace          string        `bson:"namespace"`
+	Groups             [][]string    `bson:"groups"`
+	MetricProfiles     []string      `bson:"metricprofiles"`
 }
 
 func prepareFilter(input AvailabilityProfileSearch) bson.M {
@@ -100,10 +100,10 @@ func prepareFilter(input AvailabilityProfileSearch) bson.M {
 
 func createOne(input AvailabilityProfileInput) bson.M {
 	query := bson.M{
-		"name":      input.Name,
-		"namespace": input.Namespace,
-		"groups":    input.Groups,
-		"poems":     input.Poems,
+		"name":               input.Name,
+		"namespace":          input.Namespace,
+		"groups":             input.Groups,
+		"metricprofiles":     input.MetricProfiles,
 	}
 	return query
 }

--- a/app/availabilityProfiles/availabilityProfilesModel.go
+++ b/app/availabilityProfiles/availabilityProfilesModel.go
@@ -34,7 +34,7 @@ import (
 type Group struct {
 	XMLName          xml.Name
 	ServiceFlavor    string `xml:"service_flavor,attr"`
-  ServiceOperation string `xml:"operation,attr"`
+    ServiceOperation string `xml:"operation,attr"`
 }
 
 type Or struct {
@@ -67,8 +67,8 @@ type Message struct {
 }
 
 type ServiceSetInput struct {
-  Services map[string]string `json:"services"`
-  Operation string           `json:"operation"`
+    Services map[string]string `json:"services"`
+    Operation string           `json:"operation"`
 }
 
 //Struct for inserting data into DB
@@ -86,8 +86,8 @@ type AvailabilityProfileSearch struct {
 }
 
 type ServiceSetOutput struct {
-  Services map[string]string `bson:"services"`
-  Operation string           `bson:"operation"`
+    Services map[string]string `bson:"services"`
+    Operation string           `bson:"operation"`
 }
 
 //Struct for record retrieval

--- a/app/availabilityProfiles/availabilityProfilesView.go
+++ b/app/availabilityProfiles/availabilityProfilesView.go
@@ -55,7 +55,7 @@ func createView(results []AvailabilityProfileOutput) ([]byte, error) {
 			for sf, op := range group.Services {
 				group := &Group{
 					ServiceFlavor: sf,
-          ServiceOperation: op,
+                    ServiceOperation: op,
 				}
 				or.Group = append(or.Group, group)
 			}

--- a/app/availabilityProfiles/availabilityProfilesView.go
+++ b/app/availabilityProfiles/availabilityProfilesView.go
@@ -35,7 +35,7 @@ func createView(results []AvailabilityProfileOutput) ([]byte, error) {
 	docRoot := &ReadRoot{}
 	for _, row := range results {
 
-		// If poem array doesn't contain items add empty string to poem attribute
+		// If metricprofiles array doesn't contain items add empty string to metricprofiles attribute
 		if len(row.MetricProfiles) > 0 {
 			metricProfileName = row.MetricProfiles[0]
 		} else {
@@ -52,9 +52,10 @@ func createView(results []AvailabilityProfileOutput) ([]byte, error) {
 		docRoot.Profile = append(docRoot.Profile, profile)
 		for _, group := range row.Groups {
 			or := &Or{}
-			for _, sf := range group {
+			for sf, op := range group.Services {
 				group := &Group{
 					ServiceFlavor: sf,
+          ServiceOperation: op,
 				}
 				or.Group = append(or.Group, group)
 			}

--- a/app/availabilityProfiles/availabilityProfilesView.go
+++ b/app/availabilityProfiles/availabilityProfilesView.go
@@ -30,23 +30,23 @@ import "encoding/xml"
 
 func createView(results []AvailabilityProfileOutput) ([]byte, error) {
 
-	poem_name := ""
+	metricProfileName := ""
 
 	docRoot := &ReadRoot{}
 	for _, row := range results {
 
 		// If poem array doesn't contain items add empty string to poem attribute
-		if len(row.Poems) > 0 {
-			poem_name = row.Poems[0]
+		if len(row.MetricProfiles) > 0 {
+			metricProfileName = row.MetricProfiles[0]
 		} else {
-			poem_name = ""
+			metricProfileName = ""
 		}
 
 		profile := &Profile{
-			ID:        row.ID.Hex(),
-			Name:      row.Name,
-			Namespace: row.Namespace,
-			Poem:      poem_name,
+			ID:              row.ID.Hex(),
+			Name:            row.Name,
+			Namespace:       row.Namespace,
+			MetricProfile:   metricProfileName,
 		}
 		and := &And{}
 		docRoot.Profile = append(docRoot.Profile, profile)

--- a/app/availabilityProfiles/availabilityProfilesView.go
+++ b/app/availabilityProfiles/availabilityProfilesView.go
@@ -43,10 +43,10 @@ func createView(results []AvailabilityProfileOutput) ([]byte, error) {
 		}
 
 		profile := &Profile{
-			ID:              row.ID.Hex(),
-			Name:            row.Name,
-			Namespace:       row.Namespace,
-			MetricProfile:   metricProfileName,
+			ID:            row.ID.Hex(),
+			Name:          row.Name,
+			Namespace:     row.Namespace,
+			MetricProfile: metricProfileName,
 		}
 		and := &And{}
 		docRoot.Profile = append(docRoot.Profile, profile)
@@ -54,8 +54,8 @@ func createView(results []AvailabilityProfileOutput) ([]byte, error) {
 			or := &Or{}
 			for sf, op := range group.Services {
 				group := &Group{
-					ServiceFlavor: sf,
-                    ServiceOperation: op,
+					ServiceFlavor:    sf,
+					ServiceOperation: op,
 				}
 				or.Group = append(or.Group, group)
 			}

--- a/app/availabilityProfiles/availabilityProfilesView.go
+++ b/app/availabilityProfiles/availabilityProfilesView.go
@@ -43,10 +43,13 @@ func createView(results []AvailabilityProfileOutput) ([]byte, error) {
 		}
 
 		profile := &Profile{
-			ID:            row.ID.Hex(),
-			Name:          row.Name,
-			Namespace:     row.Namespace,
-			MetricProfile: metricProfileName,
+			ID:               row.ID.Hex(),
+			Name:             row.Name,
+			Namespace:        row.Namespace,
+			MetricProfile:    metricProfileName,
+			EndpointGroup:    row.EndpointGroup,
+			MetricOperation:  row.MetricOperation,
+			ProfileOperation: row.ProfileOperation,
 		}
 		and := &And{}
 		docRoot.Profile = append(docRoot.Profile, profile)

--- a/app/availabilityProfiles/availabilityProfiles_test.go
+++ b/app/availabilityProfiles/availabilityProfiles_test.go
@@ -89,18 +89,42 @@ type ServiceIn struct {
 }
 
 // Prepare maps for services and groups for ap1
-var apGroup1 = ServiceIn{ServiceSetIn: map[string]string{
-	"ap1-service1": "OR", "ap1-service2": "AND", "ap1-service3": "AND"}, Operator: "OR"}
-var apGroup2 = ServiceIn{ServiceSetIn: map[string]string{
-	"ap1-service4": "AND", "ap1-service5": "OR", "ap1-service6": "AND"}, Operator: "AND"}
-var profileGroup1 = map[string]ServiceIn{"compute": apGroup1, "storage": apGroup2}
+var apGroup1 = ServiceIn{
+	ServiceSetIn: map[string]string{
+		"ap1-service1": "OR",
+		"ap1-service2": "AND",
+		"ap1-service3": "AND"},
+	Operator: "OR"}
+
+var apGroup2 = ServiceIn{
+	ServiceSetIn: map[string]string{
+		"ap1-service4": "AND",
+		"ap1-service5": "OR",
+		"ap1-service6": "AND"},
+	Operator: "AND"}
+
+var profileGroup1 = map[string]ServiceIn{
+	"compute": apGroup1,
+	"storage": apGroup2}
 
 // Prepare maps for services and groups for ap2
-var apGroup3 = ServiceIn{ServiceSetIn: map[string]string{
-	"ap2-service1": "OR", "ap2-service2": "AND", "ap2-service3": "AND"}, Operator: "OR"}
-var apGroup4 = ServiceIn{ServiceSetIn: map[string]string{
-	"ap2-service4": "AND", "ap2-service5": "AND", "ap2-service6": "OR"}, Operator: "OR"}
-var profileGroup2 = map[string]ServiceIn{"compute": apGroup3, "storage": apGroup4}
+var apGroup3 = ServiceIn{
+	ServiceSetIn: map[string]string{
+		"ap2-service1": "OR",
+		"ap2-service2": "AND",
+		"ap2-service3": "AND"},
+	Operator: "OR"}
+
+var apGroup4 = ServiceIn{
+	ServiceSetIn: map[string]string{
+		"ap2-service4": "AND",
+		"ap2-service5": "AND",
+		"ap2-service6": "OR"},
+	Operator: "OR"}
+
+var profileGroup2 = map[string]ServiceIn{
+	"compute": apGroup3,
+	"storage": apGroup4}
 
 // Setup the Test Environment
 // This function runs before any test and setups the environment
@@ -162,12 +186,24 @@ func (suite *AvProfileTestSuite) SetupTest() {
 	c := session.DB(suite.cfg.MongoDB.Db).C("aps")
 
 	// Insert first seed profile
-	c.Insert(bson.M{"name": "ap1", "namespace": "namespace1", "metricprofiles": []string{"metricprofile01"},
-		"endpointgroup": "sites", "metricoperation": "AND", "profileoperation": "AND", "groups": profileGroup1})
+	c.Insert(
+		bson.M{"name": "ap1",
+			"namespace":        "namespace1",
+			"metricprofiles":   []string{"metricprofile01"},
+			"endpointgroup":    "sites",
+			"metricoperation":  "AND",
+			"profileoperation": "AND",
+			"groups":           profileGroup1})
 
 	// Insert second seed profile
-	c.Insert(bson.M{"name": "ap2", "namespace": "namespace2", "metricprofiles": []string{"metricprofile02"},
-		"endpointgroup": "sites", "metricoperation": "AND", "profileoperation": "AND", "groups": profileGroup2})
+	c.Insert(
+		bson.M{"name": "ap2",
+			"namespace":        "namespace2",
+			"metricprofiles":   []string{"metricprofile02"},
+			"endpointgroup":    "sites",
+			"metricoperation":  "AND",
+			"profileoperation": "AND",
+			"groups":           profileGroup2})
 
 }
 
@@ -383,8 +419,14 @@ func (suite *AvProfileTestSuite) TestUpdateProfile() {
 
 	// Reestablish ap2 profile (remove and reinsert)
 	c.Remove(bson.M{"name": "ap2"})
-	c.Insert(bson.M{"name": "ap2", "namespace": "namespace2", "metricprofiles": []string{"metricprofile02"},
-		"endpointgroup": "sites", "metricoperation": "AND", "profileoperation": "AND", "groups": profileGroup2})
+	c.Insert(
+		bson.M{"name": "ap2",
+			"namespace":        "namespace2",
+			"metricprofiles":   []string{"metricprofile02"},
+			"endpointgroup":    "sites",
+			"metricoperation":  "AND",
+			"profileoperation": "AND",
+			"groups":           profileGroup2})
 
 }
 
@@ -476,8 +518,14 @@ func (suite *AvProfileTestSuite) TestDeleteProfile() {
 	}
 
 	// Reestablish ap2 profile (reinsert)
-	c.Insert(bson.M{"name": "ap2", "namespace": "namespace2", "metricprofiles": []string{"metricprofile02"},
-		"endpointgroup": "sites", "metricoperation": "AND", "profileoperation": "AND", "groups": profileGroup2})
+	c.Insert(
+		bson.M{"name": "ap2",
+			"namespace":        "namespace2",
+			"metricprofiles":   []string{"metricprofile02"},
+			"endpointgroup":    "sites",
+			"metricoperation":  "AND",
+			"profileoperation": "AND",
+			"groups":           profileGroup2})
 
 }
 
@@ -637,7 +685,6 @@ func (suite *AvProfileTestSuite) TestUpdateBadJson() {
 func (suite *AvProfileTestSuite) TearDownTest() {
 
 	session, _ := mongo.OpenSession(suite.cfg.MongoDB)
-
 	session.DB("AR_test").DropDatabase()
 
 }

--- a/app/availabilityProfiles/availabilityProfiles_test.go
+++ b/app/availabilityProfiles/availabilityProfiles_test.go
@@ -431,14 +431,13 @@ func (suite *AvProfileTestSuite) TestReadProfile() {
 		suite.Fail("Unmarshal error: ", xmlErr.Error())
 	}
 
-	// Compare the expected and actual XML result
-	suite.Regexp(schema, string(output), "Response body mismatch")
-
 	// Compare only the structure of the XML
 	cmp := reflect.DeepEqual(v, d)
 	if cmp != true {
 		suite.Fail("XML schema mismatch")
 	}
+	// Compare the expected and actual XML result
+	suite.Regexp(schema, string(output), "Response body mismatch")
 }
 
 // Testing update of a profile  using POST request.

--- a/app/availabilityProfiles/availabilityProfiles_test.go
+++ b/app/availabilityProfiles/availabilityProfiles_test.go
@@ -108,12 +108,12 @@ func (suite *AvProfileTestSuite) SetupTest() {
 
 	// Insert first seed profile
 	c := session.DB(suite.cfg.MongoDB.Db).C("aps")
-	c.Insert(bson.M{"name": "ap1", "namespace": "namespace1", "poems": []string{"poem01"},
+	c.Insert(bson.M{"name": "ap1", "namespace": "namespace1", "metricprofiles": []string{"metricprofile01"},
 		"groups": [][]string{
 			[]string{"ap1-service1", "ap1-service2", "ap1-service3"},
 			[]string{"ap1-service4", "ap1-service5", "ap1-service6"}}})
 	// Insert first seed profile
-	c.Insert(bson.M{"name": "ap2", "namespace": "namespace2", "poems": []string{"poem02"},
+	c.Insert(bson.M{"name": "ap2", "namespace": "namespace2", "metricprofiles": []string{"metricprofile02"},
 		"groups": [][]string{
 			[]string{"ap2-service1", "ap2-service2", "ap2-service3"},
 			[]string{"ap2-service4", "ap2-service5", "ap2-service6"}}})
@@ -133,7 +133,7 @@ func (suite *AvProfileTestSuite) TestCreateProfile() {
     {
         "name": "fresh_test_profile",
         "namespace": "test_namespace",
-        "poems": ["test_poem"],
+        "metricprofiles": ["test_metricprofile"],
         "groups": [
             [
                "service1",
@@ -202,7 +202,7 @@ func (suite *AvProfileTestSuite) TestReadProfile() {
 	id2 := (results.ID.Hex())
 	// Hold a string multiline literal including the two profile ids retrieved
 	profile_list_xml := ` <root>
-   <profile id="` + id1 + `" name="ap1" namespace="namespace1" poems="poem01">
+   <profile id="` + id1 + `" name="ap1" namespace="namespace1" metricprofiles="metricprofile01">
      <AND>
        <OR>
          <Group service_flavor="ap1-service1"></Group>
@@ -216,7 +216,7 @@ func (suite *AvProfileTestSuite) TestReadProfile() {
        </OR>
      </AND>
    </profile>
-   <profile id="` + id2 + `" name="ap2" namespace="namespace2" poems="poem02">
+   <profile id="` + id2 + `" name="ap2" namespace="namespace2" metricprofiles="metricprofile02">
      <AND>
        <OR>
          <Group service_flavor="ap2-service1"></Group>
@@ -256,7 +256,7 @@ func (suite *AvProfileTestSuite) TestUpdateProfile() {
     {
         "name": "updated-ap2",
         "namespace": "updated-ap2-namespace",
-        "poems": ["updated-ap2-poem"],
+        "metricprofiles": ["updated-ap2-metricprofile"],
         "groups": [
             [
                "updated-srv1",
@@ -301,7 +301,7 @@ func (suite *AvProfileTestSuite) TestUpdateProfile() {
 
 	// Reestablish ap2 profile (remove and reinsert)
 	c.Remove(bson.M{"name": "ap2"})
-	c.Insert(bson.M{"name": "ap2", "namespace": "namespace2", "poems": []string{"poem02"},
+	c.Insert(bson.M{"name": "ap2", "namespace": "namespace2", "metricprofiles": []string{"metricprofile02"},
 		"groups": [][]string{
 			[]string{"ap2-service1", "ap2-service2", "ap2-service3"},
 			[]string{"ap2-service4", "ap2-service5", "ap2-service6"}}})
@@ -341,7 +341,7 @@ func (suite *AvProfileTestSuite) TestDeleteProfile() {
 
 	// Prepare the expected xml response after deleting ap2
 	profile_list_xml := ` <root>
-   <profile id="` + id1 + `" name="ap1" namespace="namespace1" poems="poem01">
+   <profile id="` + id1 + `" name="ap1" namespace="namespace1" metricprofiles="metricprofile01">
      <AND>
        <OR>
          <Group service_flavor="ap1-service1"></Group>
@@ -381,7 +381,7 @@ func (suite *AvProfileTestSuite) TestDeleteProfile() {
 	suite.Equal(profile_list_xml, string(output), "Response body mismatch")
 
 	// Reestablish ap2 profile (reinsert)
-	c.Insert(bson.M{"name": "ap2", "namespace": "namespace2", "poems": []string{"poem02"},
+	c.Insert(bson.M{"name": "ap2", "namespace": "namespace2", "metricprofiles": []string{"metricprofile02"},
 		"groups": [][]string{
 			[]string{"ap2-service1", "ap2-service2", "ap2-service3"},
 			[]string{"ap2-service4", "ap2-service5", "ap2-service6"}}})

--- a/app/availabilityProfiles/availabilityProfiles_test.go
+++ b/app/availabilityProfiles/availabilityProfiles_test.go
@@ -52,21 +52,21 @@ type AvProfileTestSuite struct {
 
 type ServiceIn struct {
 	ServiceSetIn map[string]string `bson:"services"`
-	Operator string                `bson:"operation"`
+	Operator     string            `bson:"operation"`
 }
 
 // Prepare maps for services and groups for ap1
 var apGroup1 = ServiceIn{ServiceSetIn: map[string]string{
-    "ap1-service1": "OR", "ap1-service2": "AND", "ap1-service3": "AND"}, Operator: "OR"}
+	"ap1-service1": "OR", "ap1-service2": "AND", "ap1-service3": "AND"}, Operator: "OR"}
 var apGroup2 = ServiceIn{ServiceSetIn: map[string]string{
-    "ap1-service4": "AND", "ap1-service5": "OR", "ap1-service6": "AND"}, Operator: "AND"}
+	"ap1-service4": "AND", "ap1-service5": "OR", "ap1-service6": "AND"}, Operator: "AND"}
 var profileGroup1 = map[string]ServiceIn{"compute": apGroup1, "storage": apGroup2}
 
 // Prepare maps for services and groups for ap2
 var apGroup3 = ServiceIn{ServiceSetIn: map[string]string{
-    "ap2-service1": "OR", "ap2-service2": "AND", "ap2-service3": "AND"}, Operator: "OR"}
+	"ap2-service1": "OR", "ap2-service2": "AND", "ap2-service3": "AND"}, Operator: "OR"}
 var apGroup4 = ServiceIn{ServiceSetIn: map[string]string{
-    "ap2-service4": "AND", "ap2-service5": "AND", "ap2-service6": "OR"}, Operator: "OR"}
+	"ap2-service4": "AND", "ap2-service5": "AND", "ap2-service6": "OR"}, Operator: "OR"}
 var profileGroup2 = map[string]ServiceIn{"compute": apGroup3, "storage": apGroup4}
 
 // Setup the Test Environment
@@ -126,15 +126,15 @@ func (suite *AvProfileTestSuite) SetupTest() {
 	defer session.Close()
 
 	// Open DB session
-    c := session.DB(suite.cfg.MongoDB.Db).C("aps")
+	c := session.DB(suite.cfg.MongoDB.Db).C("aps")
 
-    // Insert first seed profile
+	// Insert first seed profile
 	c.Insert(bson.M{"name": "ap1", "namespace": "namespace1", "metricprofiles": []string{"metricprofile01"},
-    "groups": profileGroup1})
+		"groups": profileGroup1})
 
 	// Insert second seed profile
 	c.Insert(bson.M{"name": "ap2", "namespace": "namespace2", "metricprofiles": []string{"metricprofile02"},
-    "groups": profileGroup2})
+		"groups": profileGroup2})
 
 }
 
@@ -147,7 +147,7 @@ func (suite *AvProfileTestSuite) SetupTest() {
 func (suite *AvProfileTestSuite) TestCreateProfile() {
 
 	// create json input data for the request
-    post_data := `
+	post_data := `
       {
           "name": "fresh_test_profile",
           "namespace": "test_namespace",
@@ -226,7 +226,7 @@ func (suite *AvProfileTestSuite) TestReadProfile() {
 	c.Find(bson.M{"name": "ap2"}).One(&results)
 	id2 := (results.ID.Hex())
 	// Hold a string multiline literal including the two profile ids retrieved
-    profile_list_xml := ` <root>
+	profile_list_xml := ` <root>
      <profile id="` + id1 + `" name="ap1" namespace="namespace1" metricprofiles="metricprofile01">
        <AND>
          <OR>
@@ -278,7 +278,7 @@ func (suite *AvProfileTestSuite) TestReadProfile() {
 func (suite *AvProfileTestSuite) TestUpdateProfile() {
 
 	// We will make update to ap2 profile
-    put_data := `
+	put_data := `
       {
           "name": "updated-ap2",
           "namespace": "updated-ap2-namespace",
@@ -333,7 +333,7 @@ func (suite *AvProfileTestSuite) TestUpdateProfile() {
 	// Reestablish ap2 profile (remove and reinsert)
 	c.Remove(bson.M{"name": "ap2"})
 	c.Insert(bson.M{"name": "ap2", "namespace": "namespace2", "metricprofiles": []string{"metricprofile02"},
-    "groups": profileGroup2})
+		"groups": profileGroup2})
 
 }
 
@@ -411,7 +411,7 @@ func (suite *AvProfileTestSuite) TestDeleteProfile() {
 
 	// Reestablish ap2 profile (reinsert)
 	c.Insert(bson.M{"name": "ap2", "namespace": "namespace2", "metricprofiles": []string{"metricprofile02"},
-    "groups": profileGroup2})
+		"groups": profileGroup2})
 
 }
 

--- a/app/availabilityProfiles/availabilityProfiles_test.go
+++ b/app/availabilityProfiles/availabilityProfiles_test.go
@@ -66,12 +66,15 @@ type Andtest struct {
 	Ors     []Ortest `xml:"OR"`
 }
 type Profiletest struct {
-	XMLName       xml.Name `xml:"profile"`
-	ID            string   `xml:"id,attr"`
-	Name          string   `xml:"name,attr"`
-	Namespace     string   `xml:"namespace,attr"`
-	MetricProfile string   `xml:"metricprofiles,attr"`
-	Ands          Andtest
+	XMLName          xml.Name `xml:"profile"`
+	ID               string   `xml:"id,attr"`
+	Name             string   `xml:"name,attr"`
+	Namespace        string   `xml:"namespace,attr"`
+	MetricProfile    string   `xml:"metricprofiles,attr"`
+	EndpointGroup    string   `xml:"endpointgroup,attr"`
+	MetricOperation  string   `xml:"metricoperation,attr"`
+	ProfileOperation string   `xml:"profileoperation,attr"`
+	Ands             Andtest
 }
 
 type Resulttest struct {
@@ -160,11 +163,11 @@ func (suite *AvProfileTestSuite) SetupTest() {
 
 	// Insert first seed profile
 	c.Insert(bson.M{"name": "ap1", "namespace": "namespace1", "metricprofiles": []string{"metricprofile01"},
-		"groups": profileGroup1})
+		"endpointgroup": "sites", "metricoperation": "AND", "profileoperation": "AND", "groups": profileGroup1})
 
 	// Insert second seed profile
 	c.Insert(bson.M{"name": "ap2", "namespace": "namespace2", "metricprofiles": []string{"metricprofile02"},
-		"groups": profileGroup2})
+		"endpointgroup": "sites", "metricoperation": "AND", "profileoperation": "AND", "groups": profileGroup2})
 
 }
 
@@ -182,6 +185,9 @@ func (suite *AvProfileTestSuite) TestCreateProfile() {
           "name": "fresh_test_profile",
           "namespace": "test_namespace",
           "metricprofiles": ["test_metricprofile"],
+          "endpointgroup": "sites",
+          "metricoperation": "AND",
+          "profileoperation": "AND",
           "groups" : {
             "compute" : {
               "services" : {
@@ -258,7 +264,7 @@ func (suite *AvProfileTestSuite) TestReadProfile() {
 	// Hold a string multiline literal including the two profile ids retrieved.
 	// This would be the representation for the XML expected schema.
 	schema := ` <root>
-	     <profile id="` + id1 + `" name="ap1" namespace="namespace1" metricprofiles="metricprofile01">
+	     <profile id="` + id1 + `" name="ap1" namespace="namespace1" metricprofiles="metricprofile01" endpointgroup="sites" metricoperation="AND" profileoperation="AND">
 	       <AND>
 	         <OR>
 	           <Group></Group>
@@ -272,7 +278,7 @@ func (suite *AvProfileTestSuite) TestReadProfile() {
 	         </OR>
 	       </AND>
 	     </profile>
-	     <profile id="` + id2 + `" name="ap2" namespace="namespace2" metricprofiles="metricprofile02">
+	     <profile id="` + id2 + `" name="ap2" namespace="namespace2" metricprofiles="metricprofile02" endpointgroup="sites" metricoperation="AND" profileoperation="AND">
 	       <AND>
 	         <OR>
 	           <Group></Group>
@@ -327,6 +333,9 @@ func (suite *AvProfileTestSuite) TestUpdateProfile() {
           "name": "updated-ap2",
           "namespace": "updated-ap2-namespace",
           "metricprofiles": ["updated-ap2-metricprofile"],
+          "endpointgroup": "sites",
+          "metricoperation": "AND",
+          "profileoperation": "AND",
           "groups" : {
             "compute" : {
               "services" : {
@@ -375,7 +384,7 @@ func (suite *AvProfileTestSuite) TestUpdateProfile() {
 	// Reestablish ap2 profile (remove and reinsert)
 	c.Remove(bson.M{"name": "ap2"})
 	c.Insert(bson.M{"name": "ap2", "namespace": "namespace2", "metricprofiles": []string{"metricprofile02"},
-		"groups": profileGroup2})
+		"endpointgroup": "sites", "metricoperation": "AND", "profileoperation": "AND", "groups": profileGroup2})
 
 }
 
@@ -412,7 +421,7 @@ func (suite *AvProfileTestSuite) TestDeleteProfile() {
 
 	// Prepare the expected xml response after deleting ap2
 	schema := ` <root>
-     <profile id="` + id1 + `" name="ap1" namespace="namespace1" metricprofiles="metricprofile01">
+     <profile id="` + id1 + `" name="ap1" namespace="namespace1" metricprofiles="metricprofile01" endpointgroup="sites" metricoperation="AND" profileoperation="AND">
        <AND>
          <OR>
            <Group></Group>
@@ -468,7 +477,7 @@ func (suite *AvProfileTestSuite) TestDeleteProfile() {
 
 	// Reestablish ap2 profile (reinsert)
 	c.Insert(bson.M{"name": "ap2", "namespace": "namespace2", "metricprofiles": []string{"metricprofile02"},
-		"groups": profileGroup2})
+		"endpointgroup": "sites", "metricoperation": "AND", "profileoperation": "AND", "groups": profileGroup2})
 
 }
 

--- a/app/availabilityProfiles/availabilityProfiles_test.go
+++ b/app/availabilityProfiles/availabilityProfiles_test.go
@@ -57,16 +57,16 @@ type ServiceIn struct {
 
 // Prepare maps for services and groups for ap1
 var apGroup1 = ServiceIn{ServiceSetIn: map[string]string{
-  "ap1-service1": "OR", "ap1-service2": "AND", "ap1-service3": "AND"}, Operator: "OR"}
+    "ap1-service1": "OR", "ap1-service2": "AND", "ap1-service3": "AND"}, Operator: "OR"}
 var apGroup2 = ServiceIn{ServiceSetIn: map[string]string{
-  "ap1-service4": "AND", "ap1-service5": "OR", "ap1-service6": "AND"}, Operator: "AND"}
+    "ap1-service4": "AND", "ap1-service5": "OR", "ap1-service6": "AND"}, Operator: "AND"}
 var profileGroup1 = map[string]ServiceIn{"compute": apGroup1, "storage": apGroup2}
 
 // Prepare maps for services and groups for ap2
 var apGroup3 = ServiceIn{ServiceSetIn: map[string]string{
-  "ap2-service1": "OR", "ap2-service2": "AND", "ap2-service3": "AND"}, Operator: "OR"}
+    "ap2-service1": "OR", "ap2-service2": "AND", "ap2-service3": "AND"}, Operator: "OR"}
 var apGroup4 = ServiceIn{ServiceSetIn: map[string]string{
-  "ap2-service4": "AND", "ap2-service5": "AND", "ap2-service6": "OR"}, Operator: "OR"}
+    "ap2-service4": "AND", "ap2-service5": "AND", "ap2-service6": "OR"}, Operator: "OR"}
 var profileGroup2 = map[string]ServiceIn{"compute": apGroup3, "storage": apGroup4}
 
 // Setup the Test Environment
@@ -126,15 +126,15 @@ func (suite *AvProfileTestSuite) SetupTest() {
 	defer session.Close()
 
 	// Open DB session
-  c := session.DB(suite.cfg.MongoDB.Db).C("aps")
+    c := session.DB(suite.cfg.MongoDB.Db).C("aps")
 
-  // Insert first seed profile
+    // Insert first seed profile
 	c.Insert(bson.M{"name": "ap1", "namespace": "namespace1", "metricprofiles": []string{"metricprofile01"},
-  "groups": profileGroup1})
+    "groups": profileGroup1})
 
 	// Insert second seed profile
 	c.Insert(bson.M{"name": "ap2", "namespace": "namespace2", "metricprofiles": []string{"metricprofile02"},
-  "groups": profileGroup2})
+    "groups": profileGroup2})
 
 }
 
@@ -226,35 +226,35 @@ func (suite *AvProfileTestSuite) TestReadProfile() {
 	c.Find(bson.M{"name": "ap2"}).One(&results)
 	id2 := (results.ID.Hex())
 	// Hold a string multiline literal including the two profile ids retrieved
-  profile_list_xml := ` <root>
-   <profile id="` + id1 + `" name="ap1" namespace="namespace1" metricprofiles="metricprofile01">
-     <AND>
-       <OR>
-         <Group service_flavor="ap1-service1" operation="OR"></Group>
-         <Group service_flavor="ap1-service2" operation="AND"></Group>
-         <Group service_flavor="ap1-service3" operation="AND"></Group>
-       </OR>
-       <OR>
-         <Group service_flavor="ap1-service4" operation="AND"></Group>
-         <Group service_flavor="ap1-service5" operation="OR"></Group>
-         <Group service_flavor="ap1-service6" operation="AND"></Group>
-       </OR>
-     </AND>
-   </profile>
-   <profile id="` + id2 + `" name="ap2" namespace="namespace2" metricprofiles="metricprofile02">
-     <AND>
-       <OR>
-         <Group service_flavor="ap2-service1" operation="OR"></Group>
-         <Group service_flavor="ap2-service2" operation="AND"></Group>
-         <Group service_flavor="ap2-service3" operation="AND"></Group>
-       </OR>
-       <OR>
-         <Group service_flavor="ap2-service4" operation="AND"></Group>
-         <Group service_flavor="ap2-service5" operation="AND"></Group>
-         <Group service_flavor="ap2-service6" operation="OR"></Group>
-       </OR>
-     </AND>
-   </profile>
+    profile_list_xml := ` <root>
+     <profile id="` + id1 + `" name="ap1" namespace="namespace1" metricprofiles="metricprofile01">
+       <AND>
+         <OR>
+           <Group service_flavor="ap1-service1" operation="OR"></Group>
+           <Group service_flavor="ap1-service2" operation="AND"></Group>
+           <Group service_flavor="ap1-service3" operation="AND"></Group>
+         </OR>
+         <OR>
+           <Group service_flavor="ap1-service4" operation="AND"></Group>
+           <Group service_flavor="ap1-service5" operation="OR"></Group>
+           <Group service_flavor="ap1-service6" operation="AND"></Group>
+         </OR>
+       </AND>
+     </profile>
+     <profile id="` + id2 + `" name="ap2" namespace="namespace2" metricprofiles="metricprofile02">
+       <AND>
+         <OR>
+           <Group service_flavor="ap2-service1" operation="OR"></Group>
+           <Group service_flavor="ap2-service2" operation="AND"></Group>
+           <Group service_flavor="ap2-service3" operation="AND"></Group>
+         </OR>
+         <OR>
+           <Group service_flavor="ap2-service4" operation="AND"></Group>
+           <Group service_flavor="ap2-service5" operation="AND"></Group>
+           <Group service_flavor="ap2-service6" operation="OR"></Group>
+         </OR>
+       </AND>
+     </profile>
  </root>`
 
 	// Prepare the request object
@@ -333,7 +333,7 @@ func (suite *AvProfileTestSuite) TestUpdateProfile() {
 	// Reestablish ap2 profile (remove and reinsert)
 	c.Remove(bson.M{"name": "ap2"})
 	c.Insert(bson.M{"name": "ap2", "namespace": "namespace2", "metricprofiles": []string{"metricprofile02"},
-  "groups": profileGroup2})
+    "groups": profileGroup2})
 
 }
 
@@ -370,20 +370,20 @@ func (suite *AvProfileTestSuite) TestDeleteProfile() {
 
 	// Prepare the expected xml response after deleting ap2
 	profile_list_xml := ` <root>
-   <profile id="` + id1 + `" name="ap1" namespace="namespace1" metricprofiles="metricprofile01">
-     <AND>
-       <OR>
-         <Group service_flavor="ap1-service1" operation="OR"></Group>
-         <Group service_flavor="ap1-service2" operation="AND"></Group>
-         <Group service_flavor="ap1-service3" operation="AND"></Group>
-       </OR>
-       <OR>
-         <Group service_flavor="ap1-service4" operation="AND"></Group>
-         <Group service_flavor="ap1-service5" operation="OR"></Group>
-         <Group service_flavor="ap1-service6" operation="AND"></Group>
-       </OR>
-     </AND>
-   </profile>
+     <profile id="` + id1 + `" name="ap1" namespace="namespace1" metricprofiles="metricprofile01">
+       <AND>
+         <OR>
+           <Group service_flavor="ap1-service1" operation="OR"></Group>
+           <Group service_flavor="ap1-service2" operation="AND"></Group>
+           <Group service_flavor="ap1-service3" operation="AND"></Group>
+         </OR>
+         <OR>
+           <Group service_flavor="ap1-service4" operation="AND"></Group>
+           <Group service_flavor="ap1-service5" operation="OR"></Group>
+           <Group service_flavor="ap1-service6" operation="AND"></Group>
+         </OR>
+       </AND>
+     </profile>
  </root>`
 
 	// Prepare the request object (use id2 for path)
@@ -411,7 +411,7 @@ func (suite *AvProfileTestSuite) TestDeleteProfile() {
 
 	// Reestablish ap2 profile (reinsert)
 	c.Insert(bson.M{"name": "ap2", "namespace": "namespace2", "metricprofiles": []string{"metricprofile02"},
-  "groups": profileGroup2})
+    "groups": profileGroup2})
 
 }
 

--- a/app/availabilityProfiles/availabilityProfiles_test.go
+++ b/app/availabilityProfiles/availabilityProfiles_test.go
@@ -272,6 +272,15 @@ func (suite *AvProfileTestSuite) TestCreateProfile() {
 
 }
 
+// TODO: The TestReadProfile function will be refactored in future releases.
+// The GO runtime randmonizes the map iteration order.
+// So when we try to compare the produced xml view
+// with a static one declared in unit test it always fails
+// because the xml attributes' order is random.
+// For now we use two tests. One to check if the XML structure is the desired one
+// and the XML can be unmarshaled using the test structs,
+// and a comparizon between the XMLs as strings using regex to match the actual attributes values.
+
 // Testing Reading of profile list using GET request.
 // During Setup of the test environment the testdb is seeded with
 // two availability profiles ("ap1","ap2"). Mongo assigns
@@ -300,35 +309,35 @@ func (suite *AvProfileTestSuite) TestReadProfile() {
 	// Hold a string multiline literal including the two profile ids retrieved.
 	// This would be the representation for the XML expected schema.
 	schema := ` <root>
-	     <profile id="` + id1 + `" name="ap1" namespace="namespace1" metricprofiles="metricprofile01" endpointgroup="sites" metricoperation="AND" profileoperation="AND">
-	       <AND>
-	         <OR>
-	           <Group></Group>
-	           <Group></Group>
-	           <Group></Group>
-	         </OR>
-	         <OR>
-	           <Group></Group>
-	           <Group></Group>
-	           <Group></Group>
-	         </OR>
-	       </AND>
-	     </profile>
-	     <profile id="` + id2 + `" name="ap2" namespace="namespace2" metricprofiles="metricprofile02" endpointgroup="sites" metricoperation="AND" profileoperation="AND">
-	       <AND>
-	         <OR>
-	           <Group></Group>
-	           <Group></Group>
-	           <Group></Group>
-	         </OR>
-	         <OR>
-	           <Group></Group>
-	           <Group></Group>
-	           <Group></Group>
-	         </OR>
-	       </AND>
-	     </profile>
-	<root>`
+   <profile id="` + id1 + `" name="ap1" namespace="namespace1" metricprofiles="metricprofile01" endpointgroup="sites" metricoperation="AND" profileoperation="AND">
+     <AND>
+       <OR>
+         <Group service_flavor="ap1-service([1-6]{1})" operation="(AND|OR)"></Group>
+         <Group service_flavor="ap1-service([1-6]{1})" operation="(AND|OR)"></Group>
+         <Group service_flavor="ap1-service([1-6]{1})" operation="(AND|OR)"></Group>
+       </OR>
+       <OR>
+         <Group service_flavor="ap1-service([1-6]{1})" operation="(AND|OR)"></Group>
+         <Group service_flavor="ap1-service([1-6]{1})" operation="(AND|OR)"></Group>
+         <Group service_flavor="ap1-service([1-6]{1})" operation="(AND|OR)"></Group>
+       </OR>
+     </AND>
+   </profile>
+   <profile id="` + id2 + `" name="ap2" namespace="namespace2" metricprofiles="metricprofile02" endpointgroup="sites" metricoperation="AND" profileoperation="AND">
+     <AND>
+       <OR>
+         <Group service_flavor="ap2-service([1-6]{1})" operation="(AND|OR)"></Group>
+         <Group service_flavor="ap2-service([1-6]{1})" operation="(AND|OR)"></Group>
+         <Group service_flavor="ap2-service([1-6]{1})" operation="(AND|OR)"></Group>
+       </OR>
+       <OR>
+         <Group service_flavor="ap2-service([1-6]{1})" operation="(AND|OR)"></Group>
+         <Group service_flavor="ap2-service([1-6]{1})" operation="(AND|OR)"></Group>
+         <Group service_flavor="ap2-service([1-6]{1})" operation="(AND|OR)"></Group>
+       </OR>
+     </AND>
+   </profile>
+ </root>`
 
 	// Prepare the request object
 	request, _ := http.NewRequest("GET", "", strings.NewReader(""))
@@ -338,7 +347,9 @@ func (suite *AvProfileTestSuite) TestReadProfile() {
 	suite.Equal(200, code, "Internal Server Error")
 	// Unmarshal the produced XML using the test structs
 	v := &Resulttest{}
+
 	xmlErr := xml.Unmarshal(output, v)
+
 	// Unmarshal the test schema that will be used in the comparison
 	d := &Resulttest{}
 	_ = xml.Unmarshal([]byte(schema), d)
@@ -348,7 +359,10 @@ func (suite *AvProfileTestSuite) TestReadProfile() {
 		suite.Fail("Unmarshal error: ", xmlErr.Error())
 	}
 
-	// Compare the expected and actual xml schema
+	// Compare the expected and actual XML result
+	suite.Regexp(schema, string(output), "Response body mismatch")
+
+	// Compare only the structure of the XML
 	cmp := reflect.DeepEqual(v, d)
 	if cmp != true {
 		suite.Fail("XML schema mismatch")
@@ -430,6 +444,15 @@ func (suite *AvProfileTestSuite) TestUpdateProfile() {
 
 }
 
+// TODO: The TestDeleteProfile function will be refactored in future releases.
+// The GO runtime randmonizes the map iteration order.
+// So when we try to compare the produced xml view
+// with a static one declared in unit test it always fails
+// because the xml attributes' order is random.
+// For now we use two tests. One to check if the XML structure is the desired one
+// and the XML can be unmarshaled using the test structs,
+// and a comparizon between the XMLs as strings using regex to match the actual attributes values.
+
 // Testing deletion of a profile  using DELETE request.
 // During Setup of the test environment the testdb is seeded with
 // two availability profiles ("ap1","ap2"). Mongo assigns
@@ -463,20 +486,20 @@ func (suite *AvProfileTestSuite) TestDeleteProfile() {
 
 	// Prepare the expected xml response after deleting ap2
 	schema := ` <root>
-     <profile id="` + id1 + `" name="ap1" namespace="namespace1" metricprofiles="metricprofile01" endpointgroup="sites" metricoperation="AND" profileoperation="AND">
-       <AND>
-         <OR>
-           <Group></Group>
-           <Group></Group>
-           <Group></Group>
-         </OR>
-         <OR>
-           <Group></Group>
-           <Group></Group>
-           <Group></Group>
-         </OR>
-       </AND>
-     </profile>
+   <profile id="` + id1 + `" name="ap1" namespace="namespace1" metricprofiles="metricprofile01" endpointgroup="sites" metricoperation="AND" profileoperation="AND">
+     <AND>
+       <OR>
+         <Group service_flavor="ap1-service([1-6]{1})" operation="(AND|OR)"></Group>
+         <Group service_flavor="ap1-service([1-6]{1})" operation="(AND|OR)"></Group>
+         <Group service_flavor="ap1-service([1-6]{1})" operation="(AND|OR)"></Group>
+       </OR>
+       <OR>
+         <Group service_flavor="ap1-service([1-6]{1})" operation="(AND|OR)"></Group>
+         <Group service_flavor="ap1-service([1-6]{1})" operation="(AND|OR)"></Group>
+         <Group service_flavor="ap1-service([1-6]{1})" operation="(AND|OR)"></Group>
+       </OR>
+     </AND>
+   </profile>
  </root>`
 
 	// Prepare the request object (use id2 for path)
@@ -490,6 +513,8 @@ func (suite *AvProfileTestSuite) TestDeleteProfile() {
 	code, _, output, _ := Delete(request, suite.cfg)
 	// Check proper response that the profile successfully deleted
 	suite.Equal(200, code, "Internal Server Error")
+
+	// Compare the expected and actual response
 	suite.Equal(suite.respProfileDeleted, string(output), "Response body mismatch")
 
 	// Double-check that the profile is actually missing from the profile list
@@ -499,23 +524,9 @@ func (suite *AvProfileTestSuite) TestDeleteProfile() {
 	code, _, output, _ = List(request, suite.cfg)
 	// Check that we must have a 200 ok code
 	suite.Equal(200, code, "Internal Server Error")
-	// Unmarshal the produced XML using the test structs
-	v := &Resulttest{}
-	xmlErr := xml.Unmarshal(output, v)
-	// Unmarshal the test schema that will be used in the comparison
-	d := &Resulttest{}
-	_ = xml.Unmarshal([]byte(schema), d)
 
-	if xmlErr != nil {
-		fmt.Printf("error: %v", xmlErr)
-		suite.Fail("Unmarshal error: ", xmlErr.Error())
-	}
-
-	// Compare the expected and actual xml schema
-	cmp := reflect.DeepEqual(v, d)
-	if cmp != true {
-		suite.Fail("XML schema mismatch")
-	}
+	// Compare the expected and actual XML
+	suite.Regexp(schema, string(output), "Response body mismatch")
 
 	// Reestablish ap2 profile (reinsert)
 	c.Insert(


### PR DESCRIPTION
- Modified structs in Model-View and Test to support maps and additional attributes. Renamed collection as discussed.
- Changed the way we check the validity of the XML result in Read and Delete test functions - compare their schemas instead of trying to compare two strings (static expected xml and actual). The reason is that the GO runtime randomizes the map iteration order. So when we try to compare the produced xml view with a static one declared in unit test it always fails because the xml attributes' order is random. Added one more regex check in `TestDeleteProfile()` and `TestReadProfile()` functions.
- Added multi-tenant authentication support.
- Code style and godoc improvements.