### PR TITLE
ARGO-359 Fix response messages and code in case of wrong api key usage

### DIFF
--- a/app/statusEndpointGroups/routing.go
+++ b/app/statusEndpointGroups/routing.go
@@ -74,11 +74,20 @@ func routeCheckGroup(r *http.Request, cfg config.Config) (int, http.Header, []by
 	vars := mux.Vars(r)
 	tenantcfg, err := authentication.AuthenticateTenant(r.Header, cfg)
 	if err != nil {
+		if err.Error() == "Unauthorized" {
+			code = http.StatusUnauthorized
+			output, _ = respond.MarshalContent(respond.UnauthorizedMessage, contentType, "", " ")
+			return code, h, output, err
+		}
+		code = http.StatusInternalServerError
+		output, _ = respond.MarshalContent(respond.InternalServerErrorMessage, contentType, "", " ")
 		return code, h, output, err
 	}
 	session, err := mongo.OpenSession(tenantcfg)
 	defer mongo.CloseSession(session)
 	if err != nil {
+		code = http.StatusInternalServerError
+		output, _ = respond.MarshalContent(respond.InternalServerErrorMessage, contentType, "", " ")
 		return code, h, output, err
 	}
 	result := reports.MongoInterface{}

--- a/app/statusEndpointGroups/statusEndpointGroups_test.go
+++ b/app/statusEndpointGroups/statusEndpointGroups_test.go
@@ -355,6 +355,14 @@ func (suite *StatusEndpointGroupsTestSuite) TestListStatusEndpointGroups() {
  ]
 }`
 
+	respUnauthorized := `{
+ "status": {
+  "message": "Unauthorized",
+  "code": "401",
+  "details": "You need to provide a correct authentication token using the header 'x-api-key'"
+ }
+}`
+
 	fullurl1 := "/api/v2/status/Report_A/SITES/HG-03-AUTH" +
 		"?start_time=2015-05-01T00:00:00Z&end_time=2015-05-01T23:00:00Z"
 
@@ -443,6 +451,22 @@ func (suite *StatusEndpointGroupsTestSuite) TestListStatusEndpointGroups() {
 	suite.Equal(200, response.Code, "Internal Server Error")
 	// Compare the expected and actual xml response
 	suite.Equal(respJSON2, response.Body.String(), "Response body mismatch")
+
+	// 6. WRONG KEY REQUEST
+	// init the response placeholder
+	response = httptest.NewRecorder()
+	// Prepare the request object for second tenant
+	request, _ = http.NewRequest("GET", fullurl2, strings.NewReader(""))
+	// add json accept header
+	request.Header.Set("Accept", "application/json")
+	// add the authentication token which is seeded in testdb
+	request.Header.Set("x-api-key", "KEYISWRONG")
+	// Serve the http request
+	suite.router.ServeHTTP(response, request)
+	// Check that we must have a 200 ok code
+	suite.Equal(401, response.Code, "Response code mismatch")
+	// Compare the expected and actual xml response
+	suite.Equal(respUnauthorized, response.Body.String(), "Response body mismatch")
 
 }
 

--- a/app/statusEndpoints/routing.go
+++ b/app/statusEndpoints/routing.go
@@ -74,12 +74,21 @@ func routeCheckGroup(r *http.Request, cfg config.Config) (int, http.Header, []by
 	vars := mux.Vars(r)
 	tenantcfg, err := authentication.AuthenticateTenant(r.Header, cfg)
 	if err != nil {
+		if err.Error() == "Unauthorized" {
+			code = http.StatusUnauthorized
+			output, _ = respond.MarshalContent(respond.UnauthorizedMessage, contentType, "", " ")
+			return code, h, output, err
+		}
+		code = http.StatusInternalServerError
+		output, _ = respond.MarshalContent(respond.InternalServerErrorMessage, contentType, "", " ")
 		return code, h, output, err
 	}
 
 	session, err := mongo.OpenSession(tenantcfg)
 	defer mongo.CloseSession(session)
 	if err != nil {
+		code = http.StatusInternalServerError
+		output, _ = respond.MarshalContent(respond.InternalServerErrorMessage, contentType, "", " ")
 		return code, h, output, err
 	}
 	result := reports.MongoInterface{}

--- a/app/statusEndpoints/statusEndpoints_test.go
+++ b/app/statusEndpoints/statusEndpoints_test.go
@@ -402,6 +402,14 @@ func (suite *StatusEndpointsTestSuite) TestListStatusEndpoints() {
  ]
 }`
 
