### PR TITLE
ARGO-120  Job definitions for each tenant

### DIFF
--- a/app/jobs/jobsController.go
+++ b/app/jobs/jobsController.go
@@ -1,0 +1,456 @@
+/*
+ * Copyright (c) 2014 GRNET S.A., SRCE, IN2P3 CNRS Computing Centre
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS
+ * IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ *
+ * The views and conclusions contained in the software and
+ * documentation are those of the authors and should not be
+ * interpreted as representing official policies, either expressed
+ * or implied, of either GRNET S.A., SRCE or IN2P3 CNRS Computing
+ * Centre
+ *
+ * The work represented by this source file is partially funded by
+ * the EGI-InSPIRE project through the European Commission's 7th
+ * Framework Programme (contract # INFSO-RI-261323)
+ */
+
+package jobs
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+
+	"github.com/argoeu/argo-web-api/utils/authentication"
+	"github.com/argoeu/argo-web-api/utils/config"
+	"github.com/argoeu/argo-web-api/utils/mongo"
+)
+
+// Create function is used to implement the create job request.
+// The request is an http POST request with the job description
+// provided as json structure in the request body
+func Create(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
+
+	//STANDARD DECLARATIONS START
+	code := http.StatusOK
+	h := http.Header{}
+	output := []byte("")
+	err := error(nil)
+	contentType := "text/xml"
+	charset := "utf-8"
+	//STANDARD DECLARATIONS END
+
+	// Authenticate user's api key and find corresponding tenant
+	tenantDbConf, err := authentication.AuthenticateTenant(r.Header, cfg)
+
+	// if authentication procedure fails then
+	// return unauthorized http status
+	if err != nil {
+
+		output = []byte(http.StatusText(http.StatusUnauthorized))
+		//If wrong api key is passed we return UNAUTHORIZED http status
+		code = http.StatusUnauthorized
+		h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+		return code, h, output, err
+	}
+
+	//Reading the json input from the request body
+	reqBody, err := ioutil.ReadAll(r.Body)
+	input := Job{}
+	//Unmarshalling the json input into byte form
+	err = json.Unmarshal(reqBody, &input)
+
+	// Check if json body is malformed
+	if err != nil {
+		if err != nil {
+			// Msg in xml style, to notify for malformed json
+			output, err := messageXML("Malformated json input data")
+
+			if err != nil {
+				code = http.StatusInternalServerError
+				return code, h, output, err
+			}
+
+			code = http.StatusBadRequest
+			h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+			return code, h, output, err
+		}
+	}
+
+	// Try to open the mongo session
+	session, err := mongo.OpenSession(tenantDbConf)
+	defer session.Close()
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	// Prepare structure for storing query results
+	results := []Job{}
+
+	// Check if job with the same name exists in datastore
+	query := searchName(input.Name)
+	err = mongo.Find(session, tenantDbConf.Db, "jobs", query, "name", &results)
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	// If results are returned for the specific name
+	// then we already have an existing job and we must
+	// abort creation notifing the user
+	if len(results) > 0 {
+		// Name was found so print the error message in xml
+		output, err = messageXML("Job with the same name already exists")
+
+		if err != nil {
+			code = http.StatusInternalServerError
+			return code, h, output, err
+		}
+
+		code = http.StatusBadRequest
+		h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+		return code, h, output, err
+
+	}
+
+	// If no job exists with this name create a new one
+	query = createJob(input)
+	err = mongo.Insert(session, tenantDbConf.Db, "jobs", query)
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	// Notify user that the job has been created. In xml style
+	output, err = messageXML("Job was successfully created")
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+	return code, h, output, err
+
+}
+
+// List function that implements the http GET request that retrieves
+// all avaiable job information
+func List(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
+
+	//STANDARD DECLARATIONS START
+	code := http.StatusOK
+	h := http.Header{}
+	output := []byte("")
+	err := error(nil)
+	contentType := "text/xml"
+	charset := "utf-8"
+	//STANDARD DECLARATIONS END
+
+	// Authenticate user's api key and find corresponding tenant
+	tenantDbConf, err := authentication.AuthenticateTenant(r.Header, cfg)
+
+	// if authentication procedure fails then
+	// return unauthorized http status
+	if err != nil {
+
+		output = []byte(http.StatusText(http.StatusUnauthorized))
+		//If wrong api key is passed we return UNAUTHORIZED http status
+		code = http.StatusUnauthorized
+		h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+		return code, h, output, err
+	}
+
+	// Try to open the mongo session
+	session, err := mongo.OpenSession(cfg.MongoDB)
+	defer session.Close()
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	// Create structure for storing query results
+	results := []Job{}
+	// Query tenant collection for all available documents.
+	// nil query param == match everything
+	err = mongo.Find(session, tenantDbConf.Db, "jobs", nil, "name", &results)
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	// After successfully retrieving the db results
+	// call the createView function to render them into idented xml
+	output, err = createView(results)
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+	return code, h, output, err
+}
+
+// ListOne function that implements the http GET request that retrieves
+// all avaiable job information
+func ListOne(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
+
+	//STANDARD DECLARATIONS START
+	code := http.StatusOK
+	h := http.Header{}
+	output := []byte("")
+	err := error(nil)
+	contentType := "text/xml"
+	charset := "utf-8"
+	//STANDARD DECLARATIONS END
+
+	// Authenticate user's api key and find corresponding tenant
+	tenantDbConf, err := authentication.AuthenticateTenant(r.Header, cfg)
+
+	// if authentication procedure fails then
+	// return unauthorized http status
+	if err != nil {
+
+		output = []byte(http.StatusText(http.StatusUnauthorized))
+		//If wrong api key is passed we return UNAUTHORIZED http status
+		code = http.StatusUnauthorized
+		h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+		return code, h, output, err
+	}
+
+	//Extracting urlvar "name" from url path
+	urlValues := r.URL.Path
+	nameFromURL := strings.Split(urlValues, "/")[4]
+
+	// Try to open the mongo session
+	session, err := mongo.OpenSession(tenantDbConf)
+	defer session.Close()
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	// Create structure for storing query results
+	results := []Job{}
+	// Create a simple query object to query by name
+	query := searchName(nameFromURL)
+	// Query collection tenants for the specific tenant name
+	err = mongo.Find(session, tenantDbConf.Db, "jobs", query, "name", &results)
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	// If query returned zero result then no tenant matched this name,
+	// abort and notify user accordingly
+	if len(results) == 0 {
+
+		output, err := messageXML("Job not found")
+
+		if err != nil {
+			code = http.StatusInternalServerError
+			return code, h, output, err
+		}
+
+		code = http.StatusBadRequest
+		h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+		return code, h, output, err
+	}
+
+	// After successfully retrieving the db results
+	// call the createView function to render them into idented xml
+	output, err = createView(results)
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+	return code, h, output, err
+}
+
+// Update function used to implement update job request.
+// This is an http PUT request that gets a specific job's name
+// as a urlvar parameter input and a json structure in the request
+// body in order to update the datastore document for the specific
+// job
+func Update(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
+
+	//STANDARD DECLARATIONS START
+	code := http.StatusOK
+	h := http.Header{}
+	output := []byte("")
+	err := error(nil)
+	contentType := "text/xml"
+	charset := "utf-8"
+
+	//STANDARD DECLARATIONS END
+
+	// Authenticate user's api key and find corresponding tenant
+	tenantDbConf, err := authentication.AuthenticateTenant(r.Header, cfg)
+
+	// if authentication procedure fails then
+	// return unauthorized http status
+	if err != nil {
+
+		output = []byte(http.StatusText(http.StatusUnauthorized))
+		//If wrong api key is passed we return UNAUTHORIZED http status
+		code = http.StatusUnauthorized
+		h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+		return code, h, output, err
+	}
+
+	//Extracting job name from url
+	urlValues := r.URL.Path
+	nameFromURL := strings.Split(urlValues, "/")[4]
+
+	//Reading the json input
+	reqBody, err := ioutil.ReadAll(r.Body)
+
+	input := Job{}
+	//Unmarshalling the json input into byte form
+	err = json.Unmarshal(reqBody, &input)
+
+	if err != nil {
+		if err != nil {
+			// User provided malformed json input data
+			output, err := messageXML("Malformated json input data")
+
+			if err != nil {
+				code = http.StatusInternalServerError
+				return code, h, output, err
+			}
+
+			code = http.StatusBadRequest
+			h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+			return code, h, output, err
+		}
+	}
+
+	// Try to open the mongo session
+	session, err := mongo.OpenSession(tenantDbConf)
+	defer session.Close()
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	// We search by name and update
+	query := searchName(nameFromURL)
+	err = mongo.Update(session, tenantDbConf.Db, "jobs", query, input)
+
+	if err != nil {
+
+		if err.Error() != "not found" {
+			code = http.StatusInternalServerError
+			return code, h, output, err
+		}
+		//Render the response into XML
+		output, err = messageXML("Job not found")
+
+	} else {
+		//Render the response into XML
+		output, err = messageXML("Job was successfully updated")
+	}
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+	return code, h, output, err
+
+}
+
+// Delete function used to implement remove job request
+func Delete(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
+
+	//STANDARD DECLARATIONS START
+
+	code := http.StatusOK
+	h := http.Header{}
+	output := []byte("")
+	err := error(nil)
+	contentType := "text/xml"
+	charset := "utf-8"
+
+	//STANDARD DECLARATIONS END
+
+	// Authenticate user's api key and find corresponding tenant
+	tenantDbConf, err := authentication.AuthenticateTenant(r.Header, cfg)
+
+	// if authentication procedure fails then
+	// return unauthorized http status
+	if err != nil {
+
+		output = []byte(http.StatusText(http.StatusUnauthorized))
+		//If wrong api key is passed we return UNAUTHORIZED http status
+		code = http.StatusUnauthorized
+		h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+		return code, h, output, err
+	}
+
+	//Extracting record id from url
+	urlValues := r.URL.Path
+	nameFromURL := strings.Split(urlValues, "/")[4]
+
+	// Try to open the mongo session
+	session, err := mongo.OpenSession(tenantDbConf)
+	defer session.Close()
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	// We search by name and delete the document in db
+	query := searchName(nameFromURL)
+	info, err := mongo.Remove(session, tenantDbConf.Db, "jobs", query)
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	// info.Removed > 0 means that many documents have been removed
+	// If deletion took place we notify user accordingly.
+	// Else we notify that no tenant matched the specific name
+	if info.Removed > 0 {
+		output, err = messageXML("Job was successfully deleted")
+	} else {
+		output, err = messageXML("Job not found")
+	}
+	//Render the response into XML
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+	return code, h, output, err
+
+}

