### PR TITLE
ARGO-130 multitenancy on status detail results

### DIFF
--- a/app/jobs/jobsModel.go
+++ b/app/jobs/jobsModel.go
@@ -28,6 +28,7 @@ package jobs
 
 import (
 	"encoding/xml"
+	"errors"
 
 	"labix.org/v2/mgo/bson"
 )
@@ -80,6 +81,18 @@ func createJob(input Job) bson.M {
 		"filter_tags":     input.FilterTags,
 	}
 	return query
+}
+
+// GetMetricProfile is a function that takes a job struc element
+// and returns the name of the metric profile (if exists)
+func GetMetricProfile(input Job) (string, error) {
+	for _, element := range input.Profiles {
+		if element.Name == "metric" {
+			return element.Value, nil
+		}
+	}
+
+	return "", errors.New("Unable to find metric profile with specified name")
 }
 
 // searchName is used to create a simple query object based on name

--- a/app/statusDetail/statusDetailController.go
+++ b/app/statusDetail/statusDetailController.go
@@ -102,7 +102,7 @@ func List(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) 
 	session, err := mongo.OpenSession(tenantDbConfig)
 
 	c := session.DB(tenantDbConfig.Db).C("status_metric")
-	pc := session.DB("AR").C("poem_details")
+	pc := session.DB(tenantDbConfig.Db).C("metric_profiles")
 
 	err = pc.Find(bson.M{"p": input.profile}).All(&metricResults)
 	err = c.Find(prepQuery(input)).All(&results)

