### PR TITLE
Fixes make sources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,12 @@
 PKGNAME=argo-web-api
 SPECFILE=${PKGNAME}.spec
+SHELL=bash
 PKGVERSION = $(shell grep -s '^Version:' $(SPECFILE) | sed -e 's/Version: *//')
+TMPDIR := $(shell mktemp -d /tmp/${PKGNAME}.XXXXXXXXXX)
 
 sources:
-	mkdir -p ${PKGNAME}-${PKGVERSION}/src/github.com/ARGOeu/argo-web-api
-	cp -rp argo-web-api.conf app utils *.go ${PKGNAME}-${PKGVERSION}/src/github.com/ARGOeu/argo-web-api
-	cp ${SPECFILE} ${PKGNAME}-${PKGVERSION}/src/github.com/ARGOeu/argo-web-api
-	tar czf ${PKGNAME}-${PKGVERSION}.tar.gz ${PKGNAME}-${PKGVERSION}
-	rm -fr ${PKGNAME}-${PKGVERSION}
+	mkdir -p ${TMPDIR}/${PKGNAME}-${PKGVERSION}/src/github.com/ARGOeu/argo-web-api
+	cp -rp . ${TMPDIR}/${PKGNAME}-${PKGVERSION}/src/github.com/ARGOeu/argo-web-api
+	cd ${TMPDIR} && tar czf ${PKGNAME}-${PKGVERSION}.tar.gz ${PKGNAME}-${PKGVERSION}
+	mv ${TMPDIR}/${PKGNAME}-${PKGVERSION}.tar.gz .
+	if [[ ${TMPDIR} == /tmp* ]]; then rm -rf ${TMPDIR} ;fi


### PR DESCRIPTION
In the Makefile we specify the directories that will be included in
the tarball. This means that everytime we add a new directory we
have to update the Makefile.

Furthermore, the tarball does not include .git, which breaks the
building process when we attempt to build app.

With this fix we add all the files to the tarball.