### PR TITLE
[Proposed] Remove authGetSubrouter

### DIFF
--- a/main.go
+++ b/main.go
@@ -55,8 +55,7 @@ func main() {
 	//Create the server router
 	mainRouter := mux.NewRouter()
 	//SUBROUTER DEFINITIONS
-	getSubrouter := mainRouter.Methods("GET").Subrouter()                                //Routes GET requests
-	authGetSubrouter := mainRouter.Methods("GET").Headers("x-api-key", "").Subrouter()   //Routes GET requests with auth
+	getSubrouter := mainRouter.Methods("GET").Headers("x-api-key", "").Subrouter()       //Routes GET requests
 	postSubrouter := mainRouter.Methods("POST").Headers("x-api-key", "").Subrouter()     //Routes only POST requests
 	deleteSubrouter := mainRouter.Methods("DELETE").Headers("x-api-key", "").Subrouter() //Routes only DELETE requests
 	putSubrouter := mainRouter.Methods("PUT").Headers("x-api-key", "").Subrouter()       //Routes only PUT requests
@@ -108,7 +107,7 @@ func main() {
 	postSubrouter.HandleFunc("/api/v1/recomputations", Respond(recomputations.Create))
 	getSubrouter.HandleFunc("/api/v1/recomputations", Respond(recomputations.List))
 
-	authGetSubrouter.HandleFunc("/api/v1/factors", Respond(factors.List))
+	getSubrouter.HandleFunc("/api/v1/factors", Respond(factors.List))
 
 	//Status
 	getSubrouter.HandleFunc("/api/v1/status/metrics/timeline/{group}", Respond(statusDetail.List))
@@ -126,7 +125,7 @@ func main() {
 	getSubrouter.HandleFunc("/api/v1/status/sites/timeline/{group}", Respond(statusEndpointGroups.List))
 
 	//Tenants Operations
-	authGetSubrouter.HandleFunc("/api/v1/tenants", Respond(tenants.List))
+	getSubrouter.HandleFunc("/api/v1/tenants", Respond(tenants.List))
 
 	http.Handle("/", mainRouter)
 


### PR DESCRIPTION
- Removes the extra subrouter added temporarily in a previous sprint
- Makes `x-api-key` header compulsory for `GET` requests