### PR TITLE
Disables extracting debug info

### DIFF
--- a/argo-web-api.spec
+++ b/argo-web-api.spec
@@ -1,3 +1,6 @@
+#debuginfo not supported with Go
+%global debug_package %{nil}
+
 Name: argo-web-api
 Summary: A/R API
 Version: 1.6.0


### PR DESCRIPTION
debuginfo is not supported in Go. When attempting to package the
argo-web-api as an RPM, the build process fails with the following
error:

*** ERROR: No build ID note found...