--- a/app/jobs/jobsModel.go
+++ b/app/jobs/jobsModel.go
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2014 GRNET S.A., SRCE, IN2P3 CNRS Computing Centre
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS
+ * IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ *
+ * The views and conclusions contained in the software and
+ * documentation are those of the authors and should not be
+ * interpreted as representing official policies, either expressed
+ * or implied, of either GRNET S.A., SRCE or IN2P3 CNRS Computing
+ * Centre
+ *
+ * The work represented by this source file is partially funded by
+ * the EGI-InSPIRE project through the European Commission's 7th
+ * Framework Programme (contract # INFSO-RI-261323)
+ */
+
+package jobs
+
+import (
+	"encoding/xml"
+
+	"labix.org/v2/mgo/bson"
+)
+
+// Job structure holds information for a defined computational job
+type Job struct {
+	XMLName       xml.Name     `bson:",omitempty"      json:"-"               xml:"job"`
+	Name          string       `bson:"name"            json:"name"            xml:"name,attr"`
+	Tenant        string       `bson:"tenant"          json:"tenant"          xml:"tenant,attr"`
+	EndpointGroup string       `bson:"endpoint_group"  json:"endpoint_group"  xml:"endpoint_group,attr"`
+	GroupOfGroups string       `bson:"group_of_groups" json:"group_of_groups" xml:"group_of_groups,attr"`
+	Profiles      []JobProfile `bson:"profiles"        json:"profiles"        xml:"profiles>profile"`
+	FilterTags    []JobTag     `bson:"filter_tags"     json:"filter_tags"     xml:"filter_tags>tag"`
+}
+
+// JobProfile holds info about the profiles included in a job definition
+type JobProfile struct {
+	XMLName xml.Name `bson:",omitempty" json:"-"     xml:"profile"`
+	Name    string   `bson:"name"       json:"name"  xml:"name,attr"`
+	Value   string   `bson:"value"      json:"value" xml:"value,attr"`
+}
+
+// JobTag holds info about the tags used in filtering in a job definition
+type JobTag struct {
+	XMLName xml.Name `bson:",omitempty" json:"-"     xml:"tag"`
+	Name    string   `bson:"name"       json:"name"  xml:"name,attr"`
+	Value   string   `bson:"value"      json:"value" xml:"value,attr"`
+}
+
+// Message struct for xml message response
+type Message struct {
+	XMLName xml.Name `xml:"root"`
+	Message string
+}
+
+// RootXML struct to represent the root of the xml document
+type RootXML struct {
+	XMLName xml.Name `xml:"root" json:"-"`
+	Jobs    *[]Job
+}
+
+// createJob is used to create a new job definition
+func createJob(input Job) bson.M {
+	query := bson.M{
+		"name":            input.Name,
+		"tenant":          input.Tenant,
+		"endpoint_group":  input.EndpointGroup,
+		"group_of_groups": input.GroupOfGroups,
+		"profiles":        input.Profiles,
+		"filter_tags":     input.FilterTags,
+	}
+	return query
+}
+
+// searchName is used to create a simple query object based on name
+func searchName(name string) bson.M {
+	query := bson.M{
+		"name": name,
+	}
+
+	return query
+}

--- a/app/jobs/jobsView.go
+++ b/app/jobs/jobsView.go
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2014 GRNET S.A., SRCE, IN2P3 CNRS Computing Centre
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS
+ * IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ *
+ * The views and conclusions contained in the software and
+ * documentation are those of the authors and should not be
+ * interpreted as representing official policies, either expressed
+ * or implied, of either GRNET S.A., SRCE or IN2P3 CNRS Computing
+ * Centre
+ *
+ * The work represented by this source file is partially funded by
+ * the EGI-InSPIRE project through the European Commission's 7th
+ * Framework Programme (contract # INFSO-RI-261323)
+ */
+
+package jobs
+
+import "encoding/xml"
+
+func messageXML(answer string) ([]byte, error) {
+	docRoot := &Message{}
+	docRoot.Message = answer
+	output, err := xml.MarshalIndent(docRoot, " ", "  ")
+	return output, err
+}
+
+func createView(results []Job) ([]byte, error) {
+	docRoot := &RootXML{}
+	docRoot.Jobs = &results
+	output, err := xml.MarshalIndent(docRoot, "", " ")
+	return output, err
+}

--- a/app/jobs/jobs_test.go
+++ b/app/jobs/jobs_test.go
@@ -1,0 +1,592 @@
+/*
+ * Copyright (c) 2014 GRNET S.A., SRCE, IN2P3 CNRS Computing Centre
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS
+ * IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ *
+ * The views and conclusions contained in the software and
+ * documentation are those of the authors and should not be
+ * interpreted as representing official policies, either expressed
+ * or implied, of either GRNET S.A., SRCE or IN2P3 CNRS Computing
+ * Centre
+ *
+ * The work represented by this source file is partially funded by
+ * the EGI-InSPIRE project through the European Commission's 7th
+ * Framework Programme (contract # INFSO-RI-261323)
+ */
+
+package jobs
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"code.google.com/p/gcfg"
+	"github.com/argoeu/argo-web-api/utils/authentication"
+	"github.com/argoeu/argo-web-api/utils/config"
+	"github.com/argoeu/argo-web-api/utils/mongo"
+	"github.com/stretchr/testify/suite"
+	"labix.org/v2/mgo"
+	"labix.org/v2/mgo/bson"
+)
+
+// This is a util. suite struct used in tests (see pkg "testify")
+type JobTestSuite struct {
+	suite.Suite
+	cfg              config.Config
+	tenantDbConf     config.MongoConfig
+	respJobCreated   string
+	respJobUpdated   string
+	respJobDeleted   string
+	respJobNotFound  string
+	respUnauthorized string
+	respBadJSON      string
+}
+
+// Setup the Test Environment
+// This function runs before any test and setups the environment
+// A test configuration object is instantiated using a reference
+// to testdb: argo_test_jobs. Also here is are instantiated some expected
+// xml response validation messages (authorization,crud responses).
+// Also the testdb is seeded with two jobs
+func (suite *JobTestSuite) SetupTest() {
+
+	const testConfig = `
+    [server]
+    bindip = ""
+    port = 8080
+    maxprocs = 4
+    cache = false
+    lrucache = 700000000
+    gzip = true
+    [mongodb]
+    host = "127.0.0.1"
+    port = 27017
+    db = "argo_test_jobs"
+`
+
+	_ = gcfg.ReadStringInto(&suite.cfg, testConfig)
+
+	suite.respJobCreated = " <root>\n" +
+		"   <Message>Job was successfully created</Message>\n </root>"
+
+	suite.respJobUpdated = " <root>\n" +
+		"   <Message>Job was successfully updated</Message>\n </root>"
+
+	suite.respJobDeleted = " <root>\n" +
+		"   <Message>Job was successfully deleted</Message>\n </root>"
+
+	suite.respJobNotFound = " <root>\n" +
+		"   <Message>Job not found</Message>\n </root>"
+
+	suite.respBadJSON = " <root>\n" +
+		"   <Message>Malformated json input data</Message>\n </root>"
+
+	suite.respUnauthorized = "Unauthorized"
+
+	// Connect to mongo testdb
+	session, _ := mongo.OpenSession(suite.cfg.MongoDB)
+
+	// Add authentication token to mongo testdb
+	seedAuth := bson.M{"api_key": "S3CR3T"}
+	_ = mongo.Insert(session, suite.cfg.MongoDB.Db, "authentication", seedAuth)
+
+	// seed mongo
+	session, err := mgo.Dial(suite.cfg.MongoDB.Host)
+	if err != nil {
+		panic(err)
+	}
+	defer session.Close()
+
+	// seed a tenant to use
+	c := session.DB(suite.cfg.MongoDB.Db).C("tenants")
+	c.Insert(bson.M{
+		"name": "AVENGERS",
+		"db_conf": []bson.M{
+			bson.M{
+				"store":    "ar",
+				"server":   "localhost",
+				"port":     27017,
+				"database": "argo_test_jobs_db1",
+				"username": "admin",
+				"password": "3NCRYPT3D"},
+			bson.M{
+				"store":    "status",
+				"server":   "b.mongodb.org",
+				"port":     27017,
+				"database": "status_db",
+				"username": "admin",
+				"password": "3NCRYPT3D"},
+		},
+		"users": []bson.M{
+			bson.M{
+				"name":    "cap",
+				"email":   "cap@email.com",
+				"api_key": "C4PK3Y"},
+			bson.M{
+				"name":    "thor",
+				"email":   "thor@email.com",
+				"api_key": "TH0RK3Y"},
+		}})
+
+	// get dbconfiguration based on the tenant
+	// Prepare the request object
+	request, _ := http.NewRequest("GET", "", strings.NewReader(""))
+	// add the content-type header to application/json
+	request.Header.Set("Content-Type", "application/json;")
+	// add the authentication token which is seeded in testdb
+	request.Header.Set("x-api-key", "C4PK3Y")
+	// authenticate user's api key and find corresponding tenant
+	suite.tenantDbConf, err = authentication.AuthenticateTenant(request.Header, suite.cfg)
+
+	// Now seed the job DEFINITIONS
+	c = session.DB(suite.tenantDbConf.Db).C("jobs")
+	c.Insert(bson.M{
+		"name":            "Job_A",
+		"tenant":          "AVENGERS",
+		"endpoint_group":  "SITES",
+		"group_of_groups": "NGI",
+		"profiles": []bson.M{
+			bson.M{
+				"name":  "metric",
+				"value": "profile1"},
+			bson.M{
+				"name":  "ops",
+				"value": "profile2"},
+		},
+		"filter_tags": []bson.M{
+			bson.M{
+				"name":  "name1",
+				"value": "value1"},
+			bson.M{
+				"name":  "name2",
+				"value": "value2"},
+		}})
+
+	c.Insert(bson.M{
+		"name":            "Job_B",
+		"tenant":          "AVENGERS",
+		"endpoint_group":  "SITES",
+		"group_of_groups": "NGI",
+		"profiles": []bson.M{
+			bson.M{
+				"name":  "metric",
+				"value": "profile1"},
+			bson.M{
+				"name":  "ops",
+				"value": "profile2"},
+		},
+		"filter_tags": []bson.M{
+			bson.M{
+				"name":  "name1",
+				"value": "value1"},
+			bson.M{
+				"name":  "name2",
+				"value": "value2"},
+		}})
+}
+
+// TestCreateJob function implements testing the http POST create job request.
+// Request requires admin authentication and gets as input a json body containing
+// all the available information to be added to the datastore
+// After the operation succeeds is double-checked
+// that the newly created job is correctly retrieved
+func (suite *JobTestSuite) TestCreateJob() {
+
+	// create json input data for the request
+	postData := `
+  {
+    "name":"Foo_Job",
+    "tenant":"AVENGERS",
+    "profiles":[
+      { "name":"metric","value":"profA"},
+      { "name":"ap","value":"profB"}
+     ],
+    "endpoint_group":"SITES",
+    "group_of_groups":"NGI",
+    "filter_tags":[
+      { "name":"production","value":"Y"},
+      { "name":"monitored","value":"Y"}
+    ]
+  }
+    `
+	// Prepare the request object
+	request, _ := http.NewRequest("POST", "", strings.NewReader(postData))
+	// add the content-type header to application/json
+	request.Header.Set("Content-Type", "application/json;")
+	// add the authentication token which is seeded in testdb
+	request.Header.Set("x-api-key", "C4PK3Y")
+
+	// Execute the request in the controller
+	code, _, output, _ := Create(request, suite.cfg)
+
+	suite.Equal(200, code, "Internal Server Error")
+	suite.Equal(suite.respJobCreated, string(output), "Response body mismatch")
+
+	// Double check that you read the newly inserted profile
+	// Create a string literal of the expected xml Response
+	respXML := `<root>
+ <job name="Foo_Job" tenant="AVENGERS" endpoint_group="SITES" group_of_groups="NGI">
+  <profiles>
+   <profile name="metric" value="profA"></profile>
+   <profile name="ap" value="profB"></profile>
+  </profiles>
+  <filter_tags>
+   <tag name="production" value="Y"></tag>
+   <tag name="monitored" value="Y"></tag>
+  </filter_tags>
+ </job>
+</root>`
+
+	// Prepare the request object using job name as urlvar in url path
+	request, _ = http.NewRequest("GET", "/api/v1/jobs/Foo_Job", strings.NewReader(""))
+	// add the content-type header to application/json
+	request.Header.Set("Content-Type", "application/json;")
+	// add the authentication token which is seeded in testdb
+	request.Header.Set("x-api-key", "C4PK3Y")
+	// Pass request to controller calling List() handler method
+	code, _, output, _ = ListOne(request, suite.cfg)
+	// Check that we must have a 200 ok code
+	suite.Equal(200, code, "Internal Server Error")
+	// Compare the expected and actual xml response
+	suite.Equal(respXML, string(output), "Response body mismatch")
+}
+
+// TestUpdateJob function implements testing the http PUT update job request.
+// Request requires admin authentication and gets as input the name of the
+// job to be updated and a json body with the update.
+// After the operation succeeds is double-checked
+// that the specific job has been updated
+func (suite *JobTestSuite) TestUpdateJob() {
+
+	// create json input data for the request
+	postData := `
+  {
+    "name":"Job_A_modified",
+    "tenant":"AVENGERS",
+    "profiles":[
+      { "name":"metric","value":"profA_mod"},
+      { "name":"ap","value":"profB_mod"}
+     ],
+    "endpoint_group":"SITES",
+    "group_of_groups":"NGI",
+    "filter_tags":[
+      { "name":"production","value":"Y"},
+      { "name":"monitored","value":"Y"}
+    ]
+  }
+    `
+	// Prepare the request object
+	request, _ := http.NewRequest("PUT", "/api/v1/jobs/Job_A", strings.NewReader(postData))
+	// add the content-type header to application/json
+	request.Header.Set("Content-Type", "application/json;")
+	// add the authentication token which is seeded in testdb
+	request.Header.Set("x-api-key", "C4PK3Y")
+
+	// Execute the request in the controller
+	code, _, output, _ := Update(request, suite.cfg)
+
+	suite.Equal(200, code, "Internal Server Error")
+	suite.Equal(suite.respJobUpdated, string(output), "Response body mismatch")
+
+	// Double check that you read the newly inserted profile
+	// Create a string literal of the expected xml Response
+	respXML := `<root>
+ <job name="Job_A_modified" tenant="AVENGERS" endpoint_group="SITES" group_of_groups="NGI">
+  <profiles>
+   <profile name="metric" value="profA_mod"></profile>
+   <profile name="ap" value="profB_mod"></profile>
+  </profiles>
+  <filter_tags>
+   <tag name="production" value="Y"></tag>
+   <tag name="monitored" value="Y"></tag>
+  </filter_tags>
+ </job>
+</root>`
+
+	// Prepare the request object using job name as urlvar in url path
+	request, _ = http.NewRequest("GET", "/api/v1/jobs/Job_A_modified", strings.NewReader(""))
+	// add the content-type header to application/json
+	request.Header.Set("Content-Type", "application/json;")
+	// add the authentication token which is seeded in testdb
+	request.Header.Set("x-api-key", "C4PK3Y")
+	// Pass request to controller calling List() handler method
+	code, _, output, _ = ListOne(request, suite.cfg)
+	// Check that we must have a 200 ok code
+	suite.Equal(200, code, "Internal Server Error")
+	// Compare the expected and actual xml response
+	suite.Equal(respXML, string(output), "Response body mismatch")
+}
+
+// TestDeleteJob function implements testing the http DELETE job request.
+// Request requires admin authentication and gets as input the name of the
+// job to be deleted. After the operation succeeds is double-checked
+// that the deleted job is actually missing from the datastore
+func (suite *JobTestSuite) TestDeleteJob() {
+
+	// Prepare the request object
+	request, _ := http.NewRequest("DELETE", "/api/v1/job/Job_B", strings.NewReader(""))
+	// add the content-type header to application/json
+	request.Header.Set("Content-Type", "application/json;")
+	// add the authentication token which is seeded in testdb
+	request.Header.Set("x-api-key", "C4PK3Y")
+
+	// Execute the request in the controller
+	code, _, output, _ := Delete(request, suite.cfg)
+
+	suite.Equal(200, code, "Internal Server Error")
+	suite.Equal(suite.respJobDeleted, string(output), "Response body mismatch")
+
+	// Double check that the job is actually removed when you try
+	// to retrieve it's information by name
+	// Prepare the request object using job name as urlvar in url path
+	request, _ = http.NewRequest("GET", "/api/v1/job/Job_B", strings.NewReader(""))
+	// add the content-type header to application/json
+	request.Header.Set("Content-Type", "application/json;")
+	// add the authentication token which is seeded in testdb
+	request.Header.Set("x-api-key", "C4PK3Y")
+	// Pass request to controller calling List() handler method
+	code, _, output, _ = ListOne(request, suite.cfg)
+	// Check that we must have a 200 ok code
+	suite.Equal(400, code, "Internal Server Error")
+	// Compare the expected and actual xml response
+	suite.Equal(suite.respJobNotFound, string(output), "Response body mismatch")
+}
+
+// TestReadOneJob function implements the testing
+// of the get request which retrieves information
+// about a specific job (using it's name as input)
+func (suite *JobTestSuite) TestReadOneJob() {
+
+	// Create a string literal of the expected xml Response
+	respXML := `<root>
+ <job name="Job_A" tenant="AVENGERS" endpoint_group="SITES" group_of_groups="NGI">
+  <profiles>
+   <profile name="metric" value="profile1"></profile>
+   <profile name="ops" value="profile2"></profile>
+  </profiles>
+  <filter_tags>
+   <tag name="name1" value="value1"></tag>
+   <tag name="name2" value="value2"></tag>
+  </filter_tags>
+ </job>
+</root>`
+
+	// Prepare the request object using job name as urlvar in url path
+	request, _ := http.NewRequest("GET", "/api/v1/jobs/Job_A", strings.NewReader(""))
+	// add the content-type header to application/json
+	request.Header.Set("Content-Type", "application/json;")
+	// add the authentication token which is seeded in testdb
+	request.Header.Set("x-api-key", "C4PK3Y")
+	// Pass request to controller calling List() handler method
+	code, _, output, _ := ListOne(request, suite.cfg)
+	// Check that we must have a 200 ok code
+	suite.Equal(200, code, "Internal Server Error")
+	// Compare the expected and actual xml response
+	suite.Equal(respXML, string(output), "Response body mismatch")
+}
+
+// TestReadJobs function implements the testing
+// of the get request which retrieves information
+// about all available jobs
+func (suite *JobTestSuite) TestReadJobs() {
+
+	// Create a string literal of the expected xml Response
+	respXML := `<root>
+ <job name="Job_A" tenant="AVENGERS" endpoint_group="SITES" group_of_groups="NGI">
+  <profiles>
+   <profile name="metric" value="profile1"></profile>
+   <profile name="ops" value="profile2"></profile>
+  </profiles>
+  <filter_tags>
+   <tag name="name1" value="value1"></tag>
+   <tag name="name2" value="value2"></tag>
+  </filter_tags>
+ </job>
+ <job name="Job_B" tenant="AVENGERS" endpoint_group="SITES" group_of_groups="NGI">
+  <profiles>
+   <profile name="metric" value="profile1"></profile>
+   <profile name="ops" value="profile2"></profile>
+  </profiles>
+  <filter_tags>
+   <tag name="name1" value="value1"></tag>
+   <tag name="name2" value="value2"></tag>
+  </filter_tags>
+ </job>
+</root>`
+
+	// Prepare the request object
+	request, _ := http.NewRequest("GET", "", strings.NewReader(""))
+	// add the content-type header to application/json
+	request.Header.Set("Content-Type", "application/json;")
+	// add the authentication token which is seeded in testdb
+	request.Header.Set("x-api-key", "C4PK3Y")
+	// Pass request to controller calling List() handler method
+	code, _, output, _ := List(request, suite.cfg)
+	// Check that we must have a 200 ok code
+	suite.Equal(200, code, "Internal Server Error")
+	// Compare the expected and actual xml response
+	suite.Equal(respXML, string(output), "Response body mismatch")
+}
+
+// TestCreateUnauthorized function tests calling the create job request (POST) and
+// providing a wrong api-key. The response should be unauthorized
+func (suite *JobTestSuite) TestCreateUnauthorized() {
+	// Prepare the request object (use id2 for path)
+	request, _ := http.NewRequest("POST", "", strings.NewReader(""))
+	// add the content-type header to application/json
+	request.Header.Set("Content-Type", "application/json;")
+	// add the authentication token which is seeded in testdb
+	request.Header.Set("x-api-key", "F00T0K3N")
+
+	// Execute the request in the controller
+	code, _, output, _ := Create(request, suite.cfg)
+
+	suite.Equal(401, code, "Internal Server Error")
+	suite.Equal(suite.respUnauthorized, string(output), "Response body mismatch")
+}
+
+// TestUpdateUnauthorized function tests calling the update job request (PUT)
+// and providing  a wrong api-key. The response should be unauthorized
+func (suite *JobTestSuite) TestUpdateUnauthorized() {
+	// Prepare the request object
+	request, _ := http.NewRequest("PUT", "", strings.NewReader("{}"))
+	// add the content-type header to application/json
+	request.Header.Set("Content-Type", "application/json;")
+	// add the authentication token which is seeded in testdb
+	request.Header.Set("x-api-key", "F00T0K3N")
+
+	// Execute the request in the controller
+	code, _, output, _ := Update(request, suite.cfg)
+
+	suite.Equal(401, code, "Internal Server Error")
+	suite.Equal(suite.respUnauthorized, string(output), "Response body mismatch")
+}
+
+// TestDeleteUnauthorized function tests calling the remove job request (DELETE)
+// and providing a wrong api-key. The response should be unauthorized
+func (suite *JobTestSuite) TestDeleteUnauthorized() {
+	// Prepare the request object
+	request, _ := http.NewRequest("DELETE", "", strings.NewReader("{}"))
+	// add the content-type header to application/json
+	request.Header.Set("Content-Type", "application/json;")
+	// add the authentication token which is seeded in testdb
+	request.Header.Set("x-api-key", "F00T0K3N")
+
+	// Execute the request in the controller
+	code, _, output, _ := Delete(request, suite.cfg)
+
+	suite.Equal(401, code, "Internal Server Error")
+	suite.Equal(suite.respUnauthorized, string(output), "Response body mismatch")
+}
+
+// TestCreateBadJson tests calling the create job request (POST) and providing
+// bad json input. The response should be malformed json
+func (suite *JobTestSuite) TestCreateBadJson() {
+	// Prepare the request object
+	request, _ := http.NewRequest("POST", "/api/v1/jobs/Job_A", strings.NewReader("{ bad json"))
+	// add the content-type header to application/json
+	request.Header.Set("Content-Type", "application/json;")
+	// add the authentication token which is seeded in testdb
+	request.Header.Set("x-api-key", "C4PK3Y")
+
+	// Execute the request in the controller
+	code, _, output, _ := Create(request, suite.cfg)
+
+	suite.Equal(400, code, "Internal Server Error")
+	suite.Equal(suite.respBadJSON, string(output), "Response body mismatch")
+}
+
+// TestUpdateBadJson tests calling the update job request (PUT) and providing
+// bad json input. The response should be malformed json
+func (suite *JobTestSuite) TestUpdateBadJson() {
+	// Prepare the request object
+	request, _ := http.NewRequest("PUT", "/api/v1/jobs/Job_A", strings.NewReader("{ bad json"))
+	// add the content-type header to application/json
+	request.Header.Set("Content-Type", "application/json;")
+	// add the authentication token which is seeded in testdb
+	request.Header.Set("x-api-key", "C4PK3Y")
+
+	// Execute the request in the controller
+	code, _, output, _ := Update(request, suite.cfg)
+
+	suite.Equal(400, code, "Internal Server Error")
+	suite.Equal(suite.respBadJSON, string(output), "Response body mismatch")
+}
+
+// TestListOneNotFound tests calling the http (GET) job info request
+// and provide a non-existing job name. The response should be job not found
+func (suite *JobTestSuite) TestListOneNotFound() {
+	// Prepare the request object
+	request, _ := http.NewRequest("GET", "/api/v1/jobs/BADNAME", strings.NewReader(""))
+	// add the content-type header to application/json
+	request.Header.Set("Content-Type", "application/json;")
+	// add the authentication token which is seeded in testdb
+	request.Header.Set("x-api-key", "C4PK3Y")
+
+	// Execute the request in the controller
+	code, _, output, _ := ListOne(request, suite.cfg)
+
+	suite.Equal(400, code, "Internal Server Error")
+	suite.Equal(suite.respJobNotFound, string(output), "Response body mismatch")
+}
+
+// TestUpdateNotFound tests calling the http (PUT) update job request
+// and provide a non-existing job name. The response should be job not found
+func (suite *JobTestSuite) TestUpdateNotFound() {
+	// Prepare the request object
+	request, _ := http.NewRequest("PUT", "/api/v1/jobs/BADNAME", strings.NewReader("{}"))
+	// add the content-type header to application/json
+	request.Header.Set("Content-Type", "application/json;")
+	// add the authentication token which is seeded in testdb
+	request.Header.Set("x-api-key", "C4PK3Y")
+
+	// Execute the request in the controller
+	code, _, output, _ := Update(request, suite.cfg)
+
+	suite.Equal(200, code, "Internal Server Error")
+	suite.Equal(suite.respJobNotFound, string(output), "Response body mismatch")
+}
+
+// TestDeleteNotFound tests calling the http (PUT) update job request
+// and provide a non-existing job name. The response should be job not found
+func (suite *JobTestSuite) TestDeleteNotFound() {
+	// Prepare the request object
+	request, _ := http.NewRequest("DELETE", "/api/v1/jobs/BADNAME", strings.NewReader(""))
+	// add the content-type header to application/json
+	request.Header.Set("Content-Type", "application/json;")
+	// add the authentication token which is seeded in testdb
+	request.Header.Set("x-api-key", "C4PK3Y")
+
+	// Execute the request in the controller
+	code, _, output, _ := Delete(request, suite.cfg)
+
+	suite.Equal(200, code, "Internal Server Error")
+	suite.Equal(suite.respJobNotFound, string(output), "Response body mismatch")
+}
+
+// This function is actually called in the end of all tests
+// and clears the test environment.
+// Mainly it's purpose is to drop the testdb
+func (suite *JobTestSuite) TearDownTest() {
+
+	session, _ := mongo.OpenSession(suite.cfg.MongoDB)
+
+	session.DB("argo_test_jobs").DropDatabase()
+	session.DB("argo_test_jobs_db1").DropDatabase()
+}
+
+// This is the first function called when go test is issued
+func TestJobsSuite(t *testing.T) {
+	suite.Run(t, new(JobTestSuite))
+}

--- a/app/tenants/tenantsController.go
+++ b/app/tenants/tenantsController.go
@@ -54,7 +54,7 @@ func Create(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 
 	// if authentication procedure fails then
 	// return unauthorized http status
-	if authentication.Authenticate(r.Header, cfg) == false {
+	if authentication.AuthenticateAdmin(r.Header, cfg) == false {
 
 		output = []byte(http.StatusText(http.StatusUnauthorized))
 		//If wrong api key is passed we return UNAUTHORIZED http status
@@ -160,6 +160,17 @@ func List(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) 
 	charset := "utf-8"
 	//STANDARD DECLARATIONS END
 
+	// if authentication procedure fails then
+	// return unauthorized http status
+	if authentication.AuthenticateAdmin(r.Header, cfg) == false {
+
+		output = []byte(http.StatusText(http.StatusUnauthorized))
+		//If wrong api key is passed we return UNAUTHORIZED http status
+		code = http.StatusUnauthorized
+		h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+		return code, h, output, err
+	}
+
 	// Try to open the mongo session
 	session, err := mongo.OpenSession(cfg.MongoDB)
 	defer session.Close()
@@ -205,6 +216,17 @@ func ListOne(r *http.Request, cfg config.Config) (int, http.Header, []byte, erro
 	contentType := "text/xml"
 	charset := "utf-8"
 	//STANDARD DECLARATIONS END
+
+	// if authentication procedure fails then
+	// return unauthorized http status
+	if authentication.AuthenticateAdmin(r.Header, cfg) == false {
+
+		output = []byte(http.StatusText(http.StatusUnauthorized))
+		//If wrong api key is passed we return UNAUTHORIZED http status
+		code = http.StatusUnauthorized
+		h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+		return code, h, output, err
+	}
 
 	//Extracting urlvar "name" from url path
 	urlValues := r.URL.Path
@@ -280,7 +302,7 @@ func Update(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 
 	// if authentication procedure fails then
 	// return unauthorized
-	if authentication.Authenticate(r.Header, cfg) == false {
+	if authentication.AuthenticateAdmin(r.Header, cfg) == false {
 
 		output = []byte(http.StatusText(http.StatusUnauthorized))
 		//If wrong api key is passed we return UNAUTHORIZED http status
@@ -369,7 +391,7 @@ func Delete(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 
 	// if authentication procedure fails then
 	// return unauthorized
-	if authentication.Authenticate(r.Header, cfg) == false {
+	if authentication.AuthenticateAdmin(r.Header, cfg) == false {
 
 		output = []byte(http.StatusText(http.StatusUnauthorized))
 		//If wrong api key is passed we return UNAUTHORIZED http status

--- a/app/tenants/tenantsController.go
+++ b/app/tenants/tenantsController.go
@@ -27,15 +27,334 @@
 package tenants
 
 import (
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+
 	"github.com/argoeu/argo-web-api/utils/authentication"
 	"github.com/argoeu/argo-web-api/utils/config"
 	"github.com/argoeu/argo-web-api/utils/mongo"
-	"net/http"
 )
 
-// List returns a list of ARGO tenants
+// Create function is used to implement the create tenant request.
+// The request is an http POST request with the tenant description
+// provided as json structure in the request body
+func Create(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
+
+	//STANDARD DECLARATIONS START
+	code := http.StatusOK
+	h := http.Header{}
+	output := []byte("")
+	err := error(nil)
+	contentType := "text/xml"
+	charset := "utf-8"
+	//STANDARD DECLARATIONS END
+
+	// if authentication procedure fails then
+	// return unauthorized http status
+	if authentication.Authenticate(r.Header, cfg) == false {
+
+		output = []byte(http.StatusText(http.StatusUnauthorized))
+		//If wrong api key is passed we return UNAUTHORIZED http status
+		code = http.StatusUnauthorized
+		h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+		return code, h, output, err
+	}
+
+	//Reading the json input from the request body
+	reqBody, err := ioutil.ReadAll(r.Body)
+	input := Tenant{}
+	//Unmarshalling the json input into byte form
+	err = json.Unmarshal(reqBody, &input)
+
+	// Check if json body is malformed
+	if err != nil {
+		if err != nil {
+			// Msg in xml style, to notify for malformed json
+			output, err := messageXML("Malformated json input data")
+
+			if err != nil {
+				code = http.StatusInternalServerError
+				return code, h, output, err
+			}
+
+			code = http.StatusBadRequest
+			h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+			return code, h, output, err
+		}
+	}
+
+	// Try to open the mongo session
+	session, err := mongo.OpenSession(cfg.MongoDB)
+	defer session.Close()
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	// Prepare structure for storing query results
+	results := []Tenant{}
+
+	//Making sure that no profile with the requested name and namespace combination already exists in the DB
+	query := searchName(input.Name)
+	err = mongo.Find(session, cfg.MongoDB.Db, "tenants", query, "name", &results)
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	// If results are returned for the specific name
+	// then we already have an existing tenant and we must
+	// abort creation notifing the user
+	if len(results) > 0 {
+		// Name was found so print the error message in xml
+		output, err = messageXML("Tenant with the same name already exists")
+
+		if err != nil {
+			code = http.StatusInternalServerError
+			return code, h, output, err
+		}
+
+		code = http.StatusBadRequest
+		h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+		return code, h, output, err
+
+	}
+
+	// If no tenant exists with this name create a new one
+	query = createTenant(input)
+	err = mongo.Insert(session, cfg.MongoDB.Db, "tenants", query)
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	// Notify user that the tenant has been created. In xml style
+	output, err = messageXML("Tenant was successfully created")
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+	return code, h, output, err
+
+}
+
+// List function that implements the http GET request that retrieves
+// all avaiable tenant information
 func List(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
+
+	//STANDARD DECLARATIONS START
+	code := http.StatusOK
+	h := http.Header{}
+	output := []byte("")
+	err := error(nil)
+	contentType := "text/xml"
+	charset := "utf-8"
+	//STANDARD DECLARATIONS END
+
+	// Try to open the mongo session
+	session, err := mongo.OpenSession(cfg.MongoDB)
+	defer session.Close()
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	// Create structure for storing query results
+	results := []Tenant{}
+	// Query tenant collection for all available documents.
+	// nil query param == match everything
+	err = mongo.Find(session, cfg.MongoDB.Db, "tenants", nil, "name", &results)
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+	// After successfully retrieving the db results
+	// call the createView function to render them into idented xml
+	output, err = createView(results)
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+	return code, h, output, err
+}
+
+// ListOne function implement an http GET request that accepts
+// a name parameter urlvar and retrieves information only for the
+// specific tenant
+func ListOne(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
+
+	//STANDARD DECLARATIONS START
+	code := http.StatusOK
+	h := http.Header{}
+	output := []byte("")
+	err := error(nil)
+	contentType := "text/xml"
+	charset := "utf-8"
+	//STANDARD DECLARATIONS END
+
+	//Extracting urlvar "name" from url path
+	urlValues := r.URL.Path
+	nameFromURL := strings.Split(urlValues, "/")[4]
+
+	// Try to open the mongo session
+	session, err := mongo.OpenSession(cfg.MongoDB)
+	defer session.Close()
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	// Create structure to hold query results
+	results := []Tenant{}
+
+	// Create a simple query object to query by name
+	query := searchName(nameFromURL)
+	// Query collection tenants for the specific tenant name
+	err = mongo.Find(session, cfg.MongoDB.Db, "tenants", query, "name", &results)
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	// If query returned zero result then no tenant matched this name,
+	// abort and notify user accordingly
+	if len(results) == 0 {
+
+		output, err := messageXML("Tenant not found")
+
+		if err != nil {
+			code = http.StatusInternalServerError
+			return code, h, output, err
+		}
+
+		code = http.StatusBadRequest
+		h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+		return code, h, output, err
+	}
+
+	// After successfully retrieving the db results
+	// call the createView function to render them into idented xml
+	output, err = createView(results)
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+	return code, h, output, err
+}
+
+// Update function used to implement update tenant request.
+// This is an http PUT request that gets a specific tenant's name
+// as a urlvar parameter input and a json structure in the request
+// body in order to update the datastore document for the specific
+// tenant
+func Update(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
+
+	//STANDARD DECLARATIONS START
+	code := http.StatusOK
+	h := http.Header{}
+	output := []byte("")
+	err := error(nil)
+	contentType := "text/xml"
+	charset := "utf-8"
+
+	//STANDARD DECLARATIONS END
+
+	// if authentication procedure fails then
+	// return unauthorized
+	if authentication.Authenticate(r.Header, cfg) == false {
+
+		output = []byte(http.StatusText(http.StatusUnauthorized))
+		//If wrong api key is passed we return UNAUTHORIZED http status
+		code = http.StatusUnauthorized
+		h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+		return code, h, output, err
+	}
+
+	//Extracting record id from url
+	urlValues := r.URL.Path
+	nameFromURL := strings.Split(urlValues, "/")[4]
+
+	//Reading the json input
+	reqBody, err := ioutil.ReadAll(r.Body)
+
+	input := Tenant{}
+	//Unmarshalling the json input into byte form
+	err = json.Unmarshal(reqBody, &input)
+
+	if err != nil {
+		if err != nil {
+			// User provided malformed json input data
+			output, err := messageXML("Malformated json input data")
+
+			if err != nil {
+				code = http.StatusInternalServerError
+				return code, h, output, err
+			}
+
+			code = http.StatusBadRequest
+			h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+			return code, h, output, err
+		}
+	}
+
+	// Try to open the mongo session
+	session, err := mongo.OpenSession(cfg.MongoDB)
+	defer session.Close()
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	// We search by name and update
+	query := searchName(nameFromURL)
+	err = mongo.Update(session, cfg.MongoDB.Db, "tenants", query, input)
+
+	if err != nil {
+
+		if err.Error() != "not found" {
+			code = http.StatusInternalServerError
+			return code, h, output, err
+		}
+		//Render the response into XML
+		output, err = messageXML("Tenant not found")
+
+	} else {
+		//Render the response into XML
+		output, err = messageXML("Tenant was successfully updated")
+	}
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+	return code, h, output, err
+
+}
+
+// Delete function used to implement remove tenant request
+func Delete(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
 
 	//STANDARD DECLARATIONS START
 
@@ -47,37 +366,55 @@ func List(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) 
 	charset := "utf-8"
 
 	//STANDARD DECLARATIONS END
-	if authentication.AuthenticateAdmin(r.Header, cfg) {
-		session, err := mongo.OpenSession(cfg.MongoDB)
 
-		if err != nil {
-			code = http.StatusInternalServerError
-			return code, h, output, err
-		}
+	// if authentication procedure fails then
+	// return unauthorized
+	if authentication.Authenticate(r.Header, cfg) == false {
 
-		results := []TenantsOutput{}
-		err = mongo.Find(session, cfg.MongoDB.Db, "tenants", nil, "name", &results)
-
-		if err != nil {
-			code = http.StatusInternalServerError
-			return code, h, output, err
-		}
-
-		output, err = createView(results) //Render the results into XML format
-
-		if err != nil {
-			code = http.StatusInternalServerError
-			return code, h, output, err
-		}
-
-		mongo.CloseSession(session)
-		h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
-		return code, h, output, err
-	} else {
+		output = []byte(http.StatusText(http.StatusUnauthorized))
+		//If wrong api key is passed we return UNAUTHORIZED http status
 		code = http.StatusUnauthorized
-		output = []byte(http.StatusText(http.StatusUnauthorized)) //If wrong api key is passed we return UNAUTHORIZED http status
 		h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
 		return code, h, output, err
 	}
+
+	//Extracting record id from url
+	urlValues := r.URL.Path
+	nameFromURL := strings.Split(urlValues, "/")[4]
+
+	// Try to open the mongo session
+	session, err := mongo.OpenSession(cfg.MongoDB)
+	defer session.Close()
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	// We search by name and delete the document in db
+	query := searchName(nameFromURL)
+	info, err := mongo.Remove(session, cfg.MongoDB.Db, "tenants", query)
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	// info.Removed > 0 means that many documents have been removed
+	// If deletion took place we notify user accordingly.
+	// Else we notify that no tenant matched the specific name
+	if info.Removed > 0 {
+		output, err = messageXML("Tenant was successfully deleted")
+	} else {
+		output, err = messageXML("Tenant not found")
+	}
+	//Render the response into XML
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+	return code, h, output, err
 
 }

--- a/app/tenants/tenantsModel.go
+++ b/app/tenants/tenantsModel.go
@@ -26,16 +26,69 @@
 
 package tenants
 
-// Tenant is an XML respresentation of an ARGO tenant
+import (
+	"encoding/xml"
+
+	"labix.org/v2/mgo/bson"
+)
+
+// Tenant structure holds information about tenant information
+// including db conf and users. Used in
 type Tenant struct {
-	Name    string `xml:"name,attr"`
+	XMLName xml.Name       `bson:",omitempty" json:"-"       xml:"tenant" `
+	Name    string         `bson:"name"       json:"name"    xml:"name,attr" `
+	DbConf  []TenantDbConf `bson:"db_conf"    json:"db_conf" xml:"db_confs>db_conf"`
+	Users   []TenantUser   `bson:"users"      json:"users"   xml:"users>user"`
 }
 
-type root struct {
-	Tenant []*Tenant
+// TenantDbConf structure holds information about tenant's
+// database configuration
+type TenantDbConf struct {
+	XMLName  xml.Name `bson:",omitempty" json:"-"        xml:"db_conf"`
+	Store    string   `bson:"store"      json:"store"    xml:"store,attr"`
+	Server   string   `bson:"server"     json:"server"   xml:"server,attr"`
+	Port     int      `bson:"port"       json:"port"     xml:"port,attr"`
+	Database string   `bson:"database"   json:"database" xml:"database,attr"`
+	Username string   `bson:"username"   json:"username" xml:"username,attr"`
+	Password string   `bson:"password"   json:"password" xml:"password,attr"`
 }
 
-// TenantsOutput is a JSON respresentation of an ARGO tenant name
-type TenantsOutput struct {
-	Name    string `bson:"name"`
+// TenantUser structure holds information about tenant's
+// database configuration
+type TenantUser struct {
+	XMLName xml.Name `bson:",omitempty" json:"-"       xml:"user"`
+	Name    string   `bson:"name"       json:"name"    xml:"name,attr"`
+	Email   string   `bson:"email"      json:"email"   xml:"email,attr"`
+	APIkey  string   `bson:"api_key"    json:"api_key" xml:"api_key,attr"`
+}
+
+// Message struct for xml message response
+type Message struct {
+	XMLName xml.Name `xml:"root"`
+	Message string
+}
+
+// RootXML struct to represent the root of the xml/json document
+type RootXML struct {
+	XMLName xml.Name `xml:"root" json:"-"`
+	Tenants *[]Tenant
+}
+
+// createTenant is used to create a new
+func createTenant(input Tenant) bson.M {
+	query := bson.M{
+		"name":    input.Name,
+		"db_conf": input.DbConf,
+		"users":   input.Users,
+	}
+	return query
+}
+
+// searchName is used to create a simple query object based on name
+func searchName(name string) bson.M {
+	query := bson.M{
+		"name": name,
+	}
+
+	return query
 }

--- a/app/tenants/tenantsView.go
+++ b/app/tenants/tenantsView.go
@@ -26,22 +26,19 @@
 
 package tenants
 
-import (
-	"encoding/xml"
-)
+import "encoding/xml"
 
-// createView returns an XML view of the results to the controller
-func createView(results []TenantsOutput) ([]byte, error) {
+func messageXML(answer string) ([]byte, error) {
+	docRoot := &Message{}
+	docRoot.Message = answer
+	output, err := xml.MarshalIndent(docRoot, " ", "  ")
+	return output, err
+}
 
-	docRoot := &root{}
+func createView(results []Tenant) ([]byte, error) {
 
-	for _, row := range results {
-		f := &Tenant{}
-		f.Name = row.Name
-		docRoot.Tenant = append(docRoot.Tenant, f)
-	}
-
+	docRoot := &RootXML{}
+	docRoot.Tenants = &results
 	output, err := xml.MarshalIndent(docRoot, "", " ")
 	return output, err
-
 }

--- a/app/tenants/tenants_test.go
+++ b/app/tenants/tenants_test.go
@@ -97,7 +97,7 @@ func (suite *TenantTestSuite) SetupTest() {
 	session, _ := mongo.OpenSession(suite.cfg.MongoDB)
 
 	// Add authentication token to mongo testdb
-	seedAuth := bson.M{"apiKey": "S3CR3T"}
+	seedAuth := bson.M{"api_key": "S3CR3T"}
 	_ = mongo.Insert(session, suite.cfg.MongoDB.Db, "authentication", seedAuth)
 
 	// seed mongo
@@ -240,7 +240,10 @@ func (suite *TenantTestSuite) TestCreateTenant() {
 
 	// Prepare the request object using tenant name as urlvar in url path
 	request, _ = http.NewRequest("GET", "/api/v1/tenants/MUTANTS", strings.NewReader(""))
-
+	// add the content-type header to application/json
+	request.Header.Set("Content-Type", "application/json;")
+	// add the authentication token which is seeded in testdb
+	request.Header.Set("x-api-key", "S3CR3T")
 	// Pass request to controller calling List() handler method
 	code, _, output, _ = ListOne(request, suite.cfg)
 	// Check that we must have a 200 ok code
@@ -325,7 +328,10 @@ func (suite *TenantTestSuite) TestUpdateTenant() {
 
 	// Prepare the request object using tenant name as urlvar in url path
 	request, _ = http.NewRequest("GET", "/api/v1/tenants/AVENGERS_modified", strings.NewReader(""))
-
+	// add the content-type header to application/json
+	request.Header.Set("Content-Type", "application/json;")
+	// add the authentication token which is seeded in testdb
+	request.Header.Set("x-api-key", "S3CR3T")
 	// Pass request to controller calling List() handler method
 	code, _, output, _ = ListOne(request, suite.cfg)
 	// Check that we must have a 200 ok code
@@ -357,7 +363,10 @@ func (suite *TenantTestSuite) TestDeleteTenant() {
 	// to retrieve it's information by name
 	// Prepare the request object using tenant name as urlvar in url path
 	request, _ = http.NewRequest("GET", "/api/v1/tenants/AVENGERS", strings.NewReader(""))
-
+	// add the content-type header to application/json
+	request.Header.Set("Content-Type", "application/json;")
+	// add the authentication token which is seeded in testdb
+	request.Header.Set("x-api-key", "S3CR3T")
 	// Pass request to controller calling List() handler method
 	code, _, output, _ = ListOne(request, suite.cfg)
 	// Check that we must have a 200 ok code
@@ -394,7 +403,10 @@ func (suite *TenantTestSuite) TestReadOneTenant() {
 
 	// Prepare the request object using tenant name as urlvar in url path
 	request, _ := http.NewRequest("GET", "/api/v1/tenants/GUARDIANS", strings.NewReader(""))
-
+	// add the content-type header to application/json
+	request.Header.Set("Content-Type", "application/json;")
+	// add the authentication token which is seeded in testdb
+	request.Header.Set("x-api-key", "S3CR3T")
 	// Pass request to controller calling List() handler method
 	code, _, output, _ := ListOne(request, suite.cfg)
 	// Check that we must have a 200 ok code
@@ -440,7 +452,10 @@ func (suite *TenantTestSuite) TestReadTenants() {
 
 	// Prepare the request object
 	request, _ := http.NewRequest("GET", "", strings.NewReader(""))
-
+	// add the content-type header to application/json
+	request.Header.Set("Content-Type", "application/json;")
+	// add the authentication token which is seeded in testdb
+	request.Header.Set("x-api-key", "S3CR3T")
 	// Pass request to controller calling List() handler method
 	code, _, output, _ := List(request, suite.cfg)
 	// Check that we must have a 200 ok code

--- a/app/tenants/tenants_test.go
+++ b/app/tenants/tenants_test.go
@@ -380,13 +380,6 @@ func (suite *TenantTestSuite) TestDeleteTenant() {
 // about a specific tenant (using it's name as input)
 func (suite *TenantTestSuite) TestReadOneTenant() {
 
-	// Open a session to mongo
-	session, err := mgo.Dial(suite.cfg.MongoDB.Host)
-	if err != nil {
-		panic(err)
-	}
-	defer session.Close()
-
 	// Create a string literal of the expected xml Response
 	respXML := `<root>
  <tenant name="GUARDIANS">
@@ -418,13 +411,6 @@ func (suite *TenantTestSuite) TestReadOneTenant() {
 // TestReadTeanants function implements the testing
 // of the get request which retrieves all tenant information
 func (suite *TenantTestSuite) TestReadTenants() {
-
-	// Open a session to mongo
-	session, err := mgo.Dial(suite.cfg.MongoDB.Host)
-	if err != nil {
-		panic(err)
-	}
-	defer session.Close()
 
 	// Create a string literal of the expected xml Response
 	respXML := `<root>

--- a/app/tenants/tenants_test.go
+++ b/app/tenants/tenants_test.go
@@ -27,27 +27,38 @@
 package tenants
 
 import (
+	"net/http"
+	"strings"
+	"testing"
+
 	"code.google.com/p/gcfg"
 	"github.com/argoeu/argo-web-api/utils/config"
 	"github.com/argoeu/argo-web-api/utils/mongo"
 	"github.com/stretchr/testify/suite"
 	"labix.org/v2/mgo"
 	"labix.org/v2/mgo/bson"
-	"net/http"
-	"strings"
-	"testing"
 )
 
-// TenantsTestSuite is a utility suite struct used in tests
-type TenantsTestSuite struct {
+// This is a util. suite struct used in tests (see pkg "testify")
+type TenantTestSuite struct {
 	suite.Suite
-	cfg                 config.Config
-	resp_unauthorized   string
-	resp_tenantsList    string
+	cfg                config.Config
+	respTenantCreated  string
+	respTenantUpdated  string
+	respTenantDeleted  string
+	respTenantNotFound string
+	respUnauthorized   string
+	respBadJSON        string
 }
 
-// SetupTest will bootstrap and provide the testing environment
-func (suite *TenantsTestSuite) SetupTest() {
+// Setup the Test Environment
+// This function runs before any test and setups the environment
+// A test configuration object is instantiated using a reference
+// to testdb: AR_test_tenants. Also here is are instantiated some expected
+// xml response validation messages (authorization,crud responses).
+// Also the testdb is seeded with two tenants
+// and with an authorization token:"S3CR3T"
+func (suite *TenantTestSuite) SetupTest() {
 
 	const testConfig = `
     [server]
@@ -60,21 +71,34 @@ func (suite *TenantsTestSuite) SetupTest() {
     [mongodb]
     host = "127.0.0.1"
     port = 27017
-    db = "argo_core_test_tenants"
+    db = "argo_test_tenants"
 `
+
 	_ = gcfg.ReadStringInto(&suite.cfg, testConfig)
-	suite.resp_unauthorized = "Unauthorized"
-	suite.resp_tenantsList = `<root>
- <Tenant name="PREIS"></Tenant>
- <Tenant name="USDAT"></Tenant>
-</root>`
+
+	suite.respTenantCreated = " <root>\n" +
+		"   <Message>Tenant was successfully created</Message>\n </root>"
+
+	suite.respTenantUpdated = " <root>\n" +
+		"   <Message>Tenant was successfully updated</Message>\n </root>"
+
+	suite.respTenantDeleted = " <root>\n" +
+		"   <Message>Tenant was successfully deleted</Message>\n </root>"
+
+	suite.respTenantNotFound = " <root>\n" +
+		"   <Message>Tenant not found</Message>\n </root>"
+
+	suite.respBadJSON = " <root>\n" +
+		"   <Message>Malformated json input data</Message>\n </root>"
+
+	suite.respUnauthorized = "Unauthorized"
 
 	// Connect to mongo testdb
 	session, _ := mongo.OpenSession(suite.cfg.MongoDB)
 
 	// Add authentication token to mongo testdb
-	seed_auth := bson.M{"name" : "John Doe", "email" : "john.doe@example.com", "api_key" : "mysecretcombination"}
-	_ = mongo.Insert(session, suite.cfg.MongoDB.Db, "authentication", seed_auth)
+	seedAuth := bson.M{"apiKey": "S3CR3T"}
+	_ = mongo.Insert(session, suite.cfg.MongoDB.Db, "authentication", seedAuth)
 
 	// seed mongo
 	session, err := mgo.Dial(suite.cfg.MongoDB.Host)
@@ -83,69 +107,496 @@ func (suite *TenantsTestSuite) SetupTest() {
 	}
 	defer session.Close()
 
-	// Insert first seed profile
+	// seed first tenant
 	c := session.DB(suite.cfg.MongoDB.Db).C("tenants")
-	c.Insert(bson.M{"name" : "USDAT",
-		"db_conf" : []bson.M{ bson.M{"server" : "127.0.0.1", "port" : 27017, "database" : "USDAT_test"} } ,
-		"users" : []bson.M{ bson.M{"name" : "Jack Doe", "email" : "jack.doe@example.com", "api_key" : "anothersecret"} }})
-	c.Insert(bson.M{"name" : "PREIS",
-		"db_conf" : []bson.M{ bson.M{"server" : "127.0.0.1", "port" : 27017, "database" : "PREIS_test"} } ,
-		"users" : []bson.M{ bson.M{"name" : "Jill Doe", "email" : "jill.doe@example.com", "api_key" : "onemoresecret"} }})
+	c.Insert(bson.M{
+		"name": "AVENGERS",
+		"db_conf": []bson.M{
+			bson.M{
+				"store":    "ar",
+				"server":   "a.mongodb.org",
+				"port":     27017,
+				"database": "ar_db",
+				"username": "admin",
+				"password": "3NCRYPT3D"},
+			bson.M{
+				"store":    "status",
+				"server":   "b.mongodb.org",
+				"port":     27017,
+				"database": "status_db",
+				"username": "admin",
+				"password": "3NCRYPT3D"},
+		},
+		"users": []bson.M{
+			bson.M{
+				"name":    "cap",
+				"email":   "cap@email.com",
+				"api_key": "C4PK3Y"},
+			bson.M{
+				"name":    "thor",
+				"email":   "thor@email.com",
+				"api_key": "TH0RK3Y"},
+		}})
 
+	// seed second tenant
+	c.Insert(bson.M{
+		"name": "GUARDIANS",
+		"db_conf": []bson.M{
+			bson.M{
+				"store":    "ar",
+				"server":   "a.mongodb.org",
+				"port":     27017,
+				"database": "ar_db",
+				"username": "admin",
+				"password": "3NCRYPT3D"},
+			bson.M{
+				"store":    "status",
+				"server":   "b.mongodb.org",
+				"port":     27017,
+				"database": "status_db",
+				"username": "admin",
+				"password": "3NCRYPT3D"},
+		},
+		"users": []bson.M{
+			bson.M{
+				"name":    "groot",
+				"email":   "groot@email.com",
+				"api_key": "GR00TK3Y"},
+			bson.M{
+				"name":    "starlord",
+				"email":   "starlord@email.com",
+				"api_key": "ST4RL0RDK3Y"},
+		}})
 }
 
-// TestListTenants will run unit tests against the List function
-func (suite *TenantsTestSuite) TestListTenants() {
+// TestCreateTenant function implements testing the http POST create tenant request.
+// Request requires admin authentication and gets as input a json body containing
+// all the available information to be added to the datastore
+// After the operation succeeds is double-checked
+// that the newly created tenant is correctly retrieved
+func (suite *TenantTestSuite) TestCreateTenant() {
+
+	// create json input data for the request
+	postData := `
+  {
+      "name": "MUTANTS",
+      "db_conf": [
+        {
+          "store":"ar",
+          "server":"localhost",
+          "port":27017,
+          "database":"ar_db",
+          "username":"admin",
+          "password":"3NCRYPT3D"
+        },
+        {
+          "store":"status",
+          "server":"localhost",
+          "port":27017,
+          "database":"status_db",
+          "username":"admin",
+          "password":"3NCRYPT3D"
+        }],
+      "users": [
+          {
+            "name":"xavier",
+            "email":"xavier@email.com",
+            "api_key":"X4V13R"
+          },
+          {
+            "name":"magneto",
+            "email":"magneto@email.com",
+            "api_key":"M4GN3T0"
+          }]
+  }
+    `
+	// Prepare the request object
+	request, _ := http.NewRequest("POST", "", strings.NewReader(postData))
+	// add the content-type header to application/json
+	request.Header.Set("Content-Type", "application/json;")
+	// add the authentication token which is seeded in testdb
+	request.Header.Set("x-api-key", "S3CR3T")
+
+	// Execute the request in the controller
+	code, _, output, _ := Create(request, suite.cfg)
+
+	suite.Equal(200, code, "Internal Server Error")
+	suite.Equal(suite.respTenantCreated, string(output), "Response body mismatch")
+
+	// Double check that you read the newly inserted profile
+	// Create a string literal of the expected xml Response
+	respXML := `<root>
+ <tenant name="MUTANTS">
+  <db_confs>
+   <db_conf store="ar" server="localhost" port="27017" database="ar_db" username="admin" password="3NCRYPT3D"></db_conf>
+   <db_conf store="status" server="localhost" port="27017" database="status_db" username="admin" password="3NCRYPT3D"></db_conf>
+  </db_confs>
+  <users>
+   <user name="xavier" email="xavier@email.com" api_key="X4V13R"></user>
+   <user name="magneto" email="magneto@email.com" api_key="M4GN3T0"></user>
+  </users>
+ </tenant>
+</root>`
+
+	// Prepare the request object using tenant name as urlvar in url path
+	request, _ = http.NewRequest("GET", "/api/v1/tenants/MUTANTS", strings.NewReader(""))
+
+	// Pass request to controller calling List() handler method
+	code, _, output, _ = ListOne(request, suite.cfg)
+	// Check that we must have a 200 ok code
+	suite.Equal(200, code, "Internal Server Error")
+	// Compare the expected and actual xml response
+	suite.Equal(respXML, string(output), "Response body mismatch")
+}
+
+// TestUpdateTenant function implements testing the http PUT update tenant request.
+// Request requires admin authentication and gets as input the name of the
+// tenant to be updated and a json body with the update.
+// After the operation succeeds is double-checked
+// that the specific tenant has been updated
+func (suite *TenantTestSuite) TestUpdateTenant() {
+
+	// create json input data for the request
+	postData := `
+  {
+      "name": "AVENGERS_modified",
+      "db_conf": [
+        {
+          "store":"ar_mod",
+          "server":"localhost",
+          "port":27017,
+          "database":"ar_db",
+          "username":"admin",
+          "password":"3NCRYPT3D"
+        },
+        {
+          "store":"status_mod",
+          "server":"localhost",
+          "port":27017,
+          "database":"status_db",
+          "username":"admin",
+          "password":"3NCRYPT3D"
+        }],
+      "users": [
+          {
+            "name":"thor",
+            "email":"thor@email.com",
+            "api_key":"TH0RK3Y"
+          },
+          {
+            "name":"cap",
+            "email":"cap@email.com",
+            "api_key":"C4PK3Y"
+          },
+          {
+            "name":"hulk",
+            "email":"hulk@email.com",
+            "api_key":"HULKK3Y"
+          }]
+  }`
+	// Prepare the request object
+	request, _ := http.NewRequest("PUT", "/api/v1/tenants/AVENGERS", strings.NewReader(postData))
+	// add the content-type header to application/json
+	request.Header.Set("Content-Type", "application/json;")
+	// add the authentication token which is seeded in testdb
+	request.Header.Set("x-api-key", "S3CR3T")
+
+	// Execute the request in the controller
+	code, _, output, _ := Update(request, suite.cfg)
+
+	suite.Equal(200, code, "Internal Server Error")
+	suite.Equal(suite.respTenantUpdated, string(output), "Response body mismatch")
+
+	// Double check that you read the newly updated profile
+	// Create a string literal of the expected xml Response
+	respXML := `<root>
+ <tenant name="AVENGERS_modified">
+  <db_confs>
+   <db_conf store="ar_mod" server="localhost" port="27017" database="ar_db" username="admin" password="3NCRYPT3D"></db_conf>
+   <db_conf store="status_mod" server="localhost" port="27017" database="status_db" username="admin" password="3NCRYPT3D"></db_conf>
+  </db_confs>
+  <users>
+   <user name="thor" email="thor@email.com" api_key="TH0RK3Y"></user>
+   <user name="cap" email="cap@email.com" api_key="C4PK3Y"></user>
+   <user name="hulk" email="hulk@email.com" api_key="HULKK3Y"></user>
+  </users>
+ </tenant>
+</root>`
+
+	// Prepare the request object using tenant name as urlvar in url path
+	request, _ = http.NewRequest("GET", "/api/v1/tenants/AVENGERS_modified", strings.NewReader(""))
+
+	// Pass request to controller calling List() handler method
+	code, _, output, _ = ListOne(request, suite.cfg)
+	// Check that we must have a 200 ok code
+	suite.Equal(200, code, "Internal Server Error")
+	// Compare the expected and actual xml response
+	suite.Equal(respXML, string(output), "Response body mismatch")
+}
+
+// TestDeleteTenant function implements testing the http DELETE tenant request.
+// Request requires admin authentication and gets as input the name of the
+// tenant to be deleted. After the operation succeeds is double-checked
+// that the deleted tenant is actually missing from the datastore
+func (suite *TenantTestSuite) TestDeleteTenant() {
 
 	// Prepare the request object
-	request, _ := http.NewRequest("GET", "/api/v1/tenants", strings.NewReader(""))
+	request, _ := http.NewRequest("DELETE", "/api/v1/tenants/AVENGERS", strings.NewReader(""))
+	// add the content-type header to application/json
+	request.Header.Set("Content-Type", "application/json;")
 	// add the authentication token which is seeded in testdb
-	request.Header.Set("x-api-key", "mysecretcombination")
+	request.Header.Set("x-api-key", "S3CR3T")
+
 	// Execute the request in the controller
-	code, _, output, _ := List(request, suite.cfg)
+	code, _, output, _ := Delete(request, suite.cfg)
+
 	suite.Equal(200, code, "Internal Server Error")
-	suite.Equal(suite.resp_tenantsList, string(output), "Response body mismatch")
+	suite.Equal(suite.respTenantDeleted, string(output), "Response body mismatch")
 
-	// Prepare new request object
-	request, _ = http.NewRequest("GET", "/api/v1/tenants", strings.NewReader(""))
-	// add the authentication token which is seeded in testdb
-	request.Header.Set("x-api-key", "wrongkey")
-	// Execute the request in the controller
-	code, _, output, _ = List(request, suite.cfg)
-	suite.Equal(401, code, "Should have gotten return code 401 (Unauthorized)")
-	suite.Equal(suite.resp_unauthorized, string(output), "Should have gotten reply Unauthorized")
+	// Double check that the tenant is actually removed when you try
+	// to retrieve it's information by name
+	// Prepare the request object using tenant name as urlvar in url path
+	request, _ = http.NewRequest("GET", "/api/v1/tenants/AVENGERS", strings.NewReader(""))
 
-	// Remove the profile not to contaminate other tests
-	// Open session to mongo
+	// Pass request to controller calling List() handler method
+	code, _, output, _ = ListOne(request, suite.cfg)
+	// Check that we must have a 200 ok code
+	suite.Equal(400, code, "Internal Server Error")
+	// Compare the expected and actual xml response
+	suite.Equal(suite.respTenantNotFound, string(output), "Response body mismatch")
+}
+
+// TestReadOneTeanant function implements the testing
+// of the get request which retrieves information
+// about a specific tenant (using it's name as input)
+func (suite *TenantTestSuite) TestReadOneTenant() {
+
+	// Open a session to mongo
 	session, err := mgo.Dial(suite.cfg.MongoDB.Host)
 	if err != nil {
 		panic(err)
 	}
 	defer session.Close()
-	// Open collection authentication
-	c := session.DB(suite.cfg.MongoDB.Db).C("authentication")
-	// Remove the specific entries inserted during this test
-	c.Remove(bson.M{"name": "John Doe"})
 
-	// Open collection tenants
-	c = session.DB(suite.cfg.MongoDB.Db).C("tenants")
-	// Remove the specific entries inserted during this test
-	c.Remove(bson.M{"name": "USDAT"})
-	c.Remove(bson.M{"name": "PREIS"})
+	// Create a string literal of the expected xml Response
+	respXML := `<root>
+ <tenant name="GUARDIANS">
+  <db_confs>
+   <db_conf store="ar" server="a.mongodb.org" port="27017" database="ar_db" username="admin" password="3NCRYPT3D"></db_conf>
+   <db_conf store="status" server="b.mongodb.org" port="27017" database="status_db" username="admin" password="3NCRYPT3D"></db_conf>
+  </db_confs>
+  <users>
+   <user name="groot" email="groot@email.com" api_key="GR00TK3Y"></user>
+   <user name="starlord" email="starlord@email.com" api_key="ST4RL0RDK3Y"></user>
+  </users>
+ </tenant>
+</root>`
 
+	// Prepare the request object using tenant name as urlvar in url path
+	request, _ := http.NewRequest("GET", "/api/v1/tenants/GUARDIANS", strings.NewReader(""))
+
+	// Pass request to controller calling List() handler method
+	code, _, output, _ := ListOne(request, suite.cfg)
+	// Check that we must have a 200 ok code
+	suite.Equal(200, code, "Internal Server Error")
+	// Compare the expected and actual xml response
+	suite.Equal(respXML, string(output), "Response body mismatch")
 }
 
-//TearDownTest to tear down every test
-func (suite *TenantsTestSuite) TearDownTest() {
+// TestReadTeanants function implements the testing
+// of the get request which retrieves all tenant information
+func (suite *TenantTestSuite) TestReadTenants() {
 
+	// Open a session to mongo
 	session, err := mgo.Dial(suite.cfg.MongoDB.Host)
 	if err != nil {
 		panic(err)
 	}
-	session.DB(suite.cfg.MongoDB.Db).DropDatabase()
+	defer session.Close()
+
+	// Create a string literal of the expected xml Response
+	respXML := `<root>
+ <tenant name="AVENGERS">
+  <db_confs>
+   <db_conf store="ar" server="a.mongodb.org" port="27017" database="ar_db" username="admin" password="3NCRYPT3D"></db_conf>
+   <db_conf store="status" server="b.mongodb.org" port="27017" database="status_db" username="admin" password="3NCRYPT3D"></db_conf>
+  </db_confs>
+  <users>
+   <user name="cap" email="cap@email.com" api_key="C4PK3Y"></user>
+   <user name="thor" email="thor@email.com" api_key="TH0RK3Y"></user>
+  </users>
+ </tenant>
+ <tenant name="GUARDIANS">
+  <db_confs>
+   <db_conf store="ar" server="a.mongodb.org" port="27017" database="ar_db" username="admin" password="3NCRYPT3D"></db_conf>
+   <db_conf store="status" server="b.mongodb.org" port="27017" database="status_db" username="admin" password="3NCRYPT3D"></db_conf>
+  </db_confs>
+  <users>
+   <user name="groot" email="groot@email.com" api_key="GR00TK3Y"></user>
+   <user name="starlord" email="starlord@email.com" api_key="ST4RL0RDK3Y"></user>
+  </users>
+ </tenant>
+</root>`
+
+	// Prepare the request object
+	request, _ := http.NewRequest("GET", "", strings.NewReader(""))
+
+	// Pass request to controller calling List() handler method
+	code, _, output, _ := List(request, suite.cfg)
+	// Check that we must have a 200 ok code
+	suite.Equal(200, code, "Internal Server Error")
+	// Compare the expected and actual xml response
+	suite.Equal(respXML, string(output), "Response body mismatch")
+}
+
+// TestCreateUnauthorized function tests calling the create tenant request (POST) and
+// providing a wrong api-key. The response should be unauthorized
+func (suite *TenantTestSuite) TestCreateUnauthorized() {
+	// Prepare the request object (use id2 for path)
+	request, _ := http.NewRequest("POST", "", strings.NewReader(""))
+	// add the content-type header to application/json
+	request.Header.Set("Content-Type", "application/json;")
+	// add the authentication token which is seeded in testdb
+	request.Header.Set("x-api-key", "F00T0K3N")
+
+	// Execute the request in the controller
+	code, _, output, _ := Create(request, suite.cfg)
+
+	suite.Equal(401, code, "Internal Server Error")
+	suite.Equal(suite.respUnauthorized, string(output), "Response body mismatch")
+}
+
+// TestUpdateUnauthorized function tests calling the update tenant request (PUT)
+// and providing  a wrong api-key. The response should be unauthorized
+func (suite *TenantTestSuite) TestUpdateUnauthorized() {
+	// Prepare the request object
+	request, _ := http.NewRequest("PUT", "", strings.NewReader("{}"))
+	// add the content-type header to application/json
+	request.Header.Set("Content-Type", "application/json;")
+	// add the authentication token which is seeded in testdb
+	request.Header.Set("x-api-key", "F00T0K3N")
+
+	// Execute the request in the controller
+	code, _, output, _ := Update(request, suite.cfg)
+
+	suite.Equal(401, code, "Internal Server Error")
+	suite.Equal(suite.respUnauthorized, string(output), "Response body mismatch")
+}
+
+// TestDeleteUnauthorized function tests calling the remove tenant request (DELETE)
+// and providing a wrong api-key. The response should be unauthorized
+func (suite *TenantTestSuite) TestDeleteUnauthorized() {
+	// Prepare the request object
+	request, _ := http.NewRequest("DELETE", "", strings.NewReader("{}"))
+	// add the content-type header to application/json
+	request.Header.Set("Content-Type", "application/json;")
+	// add the authentication token which is seeded in testdb
+	request.Header.Set("x-api-key", "F00T0K3N")
+
+	// Execute the request in the controller
+	code, _, output, _ := Delete(request, suite.cfg)
+
+	suite.Equal(401, code, "Internal Server Error")
+	suite.Equal(suite.respUnauthorized, string(output), "Response body mismatch")
+}
+
+// TestCreateBadJson tests calling the create tenant request (POST) and providing
+// bad json input. The response should be malformed json
+func (suite *TenantTestSuite) TestCreateBadJson() {
+	// Prepare the request object
+	request, _ := http.NewRequest("POST", "/api/v1/tenants/AVENGERS", strings.NewReader("{ bad json"))
+	// add the content-type header to application/json
+	request.Header.Set("Content-Type", "application/json;")
+	// add the authentication token which is seeded in testdb
+	request.Header.Set("x-api-key", "S3CR3T")
+
+	// Execute the request in the controller
+	code, _, output, _ := Create(request, suite.cfg)
+
+	suite.Equal(400, code, "Internal Server Error")
+	suite.Equal(suite.respBadJSON, string(output), "Response body mismatch")
+}
+
+// TestUpdateBadJson tests calling the update tenant request (PUT) and providing
+// bad json input. The response should be malformed json
+func (suite *TenantTestSuite) TestUpdateBadJson() {
+	// Prepare the request object
+	request, _ := http.NewRequest("PUT", "/api/v1/tenants/AVENGERS", strings.NewReader("{ bad json"))
+	// add the content-type header to application/json
+	request.Header.Set("Content-Type", "application/json;")
+	// add the authentication token which is seeded in testdb
+	request.Header.Set("x-api-key", "S3CR3T")
+
+	// Execute the request in the controller
+	code, _, output, _ := Update(request, suite.cfg)
+
+	suite.Equal(400, code, "Internal Server Error")
+	suite.Equal(suite.respBadJSON, string(output), "Response body mismatch")
+}
+
+// TestListOneNotFound tests calling the http (GET) tenant info request
+// and provide a non-existing tenant name. The response should be tenant not found
+func (suite *TenantTestSuite) TestListOneNotFound() {
+	// Prepare the request object
+	request, _ := http.NewRequest("GET", "/api/v1/tenants/BADNAME", strings.NewReader(""))
+	// add the content-type header to application/json
+	request.Header.Set("Content-Type", "application/json;")
+	// add the authentication token which is seeded in testdb
+	request.Header.Set("x-api-key", "S3CR3T")
+
+	// Execute the request in the controller
+	code, _, output, _ := ListOne(request, suite.cfg)
+
+	suite.Equal(400, code, "Internal Server Error")
+	suite.Equal(suite.respTenantNotFound, string(output), "Response body mismatch")
+}
+
+// TestUpdateNotFound tests calling the http (PUT) update tenant request
+// and provide a non-existing tenant name. The response should be tenant not found
+func (suite *TenantTestSuite) TestUpdateNotFound() {
+	// Prepare the request object
+	request, _ := http.NewRequest("PUT", "/api/v1/tenants/BADNAME", strings.NewReader("{}"))
+	// add the content-type header to application/json
+	request.Header.Set("Content-Type", "application/json;")
+	// add the authentication token which is seeded in testdb
+	request.Header.Set("x-api-key", "S3CR3T")
+
+	// Execute the request in the controller
+	code, _, output, _ := Update(request, suite.cfg)
+
+	suite.Equal(200, code, "Internal Server Error")
+	suite.Equal(suite.respTenantNotFound, string(output), "Response body mismatch")
+}
+
+// TestDeleteNotFound tests calling the http (PUT) update tenant request
+// and provide a non-existing tenant name. The response should be tenant not found
+func (suite *TenantTestSuite) TestDeleteNotFound() {
+	// Prepare the request object
+	request, _ := http.NewRequest("DELETE", "/api/v1/tenants/BADNAME", strings.NewReader(""))
+	// add the content-type header to application/json
+	request.Header.Set("Content-Type", "application/json;")
+	// add the authentication token which is seeded in testdb
+	request.Header.Set("x-api-key", "S3CR3T")
+
+	// Execute the request in the controller
+	code, _, output, _ := Delete(request, suite.cfg)
+
+	suite.Equal(200, code, "Internal Server Error")
+	suite.Equal(suite.respTenantNotFound, string(output), "Response body mismatch")
+}
+
+// This function is actually called in the end of all tests
+// and clears the test environment.
+// Mainly it's purpose is to drop the testdb
+func (suite *TenantTestSuite) TearDownTest() {
+
+	session, _ := mongo.OpenSession(suite.cfg.MongoDB)
+
+	session.DB("argo_test_tenants").DropDatabase()
 
 }
 
-func TestTenantsTestSuite(t *testing.T) {
-	suite.Run(t, new(TenantsTestSuite))
+// This is the first function called when go test is issued
+func TestTenantsSuite(t *testing.T) {
+	suite.Run(t, new(TenantTestSuite))
 }

--- a/main.go
+++ b/main.go
@@ -80,6 +80,13 @@ func main() {
 	putSubrouter.HandleFunc("/api/v1/AP/{id}", Respond(availabilityProfiles.Update))
 	deleteSubrouter.HandleFunc("/api/v1/AP/{id}", Respond(availabilityProfiles.Delete))
 
+	//tenants
+	postSubrouter.HandleFunc("/api/v1/tenants", Respond(tenants.Create))
+	putSubrouter.HandleFunc("/api/v1/tenants/{name}", Respond(tenants.Update))
+	deleteSubrouter.HandleFunc("/api/v1/tenants/{name}", Respond(tenants.Delete))
+	getSubrouter.HandleFunc("/api/v1/tenants", Respond(tenants.List))
+	getSubrouter.HandleFunc("/api/v1/tenants/{name}", Respond(tenants.ListOne))
+
 	//Poem Profiles compatibility
 	getSubrouter.HandleFunc("/api/v1/poems", Respond(metricProfiles.ListPoems))
 

--- a/main.go
+++ b/main.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/argoeu/argo-web-api/app/availabilityProfiles"
 	"github.com/argoeu/argo-web-api/app/factors"
+	"github.com/argoeu/argo-web-api/app/jobs"
 	"github.com/argoeu/argo-web-api/app/metricProfiles"
 	"github.com/argoeu/argo-web-api/app/ngiAvailability"
 	"github.com/argoeu/argo-web-api/app/recomputations"
@@ -86,6 +87,13 @@ func main() {
 	deleteSubrouter.HandleFunc("/api/v1/tenants/{name}", Respond(tenants.Delete))
 	getSubrouter.HandleFunc("/api/v1/tenants", Respond(tenants.List))
 	getSubrouter.HandleFunc("/api/v1/tenants/{name}", Respond(tenants.ListOne))
+
+	//jobs
+	postSubrouter.HandleFunc("/api/v1/jobs", Respond(jobs.Create))
+	putSubrouter.HandleFunc("/api/v1/jobs/{name}", Respond(jobs.Update))
+	deleteSubrouter.HandleFunc("/api/v1/jobs/{name}", Respond(jobs.Delete))
+	getSubrouter.HandleFunc("/api/v1/jobs", Respond(jobs.List))
+	getSubrouter.HandleFunc("/api/v1/jobs/{name}", Respond(jobs.ListOne))
 
 	//Poem Profiles compatibility
 	getSubrouter.HandleFunc("/api/v1/poems", Respond(metricProfiles.ListPoems))

--- a/utils/mongo/mongoQuery.go
+++ b/utils/mongo/mongoQuery.go
@@ -101,3 +101,11 @@ func IdUpdate(session *mgo.Session, dbName string, collectionName string, id str
 	err := c.UpdateId(rid, update)
 	return err
 }
+
+// Update a specfic document in a collection based on a query
+func Update(session *mgo.Session, dbName string, collectionName string, query bson.M, update interface{}) error {
+	// Check if given id is proper ObjectId
+	c := openCollection(session, dbName, collectionName)
+	err := c.Update(query, update)
+	return err
+}


### PR DESCRIPTION
__Note__:This PR has been branched from ARGO-119 (https://github.com/ARGOeu/argo-web-api/pull/85) so it should be merged after that 



Implements `app/jobs` package wich allows __per tenant__ to: 
- Create new job definitons (POST)
- List all (or a specific one) job information (GET)
- Update a job definition (PUT)
- Remove a job definition (DELETE)

All requests are authenticated against a registered tenant user by calling func: ./utils/mongo.authenticateTenant (introduced in PR:#80)
This authentication if succeeds returns a `MongoConfig` object holding information on the specific tenant's datastore 

Note: Job definition Model uses the same structures (Job, JobProfiles and JobTags) both for the mongo bson document interfacing and for the xml & json marshaling as seen in the next snippet

```go
type Job struct {
	XMLName       xml.Name     `bson:",omitempty"      json:"-"               xml:"job"`
	Name          string       `bson:"name"            json:"name"            xml:"name,attr"`
	Tenant        string       `bson:"tenant"          json:"tenant"          xml:"tenant,attr"`
	EndpointGroup string       `bson:"endpoint_group"  json:"endpoint_group"  xml:"endpoint_group,attr"`
	GroupOfGroups string       `bson:"group_of_groups" json:"group_of_groups" xml:"group_of_groups,attr"`
	Profiles      []JobProfile `bson:"profiles"        json:"profiles"        xml:"profiles>profile"`
	FilterTags    []JobTag     `bson:"filter_tags"     json:"filter_tags"     xml:"filter_tags>tag"`
}
```

```go
type JobProfile struct {
	XMLName xml.Name `bson:",omitempty" json:"-"     xml:"profile"`
	Name    string   `bson:"name"       json:"name"  xml:"name,attr"`
	Value   string   `bson:"value"      json:"value" xml:"value,attr"`
}
```

```go
type JobTag struct {
	XMLName xml.Name `bson:",omitempty" json:"-"     xml:"tag"`
	Name    string   `bson:"name"       json:"name"  xml:"name,attr"`
	Value   string   `bson:"value"      json:"value" xml:"value,attr"`
}
```

Since we mostly server xml (as of yet) in requests, the `profile` and `filter_tag` fields were implemented as individual structs instead of map[string]string (as originally planed) because it officialy causes problems on xml marshaling.

_Example of tenant information structured in_ __json__ _(input):_

```json
  {
    "name":"Job_A",
    "tenant":"Tenant_A",
    "profiles":[
      { "name":"metric","value":"profA"},
      { "name":"ap","value":"profB"}
     ],
    "endpoint_group":"SITES",
    "group_of_groups":"NGI",
    "filter_tags":[
      { "name":"production","value":"Y"},
      { "name":"monitored","value":"Y"}
    ]
  }
```

_Example of tenant information structured in_ __xml__ _(response)_:
```xml
<root>
 <job name="Job_A" tenant="Tenant_A" endpoint_group="SITES" group_of_groups="NGI">
  <profiles>
   <profile name="metric" value="profA"></profile>
   <profile name="ap" value="profB"></profile>
  </profiles>
  <filter_tags>
   <tag name="production" value="Y"></tag>
   <tag name="monitored" value="Y"></tag>
  </filter_tags>
 </job>
</root>
```