### PR TITLE
ARGO-184 Update routing to cover new API signatures

### DIFF
--- a/init.go
+++ b/init.go
@@ -27,13 +27,14 @@
 package main
 
 import (
-	"github.com/argoeu/argo-web-api/utils/config"
-	"github.com/argoeu/go-lru-cache"
 	"log"
 	"os"
 	"os/signal"
 	"runtime"
 	"runtime/pprof"
+
+	"github.com/argoeu/argo-web-api/utils/config"
+	"github.com/argoeu/go-lru-cache"
 )
 
 var httpcache *cache.LRUCache

--- a/init.go
+++ b/init.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 GRNET S.A., SRCE, IN2P3 CNRS Computing Centre
+ * Copyright (c) 2015 GRNET S.A.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the

--- a/main.go
+++ b/main.go
@@ -30,103 +30,20 @@ import (
 	"crypto/tls"
 	"log"
 	"net/http"
+	"os"
 	"strconv"
 
-	"github.com/argoeu/argo-web-api/app/availabilityProfiles"
-	"github.com/argoeu/argo-web-api/app/endpointGroupAvailability"
-	"github.com/argoeu/argo-web-api/app/factors"
-	"github.com/argoeu/argo-web-api/app/groupGroupsAvailability"
-	"github.com/argoeu/argo-web-api/app/metricProfiles"
-	"github.com/argoeu/argo-web-api/app/recomputations"
-	"github.com/argoeu/argo-web-api/app/reports"
-	"github.com/argoeu/argo-web-api/app/serviceFlavorAvailability"
-	"github.com/argoeu/argo-web-api/app/statusDetail"
-	"github.com/argoeu/argo-web-api/app/statusEndpointGroups"
-	"github.com/argoeu/argo-web-api/app/statusEndpoints"
-	"github.com/argoeu/argo-web-api/app/statusMsg"
-	"github.com/argoeu/argo-web-api/app/statusServices"
-	"github.com/argoeu/argo-web-api/app/tenants"
-
-	"github.com/gorilla/mux"
+	"github.com/argoeu/argo-web-api/routing"
+	"github.com/gorilla/handlers"
 )
 
 func main() {
 
-	//Create the server router
-	mainRouter := mux.NewRouter()
-	//SUBROUTER DEFINITIONS
-	getSubrouter := mainRouter.Methods("GET").Subrouter()                                //Routes GET requests
-	authGetSubrouter := mainRouter.Methods("GET").Headers("x-api-key", "").Subrouter()   //Routes GET requests with auth
-	postSubrouter := mainRouter.Methods("POST").Headers("x-api-key", "").Subrouter()     //Routes only POST requests
-	deleteSubrouter := mainRouter.Methods("DELETE").Headers("x-api-key", "").Subrouter() //Routes only DELETE requests
-	putSubrouter := mainRouter.Methods("PUT").Headers("x-api-key", "").Subrouter()       //Routes only PUT requests
-	//All requests that modify data must provide with authentication credentials
-
-	// Grouping calls.
-	// Groups are routed depending on the value of the parameter group type.
-	// 2) Provide with a default call informing the user of an invalid parameter
-	getSubrouter.HandleFunc("/api/v1/group_availability", Respond(endpointGroupAvailability.List)).
-		Queries("group_type", "vo")
-
-	// Group of Groups availability
-	getSubrouter.HandleFunc("/api/v1/group_groups_availability", Respond(groupGroupsAvailability.List))
-	getSubrouter.HandleFunc("/api/v1/endpoint_group_availability", Respond(endpointGroupAvailability.List))
-
-	// Service Flavor Availability
-	getSubrouter.HandleFunc("/api/v1/service_flavor_availability", Respond(serviceFlavorAvailability.List))
-
-	//Availability Profiles
-	postSubrouter.HandleFunc("/api/v1/AP", Respond(availabilityProfiles.Create))
-	getSubrouter.HandleFunc("/api/v1/AP", Respond(availabilityProfiles.List))
-	putSubrouter.HandleFunc("/api/v1/AP/{id}", Respond(availabilityProfiles.Update))
-	deleteSubrouter.HandleFunc("/api/v1/AP/{id}", Respond(availabilityProfiles.Delete))
-
-	//tenants
-	postSubrouter.HandleFunc("/api/v1/tenants", Respond(tenants.Create))
-	putSubrouter.HandleFunc("/api/v1/tenants/{name}", Respond(tenants.Update))
-	deleteSubrouter.HandleFunc("/api/v1/tenants/{name}", Respond(tenants.Delete))
-	getSubrouter.HandleFunc("/api/v1/tenants", Respond(tenants.List))
-	getSubrouter.HandleFunc("/api/v1/tenants/{name}", Respond(tenants.ListOne))
-
-	//reports
-	postSubrouter.HandleFunc("/api/v1/reports", Respond(reports.Create))
-	putSubrouter.HandleFunc("/api/v1/reports/{name}", Respond(reports.Update))
-	deleteSubrouter.HandleFunc("/api/v1/reports/{name}", Respond(reports.Delete))
-	getSubrouter.HandleFunc("/api/v1/reports", Respond(reports.List))
-	getSubrouter.HandleFunc("/api/v1/reports/{name}", Respond(reports.ListOne))
-
-	//Poem Profiles compatibility
-	getSubrouter.HandleFunc("/api/v1/poems", Respond(metricProfiles.ListPoems))
-
-	//Metric Profiles
-	getSubrouter.HandleFunc("/api/v1/metric_profiles", Respond(metricProfiles.List))
-	postSubrouter.HandleFunc("/api/v1/metric_profiles", Respond(metricProfiles.Create))
-	deleteSubrouter.HandleFunc("/api/v1/metric_profiles/{id}", Respond(metricProfiles.Delete))
-	putSubrouter.HandleFunc("/api/v1/metric_profiles/{id}", Respond(metricProfiles.Update))
-
-	//Recalculations
-	postSubrouter.HandleFunc("/api/v1/recomputations", Respond(recomputations.Create))
-	getSubrouter.HandleFunc("/api/v1/recomputations", Respond(recomputations.List))
-
-	authGetSubrouter.HandleFunc("/api/v1/factors", Respond(factors.List))
-
-	//Status
-	getSubrouter.HandleFunc("/api/v1/status/metrics/timeline/{group}", Respond(statusDetail.List))
-
-	//Status Raw Msg
-	getSubrouter.HandleFunc("/api/v1/status/metrics/msg/{hostname}/{service}/{metric}", Respond(statusMsg.List))
-
-	//Status Endpoints
-	getSubrouter.HandleFunc("/api/v1/status/endpoints/timeline/{hostname}/{service_type}", Respond(statusEndpoints.List))
-
-	//Status Services
-	getSubrouter.HandleFunc("/api/v1/status/services/timeline/{group}", Respond(statusServices.List))
-
-	//Status Sites
-	getSubrouter.HandleFunc("/api/v1/status/sites/timeline/{group}", Respond(statusEndpointGroups.List))
-
-	//Tenants Operations
-	authGetSubrouter.HandleFunc("/api/v1/tenants", Respond(tenants.List))
+	//Create the server router and add the middleware
+	var mainRouter http.Handler
+	mainRouter = routing.NewRouter(cfg)
+	mainRouter = handlers.CombinedLoggingHandler(os.Stdout, mainRouter)
+	// mainRouter = handlers.CompressHandler(mainRouter)
 
 	http.Handle("/", mainRouter)
 

--- a/main.go
+++ b/main.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 GRNET S.A., SRCE, IN2P3 CNRS Computing Centre
+ * Copyright (c) 2015 GRNET S.A.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the

--- a/respond/respond.go
+++ b/respond/respond.go
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2014 GRNET S.A., SRCE, IN2P3 CNRS Computing Centre
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS
+ * IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ *
+ * The views and conclusions contained in the software and
+ * documentation are those of the authors and should not be
+ * interpreted as representing official policies, either expressed
+ * or implied, of either GRNET S.A., SRCE or IN2P3 CNRS Computing
+ * Centre
+ *
+ * The work represented by this source file is partially funded by
+ * the EGI-InSPIRE project through the European Commission's 7th
+ * Framework Programme (contract # INFSO-RI-261323)
+ */
+
+package respond
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/argoeu/argo-web-api/utils/caches"
+	"github.com/argoeu/argo-web-api/utils/config"
+	"github.com/argoeu/argo-web-api/utils/logging"
+	"github.com/gorilla/mux"
+)
+
+type list []interface{}
+
+const zuluForm = "2006-01-02T15:04:05Z"
+const ymdForm = "20060102"
+
+// ConfHandler Keeps all the configuration/variables required by all the requests
+type ConfHandler struct {
+	Config config.Config
+}
+
+// Respond will be called to answer to http requests to the PI
+func (confhandler *ConfHandler) Respond(fn func(r *http.Request, cfg config.Config) (int, http.Header, []byte, error)) http.HandlerFunc {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		defer func() {
+			if r := recover(); r != nil {
+				logging.HandleError(r)
+			}
+		}()
+		code, header, output, err := fn(r, confhandler.Config)
+
+		if code == http.StatusInternalServerError {
+			log.Panic("Internal Server Error:", err)
+		}
+
+		// TODO: Remove this after testing the gorilla handlers.CompressHandler middleware
+		// encoding := strings.Split(r.Header.Get("Accept-Encoding"), ",")[0] //get the first accepted encoding
+		// if (confhandler.Cfg.Server.Gzip) == true && r.Header.Get("Accept-Encoding") != "" {
+		// 	var b bytes.Buffer
+		// 	if encoding == "gzip" {
+		// 		writer := gzip.NewWriter(&b)
+		// 		writer.Write(output)
+		// 		writer.Close()
+		// 		w.Header().Set("Content-Encoding", "gzip")
+		//
+		// 	} else if encoding == "deflate" {
+		// 		writer := zlib.NewWriter(&b)
+		// 		writer.Write(output)
+		// 		writer.Close()
+		// 		w.Header().Set("Content-Encoding", "deflate")
+		// 	}
+		// 	output = b.Bytes()
+		// }
+
+		//Add headers
+		header.Set("Content-Length", fmt.Sprintf("%d", len(output)))
+
+		for name, values := range header {
+			for _, value := range values {
+				w.Header().Add(name, value)
+			}
+		}
+
+		w.WriteHeader(code)
+		w.Write(output)
+	})
+
+}
+
+func (confhandler *ConfHandler) walker(route *mux.Route, router *mux.Router, ancestors []*mux.Route) error {
+	// route.Handler(route.GetHandler())
+	return nil
+}
+
+// ResetCache resets the cache if it is set
+func ResetCache(w http.ResponseWriter, r *http.Request, cfg config.Config) []byte {
+	answer := ""
+	if cfg.Server.Cache == true {
+		caches.ResetCache()
+		answer = "Cache Emptied"
+	}
+	answer = "No Caching is active"
+	return []byte(answer)
+}

