### PR TITLE
ARGO-139 Disable cache functionality until we refactor it to support multitenancy.

### DIFF
--- a/utils/caches/handleCache.go
+++ b/utils/caches/handleCache.go
@@ -40,6 +40,7 @@ func (s mystring) Size() int {
 	return len(s)
 }
 
+//TODO Add multitenant support on cache util.
 func HitCache(name string, input interface{}, cfg config.Config) (bool, []byte) {
 	output := []byte(nil)
 	found := false
@@ -52,6 +53,7 @@ func HitCache(name string, input interface{}, cfg config.Config) (bool, []byte) 
 	return found, output
 }
 
+//TODO Add multitenant support on cache util.
 func WriteCache(name string, input interface{}, output interface{}, cfg config.Config) bool {
 
 	if cfg.Server.Cache == true {

--- a/utils/config/config.go
+++ b/utils/config/config.go
@@ -90,7 +90,7 @@ const defaultConfig = `
     db = "argo_core"
 `
 
-//Loads the configurations passed either by flags or by the configuration file
+//LoadConfiguration function loads the configurations passed either by flags or by the configuration file
 func LoadConfiguration() Config {
 	flag.Parse()
 	// var cfg Config
@@ -127,8 +127,11 @@ func LoadConfiguration() Config {
 	if *flMongoDatabase != "" {
 		cfg.MongoDB.Db = *flMongoDatabase
 	}
+
+	//Keep cache disabled even if the option is set to "yes" via the cmd line.
+	//TODO Enable multitenant support on cache util.
 	if *flCache == "yes" {
-		cfg.Server.Cache = true
+		cfg.Server.Cache = false
 	}
 	if *flGzip == "no" {
 		cfg.Server.Gzip = false


### PR DESCRIPTION
Currently the default config for the web api doesn't use the cache option (cache = false) . However we have implemented two functions of LRU cache in `ngiAvailability`,`siteAvailability`, `serviceFlavorAvailability`, and `voAvailability` controllers eg.
```
caches.HitCache("vos", input, cfg)
```
```
caches.WriteCache("sites", input, output, cfg)
```

The `HitCache` and `WriteCache` functions are implemented around `Get` and `Set` functions of LRU cache module. The LRU cache is basically a key/value store which uses specific key names (eg. "ngis" and "sites") to store and retrieve the appropriate values. The cache is initialized once in init.go. 

One implementation we could have is to instantiate a unique cache instance for all tenants and hold the necessary information using tenant specific keys. However, this solution may allow cache abuse by certain tenants.

Until we refactor the cache module we keep the functionality disabled as discussed, on both default config and command line arguments.