### PR TITLE
ARGO-405 Change in name of upper level body response in results resource

### DIFF
--- a/app/results/Model.go
+++ b/app/results/Model.go
@@ -164,7 +164,7 @@ type SuperGroup struct {
 
 type root struct {
 	XMLName xml.Name      `xml:"root" json:"-"`
-	Result  []interface{} `json:"root"`
+	Result  []interface{} `json:"results"`
 }
 
 // errorMessage struct to hold the json/xml error response

--- a/app/results/endpointgroup_test.go
+++ b/app/results/endpointgroup_test.go
@@ -296,7 +296,7 @@ func (suite *endpointGroupAvailabilityTestSuite) TestListEndpointGroupAvailabili
 	suite.router.ServeHTTP(response, request)
 
 	endpointGroupAvailabilityJSON := `{
-   "root": [
+   "results": [
      {
        "name": "GROUP_A",
        "type": "GROUP",

--- a/app/results/serviceflavor_test.go
+++ b/app/results/serviceflavor_test.go
@@ -310,7 +310,7 @@ func (suite *serviceFlavorAvailabilityTestSuite) TestListServiceFlavorAvailabili
 	responseBody = response.Body.String()
 
 	serviceFlavorAvailabilityJSON := `{
-   "root": [
+   "results": [
      {
        "name": "ST01",
        "type": "SITE",
@@ -393,7 +393,7 @@ func (suite *serviceFlavorAvailabilityTestSuite) TestListServiceFlavorAvailabili
 	suite.router.ServeHTTP(response, request)
 
 	serviceFlavorAvailabilityJSON := `{
-   "root": [
+   "results": [
      {
        "name": "ST01",
        "type": "SITE",

--- a/app/results/supergroup_test.go
+++ b/app/results/supergroup_test.go
@@ -377,7 +377,7 @@ func (suite *SuperGroupAvailabilityTestSuite) TestListSuperGroupAvailability() {
 	suite.router.ServeHTTP(response, request)
 
 	SuperGrouAvailabilityJSON := `{
-   "root": [
+   "results": [
      {
        "name": "GROUP_A",
        "type": "GROUP",
@@ -453,7 +453,7 @@ func (suite *SuperGroupAvailabilityTestSuite) TestListAllSuperGroupAvailability(
 	output := response.Body.String()
 
 	SuperGroupAvailabilityJSON := `{
-   "root": [
+   "results": [
      {
        "name": "GROUP_A",
        "type": "GROUP",


### PR DESCRIPTION
Description

 - [x] Change in name of upper level body response in results resource from `root` to `results`