### PR TITLE
ARGO-360 Fix response messages within results resource

### DIFF
--- a/app/results/Controller.go
+++ b/app/results/Controller.go
@@ -83,9 +83,9 @@ func ListServiceFlavorResults(r *http.Request, cfg config.Config) (int, http.Hea
 	err = mongo.FindOne(session, tenantDbConfig.Db, "reports", bson.M{"info.name": vars["report_name"]}, &report)
 
 	if err != nil {
-		code = http.StatusBadRequest
+		code = http.StatusNotFound
 		message := "The report with the name " + vars["report_name"] + " does not exist"
-		output, err := createErrorMessage(message, contentType) //Render the response into XML or JSON
+		output, err := createErrorMessage(message, code, contentType) //Render the response into XML or JSON
 		h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
 		return code, h, output, err
 	}
@@ -114,9 +114,9 @@ func ListServiceFlavorResults(r *http.Request, cfg config.Config) (int, http.Hea
 	}
 
 	if vars["lgroup_type"] != report.GetEndpointGroupType() {
-		code = http.StatusBadRequest
+		code = http.StatusNotFound
 		message := "The report " + vars["report_name"] + " does not define endpoint group type: " + vars["lgroup_type"] + ". Try using " + report.GetEndpointGroupType() + " instead."
-		output, err := createErrorMessage(message, contentType) //Render the response into XML or JSON
+		output, err := createErrorMessage(message, code, contentType) //Render the response into XML or JSON
 		h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
 		return code, h, output, err
 	}
@@ -158,6 +158,13 @@ func ListServiceFlavorResults(r *http.Request, cfg config.Config) (int, http.Hea
 	// mongo.Find(session, tenantDbConfig.Db, "endpoint_group_ar", bson.M{}, "_id", &results)
 	if err != nil {
 		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	if len(results) == 0 {
+		code = http.StatusNotFound
+		message := "No results found for given query"
+		output, err = createErrorMessage(message, code, contentType)
 		return code, h, output, err
 	}
 
@@ -221,9 +228,9 @@ func ListEndpointGroupResults(r *http.Request, cfg config.Config) (int, http.Hea
 	err = mongo.FindOne(session, tenantDbConfig.Db, "reports", bson.M{"info.name": vars["report_name"]}, &report)
 
 	if err != nil {
-		code = http.StatusBadRequest
+		code = http.StatusNotFound
 		message := "The report with the name " + vars["report_name"] + " does not exist"
-		output, err := createErrorMessage(message, contentType) //Render the response into XML or JSON
+		output, err := createErrorMessage(message, code, contentType) //Render the response into XML or JSON
 		h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
 		return code, h, output, err
 	}
@@ -251,9 +258,9 @@ func ListEndpointGroupResults(r *http.Request, cfg config.Config) (int, http.Hea
 	}
 
 	if vars["lgroup_type"] != report.GetEndpointGroupType() {
-		code = http.StatusBadRequest
+		code = http.StatusNotFound
 		message := "The report " + vars["report_name"] + " does not define endpoint group type: " + vars["lgroup_type"] + ". Try using " + report.GetEndpointGroupType() + " instead."
-		output, err := createErrorMessage(message, contentType) //Render the response into XML or JSON
+		output, err := createErrorMessage(message, code, contentType) //Render the response into XML or JSON
 		h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
 		return code, h, output, err
 	}
@@ -291,6 +298,13 @@ func ListEndpointGroupResults(r *http.Request, cfg config.Config) (int, http.Hea
 	// mongo.Find(session, tenantDbConfig.Db, "endpoint_group_ar", bson.M{}, "_id", &results)
 	if err != nil {
 		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	if len(results) == 0 {
+		code = http.StatusNotFound
+		message := "No results found for given query"
+		output, err = createErrorMessage(message, code, contentType)
 		return code, h, output, err
 	}
 
@@ -413,6 +427,14 @@ func ListSuperGroupResults(r *http.Request, cfg config.Config) (int, http.Header
 		code = http.StatusInternalServerError
 		return code, h, output, err
 	}
+
+	if len(results) == 0 {
+		code = http.StatusNotFound
+		message := "No results found for given query"
+		output, err = createErrorMessage(message, code, contentType)
+		return code, h, output, err
+	}
+
 	output, err = createSuperGroupView(results, report, input.Format)
 
 	if err != nil {

--- a/app/results/Model.go
+++ b/app/results/Model.go
@@ -171,6 +171,7 @@ type root struct {
 type errorMessage struct {
 	XMLName xml.Name `xml:"root" json:"-"`
 	Message string   `xml:"message" json:"message"`
+	Code    int      `xml:"code" json:"code"`
 }
 
 // ErrorResponse shortcut to respond.ErrorResponse

--- a/app/results/View.go
+++ b/app/results/View.go
@@ -177,13 +177,14 @@ func createSuperGroupView(results []SuperGroupInterface, report reports.MongoInt
 	}
 }
 
-func createErrorMessage(message string, format string) ([]byte, error) {
+func createErrorMessage(message string, code int, format string) ([]byte, error) {
 
 	output := []byte("message placeholder")
 	err := error(nil)
 	docRoot := &errorMessage{}
 
 	docRoot.Message = message
+	docRoot.Code = code
 	if strings.EqualFold(format, "application/json") {
 		output, err = json.MarshalIndent(docRoot, " ", "  ")
 	} else {

--- a/app/results/endpointgroup_test.go
+++ b/app/results/endpointgroup_test.go
@@ -342,6 +342,7 @@ func (suite *endpointGroupAvailabilityTestSuite) TestListEndpointGroupAvailabili
 
 	unauthorizedresponseXML := ` <root>
    <message>Unauthorized</message>
+   <code>401</code>
  </root>`
 
 	// Check that we must have a 401 Unauthorized code
@@ -387,6 +388,7 @@ func (suite *endpointGroupAvailabilityTestSuite) TestListEndpointGroupAvailabili
 
 	reportErrorXML := ` <root>
    <message>The report with the name Report_B does not exist</message>
+   <code>404</code>
  </root>`
 
 	typeError1XML := `<root>
@@ -405,7 +407,18 @@ func (suite *endpointGroupAvailabilityTestSuite) TestListEndpointGroupAvailabili
 
 	typeError2XML := ` <root>
    <message>The report Report_A does not define any group type: Site</message>
+   <code>404</code>
  </root>`
+
+	typeError3XML := ` <root>
+   <message>No results found for given query</message>
+   <code>404</code>
+ </root>`
+
+	typeError3JSON := `{
+   "message": "No results found for given query",
+   "code": 404
+ }`
 
 	request, _ := http.NewRequest("GET", "/api/v2/results/Report_B/Site?start_time=2015-06-22T00:00:00Z&end_time=2015-06-23T23:59:59Z", strings.NewReader(""))
 	request.Header.Set("x-api-key", suite.clientkey)
@@ -415,8 +428,8 @@ func (suite *endpointGroupAvailabilityTestSuite) TestListEndpointGroupAvailabili
 
 	suite.router.ServeHTTP(response, request)
 
-	// Check that we must have a 400 bad request code
-	suite.Equal(400, response.Code, "Incorrect HTTP response code")
+	// Check that we must have a 404 bad request code
+	suite.Equal(404, response.Code, "Incorrect HTTP response code")
 	// Compare the expected and actual xml response
 	suite.Equal(reportErrorXML, response.Body.String(), "Response body mismatch")
 
@@ -428,8 +441,8 @@ func (suite *endpointGroupAvailabilityTestSuite) TestListEndpointGroupAvailabili
 
 	suite.router.ServeHTTP(response, request)
 
-	// Check that we must have a 400 bad request code
-	suite.Equal(400, response.Code, "Incorrect HTTP response code")
+	// Check that we must have a 404 bad request code
+	suite.Equal(404, response.Code, "Incorrect HTTP response code")
 	// Compare the expected and actual xml response
 	suite.Equal(reportErrorXML, response.Body.String(), "Response body mismatch")
 
@@ -441,8 +454,8 @@ func (suite *endpointGroupAvailabilityTestSuite) TestListEndpointGroupAvailabili
 
 	suite.router.ServeHTTP(response, request)
 
-	// Check that we must have a 400 bad request code
-	suite.Equal(400, response.Code, "Incorrect HTTP response code")
+	// Check that we must have a 404 not found code
+	suite.Equal(404, response.Code, "Incorrect HTTP response code")
 	// Compare the expected and actual xml response
 	suite.Equal(typeError2XML, response.Body.String(), "Response body mismatch")
 
@@ -459,6 +472,34 @@ func (suite *endpointGroupAvailabilityTestSuite) TestListEndpointGroupAvailabili
 	suite.Equal(400, response.Code, "Incorrect HTTP response code")
 	// Compare the expected and actual xml response
 	suite.Equal(typeError1XML, output, "Response body mismatch")
+
+	request, _ = http.NewRequest("GET", "/api/v2/results/Report_A/SITE/GROUP_A/Site?start_time=2025-06-22T00:00:00Z&end_time=2025-06-23T23:59:59Z", strings.NewReader(""))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/xml")
+
+	response = httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+	output = response.Body.String()
+
+	// Check that we must have a 404 not found code
+	suite.Equal(404, response.Code, "Incorrect HTTP response code")
+	// Compare the expected and actual xml response
+	suite.Equal(typeError3XML, output, "Response body mismatch")
+
+	request, _ = http.NewRequest("GET", "/api/v2/results/Report_A/SITE/GROUP_A/Site?start_time=2025-06-22T00:00:00Z&end_time=2025-06-23T23:59:59Z", strings.NewReader(""))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+
+	response = httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+	output = response.Body.String()
+
+	// Check that we must have a 404 not found code
+	suite.Equal(404, response.Code, "Incorrect HTTP response code")
+	// Compare the expected and actual xml response
+	suite.Equal(typeError3JSON, output, "Response body mismatch")
 
 }
 

--- a/app/results/routing.go
+++ b/app/results/routing.go
@@ -108,7 +108,7 @@ func routeGroup(r *http.Request, cfg config.Config) (int, http.Header, []byte, e
 		if err.Error() == "Unauthorized" {
 			code = http.StatusUnauthorized
 			message := err.Error()
-			output, err = createErrorMessage(message, contentType)
+			output, err = createErrorMessage(message, code, contentType)
 			h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
 			return code, h, output, err
 		}
@@ -126,10 +126,9 @@ func routeGroup(r *http.Request, cfg config.Config) (int, http.Header, []byte, e
 	err = mongo.FindOne(session, tenantcfg.Db, "reports", bson.M{"info.name": vars["report_name"]}, &requestedReport)
 
 	if err != nil {
-
-		code = http.StatusBadRequest
+		code = http.StatusNotFound
 		message := "The report with the name " + vars["report_name"] + " does not exist"
-		output, err := createErrorMessage(message, contentType) //Render the response into XML or JSON
+		output, err := createErrorMessage(message, code, contentType) //Render the response into XML or JSON
 		h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
 		return code, h, output, err
 	}
@@ -148,9 +147,9 @@ func routeGroup(r *http.Request, cfg config.Config) (int, http.Header, []byte, e
 		return ListSuperGroupResults(r, cfg)
 	}
 
-	code = http.StatusBadRequest
+	code = http.StatusNotFound
 	message := "The report " + vars["report_name"] + " does not define any group type: " + vars["group_type"]
-	output, err = createErrorMessage(message, format) //Render the response into XML or JSON
+	output, err = createErrorMessage(message, code, format) //Render the response into XML or JSON
 	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", format, charset))
 	return code, h, output, err
 

--- a/app/results/serviceflavor_test.go
+++ b/app/results/serviceflavor_test.go
@@ -470,6 +470,7 @@ func (suite *serviceFlavorAvailabilityTestSuite) TestListServiceFlavorAvailabili
 
 	reportErrorXML := ` <root>
    <message>The report with the name Report_B does not exist</message>
+   <code>404</code>
  </root>`
 
 	typeErrorXML := `<root>
@@ -486,6 +487,16 @@ func (suite *serviceFlavorAvailabilityTestSuite) TestListServiceFlavorAvailabili
  </errors>
 </root>`
 
+	typeError1XML := ` <root>
+   <message>No results found for given query</message>
+   <code>404</code>
+ </root>`
+
+	typeError1JSON := `{
+   "message": "No results found for given query",
+   "code": 404
+ }`
+
 	request, _ := http.NewRequest("GET", "/api/v2/results/Report_B/SITE/ST01/services?start_time=2015-06-22T00:00:00Z&end_time=2015-06-23T23:59:59Z", strings.NewReader(""))
 	request.Header.Set("x-api-key", suite.clientkey)
 	request.Header.Set("Accept", "application/xml")
@@ -494,15 +505,14 @@ func (suite *serviceFlavorAvailabilityTestSuite) TestListServiceFlavorAvailabili
 
 	suite.router.ServeHTTP(response, request)
 
-	// Check that we must have a 400 bad request code
-	suite.Equal(400, response.Code, "Incorrect HTTP response code")
+	// Check that we must have a 404 not found code
+	suite.Equal(404, response.Code, "Incorrect HTTP response code")
 	// Compare the expected and actual xml response
 	suite.Equal(reportErrorXML, response.Body.String(), "Response body mismatch")
 
 	request, _ = http.NewRequest("GET", "/api/v2/results/Report_A/Site/ST01/services?start_time=2015-06-22T00:00:00Z&end_time=2015-06-23T23:59:59Z", strings.NewReader(""))
 	request.Header.Set("Accept", "application/xml")
 	request.Header.Set("x-api-key", suite.clientkey)
-	//request.Header.Set("Accept", "application/json")
 
 	response = httptest.NewRecorder()
 
@@ -513,6 +523,34 @@ func (suite *serviceFlavorAvailabilityTestSuite) TestListServiceFlavorAvailabili
 	suite.Equal(400, response.Code, "Incorrect HTTP response code")
 	// Compare the expected and actual xml response
 	suite.Equal(typeErrorXML, output, "Response body mismatch")
+
+	request, _ = http.NewRequest("GET", "/api/v2/results/Report_A/SITE/ST01/services?start_time=2025-06-22T00:00:00Z&end_time=2025-06-23T23:59:59Z", strings.NewReader(""))
+	request.Header.Set("Accept", "application/xml")
+	request.Header.Set("x-api-key", suite.clientkey)
+
+	response = httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+	output = response.Body.String()
+
+	// Check that we must have a 404 not found code
+	suite.Equal(404, response.Code, "Incorrect HTTP response code")
+	// Compare the expected and actual xml response
+	suite.Equal(typeError1XML, output, "Response body mismatch")
+
+	request, _ = http.NewRequest("GET", "/api/v2/results/Report_A/SITE/ST01/services?start_time=2025-06-22T00:00:00Z&end_time=2025-06-23T23:59:59Z", strings.NewReader(""))
+	request.Header.Set("Accept", "application/json")
+	request.Header.Set("x-api-key", suite.clientkey)
+
+	response = httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+	output = response.Body.String()
+
+	// Check that we must have a 404 not found code
+	suite.Equal(404, response.Code, "Incorrect HTTP response code")
+	// Compare the expected and actual xml response
+	suite.Equal(typeError1JSON, output, "Response body mismatch")
 
 }
 

--- a/app/results/supergroup_test.go
+++ b/app/results/supergroup_test.go
@@ -506,11 +506,23 @@ func (suite *SuperGroupAvailabilityTestSuite) TestListSuperGroupAvailabilityErro
 
 	reportErrorXML := ` <root>
    <message>The report with the name Report_B does not exist</message>
+   <code>404</code>
  </root>`
 
 	typeErrorXML := ` <root>
    <message>The report Report_A does not define any group type: supergroup</message>
+   <code>404</code>
  </root>`
+
+	typeError1XML := ` <root>
+   <message>No results found for given query</message>
+   <code>404</code>
+ </root>`
+
+	typeError1JSON := `{
+   "message": "No results found for given query",
+   "code": 404
+ }`
 
 	request, _ := http.NewRequest("GET", "/api/v2/results/Report_B/supergroup?start_time=2015-06-22T00:00:00Z&end_time=2015-06-23T23:59:59Z", strings.NewReader(""))
 	request.Header.Set("x-api-key", suite.clientkey)
@@ -520,8 +532,8 @@ func (suite *SuperGroupAvailabilityTestSuite) TestListSuperGroupAvailabilityErro
 
 	suite.router.ServeHTTP(response, request)
 
-	// Check that we must have a 400 bad request code
-	suite.Equal(400, response.Code, "Incorrect HTTP response code")
+	// Check that we must have a 404 bad request code
+	suite.Equal(404, response.Code, "Incorrect HTTP response code")
 	// Compare the expected and actual xml response
 	suite.Equal(reportErrorXML, response.Body.String(), "Response body mismatch")
 
@@ -535,10 +547,40 @@ func (suite *SuperGroupAvailabilityTestSuite) TestListSuperGroupAvailabilityErro
 	suite.router.ServeHTTP(response, request)
 	output := response.Body.String()
 
-	// Check that we must have a 400 bad request code
-	suite.Equal(400, response.Code, "Incorrect HTTP response code")
+	// Check that we must have a 404 bad request code
+	suite.Equal(404, response.Code, "Incorrect HTTP response code")
 	// Compare the expected and actual xml response
 	suite.Equal(typeErrorXML, output, "Response body mismatch")
+
+	request, _ = http.NewRequest("GET", "/api/v2/results/Report_A/GROUP?start_time=2025-06-22T00:00:00Z&end_time=2025-06-23T23:59:59Z", strings.NewReader(""))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/xml")
+	//request.Header.Set("Accept", "application/json")
+
+	response = httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+	output = response.Body.String()
+
+	// Check that we must have a 404 not found code
+	suite.Equal(404, response.Code, "Incorrect HTTP response code")
+	// Compare the expected and actual xml response
+	suite.Equal(typeError1XML, output, "Response body mismatch")
+
+	request, _ = http.NewRequest("GET", "/api/v2/results/Report_A/GROUP?start_time=2025-06-22T00:00:00Z&end_time=2025-06-23T23:59:59Z", strings.NewReader(""))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+	//request.Header.Set("Accept", "application/json")
+
+	response = httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+	output = response.Body.String()
+
+	// Check that we must have a 404 not found code
+	suite.Equal(404, response.Code, "Incorrect HTTP response code")
+	// Compare the expected and actual xml response
+	suite.Equal(typeError1JSON, output, "Response body mismatch")
 
 }
 


### PR DESCRIPTION
# Description

Fixes in response messages within the `results` resource of the api. Also in case of empty result set responds with a proper "no results found" message. 

please review /cc @themiszamani @kaggis 