+	respUnauthorized := `{
+ "status": {
+  "message": "Unauthorized",
+  "code": "401",
+  "details": "You need to provide a correct authentication token using the header 'x-api-key'"
+ }
+}`
+
 	fullurl1 := "/api/v2/status/Report_A/SITES/HG-03-AUTH" +
 		"/services/CREAM-CE/endpoints/cream01.afroditi.gr" +
 		"?start_time=2015-05-01T00:00:00Z&end_time=2015-05-01T23:00:00Z"
@@ -473,6 +481,22 @@ func (suite *StatusEndpointsTestSuite) TestListStatusEndpoints() {
 	suite.Equal(200, response.Code, "Internal Server Error")
 	// Compare the expected and actual xml response
 	suite.Equal(respJSON2, response.Body.String(), "Response body mismatch")
+
+	// 5. WRONG KEY REQUEST
+	// init the response placeholder
+	response = httptest.NewRecorder()
+	// Prepare the request object for second tenant
+	request, _ = http.NewRequest("GET", fullurl2, strings.NewReader(""))
+	// add json accept header
+	request.Header.Set("Accept", "application/json")
+	// add the authentication token which is seeded in testdb
+	request.Header.Set("x-api-key", "KEYISWRONG")
+	// Serve the http request
+	suite.router.ServeHTTP(response, request)
+	// Check that we must have a 200 ok code
+	suite.Equal(401, response.Code, "Response code mismatch")
+	// Compare the expected and actual xml response
+	suite.Equal(respUnauthorized, response.Body.String(), "Response body mismatch")
 
 }
 

--- a/app/statusMetrics/routing.go
+++ b/app/statusMetrics/routing.go
@@ -74,11 +74,20 @@ func routeCheckGroup(r *http.Request, cfg config.Config) (int, http.Header, []by
 	vars := mux.Vars(r)
 	tenantcfg, err := authentication.AuthenticateTenant(r.Header, cfg)
 	if err != nil {
+		if err.Error() == "Unauthorized" {
+			code = http.StatusUnauthorized
+			output, _ = respond.MarshalContent(respond.UnauthorizedMessage, contentType, "", " ")
+			return code, h, output, err
+		}
+		code = http.StatusInternalServerError
+		output, _ = respond.MarshalContent(respond.InternalServerErrorMessage, contentType, "", " ")
 		return code, h, output, err
 	}
 	session, err := mongo.OpenSession(tenantcfg)
 	defer mongo.CloseSession(session)
 	if err != nil {
+		code = http.StatusInternalServerError
+		output, _ = respond.MarshalContent(respond.InternalServerErrorMessage, contentType, "", " ")
 		return code, h, output, err
 	}
 	result := reports.MongoInterface{}

--- a/app/statusMetrics/statusMetrics_test.go
+++ b/app/statusMetrics/statusMetrics_test.go
@@ -464,6 +464,14 @@ func (suite *StatusMetricsTestSuite) TestListStatusMetrics() {
  ]
 }`
 
+	respUnauthorized := `{
+ "status": {
+  "message": "Unauthorized",
+  "code": "401",
+  "details": "You need to provide a correct authentication token using the header 'x-api-key'"
+ }
+}`
+
 	fullurl1 := "/api/v2/status/Report_A/SITES/HG-03-AUTH" +
 		"/services/CREAM-CE/endpoints/cream01.afroditi.gr/metrics/emi.cream.CREAMCE-JobSubmit" +
 		"?start_time=2015-05-01T00:00:00Z&end_time=2015-05-01T23:00:00Z"
@@ -555,6 +563,22 @@ func (suite *StatusMetricsTestSuite) TestListStatusMetrics() {
 	suite.Equal(200, response.Code, "Internal Server Error")
 	// Compare the expected and actual xml response
 	suite.Equal(respJSON2, response.Body.String(), "Response body mismatch")
+
+	// 6. WRONG KEY REQUEST
+	// init the response placeholder
+	response = httptest.NewRecorder()
+	// Prepare the request object for second tenant
+	request, _ = http.NewRequest("GET", fullurl1, strings.NewReader(""))
+	// add json accept header
+	request.Header.Set("Accept", "application/json")
+	// add the authentication token which is seeded in testdb
+	request.Header.Set("x-api-key", "KEYISWRONG")
+	// Serve the http request
+	suite.router.ServeHTTP(response, request)
+	// Check that we must have a 200 ok code
+	suite.Equal(401, response.Code, "Response code mismatch")
+	// Compare the expected and actual xml response
+	suite.Equal(respUnauthorized, response.Body.String(), "Response body mismatch")
 
 }
 

--- a/app/statusServices/routing.go
+++ b/app/statusServices/routing.go
@@ -74,11 +74,20 @@ func routeCheckGroup(r *http.Request, cfg config.Config) (int, http.Header, []by
 	vars := mux.Vars(r)
 	tenantcfg, err := authentication.AuthenticateTenant(r.Header, cfg)
 	if err != nil {
+		if err.Error() == "Unauthorized" {
+			code = http.StatusUnauthorized
+			output, _ = respond.MarshalContent(respond.UnauthorizedMessage, contentType, "", " ")
+			return code, h, output, err
+		}
+		code = http.StatusInternalServerError
+		output, _ = respond.MarshalContent(respond.InternalServerErrorMessage, contentType, "", " ")
 		return code, h, output, err
 	}
 	session, err := mongo.OpenSession(tenantcfg)
 	defer mongo.CloseSession(session)
 	if err != nil {
+		code = http.StatusInternalServerError
+		output, _ = respond.MarshalContent(respond.InternalServerErrorMessage, contentType, "", " ")
 		return code, h, output, err
 	}
 	result := reports.MongoInterface{}

--- a/app/statusServices/statusServices_test.go
+++ b/app/statusServices/statusServices_test.go
@@ -377,6 +377,14 @@ func (suite *StatusServicesTestSuite) TestListStatusServices() {
  ]
 }`
 
