### PR TITLE
ARGO-245 Reference results using report.id instead of report.name

### DIFF
--- a/app/results/Controller.go
+++ b/app/results/Controller.go
@@ -123,9 +123,17 @@ func ListServiceFlavorResults(r *http.Request, cfg config.Config) (int, http.Hea
 	results := []ServiceFlavorInterface{}
 
 	// Construct the query to mongodb based on the input
+	reportID, err := mongo.GetReportID(session, tenantDbConfig.Db, vars["report_name"])
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
 	filter := bson.M{
+
 		"date":   bson.M{"$gte": input.StartTimeInt, "$lte": input.EndTimeInt},
-		"report": input.Report.Info.Name,
+		"report": reportID,
 	}
 
 	if input.Name != "" {
@@ -255,9 +263,17 @@ func ListEndpointGroupResults(r *http.Request, cfg config.Config) (int, http.Hea
 	results := []EndpointGroupInterface{}
 
 	// Construct the query to mongodb based on the input
+	reportID, err := mongo.GetReportID(session, tenantDbConfig.Db, vars["report_name"])
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
 	filter := bson.M{
+
 		"date":   bson.M{"$gte": input.StartTimeInt, "$lte": input.EndTimeInt},
-		"report": input.Report.Info.Name,
+		"report": reportID,
 	}
 
 	if input.Name != "" {
@@ -371,9 +387,17 @@ func ListSuperGroupResults(r *http.Request, cfg config.Config) (int, http.Header
 	results := []SuperGroupInterface{}
 
 	// Construct the query to mongodb based on the input
+	reportID, err := mongo.GetReportID(session, tenantDbConfig.Db, vars["report_name"])
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
 	filter := bson.M{
+
 		"date":   bson.M{"$gte": input.StartTimeInt, "$lte": input.EndTimeInt},
-		"report": input.Report.Info.Name,
+		"report": reportID,
 	}
 
 	if input.Name != "" {

--- a/app/results/endpointgroup_test.go
+++ b/app/results/endpointgroup_test.go
@@ -148,13 +148,14 @@ func (suite *endpointGroupAvailabilityTestSuite) SetupTest() {
 					"api_key": "itsamysterytoyou",
 				},
 			}})
-	// Seed database with recomputations
+
+	// Seed tenant database with data
 	c = session.DB(suite.tenantDbConf.Db).C("endpoint_group_ar")
 
 	// Insert seed data
 	c.Insert(
 		bson.M{
-			"report":       "Report_A",
+			"report":       "eba61a9e-22e9-4521-9e47-ecaa4a49436",
 			"date":         20150622,
 			"name":         "ST01",
 			"supergroup":   "GROUP_A",
@@ -172,7 +173,7 @@ func (suite *endpointGroupAvailabilityTestSuite) SetupTest() {
 			},
 		},
 		bson.M{
-			"report":       "Report_A",
+			"report":       "eba61a9e-22e9-4521-9e47-ecaa4a49436",
 			"date":         20150622,
 			"name":         "ST02",
 			"supergroup":   "GROUP_A",
@@ -190,7 +191,7 @@ func (suite *endpointGroupAvailabilityTestSuite) SetupTest() {
 			},
 		},
 		bson.M{
-			"report":       "Report_A",
+			"report":       "eba61a9e-22e9-4521-9e47-ecaa4a49436",
 			"date":         20150623,
 			"name":         "ST01",
 			"supergroup":   "GROUP_A",
@@ -208,7 +209,7 @@ func (suite *endpointGroupAvailabilityTestSuite) SetupTest() {
 			},
 		},
 		bson.M{
-			"report":       "Report_A",
+			"report":       "eba61a9e-22e9-4521-9e47-ecaa4a49436",
 			"date":         20150623,
 			"name":         "ST02",
 			"supergroup":   "GROUP_A",
@@ -229,6 +230,7 @@ func (suite *endpointGroupAvailabilityTestSuite) SetupTest() {
 	c = session.DB(suite.tenantDbConf.Db).C("reports")
 
 	c.Insert(bson.M{
+		"id": "eba61a9e-22e9-4521-9e47-ecaa4a49436",
 		"info": bson.M{
 			"name":        "Report_A",
 			"description": "lalalallala",
@@ -327,7 +329,6 @@ func (suite *endpointGroupAvailabilityTestSuite) TestListEndpointGroupAvailabili
 	suite.Equal(200, response.Code, "Incorrect HTTP response code")
 	// Compare the expected and actual xml response
 	suite.Equal(endpointGroupAvailabilityJSON, response.Body.String(), "Response body mismatch")
-
 	request, _ = http.NewRequest("GET", "/api/v2/results/Report_A/SITE/ST01?start_time=2015-06-20T12:00:00Z&end_time=2015-06-23T23:00:00Z", strings.NewReader(""))
 	request.Header.Set("x-api-key", "AWRONGKEY")
 	request.Header.Set("Accept", "application/xml")
@@ -344,6 +345,7 @@ func (suite *endpointGroupAvailabilityTestSuite) TestListEndpointGroupAvailabili
 	suite.Equal(401, response.Code, "Incorrect HTTP response code")
 	// Compare the expected and actual xml response
 	suite.Equal(unauthorizedresponseXML, response.Body.String(), "Response body mismatch")
+
 }
 
 // TestListAllEndpointGroupAvailability test if daily results are returned correctly

--- a/app/results/serviceflavor_test.go
+++ b/app/results/serviceflavor_test.go
@@ -154,7 +154,7 @@ func (suite *serviceFlavorAvailabilityTestSuite) SetupTest() {
 	// Insert seed data
 	c.Insert(
 		bson.M{
-			"report":       "Report_A",
+			"report":       "eba61a9e-22e9-4521-9e47-ecaa4a49436",
 			"date":         20150622,
 			"name":         "SF01",
 			"supergroup":   "ST01",
@@ -171,7 +171,7 @@ func (suite *serviceFlavorAvailabilityTestSuite) SetupTest() {
 			},
 		},
 		bson.M{
-			"report":       "Report_A",
+			"report":       "eba61a9e-22e9-4521-9e47-ecaa4a49436",
 			"date":         20150622,
 			"name":         "SF02",
 			"supergroup":   "ST01",
@@ -188,7 +188,7 @@ func (suite *serviceFlavorAvailabilityTestSuite) SetupTest() {
 			},
 		},
 		bson.M{
-			"report":       "Report_A",
+			"report":       "eba61a9e-22e9-4521-9e47-ecaa4a49436",
 			"date":         20150622,
 			"name":         "SF03",
 			"supergroup":   "ST02",
@@ -205,7 +205,7 @@ func (suite *serviceFlavorAvailabilityTestSuite) SetupTest() {
 			},
 		},
 		bson.M{
-			"report":       "Report_A",
+			"report":       "eba61a9e-22e9-4521-9e47-ecaa4a49436",
 			"date":         20150623,
 			"name":         "SF01",
 			"supergroup":   "ST01",
@@ -222,7 +222,7 @@ func (suite *serviceFlavorAvailabilityTestSuite) SetupTest() {
 			},
 		},
 		bson.M{
-			"report":       "Report_A",
+			"report":       "eba61a9e-22e9-4521-9e47-ecaa4a49436",
 			"date":         20150623,
 			"name":         "SF02",
 			"supergroup":   "ST01",
@@ -242,6 +242,7 @@ func (suite *serviceFlavorAvailabilityTestSuite) SetupTest() {
 	c = session.DB(suite.tenantDbConf.Db).C("reports")
 
 	c.Insert(bson.M{
+		"id": "eba61a9e-22e9-4521-9e47-ecaa4a49436",
 		"info": bson.M{
 			"name":        "Report_A",
 			"description": "lalalallala",

--- a/app/results/supergroup_test.go
+++ b/app/results/supergroup_test.go
@@ -166,7 +166,7 @@ func (suite *SuperGroupAvailabilityTestSuite) SetupTest() {
 	// Insert seed data
 	c.Insert(
 		bson.M{
-			"report":       "Report_A",
+			"report":       "eba61a9e-22e9-4521-9e47-ecaa4a49436",
 			"date":         20150622,
 			"name":         "ST01",
 			"supergroup":   "GROUP_A",
@@ -184,7 +184,7 @@ func (suite *SuperGroupAvailabilityTestSuite) SetupTest() {
 			},
 		},
 		bson.M{
-			"report":       "Report_A",
+			"report":       "eba61a9e-22e9-4521-9e47-ecaa4a49436",
 			"date":         20150622,
 			"name":         "ST02",
 			"supergroup":   "GROUP_A",
@@ -202,7 +202,7 @@ func (suite *SuperGroupAvailabilityTestSuite) SetupTest() {
 			},
 		},
 		bson.M{
-			"report":       "Report_A",
+			"report":       "eba61a9e-22e9-4521-9e47-ecaa4a49436",
 			"date":         20150623,
 			"name":         "ST01",
 			"supergroup":   "GROUP_A",
@@ -220,7 +220,7 @@ func (suite *SuperGroupAvailabilityTestSuite) SetupTest() {
 			},
 		},
 		bson.M{
-			"report":       "Report_A",
+			"report":       "eba61a9e-22e9-4521-9e47-ecaa4a49436",
 			"date":         20150623,
 			"name":         "ST04",
 			"supergroup":   "GROUP_B",
@@ -238,7 +238,7 @@ func (suite *SuperGroupAvailabilityTestSuite) SetupTest() {
 			},
 		},
 		bson.M{
-			"report":       "Report_A",
+			"report":       "eba61a9e-22e9-4521-9e47-ecaa4a49436",
 			"date":         20150623,
 			"name":         "ST05",
 			"supergroup":   "GROUP_B",
@@ -256,7 +256,7 @@ func (suite *SuperGroupAvailabilityTestSuite) SetupTest() {
 			},
 		},
 		bson.M{
-			"report":       "Report_A",
+			"report":       "eba61a9e-22e9-4521-9e47-ecaa4a49436",
 			"date":         20150624,
 			"name":         "ST05",
 			"supergroup":   "GROUP_B",
@@ -274,7 +274,7 @@ func (suite *SuperGroupAvailabilityTestSuite) SetupTest() {
 			},
 		},
 		bson.M{
-			"report":       "Report_A",
+			"report":       "eba61a9e-22e9-4521-9e47-ecaa4a49436",
 			"date":         20150625,
 			"name":         "ST05",
 			"supergroup":   "GROUP_B",
@@ -292,7 +292,7 @@ func (suite *SuperGroupAvailabilityTestSuite) SetupTest() {
 			},
 		},
 		bson.M{
-			"report":       "Report_A",
+			"report":       "eba61a9e-22e9-4521-9e47-ecaa4a49436",
 			"date":         20150623,
 			"name":         "ST02",
 			"supergroup":   "GROUP_A",
@@ -313,6 +313,7 @@ func (suite *SuperGroupAvailabilityTestSuite) SetupTest() {
 	c = session.DB(suite.tenantDbConf.Db).C("reports")
 
 	c.Insert(bson.M{
+		"id": "eba61a9e-22e9-4521-9e47-ecaa4a49436",
 		"info": bson.M{
 			"name":        "Report_A",
 			"description": "lalalallala",

--- a/app/statusEndpointGroups/statusEndpointGroups_test.go
+++ b/app/statusEndpointGroups/statusEndpointGroups_test.go
@@ -195,21 +195,21 @@ func (suite *StatusEndpointGroupsTestSuite) SetupTest() {
 	// seed the status detailed metric data
 	c = session.DB(suite.tenantDbConf.Db).C("status_endpoint_groups")
 	c.Insert(bson.M{
-		"report":         "Report_A",
+		"report":         "eba61a9e-22e9-4521-9e47-ecaa4a494364",
 		"date_integer":   20150501,
 		"timestamp":      "2015-05-01T00:00:00Z",
 		"endpoint_group": "HG-03-AUTH",
 		"status":         "OK",
 	})
 	c.Insert(bson.M{
-		"report":         "Report_A",
+		"report":         "eba61a9e-22e9-4521-9e47-ecaa4a494364",
 		"date_integer":   20150501,
 		"timestamp":      "2015-05-01T01:00:00Z",
 		"endpoint_group": "HG-03-AUTH",
 		"status":         "CRITICAL",
 	})
 	c.Insert(bson.M{
-		"report":         "Report_A",
+		"report":         "eba61a9e-22e9-4521-9e47-ecaa4a494364",
 		"date_integer":   20150501,
 		"timestamp":      "2015-05-01T05:00:00Z",
 		"endpoint_group": "HG-03-AUTH",
@@ -229,7 +229,7 @@ func (suite *StatusEndpointGroupsTestSuite) SetupTest() {
 	// Now seed the reports DEFINITIONS
 	c = session.DB(suite.tenantDbConf.Db).C("reports")
 	c.Insert(bson.M{
-		"id": "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"id": "eba61a9e-22e9-4521-9e47-ecaa4a494365",
 		"info": bson.M{
 			"name":        "Report_B",
 			"description": "report aaaaa",
@@ -270,21 +270,21 @@ func (suite *StatusEndpointGroupsTestSuite) SetupTest() {
 	// seed the status detailed metric data
 	c = session.DB(suite.tenantDbConf.Db).C("status_endpoint_groups")
 	c.Insert(bson.M{
-		"report":         "Report_B",
+		"report":         "eba61a9e-22e9-4521-9e47-ecaa4a494365",
 		"date_integer":   20150501,
 		"timestamp":      "2015-05-01T00:00:00Z",
 		"endpoint_group": "EL-01-AUTH",
 		"status":         "OK",
 	})
 	c.Insert(bson.M{
-		"report":         "Report_B",
+		"report":         "eba61a9e-22e9-4521-9e47-ecaa4a494365",
 		"date_integer":   20150501,
 		"timestamp":      "2015-05-01T01:00:00Z",
 		"endpoint_group": "EL-01-AUTH",
 		"status":         "CRITICAL",
 	})
 	c.Insert(bson.M{
-		"report":         "Report_B",
+		"report":         "eba61a9e-22e9-4521-9e47-ecaa4a494365",
 		"date_integer":   20150501,
 		"timestamp":      "2015-05-01T05:00:00Z",
 		"endpoint_group": "EL-01-AUTH",

--- a/app/statusEndpoints/controller.go
+++ b/app/statusEndpoints/controller.go
@@ -91,7 +91,14 @@ func ListEndpointTimelines(r *http.Request, cfg config.Config) (int, http.Header
 	metricCollection := session.DB(tenantDbConfig.Db).C("status_endpoints")
 
 	// Query the detailed metric results
-	err = metricCollection.Find(prepareQuery(input)).All(&results)
+	reportID, err := mongo.GetReportID(session, tenantDbConfig.Db, input.report)
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	err = metricCollection.Find(prepareQuery(input, reportID)).All(&results)
 	if err != nil {
 		code = http.StatusInternalServerError
 		return code, h, output, err
@@ -103,7 +110,7 @@ func ListEndpointTimelines(r *http.Request, cfg config.Config) (int, http.Header
 	return code, h, output, err
 }
 
-func prepareQuery(input InputParams) bson.M {
+func prepareQuery(input InputParams, reportID string) bson.M {
 
 	//Time Related
 	const zuluForm = "2006-01-02T15:04:05Z"
@@ -117,7 +124,7 @@ func prepareQuery(input InputParams) bson.M {
 	// prepare the match filter
 	filter := bson.M{
 		"date_integer":   bson.M{"$gte": tsYMD, "$lte": teYMD},
-		"report":         input.report,
+		"report":         reportID,
 		"endpoint_group": input.group,
 		"service":        input.service,
 	}

--- a/app/statusEndpoints/statusEndpoints_test.go
+++ b/app/statusEndpoints/statusEndpoints_test.go
@@ -171,15 +171,15 @@ func (suite *StatusEndpointsTestSuite) SetupTest() {
 		},
 		"profiles": []bson.M{
 			bson.M{
-				"id": "6ac7d684-1f8e-4a02-a502-720e8f11e50b",
+				"id":   "6ac7d684-1f8e-4a02-a502-720e8f11e50b",
 				"type": "metric",
 				"name": "profile1"},
 			bson.M{
-				"id": "6ac7d684-1f8e-4a02-a502-720e8f11e523",
+				"id":   "6ac7d684-1f8e-4a02-a502-720e8f11e523",
 				"type": "operations",
 				"name": "profile2"},
 			bson.M{
-				"id": "6ac7d684-1f8e-4a02-a502-720e8f11e50q",
+				"id":   "6ac7d684-1f8e-4a02-a502-720e8f11e50q",
 				"type": "aggregation",
 				"name": "profile3"},
 		},
@@ -194,7 +194,7 @@ func (suite *StatusEndpointsTestSuite) SetupTest() {
 	// seed the status detailed metric data
 	c = session.DB(suite.tenantDbConf.Db).C("status_endpoints")
 	c.Insert(bson.M{
-		"report":         "Report_A",
+		"report":         "eba61a9e-22e9-4521-9e47-ecaa4a494364",
 		"date_integer":   20150501,
 		"timestamp":      "2015-05-01T00:00:00Z",
 		"endpoint_group": "HG-03-AUTH",
@@ -204,7 +204,7 @@ func (suite *StatusEndpointsTestSuite) SetupTest() {
 		"status":         "OK",
 	})
 	c.Insert(bson.M{
-		"report":         "Report_A",
+		"report":         "eba61a9e-22e9-4521-9e47-ecaa4a494364",
 		"date_integer":   20150501,
 		"timestamp":      "2015-05-01T01:00:00Z",
 		"endpoint_group": "HG-03-AUTH",
@@ -214,7 +214,7 @@ func (suite *StatusEndpointsTestSuite) SetupTest() {
 		"status":         "CRITICAL",
 	})
 	c.Insert(bson.M{
-		"report":         "Report_A",
+		"report":         "eba61a9e-22e9-4521-9e47-ecaa4a494364",
 		"date_integer":   20150501,
 		"timestamp":      "2015-05-01T05:00:00Z",
 		"endpoint_group": "HG-03-AUTH",
@@ -237,7 +237,7 @@ func (suite *StatusEndpointsTestSuite) SetupTest() {
 	// Now seed the reports DEFINITIONS
 	c = session.DB(suite.tenantDbConf.Db).C("reports")
 	c.Insert(bson.M{
-		"id": "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"id": "eba61a9e-22e9-4521-9e47-ecaa4a494365",
 		"info": bson.M{
 			"name":        "Report_B",
 			"description": "report aaaaa",
@@ -254,15 +254,15 @@ func (suite *StatusEndpointsTestSuite) SetupTest() {
 		},
 		"profiles": []bson.M{
 			bson.M{
-				"id": "6ac7d684-1f8e-4a02-a502-720e8f11e50b",
+				"id":   "6ac7d684-1f8e-4a02-a502-720e8f11e50b",
 				"type": "metric",
 				"name": "eudat.CRITICAL"},
 			bson.M{
-				"id": "6ac7d684-1f8e-4a02-a502-720e8f11e523",
+				"id":   "6ac7d684-1f8e-4a02-a502-720e8f11e523",
 				"type": "operations",
 				"name": "profile2"},
 			bson.M{
-				"id": "6ac7d684-1f8e-4a02-a502-720e8f11e50q",
+				"id":   "6ac7d684-1f8e-4a02-a502-720e8f11e50q",
 				"type": "aggregation",
 				"name": "profile3"},
 		},
@@ -278,7 +278,7 @@ func (suite *StatusEndpointsTestSuite) SetupTest() {
 	// seed the status detailed metric data
 	c = session.DB(suite.tenantDbConf.Db).C("status_endpoints")
 	c.Insert(bson.M{
-		"report":         "Report_B",
+		"report":         "eba61a9e-22e9-4521-9e47-ecaa4a494365",
 		"date_integer":   20150501,
 		"timestamp":      "2015-05-01T00:00:00Z",
 		"endpoint_group": "EL-01-AUTH",
@@ -288,7 +288,7 @@ func (suite *StatusEndpointsTestSuite) SetupTest() {
 		"status":         "OK",
 	})
 	c.Insert(bson.M{
-		"report":         "Report_B",
+		"report":         "eba61a9e-22e9-4521-9e47-ecaa4a494365",
 		"date_integer":   20150501,
 		"timestamp":      "2015-05-01T01:00:00Z",
 		"endpoint_group": "EL-01-AUTH",
@@ -298,7 +298,7 @@ func (suite *StatusEndpointsTestSuite) SetupTest() {
 		"status":         "CRITICAL",
 	})
 	c.Insert(bson.M{
-		"report":         "Report_B",
+		"report":         "eba61a9e-22e9-4521-9e47-ecaa4a494365",
 		"date_integer":   20150501,
 		"timestamp":      "2015-05-01T05:00:00Z",
 		"endpoint_group": "EL-01-AUTH",

--- a/app/statusMetrics/controller.go
+++ b/app/statusMetrics/controller.go
@@ -92,7 +92,14 @@ func ListMetricTimelines(r *http.Request, cfg config.Config) (int, http.Header, 
 	metricCollection := session.DB(tenantDbConfig.Db).C("status_metrics")
 
 	// Query the detailed metric results
-	err = metricCollection.Find(prepareQuery(input)).All(&results)
+	reportID, err := mongo.GetReportID(session, tenantDbConfig.Db, input.report)
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	err = metricCollection.Find(prepareQuery(input, reportID)).All(&results)
 	if err != nil {
 		code = http.StatusInternalServerError
 		return code, h, output, err
@@ -104,7 +111,7 @@ func ListMetricTimelines(r *http.Request, cfg config.Config) (int, http.Header, 
 	return code, h, output, err
 }
 
-func prepareQuery(input InputParams) bson.M {
+func prepareQuery(input InputParams, reportID string) bson.M {
 
 	//Time Related
 	const zuluForm = "2006-01-02T15:04:05Z"
@@ -117,7 +124,7 @@ func prepareQuery(input InputParams) bson.M {
 
 	// prepare the match filter
 	filter := bson.M{
-		"report":         input.report,
+		"report":         reportID,
 		"date_integer":   bson.M{"$gte": tsYMD, "$lte": teYMD},
 		"endpoint_group": input.group,
 		"service":        input.service,

--- a/app/statusMetrics/statusMetrics_test.go
+++ b/app/statusMetrics/statusMetrics_test.go
@@ -171,15 +171,15 @@ func (suite *StatusMetricsTestSuite) SetupTest() {
 		},
 		"profiles": []bson.M{
 			bson.M{
-				"id": "6ac7d684-1f8e-4a02-a502-720e8f11e50b",
+				"id":   "6ac7d684-1f8e-4a02-a502-720e8f11e50b",
 				"type": "metric",
 				"name": "profile1"},
 			bson.M{
-				"id": "6ac7d684-1f8e-4a02-a502-720e8f11e523",
+				"id":   "6ac7d684-1f8e-4a02-a502-720e8f11e523",
 				"type": "operations",
 				"name": "profile2"},
 			bson.M{
-				"id": "6ac7d684-1f8e-4a02-a502-720e8f11e50q",
+				"id":   "6ac7d684-1f8e-4a02-a502-720e8f11e50q",
 				"type": "aggregation",
 				"name": "profile3"},
 		},
@@ -195,7 +195,7 @@ func (suite *StatusMetricsTestSuite) SetupTest() {
 	// seed the status detailed metric data
 	c = session.DB(suite.tenantDbConf.Db).C("status_metrics")
 	c.Insert(bson.M{
-		"report":             "Report_A",
+		"report":             "eba61a9e-22e9-4521-9e47-ecaa4a494364",
 		"monitoring_box":     "nagios3.hellasgrid.gr",
 		"date_integer":       20150501,
 		"timestamp":          "2015-05-01T00:00:00Z",
@@ -211,7 +211,7 @@ func (suite *StatusMetricsTestSuite) SetupTest() {
 		"message":            "Cream job submission test return value of ok",
 	})
 	c.Insert(bson.M{
-		"report":             "Report_A",
+		"report":             "eba61a9e-22e9-4521-9e47-ecaa4a494364",
 		"monitoring_box":     "nagios3.hellasgrid.gr",
 		"date_integer":       20150501,
 		"timestamp":          "2015-05-01T01:00:00Z",
@@ -227,7 +227,7 @@ func (suite *StatusMetricsTestSuite) SetupTest() {
 		"message":            "Cream job submission test failed",
 	})
 	c.Insert(bson.M{
-		"report":             "Report_A",
+		"report":             "eba61a9e-22e9-4521-9e47-ecaa4a494364",
 		"monitoring_box":     "nagios3.hellasgrid.gr",
 		"date_integer":       20150501,
 		"timestamp":          "2015-05-01T05:00:00Z",
@@ -256,7 +256,7 @@ func (suite *StatusMetricsTestSuite) SetupTest() {
 	// Now seed the reports DEFINITIONS
 	c = session.DB(suite.tenantDbConf.Db).C("reports")
 	c.Insert(bson.M{
-		"id": "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"id": "eba61a9e-22e9-4521-9e47-ecaa4a494365",
 		"info": bson.M{
 			"name":        "Report_B",
 			"description": "report aaaaa",
@@ -273,15 +273,15 @@ func (suite *StatusMetricsTestSuite) SetupTest() {
 		},
 		"profiles": []bson.M{
 			bson.M{
-				"id": "6ac7d684-1f8e-4a02-a502-720e8f11e50b",
+				"id":   "6ac7d684-1f8e-4a02-a502-720e8f11e50b",
 				"type": "metric",
 				"name": "eudat.CRITICAL"},
 			bson.M{
-				"id": "6ac7d684-1f8e-4a02-a502-720e8f11e523",
+				"id":   "6ac7d684-1f8e-4a02-a502-720e8f11e523",
 				"type": "operations",
 				"name": "profile2"},
 			bson.M{
-				"id": "6ac7d684-1f8e-4a02-a502-720e8f11e50q",
+				"id":   "6ac7d684-1f8e-4a02-a502-720e8f11e50q",
 				"type": "aggregation",
 				"name": "profile3"},
 		},
@@ -297,7 +297,7 @@ func (suite *StatusMetricsTestSuite) SetupTest() {
 	// seed the status detailed metric data
 	c = session.DB(suite.tenantDbConf.Db).C("status_metrics")
 	c.Insert(bson.M{
-		"report":             "Report_B",
+		"report":             "eba61a9e-22e9-4521-9e47-ecaa4a494365",
 		"monitoring_box":     "nagios3.tenant2.eu",
 		"date_integer":       20150501,
 		"timestamp":          "2015-05-01T00:00:00Z",
@@ -313,7 +313,7 @@ func (suite *StatusMetricsTestSuite) SetupTest() {
 		"message":            "someService data upload test return value of ok",
 	})
 	c.Insert(bson.M{
-		"report":             "Report_B",
+		"report":             "eba61a9e-22e9-4521-9e47-ecaa4a494365",
 		"monitoring_box":     "nagios3.tenant2.eu",
 		"date_integer":       20150501,
 		"timestamp":          "2015-05-01T01:00:00Z",
@@ -329,7 +329,7 @@ func (suite *StatusMetricsTestSuite) SetupTest() {
 		"message":            "someService data upload test failed",
 	})
 	c.Insert(bson.M{
-		"report":             "Report_B",
+		"report":             "eba61a9e-22e9-4521-9e47-ecaa4a494365",
 		"monitoring_box":     "nagios3.tenant2.eu",
 		"date_integer":       20150501,
 		"timestamp":          "2015-05-01T05:00:00Z",

--- a/app/statusServices/controller.go
+++ b/app/statusServices/controller.go
@@ -90,7 +90,14 @@ func ListServiceTimelines(r *http.Request, cfg config.Config) (int, http.Header,
 	metricCollection := session.DB(tenantDbConfig.Db).C("status_services")
 
 	// Query the detailed metric results
-	err = metricCollection.Find(prepareQuery(input)).All(&results)
+	reportID, err := mongo.GetReportID(session, tenantDbConfig.Db, input.report)
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	err = metricCollection.Find(prepareQuery(input, reportID)).All(&results)
 	if err != nil {
 		code = http.StatusInternalServerError
 		return code, h, output, err
@@ -102,7 +109,7 @@ func ListServiceTimelines(r *http.Request, cfg config.Config) (int, http.Header,
 	return code, h, output, err
 }
 
-func prepareQuery(input InputParams) bson.M {
+func prepareQuery(input InputParams, reportID string) bson.M {
 
 	//Time Related
 	const zuluForm = "2006-01-02T15:04:05Z"
@@ -116,7 +123,7 @@ func prepareQuery(input InputParams) bson.M {
 	// prepare the match filter
 	filter := bson.M{
 		"date_integer":   bson.M{"$gte": tsYMD, "$lte": teYMD},
-		"report":         input.report,
+		"report":         reportID,
 		"endpoint_group": input.group,
 	}
 

--- a/app/statusServices/statusServices_test.go
+++ b/app/statusServices/statusServices_test.go
@@ -194,7 +194,7 @@ func (suite *StatusServicesTestSuite) SetupTest() {
 	// seed the status detailed metric data
 	c = session.DB(suite.tenantDbConf.Db).C("status_services")
 	c.Insert(bson.M{
-		"report":         "Report_A",
+		"report":         "eba61a9e-22e9-4521-9e47-ecaa4a494364",
 		"date_integer":   20150501,
 		"timestamp":      "2015-05-01T00:00:00Z",
 		"endpoint_group": "HG-03-AUTH",
@@ -202,7 +202,7 @@ func (suite *StatusServicesTestSuite) SetupTest() {
 		"status":         "OK",
 	})
 	c.Insert(bson.M{
-		"report":         "Report_A",
+		"report":         "eba61a9e-22e9-4521-9e47-ecaa4a494364",
 		"date_integer":   20150501,
 		"timestamp":      "2015-05-01T01:00:00Z",
 		"endpoint_group": "HG-03-AUTH",
@@ -210,7 +210,7 @@ func (suite *StatusServicesTestSuite) SetupTest() {
 		"status":         "CRITICAL",
 	})
 	c.Insert(bson.M{
-		"report":         "Report_A",
+		"report":         "eba61a9e-22e9-4521-9e47-ecaa4a494364",
 		"date_integer":   20150501,
 		"timestamp":      "2015-05-01T05:00:00Z",
 		"endpoint_group": "HG-03-AUTH",
@@ -231,7 +231,7 @@ func (suite *StatusServicesTestSuite) SetupTest() {
 	// Now seed the reports DEFINITIONS
 	c = session.DB(suite.tenantDbConf.Db).C("reports")
 	c.Insert(bson.M{
-		"id": "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"id": "eba61a9e-22e9-4521-9e47-ecaa4a494365",
 		"info": bson.M{
 			"name":        "Report_B",
 			"description": "report aaaaa",
@@ -272,7 +272,7 @@ func (suite *StatusServicesTestSuite) SetupTest() {
 	// seed the status detailed metric data
 	c = session.DB(suite.tenantDbConf.Db).C("status_services")
 	c.Insert(bson.M{
-		"report":         "Report_B",
+		"report":         "eba61a9e-22e9-4521-9e47-ecaa4a494365",
 		"date_integer":   20150501,
 		"timestamp":      "2015-05-01T00:00:00Z",
 		"endpoint_group": "EL-01-AUTH",
@@ -280,7 +280,7 @@ func (suite *StatusServicesTestSuite) SetupTest() {
 		"status":         "OK",
 	})
 	c.Insert(bson.M{
-		"report":         "Report_B",
+		"report":         "eba61a9e-22e9-4521-9e47-ecaa4a494365",
 		"date_integer":   20150501,
 		"timestamp":      "2015-05-01T01:00:00Z",
 		"endpoint_group": "EL-01-AUTH",
@@ -288,7 +288,7 @@ func (suite *StatusServicesTestSuite) SetupTest() {
 		"status":         "CRITICAL",
 	})
 	c.Insert(bson.M{
-		"report":         "Report_B",
+		"report":         "eba61a9e-22e9-4521-9e47-ecaa4a494365",
 		"date_integer":   20150501,
 		"timestamp":      "2015-05-01T05:00:00Z",
 		"endpoint_group": "EL-01-AUTH",

--- a/utils/mongo/mongoQuery.go
+++ b/utils/mongo/mongoQuery.go
@@ -136,6 +136,23 @@ func Update(session *mgo.Session, dbName string, collectionName string, query bs
 	return err
 }
 
+// GetReportID accepts a report name and returns the report's id
+func GetReportID(session *mgo.Session, dbName string, report string) (string, error) {
+	var result map[string]interface{}
+	// reports are stored to the reports collection
+	c := openCollection(session, dbName, "reports")
+	// query based on report name which is included in the info element
+	query := bson.M{"info.name": report}
+	// Execute the query and grab only the first result
+	err := c.Find(query).One(&result)
+
+	if result != nil {
+		return result["id"].(string), err
+	}
+	return "", err
+
+}
+
 func structsToInterfaces(array interface{}) []interface{} {
 
 	v := reflect.ValueOf(array)


### PR DESCRIPTION
Each defined report in the Compute Engine is used to produce a different set of results. The results while produced and stored in datastore are tagged with the according report name for future reference.

In this PR, the argo-web-api uses the report's id (uuid) as a future reference and tags the results. This gives the flexibility to be able to update/edit report.name field without affecting the relationship with the already computed results

- Add GetRerportID in mongo package to easily retrieve report id by name 
- in pkg results use GetReportID and reportID to query results
- in pkg statusEndpointGroups, statusEndpoints, statusMetrics & statusServices use GetReportID and reportID to query results

