### PR TITLE
[Proposed] Change host to endpoint in case of detailed result

### DIFF
--- a/app/metricResult/controller.go
+++ b/app/metricResult/controller.go
@@ -87,7 +87,7 @@ func GetMetricResult(r *http.Request, cfg config.Config) (int, http.Header, []by
 
 	result := metricResultOutput{}
 
-	metricCol := session.DB(tenantDbConfig.Db).C("status_metric")
+	metricCol := session.DB(tenantDbConfig.Db).C("status_metrics")
 
 	// Query the detailed metric results
 	err = metricCol.Find(prepQuery(input)).One(&result)

--- a/app/metricResult/metric_test.go
+++ b/app/metricResult/metric_test.go
@@ -129,7 +129,7 @@ func (suite *metricResultTestSuite) SetupTest() {
 	suite.tenantDbConf, err = authentication.AuthenticateTenant(request.Header, suite.cfg)
 
 	// seed the status detailed metric data
-	c = session.DB(suite.tenantDbConf.Db).C("status_metric")
+	c = session.DB(suite.tenantDbConf.Db).C("status_metrics")
 	c.Insert(bson.M{
 		"monitoring_box":     "nagios3.hellasgrid.gr",
 		"date_integer":       20150501,

--- a/app/statusMsg/statusMsgModel.go
+++ b/app/statusMsg/statusMsgModel.go
@@ -78,7 +78,7 @@ type GroupXML struct {
 
 // HostXML struct used as xml block
 type HostXML struct {
-	XMLName xml.Name `xml:"host"`
+	XMLName xml.Name `xml:"endpoint"`
 	Name    string   `xml:"name,attr"`
 	Metrics []*MetricXML
 }

--- a/app/statusMsg/statusMsg_test.go
+++ b/app/statusMsg/statusMsg_test.go
@@ -360,14 +360,14 @@ func (suite *StatusMsgTestSuite) TestReadStatusDetail() {
      <group name="EUDAT_EL" type="EUDAT_GROUP">
        <group name="EL-01-AUTH" type="EUDAT_SITE">
          <group name="srv.typeA" type="service_type">
-           <host name="host01.eudat.gr">
+           <endpoint name="host01.eudat.gr">
              <metric name="typeA.metric.Memory">
                <status timestamp="2015-05-01T01:00:00Z" status="">
                  <summary>srv.typeA status is critical</summary>
                  <message>memory error: Out of memory </message>
                </status>
              </metric>
-           </host>
+           </endpoint>
          </group>
        </group>
      </group>
@@ -379,14 +379,14 @@ func (suite *StatusMsgTestSuite) TestReadStatusDetail() {
      <group name="NGI_GRNET" type="NGI">
        <group name="HG-03-AUTH" type="SITES">
          <group name="CREAM-CE" type="service_type">
-           <host name="cream01.afroditi.gr">
+           <endpoint name="cream01.afroditi.gr">
              <metric name="emi.cream.CREAMCE-JobSubmit">
                <status timestamp="2015-05-01T01:00:00Z" status="">
                  <summary>Cream status is CRITICAL</summary>
                  <message>Cream job submission test failed</message>
                </status>
              </metric>
-           </host>
+           </endpoint>
          </group>
        </group>
      </group>

--- a/doc/api/status-results.md
+++ b/doc/api/status-results.md
@@ -531,14 +531,14 @@ Headers: `Status: 200 OK`
          <group name="NGI_GRNET" type="ngi">
            <group name="HG-03-AUTH" type="site">
              <group name="CREAM-CE" type="service_type">
-               <host name="cream01.afroditi.gr">
+               <endpoint name="cream01.afroditi.gr">
                  <metric name="emi.cream.CREAMCE-JobSubmit">
                    <status timestamp="2015-05-01T01:00:00Z" status="">
                      <summary>Cream status is CRITICAL</summary>
                      <message>Cream job submission test failed!</message>
                    </status>
                  </metric>
-               </host>
+               </endpoint>
              </group>
            </group>
          </group>


### PR DESCRIPTION
While working on ARGO-219 I noticed that in the case of one detailed result we name the host level in the xml response as host. This PR brings homogeneity with the remaining status (timelines) responses if we want it. To be exact the XML response is changed from:

```
 <root>
   <report name="EUDAT_CRITICAL">
     <group name="EUDAT_EL" type="EUDAT_GROUP">
       <group name="EL-01-AUTH" type="EUDAT_SITE">
         <group name="srv.typeA" type="service_type">
           <host name="host01.eudat.gr">
             <metric name="typeA.metric.Memory">
               <status timestamp="2015-05-01T01:00:00Z" status="">
                 <summary>srv.typeA status is critical</summary>
                 <message>memory error: Out of memory </message>
               </status>
             </metric>
           </host>
         </group>
       </group>
     </group>
   </report>
 </root>
```

to 

```
 <root>
   <report name="EUDAT_CRITICAL">
     <group name="EUDAT_EL" type="EUDAT_GROUP">
       <group name="EL-01-AUTH" type="EUDAT_SITE">
         <group name="srv.typeA" type="service_type">
           <endpoint name="host01.eudat.gr">
             <metric name="typeA.metric.Memory">
               <status timestamp="2015-05-01T01:00:00Z" status="">
                 <summary>srv.typeA status is critical</summary>
                 <message>memory error: Out of memory </message>
               </status>
             </metric>
           </endpoint>
         </group>
       </group>
     </group>
   </report>
 </root>
```