### PR TITLE
ARGO-302 Fix spec build options

### DIFF
--- a/argo-web-api.spec
+++ b/argo-web-api.spec
@@ -25,6 +25,7 @@ Installs the ARGO API.
 
 %build
 export GOPATH=$PWD
+export PATH=$GOPATH/bin:$PATH
 cd src/github.com/ARGOeu/argo-web-api/
 go get github.com/tools/godep
 godep restore


### PR DESCRIPTION
Add GOPATH/bin to PATH in order for builder to be able to use godep tool