### PR TITLE
[ARGO-283] Fix routes to not require trailing slash

### DIFF
--- a/app/statusEndpointGroups/routing.go
+++ b/app/statusEndpointGroups/routing.go
@@ -39,19 +39,14 @@ import (
 // HandleSubrouter contains the different paths to follow during subrouting
 func HandleSubrouter(s *mux.Router, confhandler *respond.ConfHandler) {
 
-	// Goes up to /report/REPORT_NAME/group_type
-	groupSubrouter := s.PathPrefix("/{report_name}/{group_type}").Subrouter()
-
 	// eg. timelines/critical/SITES/mysite
-	groupSubrouter.
-		Path("/{group_name}").
+	s.Path("/{report_name}/{group_type}/{group_name}").
 		Methods("GET").
 		Name("endpoint group name").
 		Handler(confhandler.Respond(routeCheckGroup))
 
 	// eg. timelines/critical/SITES
-	groupSubrouter.
-		Path("/").
+	s.Path("/{report_name}/{group_type}").
 		Methods("GET").
 		Name("all endpoint groups").
 		Handler(confhandler.Respond(routeCheckGroup))

--- a/app/statusEndpointGroups/statusEndpointGroups_test.go
+++ b/app/statusEndpointGroups/statusEndpointGroups_test.go
@@ -361,6 +361,9 @@ func (suite *StatusEndpointGroupsTestSuite) TestListStatusEndpointGroups() {
 	fullurl2 := "/api/v2/status/Report_B/EUDAT_SITES/EL-01-AUTH" +
 		"?start_time=2015-05-01T00:00:00Z&end_time=2015-05-01T23:00:00Z"
 
+	fullurl3 := "/api/v2/status/Report_B/EUDAT_SITES" +
+		"?start_time=2015-05-01T00:00:00Z&end_time=2015-05-01T23:00:00Z"
+
 	// 1. EGI XML REQUEST
 	// init the response placeholder
 	response := httptest.NewRecorder()
@@ -414,6 +417,22 @@ func (suite *StatusEndpointGroupsTestSuite) TestListStatusEndpointGroups() {
 	response = httptest.NewRecorder()
 	// Prepare the request object for second tenant
 	request, _ = http.NewRequest("GET", fullurl2, strings.NewReader(""))
+	// add json accept header
+	request.Header.Set("Accept", "application/json")
+	// add the authentication token which is seeded in testdb
+	request.Header.Set("x-api-key", "KEY2")
+	// Serve the http request
+	suite.router.ServeHTTP(response, request)
+	// Check that we must have a 200 ok code
+	suite.Equal(200, response.Code, "Internal Server Error")
+	// Compare the expected and actual xml response
+	suite.Equal(respJSON2, response.Body.String(), "Response body mismatch")
+
+	// 5. EUDAT ALL JSON REQUEST
+	// init the response placeholder
+	response = httptest.NewRecorder()
+	// Prepare the request object for second tenant
+	request, _ = http.NewRequest("GET", fullurl3, strings.NewReader(""))
 	// add json accept header
 	request.Header.Set("Accept", "application/json")
 	// add the authentication token which is seeded in testdb

--- a/app/statusEndpoints/routing.go
+++ b/app/statusEndpoints/routing.go
@@ -39,19 +39,14 @@ import (
 // HandleSubrouter contains the different paths to follow during subrouting
 func HandleSubrouter(s *mux.Router, confhandler *respond.ConfHandler) {
 
-	// Goes up to /report/REPORT_NAME/group_type
-	groupSubrouter := s.PathPrefix("/{report_name}/{group_type}").Subrouter()
-
 	// eg. timelines/critical/SITE/mysite/service/apache/endpoints/apache01.host
-	groupSubrouter.
-		Path("/{group_name}/services/{service_name}/endpoints/{endpoint_name}").
+	s.Path("/{report_name}/{group_type}/{group_name}/services/{service_name}/endpoints/{endpoint_name}").
 		Methods("GET").
 		Name("metric name").
 		Handler(confhandler.Respond(routeCheckGroup))
 
 	// eg. timelines/critical/SITE/mysite/service/apache/endpoints/
-	groupSubrouter.
-		Path("/{group_name}/services/{service_name}/endpoints").
+	s.Path("/{report_name}/{group_type}/{group_name}/services/{service_name}/endpoints").
 		Methods("GET").
 		Name("all metrics").
 		Handler(confhandler.Respond(routeCheckGroup))

--- a/app/statusEndpoints/statusEndpoints_test.go
+++ b/app/statusEndpoints/statusEndpoints_test.go
@@ -473,6 +473,7 @@ func (suite *StatusEndpointsTestSuite) TestListStatusEndpoints() {
 	suite.Equal(200, response.Code, "Internal Server Error")
 	// Compare the expected and actual xml response
 	suite.Equal(respJSON2, response.Body.String(), "Response body mismatch")
+
 }
 
 // This function is actually called in the end of all tests

--- a/app/statusMetrics/routing.go
+++ b/app/statusMetrics/routing.go
@@ -39,19 +39,14 @@ import (
 // HandleSubrouter contains the different paths to follow during subrouting
 func HandleSubrouter(s *mux.Router, confhandler *respond.ConfHandler) {
 
-	// Goes up to /report/REPORT_NAME/group_type
-	groupSubrouter := s.PathPrefix("/{report_name}/{group_type}").Subrouter()
-
 	// eg. timelines/critical/SITE/mysite/service/apache/endpoints/apache01.host/metrics/memory_used
-	groupSubrouter.
-		Path("/{group_name}/services/{service_name}/endpoints/{endpoint_name}/metrics/{metric_name}").
+	s.Path("/{report_name}/{group_type}/{group_name}/services/{service_name}/endpoints/{endpoint_name}/metrics/{metric_name}").
 		Methods("GET").
 		Name("metric name").
 		Handler(confhandler.Respond(routeCheckGroup))
 
 	// eg. timelines/critical/SITE/mysite/service/apache/endpoints/apache01.host/metrics
-	groupSubrouter.
-		Path("/{group_name}/services/{service_name}/endpoints/{endpoint_name}/metrics").
+	s.Path("/{report_name}/{group_type}/{group_name}/services/{service_name}/endpoints/{endpoint_name}/metrics").
 		Methods("GET").
 		Name("all metrics").
 		Handler(confhandler.Respond(routeCheckGroup))

--- a/app/statusMetrics/statusMetrics_test.go
+++ b/app/statusMetrics/statusMetrics_test.go
@@ -472,6 +472,10 @@ func (suite *StatusMetricsTestSuite) TestListStatusMetrics() {
 		"/services/someService/endpoints/someservice.example.gr/metrics/someService-FileTransfer" +
 		"?start_time=2015-05-01T00:00:00Z&end_time=2015-05-01T23:00:00Z"
 
+	fullurl3 := "/api/v2/status/Report_B/EUDAT_SITES/EL-01-AUTH" +
+		"/services/someService/endpoints/someservice.example.gr/metrics" +
+		"?start_time=2015-05-01T00:00:00Z&end_time=2015-05-01T23:00:00Z"
+
 	// 1. EGI XML REQUEST
 	// init the response placeholder
 	response := httptest.NewRecorder()
@@ -525,6 +529,22 @@ func (suite *StatusMetricsTestSuite) TestListStatusMetrics() {
 	response = httptest.NewRecorder()
 	// Prepare the request object for second tenant
 	request, _ = http.NewRequest("GET", fullurl2, strings.NewReader(""))
+	// add json accept header
+	request.Header.Set("Accept", "application/json")
+	// add the authentication token which is seeded in testdb
+	request.Header.Set("x-api-key", "KEY2")
+	// Serve the http request
+	suite.router.ServeHTTP(response, request)
+	// Check that we must have a 200 ok code
+	suite.Equal(200, response.Code, "Internal Server Error")
+	// Compare the expected and actual xml response
+	suite.Equal(respJSON2, response.Body.String(), "Response body mismatch")
+
+	// 5. TENANT2 ALL JSON REQUEST
+	// init the response placeholder
+	response = httptest.NewRecorder()
+	// Prepare the request object for second tenant
+	request, _ = http.NewRequest("GET", fullurl3, strings.NewReader(""))
 	// add json accept header
 	request.Header.Set("Accept", "application/json")
 	// add the authentication token which is seeded in testdb

--- a/app/statusServices/routing.go
+++ b/app/statusServices/routing.go
@@ -39,19 +39,14 @@ import (
 // HandleSubrouter contains the different paths to follow during subrouting
 func HandleSubrouter(s *mux.Router, confhandler *respond.ConfHandler) {
 
-	// Goes up to /report/REPORT_NAME/group_type
-	groupSubrouter := s.PathPrefix("/{report_name}/{group_type}").Subrouter()
-
 	// eg. timelines/critical/SITE/mysite/services/apache
-	groupSubrouter.
-		Path("/{group_name}/services/{service_name}").
+	s.Path("/{report_name}/{group_type}/{group_name}/services/{service_name}").
 		Methods("GET").
 		Name("service name").
 		Handler(confhandler.Respond(routeCheckGroup))
 
 	// eg. timelines/critical/SITE/mysite/services
-	groupSubrouter.
-		Path("/{group_name}/services/").
+	s.Path("/{report_name}/{group_type}/{group_name}/services").
 		Methods("GET").
 		Name("all services").
 		Handler(confhandler.Respond(routeCheckGroup))

--- a/app/statusServices/statusServices_test.go
+++ b/app/statusServices/statusServices_test.go
@@ -385,6 +385,10 @@ func (suite *StatusServicesTestSuite) TestListStatusServices() {
 		"/services/srv.typeA" +
 		"?start_time=2015-05-01T00:00:00Z&end_time=2015-05-01T23:00:00Z"
 
+	fullurl3 := "/api/v2/status/Report_B/EUDAT_SITES/EL-01-AUTH" +
+		"/services/srv.typeA" +
+		"?start_time=2015-05-01T00:00:00Z&end_time=2015-05-01T23:00:00Z"
+
 	// 1. EGI XML REQUEST
 	// init the response placeholder
 	response := httptest.NewRecorder()
@@ -438,6 +442,22 @@ func (suite *StatusServicesTestSuite) TestListStatusServices() {
 	response = httptest.NewRecorder()
 	// Prepare the request object for second tenant
 	request, _ = http.NewRequest("GET", fullurl2, strings.NewReader(""))
+	// add json accept header
+	request.Header.Set("Accept", "application/json")
+	// add the authentication token which is seeded in testdb
+	request.Header.Set("x-api-key", "KEY2")
+	// Serve the http request
+	suite.router.ServeHTTP(response, request)
+	// Check that we must have a 200 ok code
+	suite.Equal(200, response.Code, "Internal Server Error")
+	// Compare the expected and actual xml response
+	suite.Equal(respJSON2, response.Body.String(), "Response body mismatch")
+
+	// 5. EUDAT ALL JSON REQUEST
+	// init the response placeholder
+	response = httptest.NewRecorder()
+	// Prepare the request object for second tenant
+	request, _ = http.NewRequest("GET", fullurl3, strings.NewReader(""))
 	// add json accept header
 	request.Header.Set("Accept", "application/json")
 	// add the authentication token which is seeded in testdb


### PR DESCRIPTION
## Description 
Status calls, when not using a name to specify a site, endpoint or service, require a trailing slash

## Implementation
Instead of creating a new subrouter, use the whole path pattern on each of the route definitions to make sure that the whole request route path gets validated against the pattern at once instead of multiple path prefixes. This change is required because the gorilla mux routing requires at least one slash as an argument when calling `Path` to register a new route. 