--- a/app/statusDetail/statusDetailController.go
+++ b/app/statusDetail/statusDetailController.go
@@ -112,6 +112,9 @@ func prepQuery(input InputParams) bson.M {
 	const zuluForm = "2006-01-02T15:04:05Z"
 	const ymdForm = "20060102"
 
+	selectGroup := false
+	selectEndpointGroup := false
+
 	ts, _ := time.Parse(zuluForm, input.startTime)
 	te, _ := time.Parse(zuluForm, input.endTime)
 	tsYMD, _ := strconv.Atoi(ts.Format(ymdForm))
@@ -121,35 +124,35 @@ func prepQuery(input InputParams) bson.M {
 	tsInt := (ts.Hour() * 10000) + (ts.Minute() * 100) + ts.Second()
 	teInt := (te.Hour() * 10000) + (te.Minute() * 100) + te.Second()
 
-	if input.groupType == "site" {
+	if selectEndpointGroup == true {
 
 		query := bson.M{
-			"di":   tsYMD,
-			"site": input.group,
-			"ti":   bson.M{"$gte": tsInt, "$lte": teInt},
+			"date_int":       tsYMD,
+			"endpoint_group": input.group,
+			"time_int":       bson.M{"$gte": tsInt, "$lte": teInt},
 		}
 
 		return query
 
-	} else if input.groupType == "ngi" {
+	} else if selectGroup == true {
 		query := bson.M{
-			"di":  tsYMD,
-			"roc": input.group,
-			"ti":  bson.M{"$gte": tsInt, "$lte": teInt},
+			"date_int": tsYMD,
+			"group":    input.group,
+			"time_int": bson.M{"$gte": tsInt, "$lte": teInt},
 		}
 
 		return query
 
 	} else if input.groupType == "host" {
 		query := bson.M{
-			"di": tsYMD,
-			"h":  input.group,
-			"ti": bson.M{"$gte": tsInt, "$lte": teInt},
+			"date_int": tsYMD,
+			"host":     input.group,
+			"time_int": bson.M{"$gte": tsInt, "$lte": teInt},
 		}
 
 		return query
 	}
 
-	return bson.M{"di": 0}
+	return bson.M{"date_int": 0}
 
 }

--- a/app/statusDetail/statusDetailController.go
+++ b/app/statusDetail/statusDetailController.go
@@ -65,23 +65,9 @@ func List(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) 
 	input := InputParams{
 		urlValues.Get("start_time"),
 		urlValues.Get("end_time"),
-		urlValues.Get("vo"),
-		urlValues.Get("profile"),
+		urlValues.Get("job"),
 		urlValues.Get("group_type"),
 		group,
-	}
-
-	// Set default values
-	if len(input.profile) == 0 {
-		input.profile = "ch.cern.sam.ROC_CRITICAL"
-	}
-
-	if len(input.groupType) == 0 {
-		input.groupType = "site"
-	}
-
-	if len(input.vo) == 0 {
-		input.vo = "ops"
 	}
 
 	// Call authenticateTenant to check the api key and retrieve
@@ -104,7 +90,7 @@ func List(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) 
 	c := session.DB(tenantDbConfig.Db).C("status_metric")
 	pc := session.DB(tenantDbConfig.Db).C("metric_profiles")
 
-	err = pc.Find(bson.M{"p": input.profile}).All(&metricResults)
+	err = pc.Find(bson.M{"p": input.job}).All(&metricResults)
 	err = c.Find(prepQuery(input)).All(&results)
 
 	mongo.CloseSession(session)

--- a/app/statusDetail/statusDetailController.go
+++ b/app/statusDetail/statusDetailController.go
@@ -177,8 +177,9 @@ func prepQuery(input InputParams, selectedGroupType string) bson.M {
 		}
 
 		return query
+	}
 
-	} else if selectedGroupType == "group" {
+	if selectedGroupType == "group" {
 
 		query := bson.M{
 			"job":        input.job,
@@ -188,8 +189,9 @@ func prepQuery(input InputParams, selectedGroupType string) bson.M {
 		}
 
 		return query
+	}
 
-	} else if input.groupType == "host" {
+	if input.groupType == "host" {
 		query := bson.M{
 			"job":      input.job,
 			"date_int": tsYMD,

--- a/app/statusDetail/statusDetailController.go
+++ b/app/statusDetail/statusDetailController.go
@@ -86,7 +86,7 @@ func List(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) 
 
 	// Structure to hold job information
 	jobResult := jobs.Job{}
-	metricProfileResults := metricProfiles.MongoInterface{}
+	metricProfileResult := metricProfiles.MongoInterface{}
 
 	// Mongo Session
 	results := []DataOutput{}
@@ -97,12 +97,17 @@ func List(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) 
 
 	metricCol := session.DB(tenantDbConfig.Db).C("status_metric")
 	jobCol := session.DB(tenantDbConfig.Db).C("jobs")
-
+	profileCol := session.DB(tenantDbConfig.Db).C("metric_profiles")
+	// Get Job details
 	err = jobCol.Find(bson.M{"name": input.job}).One(&jobResult)
+	// Search for metric profile
+	metricProfileName := ""
+	metricProfileName, err = jobs.GetMetricProfile(jobResult)
 
+	err = profileCol.Find(bson.M{"name": metricProfileName}).One(&metricProfileResult)
 	err = metricCol.Find(prepQuery(input, selectedGroupType)).All(&results)
 
-	output, err = createView(results, input, metricProfileResults) //Render the results into XML format
+	output, err = createView(results, input, metricProfileResult) //Render the results into XML format
 	//if strings.ToLower(input.format) == "json" {
 	//	contentType = "application/json"
 	//}

--- a/app/statusDetail/statusDetailController.go
+++ b/app/statusDetail/statusDetailController.go
@@ -102,6 +102,7 @@ func List(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) 
 	// Get Job details
 	err = jobCol.Find(bson.M{"name": input.job}).One(&jobResult)
 	if err != nil {
+		output = []byte("Error on retrieving job information")
 		code = http.StatusInternalServerError
 		return code, h, output, err
 	}
@@ -113,6 +114,8 @@ func List(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) 
 	// Query details for the metric profile used
 	err = profileCol.Find(bson.M{"name": metricProfileName}).One(&metricProfileResult)
 	if err != nil {
+
+		output = []byte("Error on retrieving metric profile information")
 		code = http.StatusInternalServerError
 		return code, h, output, err
 	}

--- a/app/statusDetail/statusDetailModel.go
+++ b/app/statusDetail/statusDetailModel.go
@@ -64,41 +64,41 @@ type MetricDetailOutput struct {
 // ReadRoot struct used as xml block
 type ReadRoot struct {
 	XMLName xml.Name `xml:"root"`
-	Job     *Job
+	Job     *JobXML
 }
 
-// Job struct used as xml block
-type Job struct {
+// JobXML struct used as xml block
+type JobXML struct {
 	XMLName xml.Name `xml:"job"`
 	Name    string   `xml:"name,attr"`
-	Groups  []*Group
+	Groups  []*GroupXML
 }
 
-// Group struct used as xml block
-type Group struct {
+// GroupXML struct used as xml block
+type GroupXML struct {
 	XMLName xml.Name `xml:"group"`
 	Name    string   `xml:"name,attr"`
 	Type    string   `xml:"type,attr"`
-	Groups  []*Group
-	Hosts   []*Host
+	Groups  []*GroupXML
+	Hosts   []*HostXML
 }
 
-// Host struct used as xml block
-type Host struct {
+// HostXML struct used as xml block
+type HostXML struct {
 	XMLName xml.Name `xml:"host"`
 	Name    string   `xml:"name,attr"`
-	Metrics []*Metric
+	Metrics []*MetricXML
 }
 
-// Metric struct used as xml block
-type Metric struct {
+// MetricXML struct used as xml block
+type MetricXML struct {
 	XMLName  xml.Name `xml:"metric"`
 	Name     string   `xml:"name,attr"`
-	Timeline []*Status
+	Timeline []*StatusXML
 }
 
-// Status struct used as xml block
-type Status struct {
+// StatusXML struct used as xml block
+type StatusXML struct {
 	XMLName   xml.Name `xml:"status"`
 	Timestamp string   `xml:"timestamp,attr"`
 	Status    string   `xml:"status,attr"`

--- a/app/statusDetail/statusDetailModel.go
+++ b/app/statusDetail/statusDetailModel.go
@@ -41,7 +41,7 @@ type InputParams struct {
 type DataOutput struct {
 	Job               string `bson:"job"`
 	Timestamp         string `bson:"timestamp"`
-	Group             string `bson:"group"`
+	Group             string `bson:"supergroup"`
 	EndpointGroup     string `bson:"endpoint_group"`
 	GroupType         string `bson:"group_type"`
 	EndpointGroupType string `bson:"endpoint_group_type"`
@@ -102,4 +102,10 @@ type StatusXML struct {
 	XMLName   xml.Name `xml:"status"`
 	Timestamp string   `xml:"timestamp,attr"`
 	Status    string   `xml:"status,attr"`
+}
+
+// Message struct to hold the xml response
+type Message struct {
+	XMLName xml.Name `xml:"root"`
+	Message string
 }

--- a/app/statusDetail/statusDetailModel.go
+++ b/app/statusDetail/statusDetailModel.go
@@ -28,44 +28,51 @@ package statusDetail
 
 import "encoding/xml"
 
-type StatusDetailInput struct {
-	start_time string // UTC time in W3C format
-	end_time   string
-	vo         string
-	profile    string
-	group_type string
-	group      string
+// InputParams struct holds as input all the url params of the request
+type InputParams struct {
+	startTime string // UTC time in W3C format
+	endTime   string
+	vo        string
+	profile   string
+	groupType string
+	group     string
 }
 
-type StatusDetailOutput struct {
-	Timestamp   string `bson:"ts"`
-	Roc         string `bson:"roc"`
-	Site        string `bson:"site"`
-	Service     string `bson:"srv"`
-	Hostname    string `bson:"h"`
-	Metric      string `bson:"m"`
-	Status      string `bson:"s"`
-	Time_int    int    `bson:"ti"`
-	P_status    string `bson:"ps"`
-	P_timestamp string `bson:"pts"`
+// DataOutput struct holds the queried data from datastore
+type DataOutput struct {
+	Timestamp  string `bson:"ts"`
+	Roc        string `bson:"roc"`
+	Site       string `bson:"site"`
+	Service    string `bson:"srv"`
+	Hostname   string `bson:"h"`
+	Metric     string `bson:"m"`
+	Status     string `bson:"s"`
+	TimeInt    int    `bson:"ti"`
+	PStatus    string `bson:"ps"`
+	PTimestamp string `bson:"pts"`
 }
 
-type PoemDetailOutput struct {
+// MetricDetailOutput struct holds metric profile data
+// from secondary collection
+type MetricDetailOutput struct {
 	Service string `bson:"s"`
 	Metric  string `bson:"m"`
 }
 
+// ReadRoot struct used as xml block
 type ReadRoot struct {
 	XMLName xml.Name `xml:"root"`
 	Profile *Profile
 }
 
+// Profile struct used as xml block
 type Profile struct {
 	XMLName xml.Name `xml:"profile"`
 	Name    string   `xml:"name,attr"`
 	Groups  []*Group
 }
 
+// Group struct used as xml block
 type Group struct {
 	XMLName xml.Name `xml:"group"`
 	Name    string   `xml:"name,attr"`
@@ -74,18 +81,21 @@ type Group struct {
 	Hosts   []*Host
 }
 
+// Host struct used as xml block
 type Host struct {
 	XMLName xml.Name `xml:"host"`
 	Name    string   `xml:"name,attr"`
 	Metrics []*Metric
 }
 
+// Metric struct used as xml block
 type Metric struct {
 	XMLName  xml.Name `xml:"metric"`
 	Name     string   `xml:"name,attr"`
 	Timeline []*Status
 }
 
+// Status struct used as xml block
 type Status struct {
 	XMLName   xml.Name `xml:"status"`
 	Timestamp string   `xml:"timestamp,attr"`

--- a/app/statusDetail/statusDetailModel.go
+++ b/app/statusDetail/statusDetailModel.go
@@ -32,24 +32,26 @@ import "encoding/xml"
 type InputParams struct {
 	startTime string // UTC time in W3C format
 	endTime   string
-	vo        string
-	profile   string
+	job       string
 	groupType string
 	group     string
 }
 
 // DataOutput struct holds the queried data from datastore
 type DataOutput struct {
-	Timestamp  string `bson:"ts"`
-	Roc        string `bson:"roc"`
-	Site       string `bson:"site"`
-	Service    string `bson:"srv"`
-	Hostname   string `bson:"h"`
-	Metric     string `bson:"m"`
-	Status     string `bson:"s"`
-	TimeInt    int    `bson:"ti"`
-	PStatus    string `bson:"ps"`
-	PTimestamp string `bson:"pts"`
+	Job               string `bson:"job"`
+	Timestamp         string `bson:"timestamp"`
+	Group             string `bson:"group"`
+	EndpointGroup     string `bson:"endpoint_group"`
+	GroupType         string `bson:"group_type"`
+	EndpointGroupType string `bson:"endpoint_group_type"`
+	Service           string `bson:"service"`
+	Hostname          string `bson:"hostname"`
+	Metric            string `bson:"metric"`
+	Status            string `bson:"status"`
+	TimeInt           int    `bson:"time_int"`
+	PrevStatus        string `bson:"prev_status"`
+	PrevTimestamp     string `bson:"prev_timestamp"`
 }
 
 // MetricDetailOutput struct holds metric profile data
@@ -62,12 +64,12 @@ type MetricDetailOutput struct {
 // ReadRoot struct used as xml block
 type ReadRoot struct {
 	XMLName xml.Name `xml:"root"`
-	Profile *Profile
+	Job     *Job
 }
 
-// Profile struct used as xml block
-type Profile struct {
-	XMLName xml.Name `xml:"profile"`
+// Job struct used as xml block
+type Job struct {
+	XMLName xml.Name `xml:"job"`
 	Name    string   `xml:"name,attr"`
 	Groups  []*Group
 }

--- a/app/statusDetail/statusDetailView.go
+++ b/app/statusDetail/statusDetailView.go
@@ -28,6 +28,7 @@ package statusDetail
 
 import (
 	"encoding/xml"
+	"fmt"
 
 	"github.com/argoeu/argo-web-api/app/metricProfiles"
 )
@@ -129,16 +130,20 @@ func createView(results []DataOutput, input InputParams, metricDetail metricProf
 
 }
 
-func filterByProfile(stype string, metric string, metricDetail metricProfiles.MongoInterface) int {
+func filterByProfile(service string, metric string, metricDetail metricProfiles.MongoInterface) int {
+	fmt.Println(metricDetail.Services)
+	for _, serviceItem := range metricDetail.Services {
+		fmt.Println(serviceItem)
+		if serviceItem.Service == service {
 
-	// for _, item := range metricDetail {
-	//
-	// 	if item.Metric == metric {
-	// 		if item.Service == stype {
-	// 			return 0
-	// 		}
-	// 	}
-	// }
+			for _, metricItem := range serviceItem.Metrics {
+				fmt.Println(serviceItem, "", metricItem)
+				if metricItem == metric {
+					return 0
+				}
+			}
+		}
+	}
 
 	return 1
 

--- a/app/statusDetail/statusDetailView.go
+++ b/app/statusDetail/statusDetailView.go
@@ -26,9 +26,13 @@
 
 package statusDetail
 
-import "encoding/xml"
+import (
+	"encoding/xml"
 
-func createView(results []DataOutput, input InputParams, metricDetail []MetricDetailOutput) ([]byte, error) {
+	"github.com/argoeu/argo-web-api/app/metricProfiles"
+)
+
+func createView(results []DataOutput, input InputParams, metricDetail metricProfiles.MongoInterface) ([]byte, error) {
 
 	docRoot := &ReadRoot{}
 
@@ -37,7 +41,7 @@ func createView(results []DataOutput, input InputParams, metricDetail []MetricDe
 		return output, err
 	}
 
-	job := &Job{}
+	job := &JobXML{}
 	job.Name = input.job
 
 	prevHostname := ""
@@ -46,11 +50,11 @@ func createView(results []DataOutput, input InputParams, metricDetail []MetricDe
 	prevGroup := ""
 	prevService := ""
 
-	var ppHost *Host
-	var ppMetric *Metric
-	var ppEndpointGroup *Group
-	var ppGroup *Group
-	var ppService *Group
+	var ppHost *HostXML
+	var ppMetric *MetricXML
+	var ppEndpointGroup *GroupXML
+	var ppGroup *GroupXML
+	var ppService *GroupXML
 
 	for _, row := range results {
 
@@ -59,7 +63,7 @@ func createView(results []DataOutput, input InputParams, metricDetail []MetricDe
 		}
 
 		if row.Group != prevGroup && row.Group != "" {
-			group := &Group{}
+			group := &GroupXML{}
 			group.Name = row.Group
 			group.Type = row.GroupType
 			job.Groups = append(job.Groups, group)
@@ -68,7 +72,7 @@ func createView(results []DataOutput, input InputParams, metricDetail []MetricDe
 		}
 
 		if row.EndpointGroup != prevEndpointGroup && row.EndpointGroup != "" {
-			endpointGroup := &Group{}
+			endpointGroup := &GroupXML{}
 			endpointGroup.Name = row.EndpointGroup
 			endpointGroup.Type = row.EndpointGroupType
 			ppGroup.Groups = append(ppGroup.Groups, endpointGroup)
@@ -77,7 +81,7 @@ func createView(results []DataOutput, input InputParams, metricDetail []MetricDe
 		}
 
 		if row.Service != prevService && row.Service != "" {
-			service := &Group{}
+			service := &GroupXML{}
 			service.Name = row.Service
 			service.Type = "service_type"
 			ppEndpointGroup.Groups = append(ppEndpointGroup.Groups, service)
@@ -87,7 +91,7 @@ func createView(results []DataOutput, input InputParams, metricDetail []MetricDe
 		}
 
 		if row.Hostname != prevHostname && row.Hostname != "" {
-			host := &Host{} //create new host
+			host := &HostXML{} //create new host
 			host.Name = row.Hostname
 			ppService.Hosts = append(ppService.Hosts, host)
 			prevHostname = row.Hostname
@@ -96,7 +100,7 @@ func createView(results []DataOutput, input InputParams, metricDetail []MetricDe
 
 		if row.Metric != prevMetric {
 
-			metric := &Metric{}
+			metric := &MetricXML{}
 			//Add the prev status as the firstone
 
 			metric.Name = row.Metric
@@ -104,13 +108,13 @@ func createView(results []DataOutput, input InputParams, metricDetail []MetricDe
 			prevMetric = row.Metric
 			ppMetric = metric
 
-			status := &Status{}
+			status := &StatusXML{}
 			status.Timestamp = row.PrevTimestamp
 			status.Status = row.PrevStatus
 			ppMetric.Timeline = append(ppMetric.Timeline, status)
 
 		} else {
-			status := &Status{}
+			status := &StatusXML{}
 			status.Timestamp = row.Timestamp
 			status.Status = row.Status
 			ppMetric.Timeline = append(ppMetric.Timeline, status)
@@ -125,16 +129,16 @@ func createView(results []DataOutput, input InputParams, metricDetail []MetricDe
 
 }
 
-func filterByProfile(stype string, metric string, metricDetail []MetricDetailOutput) int {
+func filterByProfile(stype string, metric string, metricDetail metricProfiles.MongoInterface) int {
 
-	for _, item := range metricDetail {
-
-		if item.Metric == metric {
-			if item.Service == stype {
-				return 0
-			}
-		}
-	}
+	// for _, item := range metricDetail {
+	//
+	// 	if item.Metric == metric {
+	// 		if item.Service == stype {
+	// 			return 0
+	// 		}
+	// 	}
+	// }
 
 	return 1
 

--- a/app/statusDetail/statusDetailView.go
+++ b/app/statusDetail/statusDetailView.go
@@ -37,22 +37,19 @@ func createView(results []DataOutput, input InputParams, metricDetail []MetricDe
 		return output, err
 	}
 
-	profile := &Profile{}
-	profile.Name = input.profile
-	vo := &Group{}
-	vo.Type = "vo"
-	vo.Name = input.vo
+	job := &Job{}
+	job.Name = input.job
 
 	prevHostname := ""
 	prevMetric := ""
-	prevSite := ""
-	prevRoc := ""
+	prevEndpointGroup := ""
+	prevGroup := ""
 	prevService := ""
 
 	var ppHost *Host
 	var ppMetric *Metric
-	var ppSite *Group
-	var ppRoc *Group
+	var ppEndpointGroup *Group
+	var ppGroup *Group
 	var ppService *Group
 
 	for _, row := range results {
@@ -61,29 +58,29 @@ func createView(results []DataOutput, input InputParams, metricDetail []MetricDe
 			continue
 		}
 
-		if row.Roc != prevRoc && row.Roc != "" {
-			roc := &Group{}
-			roc.Name = row.Roc
-			roc.Type = "ngi"
-			vo.Groups = append(vo.Groups, roc)
-			prevRoc = roc.Name
-			ppRoc = roc
+		if row.Group != prevGroup && row.Group != "" {
+			group := &Group{}
+			group.Name = row.Group
+			group.Type = row.GroupType
+			job.Groups = append(job.Groups, group)
+			prevGroup = group.Name
+			ppGroup = group
 		}
 
-		if row.Site != prevSite && row.Site != "" {
-			site := &Group{}
-			site.Name = row.Site
-			site.Type = "site"
-			ppRoc.Groups = append(ppRoc.Groups, site)
-			prevSite = row.Site
-			ppSite = site
+		if row.EndpointGroup != prevEndpointGroup && row.EndpointGroup != "" {
+			endpointGroup := &Group{}
+			endpointGroup.Name = row.EndpointGroup
+			endpointGroup.Type = row.EndpointGroupType
+			ppGroup.Groups = append(ppGroup.Groups, endpointGroup)
+			prevEndpointGroup = row.EndpointGroup
+			ppEndpointGroup = endpointGroup
 		}
 
 		if row.Service != prevService && row.Service != "" {
 			service := &Group{}
 			service.Name = row.Service
 			service.Type = "service_type"
-			ppSite.Groups = append(ppSite.Groups, service)
+			ppEndpointGroup.Groups = append(ppEndpointGroup.Groups, service)
 
 			prevService = row.Service
 			ppService = service
@@ -108,8 +105,8 @@ func createView(results []DataOutput, input InputParams, metricDetail []MetricDe
 			ppMetric = metric
 
 			status := &Status{}
-			status.Timestamp = row.PTimestamp
-			status.Status = row.PStatus
+			status.Timestamp = row.PrevTimestamp
+			status.Status = row.PrevStatus
 			ppMetric.Timeline = append(ppMetric.Timeline, status)
 
 		} else {
@@ -121,8 +118,7 @@ func createView(results []DataOutput, input InputParams, metricDetail []MetricDe
 
 	}
 
-	profile.Groups = append(profile.Groups, vo)
-	docRoot.Profile = profile
+	docRoot.Job = job
 
 	output, err := xml.MarshalIndent(docRoot, " ", "  ")
 	return output, err

--- a/app/statusDetail/statusDetailView.go
+++ b/app/statusDetail/statusDetailView.go
@@ -60,6 +60,7 @@ func createView(results []DataOutput, input InputParams, metricDetail metricProf
 	for _, row := range results {
 
 		if filterByProfile(row.Service, row.Metric, metricDetail) == 1 {
+			fmt.Println("skipped", row.Service, row.Metric)
 			continue
 		}
 
@@ -130,14 +131,21 @@ func createView(results []DataOutput, input InputParams, metricDetail metricProf
 
 }
 
+func messageXML(answer string) ([]byte, error) {
+	docRoot := &Message{}
+	docRoot.Message = answer
+	output, err := xml.MarshalIndent(docRoot, " ", "  ")
+	return output, err
+}
+
 func filterByProfile(service string, metric string, metricDetail metricProfiles.MongoInterface) int {
-	fmt.Println(metricDetail.Services)
+
 	for _, serviceItem := range metricDetail.Services {
-		fmt.Println(serviceItem)
+
 		if serviceItem.Service == service {
 
 			for _, metricItem := range serviceItem.Metrics {
-				fmt.Println(serviceItem, "", metricItem)
+
 				if metricItem == metric {
 					return 0
 				}

--- a/app/statusDetail/statusDetailView.go
+++ b/app/statusDetail/statusDetailView.go
@@ -28,7 +28,6 @@ package statusDetail
 
 import (
 	"encoding/xml"
-	"fmt"
 
 	"github.com/argoeu/argo-web-api/app/metricProfiles"
 )
@@ -59,8 +58,8 @@ func createView(results []DataOutput, input InputParams, metricDetail metricProf
 
 	for _, row := range results {
 
+		// Filter row of metric result based on metric profile (check metric name and service type)
 		if filterByProfile(row.Service, row.Metric, metricDetail) == 1 {
-			fmt.Println("skipped", row.Service, row.Metric)
 			continue
 		}
 

--- a/app/statusDetail/statusDetail_test.go
+++ b/app/statusDetail/statusDetail_test.go
@@ -1,0 +1,251 @@
+/*
+ * Copyright (c) 2014 GRNET S.A., SRCE, IN2P3 CNRS Computing Centre
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS
+ * IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ *
+ * The views and conclusions contained in the software and
+ * documentation are those of the authors and should not be
+ * interpreted as representing official policies, either expressed
+ * or implied, of either GRNET S.A., SRCE or IN2P3 CNRS Computing
+ * Centre
+ *
+ * The work represented by this source file is partially funded by
+ * the EGI-InSPIRE project through the European Commission's 7th
+ * Framework Programme (contract # INFSO-RI-261323)
+ */
+
+package statusDetail
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"code.google.com/p/gcfg"
+	"github.com/argoeu/argo-web-api/utils/authentication"
+	"github.com/argoeu/argo-web-api/utils/config"
+	"github.com/argoeu/argo-web-api/utils/mongo"
+	"github.com/stretchr/testify/suite"
+	"labix.org/v2/mgo"
+	"labix.org/v2/mgo/bson"
+)
+
+// This is a util. suite struct used in tests (see pkg "testify")
+type StatusDetailTestSuite struct {
+	suite.Suite
+	cfg              config.Config
+	tenantDbConf     config.MongoConfig
+	respUnauthorized string
+	respBadJSON      string
+}
+
+// Setup the Test Environment
+// This function runs before any test and setups the environment
+// A test configuration object is instantiated using a reference
+// to testdb: argo_test_jobs. Also here is are instantiated some expected
+// xml response validation messages (authorization,crud responses).
+// Also the testdb is seeded with two jobs
+func (suite *StatusDetailTestSuite) SetupTest() {
+
+	const testConfig = `
+    [server]
+    bindip = ""
+    port = 8080
+    maxprocs = 4
+    cache = false
+    lrucache = 700000000
+    gzip = true
+    [mongodb]
+    host = "127.0.0.1"
+    port = 27017
+    db = "argotest_detail"
+`
+
+	_ = gcfg.ReadStringInto(&suite.cfg, testConfig)
+
+	suite.respBadJSON = " <root>\n" +
+		"   <Message>Malformated json input data</Message>\n </root>"
+
+	suite.respUnauthorized = "Unauthorized"
+
+	// Connect to mongo testdb
+	session, _ := mongo.OpenSession(suite.cfg.MongoDB)
+
+	// Add authentication token to mongo testdb
+	seedAuth := bson.M{"api_key": "S3CR3T"}
+	_ = mongo.Insert(session, suite.cfg.MongoDB.Db, "authentication", seedAuth)
+
+	// seed mongo
+	session, err := mgo.Dial(suite.cfg.MongoDB.Host)
+	if err != nil {
+		panic(err)
+	}
+	defer session.Close()
+
+	// seed a tenant to use
+	c := session.DB(suite.cfg.MongoDB.Db).C("tenants")
+	c.Insert(bson.M{
+		"name": "AVENGERS",
+		"db_conf": []bson.M{
+			bson.M{
+				"store":    "ar",
+				"server":   "localhost",
+				"port":     27017,
+				"database": "argotest_detail_db1",
+				"username": "admin",
+				"password": "3NCRYPT3D"},
+			bson.M{
+				"store":    "status",
+				"server":   "b.mongodb.org",
+				"port":     27017,
+				"database": "status_db",
+				"username": "admin",
+				"password": "3NCRYPT3D"},
+		},
+		"users": []bson.M{
+			bson.M{
+				"name":    "cap",
+				"email":   "cap@email.com",
+				"api_key": "C4PK3Y"},
+			bson.M{
+				"name":    "thor",
+				"email":   "thor@email.com",
+				"api_key": "TH0RK3Y"},
+		}})
+
+	// get dbconfiguration based on the tenant
+	// Prepare the request object
+	request, _ := http.NewRequest("GET", "", strings.NewReader(""))
+	// add the content-type header to application/json
+	request.Header.Set("Content-Type", "application/json;")
+	// add the authentication token which is seeded in testdb
+	request.Header.Set("x-api-key", "C4PK3Y")
+	// authenticate user's api key and find corresponding tenant
+	suite.tenantDbConf, err = authentication.AuthenticateTenant(request.Header, suite.cfg)
+
+	// Now seed the job DEFINITIONS
+	c = session.DB(suite.tenantDbConf.Db).C("jobs")
+	c.Insert(bson.M{
+		"name":            "Job_A",
+		"tenant":          "AVENGERS",
+		"endpoint_group":  "SITES",
+		"group_of_groups": "NGI",
+		"profiles": []bson.M{
+			bson.M{
+				"name":  "metric",
+				"value": "profile1"},
+			bson.M{
+				"name":  "ops",
+				"value": "profile2"},
+		},
+		"filter_tags": []bson.M{
+			bson.M{
+				"name":  "name1",
+				"value": "value1"},
+			bson.M{
+				"name":  "name2",
+				"value": "value2"},
+		}})
+
+	c.Insert(bson.M{
+		"name":            "Job_B",
+		"tenant":          "AVENGERS",
+		"endpoint_group":  "SITES",
+		"group_of_groups": "NGI",
+		"profiles": []bson.M{
+			bson.M{
+				"name":  "metric",
+				"value": "profile1"},
+			bson.M{
+				"name":  "ops",
+				"value": "profile2"},
+		},
+		"filter_tags": []bson.M{
+			bson.M{
+				"name":  "name1",
+				"value": "value1"},
+			bson.M{
+				"name":  "name2",
+				"value": "value2"},
+		}})
+
+	// Now seed metric data
+	// Now seed the job DEFINITIONS
+	c = session.DB(suite.tenantDbConf.Db).C("status_metric")
+	c.Insert(bson.M{
+		"job":                 "jobA",
+		"timestamp":           "2015-05-01T00:00:00Z",
+		"group":               "NGI_GRNET",
+		"endpoint_group":      "HG-03-AUTH",
+		"group_type":          "NGI",
+		"endpoint_group_type": "SITE",
+		"service":             "CREAM-CE",
+		"hostname":            "cream01.afroditi.gr",
+		"metric":              "metric.jobsumbit",
+		"status":              "OK",
+		"time_int":            "0",
+		"prev_status":         "OK",
+		"prev_timestamp":      "2015-04-30T23:59:00Z",
+	})
+	c.Insert(bson.M{
+		"job":                 "jobA",
+		"timestamp":           "2015-05-01T01:00:00Z",
+		"group":               "NGI_GRNET",
+		"endpoint_group":      "HG-03-AUTH",
+		"group_type":          "NGI",
+		"endpoint_group_type": "SITE",
+		"service":             "CREAM-CE",
+		"hostname":            "cream01.afroditi.gr",
+		"metric":              "metric.jobsumbit",
+		"status":              "CRITICAL",
+		"time_int":            "10000",
+		"prev_status":         "OK",
+		"prev_timestamp":      "2015-05-01T00:00:00Z",
+	})
+	c.Insert(bson.M{
+		"job":                 "jobA",
+		"timestamp":           "2015-05-01T05:00:00Z",
+		"group":               "NGI_GRNET",
+		"endpoint_group":      "HG-03-AUTH",
+		"group_type":          "NGI",
+		"endpoint_group_type": "SITE",
+		"service":             "CREAM-CE",
+		"hostname":            "cream01.afroditi.gr",
+		"metric":              "metric.jobsumbit",
+		"status":              "OK",
+		"time_int":            "50000",
+		"prev_status":         "CRITICAL",
+		"prev_timestamp":      "2015-05-01T01:00:00Z",
+	})
+
+}
+
+func (suite *StatusDetailTestSuite) TestListStatusDetail() {
+
+}
+
+// This function is actually called in the end of all tests
+// and clears the test environment.
+// Mainly it's purpose is to drop the testdb
+func (suite *StatusDetailTestSuite) TearDownTest() {
+
+	session, _ := mongo.OpenSession(suite.cfg.MongoDB)
+
+	session.DB("argotest_detail").DropDatabase()
+	session.DB("argotest_detail_db1").DropDatabase()
+}
+
+// This is the first function called when go test is issued
+func TestJobsSuite(t *testing.T) {
+	suite.Run(t, new(StatusDetailTestSuite))
+}

--- a/app/statusDetail/statusDetail_test.go
+++ b/app/statusDetail/statusDetail_test.go
@@ -52,9 +52,9 @@ type StatusDetailTestSuite struct {
 // Setup the Test Environment
 // This function runs before any test and setups the environment
 // A test configuration object is instantiated using a reference
-// to testdb: argo_test_jobs. Also here is are instantiated some expected
+// to testdb: argo_test_details. Also here is are instantiated some expected
 // xml response validation messages (authorization,crud responses).
-// Also the testdb is seeded with two jobs
+// Also the testdb is seeded with tenants,jobs,metric_profiles and status_metrics
 func (suite *StatusDetailTestSuite) SetupTest() {
 
 	const testConfig = `
@@ -95,32 +95,39 @@ func (suite *StatusDetailTestSuite) SetupTest() {
 	// seed a tenant to use
 	c := session.DB(suite.cfg.MongoDB.Db).C("tenants")
 	c.Insert(bson.M{
-		"name": "AVENGERS",
+		"name": "EGI",
 		"db_conf": []bson.M{
 			bson.M{
-				"store":    "ar",
+				"store":    "main",
 				"server":   "localhost",
 				"port":     27017,
-				"database": "argotest_detail_db1",
-				"username": "admin",
-				"password": "3NCRYPT3D"},
-			bson.M{
-				"store":    "status",
-				"server":   "b.mongodb.org",
-				"port":     27017,
-				"database": "status_db",
-				"username": "admin",
-				"password": "3NCRYPT3D"},
+				"database": "argotest_detail_egi",
+				"username": "",
+				"password": ""},
 		},
 		"users": []bson.M{
 			bson.M{
-				"name":    "cap",
-				"email":   "cap@email.com",
-				"api_key": "C4PK3Y"},
+				"name":    "egi_user",
+				"email":   "egi_user@email.com",
+				"api_key": "KEY1"},
+		}})
+
+	c.Insert(bson.M{
+		"name": "EUDAT",
+		"db_conf": []bson.M{
 			bson.M{
-				"name":    "thor",
-				"email":   "thor@email.com",
-				"api_key": "TH0RK3Y"},
+				"store":    "main",
+				"server":   "localhost",
+				"port":     27017,
+				"database": "argotest_detail_eudat",
+				"username": "",
+				"password": ""},
+		},
+		"users": []bson.M{
+			bson.M{
+				"name":    "eudat_user",
+				"email":   "eudat_user@email.com",
+				"api_key": "KEY2"},
 		}})
 
 	// get dbconfiguration based on the tenant
@@ -129,24 +136,21 @@ func (suite *StatusDetailTestSuite) SetupTest() {
 	// add the content-type header to application/json
 	request.Header.Set("Content-Type", "application/json;")
 	// add the authentication token which is seeded in testdb
-	request.Header.Set("x-api-key", "C4PK3Y")
+	request.Header.Set("x-api-key", "KEY1")
 	// authenticate user's api key and find corresponding tenant
 	suite.tenantDbConf, err = authentication.AuthenticateTenant(request.Header, suite.cfg)
 
 	// Now seed the job DEFINITIONS
 	c = session.DB(suite.tenantDbConf.Db).C("jobs")
 	c.Insert(bson.M{
-		"name":            "Job_A",
-		"tenant":          "AVENGERS",
+		"name":            "ROC_CRITICAL",
+		"tenant":          "EGI",
 		"endpoint_group":  "SITES",
 		"group_of_groups": "NGI",
 		"profiles": []bson.M{
 			bson.M{
 				"name":  "metric",
-				"value": "profile1"},
-			bson.M{
-				"name":  "ops",
-				"value": "profile2"},
+				"value": "ch.cern.sam.ROC_CRITICAL"},
 		},
 		"filter_tags": []bson.M{
 			bson.M{
@@ -157,80 +161,218 @@ func (suite *StatusDetailTestSuite) SetupTest() {
 				"value": "value2"},
 		}})
 
-	c.Insert(bson.M{
-		"name":            "Job_B",
-		"tenant":          "AVENGERS",
-		"endpoint_group":  "SITES",
-		"group_of_groups": "NGI",
-		"profiles": []bson.M{
-			bson.M{
-				"name":  "metric",
-				"value": "profile1"},
-			bson.M{
-				"name":  "ops",
-				"value": "profile2"},
-		},
-		"filter_tags": []bson.M{
-			bson.M{
-				"name":  "name1",
-				"value": "value1"},
-			bson.M{
-				"name":  "name2",
-				"value": "value2"},
-		}})
+	// Now seed the metric_profiles
+	c = session.DB(suite.tenantDbConf.Db).C("metric_profiles")
+	c.Insert(
+		bson.M{
+			"name": "ch.cern.SAM.ROC_CRITICAL",
+			"services": []bson.M{
+				bson.M{"service": "CREAM-CE",
+					"metrics": []string{
+						"emi.cream.CREAMCE-JobSubmit",
+						"emi.wn.WN-Bi",
+						"emi.wn.WN-Csh",
+						"emi.wn.WN-SoftVer"},
+				},
+				bson.M{"service": "SRMv2",
+					"metrics": []string{"hr.srce.SRM2-CertLifetime",
+						"org.sam.SRM-Del",
+						"org.sam.SRM-Get",
+						"org.sam.SRM-GetSURLs",
+						"org.sam.SRM-GetTURLs",
+						"org.sam.SRM-Ls",
+						"org.sam.SRM-LsDir",
+						"org.sam.SRM-Put"},
+				},
+			},
+		})
 
-	// Now seed metric data
-	// Now seed the job DEFINITIONS
+	// seed the status detailed metric data
 	c = session.DB(suite.tenantDbConf.Db).C("status_metric")
 	c.Insert(bson.M{
-		"job":                 "jobA",
+		"job":                 "ROC_CRITICAL",
+		"date_int":            20150501,
 		"timestamp":           "2015-05-01T00:00:00Z",
-		"group":               "NGI_GRNET",
+		"supergroup":          "NGI_GRNET",
 		"endpoint_group":      "HG-03-AUTH",
 		"group_type":          "NGI",
-		"endpoint_group_type": "SITE",
+		"endpoint_group_type": "SITES",
 		"service":             "CREAM-CE",
 		"hostname":            "cream01.afroditi.gr",
-		"metric":              "metric.jobsumbit",
+		"metric":              "emi.cream.CREAMCE-JobSubmit",
 		"status":              "OK",
-		"time_int":            "0",
+		"time_int":            0,
 		"prev_status":         "OK",
 		"prev_timestamp":      "2015-04-30T23:59:00Z",
 	})
 	c.Insert(bson.M{
-		"job":                 "jobA",
+		"job":                 "ROC_CRITICAL",
+		"date_int":            20150501,
 		"timestamp":           "2015-05-01T01:00:00Z",
-		"group":               "NGI_GRNET",
+		"supergroup":          "NGI_GRNET",
 		"endpoint_group":      "HG-03-AUTH",
 		"group_type":          "NGI",
-		"endpoint_group_type": "SITE",
+		"endpoint_group_type": "SITES",
 		"service":             "CREAM-CE",
 		"hostname":            "cream01.afroditi.gr",
-		"metric":              "metric.jobsumbit",
+		"metric":              "emi.cream.CREAMCE-JobSubmit",
 		"status":              "CRITICAL",
-		"time_int":            "10000",
+		"time_int":            10000,
 		"prev_status":         "OK",
 		"prev_timestamp":      "2015-05-01T00:00:00Z",
 	})
 	c.Insert(bson.M{
-		"job":                 "jobA",
+		"job":                 "ROC_CRITICAL",
+		"date_int":            20150501,
 		"timestamp":           "2015-05-01T05:00:00Z",
-		"group":               "NGI_GRNET",
+		"supergroup":          "NGI_GRNET",
 		"endpoint_group":      "HG-03-AUTH",
 		"group_type":          "NGI",
-		"endpoint_group_type": "SITE",
+		"endpoint_group_type": "SITES",
 		"service":             "CREAM-CE",
 		"hostname":            "cream01.afroditi.gr",
-		"metric":              "metric.jobsumbit",
+		"metric":              "emi.cream.CREAMCE-JobSubmit",
 		"status":              "OK",
-		"time_int":            "50000",
+		"time_int":            50000,
+		"prev_status":         "CRITICAL",
+		"prev_timestamp":      "2015-05-01T01:00:00Z",
+	})
+
+	// get dbconfiguration based on the tenant
+	// Prepare the request object
+	request, _ = http.NewRequest("GET", "", strings.NewReader(""))
+	// add the content-type header to application/json
+	request.Header.Set("Content-Type", "application/json;")
+	// add the authentication token which is seeded in testdb
+	request.Header.Set("x-api-key", "KEY2")
+	// authenticate user's api key and find corresponding tenant
+	suite.tenantDbConf, err = authentication.AuthenticateTenant(request.Header, suite.cfg)
+
+	// Now seed the job DEFINITIONS
+	c = session.DB(suite.tenantDbConf.Db).C("jobs")
+	c.Insert(bson.M{
+		"name":            "EUDAT_CRITICAL",
+		"tenant":          "EUDAT",
+		"endpoint_group":  "EUDAT_SITE",
+		"group_of_groups": "EUDAT_GROUP",
+		"profiles": []bson.M{
+			bson.M{
+				"name":  "metric",
+				"value": "eudat.CRITICAL"},
+		},
+		"filter_tags": []bson.M{
+			bson.M{
+				"name":  "name1",
+				"value": "value1"},
+			bson.M{
+				"name":  "name2",
+				"value": "value2"},
+		}})
+
+	// Now seed the metric_profiles
+	c = session.DB(suite.tenantDbConf.Db).C("metric_profiles")
+	c.Insert(
+		bson.M{
+			"name": "eudat.CRITICAL",
+			"services": []bson.M{
+				bson.M{"service": "srv.typeA",
+					"metrics": []string{
+						"typeA.metric.Memory",
+						"typeA.metric.Disk"},
+				},
+				bson.M{"service": "srv.typeB",
+					"metrics": []string{
+						"typeB.metric.Memory",
+						"typeB.metric.Disk"},
+				},
+			},
+		})
+
+	// seed the status detailed metric data
+	c = session.DB(suite.tenantDbConf.Db).C("status_metric")
+	c.Insert(bson.M{
+		"job":                 "EUDAT_CRITICAL",
+		"date_int":            20150501,
+		"timestamp":           "2015-05-01T00:00:00Z",
+		"supergroup":          "EUDAT_EL",
+		"endpoint_group":      "EL-01-AUTH",
+		"group_type":          "EUDAT_GROUP",
+		"endpoint_group_type": "EUDAT_SITE",
+		"service":             "srv.typeA",
+		"hostname":            "host01.eudat.gr",
+		"metric":              "typeA.metric.Memory",
+		"status":              "OK",
+		"time_int":            0,
+		"prev_status":         "OK",
+		"prev_timestamp":      "2015-04-30T23:59:00Z",
+	})
+	c.Insert(bson.M{
+		"job":                 "EUDAT_CRITICAL",
+		"date_int":            20150501,
+		"timestamp":           "2015-05-01T01:00:00Z",
+		"supergroup":          "EUDAT_EL",
+		"endpoint_group":      "EL-01-AUTH",
+		"group_type":          "EUDAT_GROUP",
+		"endpoint_group_type": "EUDAT_SITE",
+		"service":             "srv.typeA",
+		"hostname":            "host01.eudat.gr",
+		"metric":              "typeA.metric.Memory",
+		"status":              "CRITICAL",
+		"time_int":            10000,
+		"prev_status":         "OK",
+		"prev_timestamp":      "2015-05-01T00:00:00Z",
+	})
+	c.Insert(bson.M{
+		"job":                 "EUDAT_CRITICAL",
+		"date_int":            20150501,
+		"timestamp":           "2015-05-01T05:00:00Z",
+		"supergroup":          "EUDAT_EL",
+		"endpoint_group":      "EL-01-AUTH",
+		"group_type":          "EUDAT_GROUP",
+		"endpoint_group_type": "EUDAT_SITE",
+		"service":             "srv.typeA",
+		"hostname":            "host01.eudat.gr",
+		"metric":              "typeA.metric.Memory",
+		"status":              "OK",
+		"time_int":            50000,
 		"prev_status":         "CRITICAL",
 		"prev_timestamp":      "2015-05-01T01:00:00Z",
 	})
 
 }
 
-func (suite *StatusDetailTestSuite) TestListStatusDetail() {
+func (suite *StatusDetailTestSuite) TestReadStatusDetail() {
+	respXML := ` <root>
+   <job name="EUDAT_CRITICAL">
+     <group name="EUDAT_EL" type="EUDAT_GROUP">
+       <group name="EL-01-AUTH" type="EUDAT_SITE">
+         <group name="srv.typeA" type="service_type">
+           <host name="host01.eudat.gr">
+             <metric name="typeA.metric.Memory">
+               <status timestamp="2015-04-30T23:59:00Z" status="OK"></status>
+               <status timestamp="2015-05-01T01:00:00Z" status="CRITICAL"></status>
+               <status timestamp="2015-05-01T05:00:00Z" status="OK"></status>
+             </metric>
+           </host>
+         </group>
+       </group>
+     </group>
+   </job>
+ </root>`
+	fullurl := "/api/v1/status/metrics/timeline/EUDAT_EL?" +
+		"group_type=EUDAT_GROUP&start_time=2015-05-01T00:00:00Z&end_time=2015-05-01T23:00:00Z&job=EUDAT_CRITICAL"
+	// Prepare the request object
+	request, _ := http.NewRequest("GET", fullurl, strings.NewReader(""))
+	// add the content-type header to application/json
+	request.Header.Set("Content-Type", "application/json;")
+	// add the authentication token which is seeded in testdb
+	request.Header.Set("x-api-key", "KEY2")
+	// Pass request to controller calling List() handler method
+	code, _, output, _ := List(request, suite.cfg)
+	// Check that we must have a 200 ok code
+	suite.Equal(200, code, "Internal Server Error")
+	// Compare the expected and actual xml response
+	suite.Equal(respXML, string(output), "Response body mismatch")
 
 }
 
@@ -242,7 +384,8 @@ func (suite *StatusDetailTestSuite) TearDownTest() {
 	session, _ := mongo.OpenSession(suite.cfg.MongoDB)
 
 	session.DB("argotest_detail").DropDatabase()
-	session.DB("argotest_detail_db1").DropDatabase()
+	session.DB("argotest_detail_eudat").DropDatabase()
+	session.DB("argotest_detail_egi").DropDatabase()
 }
 
 // This is the first function called when go test is issued


### PR DESCRIPTION
This request returns all the detailed status metric results
 - Multitenancy added based on api_key used
 - New parameter introduced: job (now results are produced by individual computational jobs and must retrieved by job name)
  - using only job name we can retrieve: 
    - grouping information used in this specific computational view (endpoint group,group_of_groups) 
    - metric profile used in this specific computational view

unittest provided using seed data for two tenants