### PR TITLE
ARGO-395 Fix in response body in case wrong api-key is being used

### DIFF
--- a/app/factors/factorsController.go
+++ b/app/factors/factorsController.go
@@ -63,9 +63,8 @@ func List(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) 
 	tenantDbConfig, err := authentication.AuthenticateTenant(r.Header, cfg)
 
 	if err != nil {
-		output = []byte(http.StatusText(http.StatusUnauthorized))
 		code = http.StatusUnauthorized //If wrong api key is passed we return UNAUTHORIZED http status
-		h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+		output, _ = respond.MarshalContent(respond.UnauthorizedMessage, contentType, "", " ")
 		return code, h, output, err
 	}
 

--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -1677,15 +1677,18 @@ definitions:
   FactorsResponse:
     type: object
     properties:
-      root:
+      factors:
+        description: "List of endpoint groups and their relevant weights"
         type: array
         items:
           type: object
           properties:
             site:
               type: string
+              description: "The name of the endpoint group"
             weight:
               type: string
+              description: "The weighting factor of the given endpoint group. The higher the factor the more significant the contribution of the given endpoint group in the overall A/R results."
 
   timestamp_value:
     type: object


### PR DESCRIPTION
# Description

Fix in response body in case a wrong api key is used under the /factors resource. Also updated unit tests.

Includes also a minor fix in swagger spec file.