--- a/respond/respond.go
+++ b/respond/respond.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 GRNET S.A., SRCE, IN2P3 CNRS Computing Centre
+ * Copyright (c) 2015 GRNET S.A.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the
@@ -61,25 +61,6 @@ func (confhandler *ConfHandler) Respond(fn func(r *http.Request, cfg config.Conf
 		if code == http.StatusInternalServerError {
 			log.Panic("Internal Server Error:", err)
 		}
-
-		// TODO: Remove this after testing the gorilla handlers.CompressHandler middleware
-		// encoding := strings.Split(r.Header.Get("Accept-Encoding"), ",")[0] //get the first accepted encoding
-		// if (confhandler.Cfg.Server.Gzip) == true && r.Header.Get("Accept-Encoding") != "" {
-		// 	var b bytes.Buffer
-		// 	if encoding == "gzip" {
-		// 		writer := gzip.NewWriter(&b)
-		// 		writer.Write(output)
-		// 		writer.Close()
-		// 		w.Header().Set("Content-Encoding", "gzip")
-		//
-		// 	} else if encoding == "deflate" {
-		// 		writer := zlib.NewWriter(&b)
-		// 		writer.Write(output)
-		// 		writer.Close()
-		// 		w.Header().Set("Content-Encoding", "deflate")
-		// 	}
-		// 	output = b.Bytes()
-		// }
 
 		//Add headers
 		header.Set("Content-Length", fmt.Sprintf("%d", len(output)))

--- a/routing/router.go
+++ b/routing/router.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 GRNET S.A., SRCE, IN2P3 CNRS Computing Centre
+ * Copyright (c) 2015 GRNET S.A.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the
@@ -36,6 +36,7 @@ import (
 	"github.com/gorilla/mux"
 )
 
+// Route represents the old style routes
 type Route struct {
 	Name        string
 	Method      string
@@ -43,14 +44,12 @@ type Route struct {
 	HandlerFunc func(*http.Request, config.Config) (int, http.Header, []byte, error)
 }
 
+// Subrouter represents the new style of routes that are handled by each package respectively
 type SubRouter struct {
 	Name             string
 	Pattern          string
 	SubrouterHandler func(*mux.Router, *respond.ConfHandler)
 }
-
-type Routes []Route
-type SubRouters []SubRouter
 
 // NewRouter creates the main router that will be used by the api
 func NewRouter(cfg config.Config) *mux.Router {

--- a/routing/router.go
+++ b/routing/router.go
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2014 GRNET S.A., SRCE, IN2P3 CNRS Computing Centre
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS
+ * IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ *
+ * The views and conclusions contained in the software and
+ * documentation are those of the authors and should not be
+ * interpreted as representing official policies, either expressed
+ * or implied, of either GRNET S.A., SRCE or IN2P3 CNRS Computing
+ * Centre
+ *
+ * The work represented by this source file is partially funded by
+ * the EGI-InSPIRE project through the European Commission's 7th
+ * Framework Programme (contract # INFSO-RI-261323)
+ */
+
+package routing
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/argoeu/argo-web-api/respond"
+	"github.com/argoeu/argo-web-api/utils/config"
+
+	"github.com/gorilla/mux"
+)
+
+type Route struct {
+	Name        string
+	Method      string
+	Pattern     string
+	HandlerFunc func(*http.Request, config.Config) (int, http.Header, []byte, error)
+}
+
+type SubRouter struct {
+	Name             string
+	Pattern          string
+	SubrouterHandler func(*mux.Router, *respond.ConfHandler)
+}
+
+type Routes []Route
+type SubRouters []SubRouter
+
+// NewRouter creates the main router that will be used by the api
+func NewRouter(cfg config.Config) *mux.Router {
+
+	confhandler := respond.ConfHandler{Config: cfg}
+	router := mux.NewRouter().StrictSlash(true)
+	for _, route := range routes {
+
+		handler := confhandler.Respond(route.HandlerFunc)
+		router.
+			PathPrefix("/api/v1").
+			Methods(route.Method).
+			Path(route.Pattern).
+			Name(route.Name).
+			Handler(handler)
+	}
+
+	for _, subroute := range subroutes {
+		subrouter := router.
+			PathPrefix("/api/v2").
+			PathPrefix(subroute.Pattern).
+			Subrouter()
+		subroute.SubrouterHandler(subrouter, &confhandler)
+	}
+	// router.Walk(PrintRoutes)
+	return router
+}
+
+// PrintRoutes Attempts to print all register routes when called using mux.Router.Walk(PrintRoutes)
+func PrintRoutes(route *mux.Route, router *mux.Router, ancestors []*mux.Route) error {
+	url, _ := route.URL()
+	fmt.Println(route.GetName(), url)
+	return nil
+}

--- a/routing/routes.go
+++ b/routing/routes.go
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2014 GRNET S.A., SRCE, IN2P3 CNRS Computing Centre
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS
+ * IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ *
+ * The views and conclusions contained in the software and
+ * documentation are those of the authors and should not be
+ * interpreted as representing official policies, either expressed
+ * or implied, of either GRNET S.A., SRCE or IN2P3 CNRS Computing
+ * Centre
+ *
+ * The work represented by this source file is partially funded by
+ * the EGI-InSPIRE project through the European Commission's 7th
+ * Framework Programme (contract # INFSO-RI-261323)
+ */
+
+package routing
+
+import (
+	"github.com/argoeu/argo-web-api/app/availabilityProfiles"
+	"github.com/argoeu/argo-web-api/app/endpointGroupAvailability"
+	"github.com/argoeu/argo-web-api/app/factors"
+	"github.com/argoeu/argo-web-api/app/groupGroupsAvailability"
+	"github.com/argoeu/argo-web-api/app/jobs"
+	"github.com/argoeu/argo-web-api/app/metricProfiles"
+	"github.com/argoeu/argo-web-api/app/recomputations"
+	"github.com/argoeu/argo-web-api/app/results"
+	"github.com/argoeu/argo-web-api/app/serviceFlavorAvailability"
+	"github.com/argoeu/argo-web-api/app/statusDetail"
+	"github.com/argoeu/argo-web-api/app/statusEndpointGroups"
+	"github.com/argoeu/argo-web-api/app/statusEndpoints"
+	"github.com/argoeu/argo-web-api/app/statusMsg"
+	"github.com/argoeu/argo-web-api/app/statusServices"
+	"github.com/argoeu/argo-web-api/app/tenants"
+)
+
+var subroutes = SubRouters{
+	{"results", "/results", results.HandleSubrouter},
+}
+
+var routes = Routes{
+
+	//-----------------------------------Old requests for here on down -------------------------------------------------
+	{"group_availability", "GET", "/group_availability", endpointGroupAvailability.List},
+	{"group_groups_availability", "GET", "/group_groups_availability", groupGroupsAvailability.List},
+	{"endpoint_group_availability", "GET", "/endpoint_group_availability", endpointGroupAvailability.List},
+	{"service_flavor_availability", "GET", "/service_flavor_availability", serviceFlavorAvailability.List},
+	{"AP List", "GET", "/AP", availabilityProfiles.List},
+	{"AP Create", "POST", "/AP", availabilityProfiles.Create},
+	{"AP update", "PUT", "/AP/{id}", availabilityProfiles.Update},
+	{"AP delete", "DELETE", "/AP/{id}", availabilityProfiles.Delete},
+	{"PLACEHOLDER", "GET", "/service_flavor_availability", serviceFlavorAvailability.List},
+	{"tenant create", "GET", "/tenants", tenants.Create},
+	{"tenant update", "PUT", "/tenants/{name}", tenants.Update},
+	{"tenant delete", "DELETE", "/tenants/{name}", tenants.Delete},
+	{"tenant list", "GET", "/tenants", tenants.List},
+	{"tenant list one", "GET", "/tenants/{name}", tenants.ListOne},
+
+	//jobs
+	{"jobs create", "POST", "/jobs", jobs.Create},
+	{"job update", "PUT", "/jobs/{name}", jobs.Update},
+	{"job delete", "DELETE", "/jobs/{name}", jobs.Delete},
+	{"job list", "GET", "/jobs", jobs.List},
+	{"job list one", "GET", "/jobs/{name}", jobs.ListOne},
+
+	//Poem Profiles compatibility
+	{"List poems", "GET", "/poems", metricProfiles.ListPoems},
+
+	//Metric Profiles
+	{"list metric profile", "GET", "/metric_profiles", metricProfiles.List},
+	{"metric profile create", "POST", "/metric_profiles", metricProfiles.Create},
+	{"metric profile delete", "DELETE", "/metric_profiles/{id}", metricProfiles.Delete},
+	{"metric profile update", "PUT", "/metric_profiles/{id}", metricProfiles.Update},
+
+	//Recalculations
+	{"recomputation create", "POST", "/recomputations", recomputations.Create},
+	{"recomputation list", "GET", "/recomputations", recomputations.List},
+
+	{"factors list", "GET", "/factors", factors.List},
+
+	//Status
+	{"status detail list", "GET", "/status/metrics/timeline/{group}", statusDetail.List},
+
+	//Status Raw Msg
+	{"status message list", "GET", "/status/metrics/msg/{hostname}/{service}/{metric}", statusMsg.List},
+
+	//Status Endpoints
+	{"status endpoint list", "GET", "/status/endpoints/timeline/{hostname}/{service_type}", statusEndpoints.List},
+
+	//Status Services
+	{"status service list", "GET", "/status/services/timeline/{group}", statusServices.List},
+
+	//Status Sites
+	{"status endpoint group list", "GET", "/status/sites/timeline/{group}", statusEndpointGroups.List},
+}

--- a/routing/routes.go
+++ b/routing/routes.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 GRNET S.A., SRCE, IN2P3 CNRS Computing Centre
+ * Copyright (c) 2015 GRNET S.A.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the
@@ -31,10 +31,9 @@ import (
 	"github.com/argoeu/argo-web-api/app/endpointGroupAvailability"
 	"github.com/argoeu/argo-web-api/app/factors"
 	"github.com/argoeu/argo-web-api/app/groupGroupsAvailability"
-	"github.com/argoeu/argo-web-api/app/jobs"
 	"github.com/argoeu/argo-web-api/app/metricProfiles"
 	"github.com/argoeu/argo-web-api/app/recomputations"
-	"github.com/argoeu/argo-web-api/app/results"
+	"github.com/argoeu/argo-web-api/app/reports"
 	"github.com/argoeu/argo-web-api/app/serviceFlavorAvailability"
 	"github.com/argoeu/argo-web-api/app/statusDetail"
 	"github.com/argoeu/argo-web-api/app/statusEndpointGroups"
@@ -44,34 +43,32 @@ import (
 	"github.com/argoeu/argo-web-api/app/tenants"
 )
 
-var subroutes = SubRouters{
-	{"results", "/results", results.HandleSubrouter},
-}
+var subroutes = []SubRouter{}
 
-var routes = Routes{
+var routes = []Route{
 
 	//-----------------------------------Old requests for here on down -------------------------------------------------
-	{"group_availability", "GET", "/group_availability", endpointGroupAvailability.List},
-	{"group_groups_availability", "GET", "/group_groups_availability", groupGroupsAvailability.List},
-	{"endpoint_group_availability", "GET", "/endpoint_group_availability", endpointGroupAvailability.List},
-	{"service_flavor_availability", "GET", "/service_flavor_availability", serviceFlavorAvailability.List},
+	{"Group Availability", "GET", "/group_availability", endpointGroupAvailability.List},
+	{"Group Groups Availability", "GET", "/group_groups_availability", groupGroupsAvailability.List},
+	{"Endpoint Group Availability", "GET", "/endpoint_group_availability", endpointGroupAvailability.List},
+	{"Service flavor Availability", "GET", "/service_flavor_availability", serviceFlavorAvailability.List},
 	{"AP List", "GET", "/AP", availabilityProfiles.List},
 	{"AP Create", "POST", "/AP", availabilityProfiles.Create},
 	{"AP update", "PUT", "/AP/{id}", availabilityProfiles.Update},
 	{"AP delete", "DELETE", "/AP/{id}", availabilityProfiles.Delete},
-	{"PLACEHOLDER", "GET", "/service_flavor_availability", serviceFlavorAvailability.List},
-	{"tenant create", "GET", "/tenants", tenants.Create},
+	{"Service Falvor Availability", "GET", "/service_flavor_availability", serviceFlavorAvailability.List},
+	{"tenant create", "POST", "/tenants", tenants.Create},
 	{"tenant update", "PUT", "/tenants/{name}", tenants.Update},
 	{"tenant delete", "DELETE", "/tenants/{name}", tenants.Delete},
 	{"tenant list", "GET", "/tenants", tenants.List},
 	{"tenant list one", "GET", "/tenants/{name}", tenants.ListOne},
 
-	//jobs
-	{"jobs create", "POST", "/jobs", jobs.Create},
-	{"job update", "PUT", "/jobs/{name}", jobs.Update},
-	{"job delete", "DELETE", "/jobs/{name}", jobs.Delete},
-	{"job list", "GET", "/jobs", jobs.List},
-	{"job list one", "GET", "/jobs/{name}", jobs.ListOne},
+	//reports
+	{"reports create", "POST", "/reports", reports.Create},
+	{"job update", "PUT", "/reports/{name}", reports.Update},
+	{"job delete", "DELETE", "/reports/{name}", reports.Delete},
+	{"job list", "GET", "/reports", reports.List},
+	{"job list one", "GET", "/reports/{name}", reports.ListOne},
 
 	//Poem Profiles compatibility
 	{"List poems", "GET", "/poems", metricProfiles.ListPoems},

--- a/utils/caches/handleCache.go
+++ b/utils/caches/handleCache.go
@@ -28,6 +28,7 @@ package caches
 
 import (
 	"fmt"
+
 	"github.com/argoeu/argo-web-api/utils/config"
 	"github.com/argoeu/go-lru-cache"
 )
@@ -60,4 +61,8 @@ func WriteCache(name string, input interface{}, output interface{}, cfg config.C
 		httpcache.Set(name+fmt.Sprint(input), output.(mystring))
 	}
 	return true
+}
+
+func ResetCache() {
+	httpcache.Clear()
 }

--- a/utils/caches/handleCache.go
+++ b/utils/caches/handleCache.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 GRNET S.A., SRCE, IN2P3 CNRS Computing Centre
+ * Copyright (c) 2015 GRNET S.A.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the

--- a/utils/logging/logger.go
+++ b/utils/logging/logger.go
@@ -3,7 +3,6 @@ package logging
 import (
 	"log"
 	"net/http"
-	"time"
 )
 
 type RequestError struct {
@@ -13,22 +12,7 @@ type RequestError struct {
 	err    error
 }
 
-func Logger(inner http.Handler, name string) http.HandlerFunc {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		start := time.Now()
-
-		inner.ServeHTTP(w, r)
-
-		log.Printf(
-			"%s\t%s\t%s\t%s",
-			r.Method,
-			r.RequestURI,
-			name,
-			time.Since(start),
-		)
-	})
-}
-
+// HandleError accepts errors and logs the appropriate information
 func HandleError(reqErr interface{}) {
-
+	log.Printf("%s", reqErr.(error).Error())
 }

--- a/utils/logging/logger.go
+++ b/utils/logging/logger.go
@@ -1,0 +1,34 @@
+package logging
+
+import (
+	"log"
+	"net/http"
+	"time"
+)
+
+type RequestError struct {
+	code   int
+	header http.Header
+	output []byte
+	err    error
+}
+
+func Logger(inner http.Handler, name string) http.HandlerFunc {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+
+		inner.ServeHTTP(w, r)
+
+		log.Printf(
+			"%s\t%s\t%s\t%s",
+			r.Method,
+			r.RequestURI,
+			name,
+			time.Since(start),
+		)
+	})
+}
+
+func HandleError(reqErr interface{}) {
+
+}

--- a/utils/mongo/mongoQuery.go
+++ b/utils/mongo/mongoQuery.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 GRNET S.A., SRCE, IN2P3 CNRS Computing Centre
+ * Copyright (c) 2015 GRNET S.A.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the

--- a/utils/mongo/mongoQuery.go
+++ b/utils/mongo/mongoQuery.go
@@ -51,9 +51,21 @@ func Pipe(session *mgo.Session, dbName string, collectionName string, query []bs
 }
 
 func Find(session *mgo.Session, dbName string, collectionName string, query interface{}, sorter string, results interface{}) error {
-
 	c := openCollection(session, dbName, collectionName)
-	err := c.Find(query).Sort(sorter).All(results)
+	var err error
+	if sorter != "" {
+		err = c.Find(query).Sort(sorter).All(results)
+	} else {
+		err = c.Find(query).All(results)
+	}
+	return err
+}
+
+func FindOne(session *mgo.Session, dbName string, collectionName string, query interface{}, result interface{}) error {
+	c := openCollection(session, dbName, collectionName)
+	var err error
+	err = c.Find(query).One(result)
+
 	return err
 }
 


### PR DESCRIPTION
#### ARGO-184
- [x] Add a new route `/api/v2/...` for new requests 
- [x] Change the old routes `/api/v1/...` so they don't break with the change
- [x] Add support for middlewares
- [x] Add Compression and Logging middlewares by gorilla/handlers