+	respUnauthorized := `{
+ "status": {
+  "message": "Unauthorized",
+  "code": "401",
+  "details": "You need to provide a correct authentication token using the header 'x-api-key'"
+ }
+}`
+
 	fullurl1 := "/api/v2/status/Report_A/SITES/HG-03-AUTH" +
 		"/services/CREAM-CE" +
 		"?start_time=2015-05-01T00:00:00Z&end_time=2015-05-01T23:00:00Z"
@@ -469,6 +477,21 @@ func (suite *StatusServicesTestSuite) TestListStatusServices() {
 	// Compare the expected and actual xml response
 	suite.Equal(respJSON2, response.Body.String(), "Response body mismatch")
 
+	// 6. WRONG KEY REQUEST
+	// init the response placeholder
+	response = httptest.NewRecorder()
+	// Prepare the request object for second tenant
+	request, _ = http.NewRequest("GET", fullurl1, strings.NewReader(""))
+	// add json accept header
+	request.Header.Set("Accept", "application/json")
+	// add the authentication token which is seeded in testdb
+	request.Header.Set("x-api-key", "KEYISWRONG")
+	// Serve the http request
+	suite.router.ServeHTTP(response, request)
+	// Check that we must have a 200 ok code
+	suite.Equal(401, response.Code, "Response code mismatch")
+	// Compare the expected and actual xml response
+	suite.Equal(respUnauthorized, response.Body.String(), "Response body mismatch")
 }
 
 // This function is actually called in the end of all tests

--- a/respond/respond.go
+++ b/respond/respond.go
@@ -262,3 +262,11 @@ var UnprocessableEntity = ResponseMessage{
 		Message: "Unprocessable Entity",
 	},
 }
+
+// InternalServerErrorMessage is used to marshal a response
+var InternalServerErrorMessage = ResponseMessage{
+	Status: StatusResponse{
+		Code:    "500",
+		Message: "Internal Server Error",
+	},
+}


### PR DESCRIPTION
# Description

In case a wrong key is being used the following response should be returned:

```
{
  "status": {
    "message": "Unauthorized",
    "code": "401",
    "details": "You need to provide a correct authentication token using the header 'x-api-key'"
  }
}
```

please review /cc @themiszamani @kaggis 