### PR TITLE
ARGO-416 Centralize authentication / Refactor Routing

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,6 +1,9 @@
 {
 	"ImportPath": "github.com/ARGOeu/argo-web-api",
 	"GoVersion": "go1.5",
+	"Packages": [
+		"./..."
+	],
 	"Deps": [
 		{
 			"ImportPath": "github.com/ARGOeu/go-lru-cache",
@@ -9,6 +12,14 @@
 		{
 			"ImportPath": "github.com/gorilla/context",
 			"Rev": "1c83b3eabd45b6d76072b66b746c20815fb2872d"
+		},
+		{
+			"ImportPath": "github.com/gorilla/handlers",
+			"Rev": "40694b40f4a928c062f56849989d3e9cd0570e5f"
+		},
+		{
+			"ImportPath": "github.com/gorilla/mux",
+			"Rev": "49c024275504f0341e5a9971eb7ba7fa3dc7af40"
 		},
 		{
 			"ImportPath": "github.com/stretchr/testify/assert",
@@ -26,14 +37,6 @@
 			"Rev": "a979bdb3ad236b6a9f508e352e1202779149e8b6"
 		},
 		{
-			"ImportPath": "github.com/gorilla/handlers",
-			"Rev": "40694b40f4a928c062f56849989d3e9cd0570e5f"
-		},
-		{
-			"ImportPath": "github.com/gorilla/mux",
-			"Rev": "49c024275504f0341e5a9971eb7ba7fa3dc7af40"
-		},
-		{
 			"ImportPath": "github.com/twinj/uuid",
 			"Rev": "70cac2bcd273ef6a371bb96cde363d28b68734c3"
 		},
@@ -42,34 +45,7 @@
 			"Rev": "0ef1a8547f99b94fac9af5377dd72febba18f37c"
 		},
 		{
-			"ImportPath": "gopkg.in/gcfg.v1/scanner",
-			"Rev": "0ef1a8547f99b94fac9af5377dd72febba18f37c"
-		},
-		{
-			"ImportPath": "gopkg.in/gcfg.v1/token",
-			"Rev": "0ef1a8547f99b94fac9af5377dd72febba18f37c"
-		},
-		{
-			"ImportPath": "gopkg.in/gcfg.v1/types",
-			"Rev": "0ef1a8547f99b94fac9af5377dd72febba18f37c"
-		},
-		{
 			"ImportPath": "gopkg.in/mgo.v2",
-			"Comment": "r2015.06.03-5-g22287ba",
-			"Rev": "22287bab4379e1fbf6002fb4eb769888f3fb224c"
-		},
-		{
-			"ImportPath": "gopkg.in/mgo.v2/bson",
-			"Comment": "r2015.06.03-5-g22287ba",
-			"Rev": "22287bab4379e1fbf6002fb4eb769888f3fb224c"
-		},
-		{
-			"ImportPath": "gopkg.in/mgo.v2/internal/sasl",
-			"Comment": "r2015.06.03-5-g22287ba",
-			"Rev": "22287bab4379e1fbf6002fb4eb769888f3fb224c"
-		},
-		{
-			"ImportPath": "gopkg.in/mgo.v2/internal/scram",
 			"Comment": "r2015.06.03-5-g22287ba",
 			"Rev": "22287bab4379e1fbf6002fb4eb769888f3fb224c"
 		}

--- a/app/aggregationProfiles/aggregationProfiles_test.go
+++ b/app/aggregationProfiles/aggregationProfiles_test.go
@@ -28,13 +28,13 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/github.com/gorilla/mux"
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/github.com/stretchr/testify/suite"
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/gopkg.in/gcfg.v1"
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/gopkg.in/mgo.v2"
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/gopkg.in/mgo.v2/bson"
 	"github.com/ARGOeu/argo-web-api/respond"
 	"github.com/ARGOeu/argo-web-api/utils/config"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/suite"
+	"gopkg.in/gcfg.v1"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
 )
 
 // This is a util. suite struct used in tests (see pkg "testify")

--- a/app/aggregationProfiles/controller.go
+++ b/app/aggregationProfiles/controller.go
@@ -33,13 +33,13 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/gopkg.in/mgo.v2/bson"
+	"github.com/gorilla/context"
+	"gopkg.in/mgo.v2/bson"
 
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/github.com/gorilla/mux"
 	"github.com/ARGOeu/argo-web-api/respond"
-	"github.com/ARGOeu/argo-web-api/utils/authentication"
 	"github.com/ARGOeu/argo-web-api/utils/config"
 	"github.com/ARGOeu/argo-web-api/utils/mongo"
+	"github.com/gorilla/mux"
 )
 
 // ListOne handles the listing of one specific profile based on its given id
@@ -68,14 +68,8 @@ func ListOne(r *http.Request, cfg config.Config) (int, http.Header, []byte, erro
 		return code, h, output, err
 	}
 
-	// Tenant Authentication
-	tenantDbConfig, err := authentication.AuthenticateTenant(r.Header, cfg)
-
-	if err != nil {
-		output, _ = respond.MarshalContent(respond.UnauthorizedMessage, contentType, "", " ")
-		code = http.StatusUnauthorized //If wrong api key is passed we return UNAUTHORIZED http status
-		return code, h, output, err
-	}
+	// Grab Tenant DB configuration from context
+	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
 
 	// Open session to tenant database
 	session, err := mongo.OpenSession(tenantDbConfig)
@@ -143,14 +137,8 @@ func List(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) 
 
 	urlValues := r.URL.Query()
 
-	// Tenant Authentication
-	tenantDbConfig, err := authentication.AuthenticateTenant(r.Header, cfg)
-
-	if err != nil {
-		output, _ = respond.MarshalContent(respond.UnauthorizedMessage, contentType, "", " ")
-		code = http.StatusUnauthorized //If wrong api key is passed we return UNAUTHORIZED http status
-		return code, h, output, err
-	}
+	// Grab Tenant DB configuration from context
+	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
 
 	// Open session to tenant database
 	session, err := mongo.OpenSession(tenantDbConfig)
@@ -209,13 +197,8 @@ func Create(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 		return code, h, output, err
 	}
 
-	tenantDbConfig, err := authentication.AuthenticateTenant(r.Header, cfg)
-
-	if err != nil {
-		output, _ = respond.MarshalContent(respond.UnauthorizedMessage, contentType, "", " ")
-		code = http.StatusUnauthorized //If wrong api key is passed we return UNAUTHORIZED http status
-		return code, h, output, err
-	}
+	// Grab Tenant DB configuration from context
+	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
 
 	session, err := mongo.OpenSession(tenantDbConfig)
 	defer mongo.CloseSession(session)
@@ -286,13 +269,8 @@ func Update(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 		return code, h, output, err
 	}
 
-	tenantDbConfig, err := authentication.AuthenticateTenant(r.Header, cfg)
-
-	if err != nil {
-		output, _ = respond.MarshalContent(respond.UnauthorizedMessage, contentType, "", " ")
-		code = http.StatusUnauthorized //If wrong api key is passed we return UNAUTHORIZED http status
-		return code, h, output, err
-	}
+	// Grab Tenant DB configuration from context
+	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
 
 	incoming := MongoInterface{}
 
@@ -387,14 +365,8 @@ func Delete(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 		return code, h, output, err
 	}
 
-	// Tenant Authentication
-	tenantDbConfig, err := authentication.AuthenticateTenant(r.Header, cfg)
-
-	if err != nil {
-		output, _ = respond.MarshalContent(respond.UnauthorizedMessage, contentType, "", " ")
-		code = http.StatusUnauthorized //If wrong api key is passed we return UNAUTHORIZED http status
-		return code, h, output, err
-	}
+	// Grab Tenant DB configuration from context
+	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
 
 	// Open session to tenant database
 	session, err := mongo.OpenSession(tenantDbConfig)
@@ -442,6 +414,7 @@ func Delete(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 	return code, h, output, err
 }
 
+//Options implements the http option request
 func Options(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
 
 	//STANDARD DECLARATIONS START

--- a/app/aggregationProfiles/model.go
+++ b/app/aggregationProfiles/model.go
@@ -29,9 +29,9 @@ package aggregationProfiles
 import (
 	"errors"
 
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/gopkg.in/mgo.v2"
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/gopkg.in/mgo.v2/bson"
 	"github.com/ARGOeu/argo-web-api/utils/mongo"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
 )
 
 // MongoInterface to retrieve and insert metricProfiles in mongo

--- a/app/aggregationProfiles/routing.go
+++ b/app/aggregationProfiles/routing.go
@@ -23,46 +23,24 @@
 package aggregationProfiles
 
 import (
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/github.com/gorilla/mux"
 	"github.com/ARGOeu/argo-web-api/respond"
+	"github.com/gorilla/mux"
 )
 
 // HandleSubrouter uses the subrouter for a specific calls and creates a tree of sorts
 // handling each route with a different subrouter
 func HandleSubrouter(s *mux.Router, confhandler *respond.ConfHandler) {
 
-	s.Methods("OPTIONS").
-		Path("/aggregation_profiles").
-		Name("List Options of Resource").
-		Handler(confhandler.Respond(Options))
+	s = respond.PrepAppRoutes(s, confhandler, appRoutesV2)
 
-	s.Methods("GET").
-		Path("/aggregation_profiles").
-		Name("List Aggregation Profiles").
-		Handler(confhandler.Respond(List))
+}
 
-	s.Methods("OPTIONS").
-		Path("/aggregation_profiles/{ID}").
-		Name("List Options of Resource").
-		Handler(confhandler.Respond(Options))
-
-	s.Methods("GET").
-		Path("/aggregation_profiles/{ID}").
-		Name("List One Aggregation Profile").
-		Handler(confhandler.Respond(ListOne))
-
-	s.Methods("POST").
-		Path("/aggregation_profiles").
-		Name("Create Aggregation Profile").
-		Handler(confhandler.Respond(Create))
-
-	s.Methods("PUT").
-		Path("/aggregation_profiles/{ID}").
-		Name("Update Aggregation Profile").
-		Handler(confhandler.Respond(Update))
-
-	s.Methods("DELETE").
-		Path("/aggregation_profiles/{ID}").
-		Name("Delete Aggregation Profile").
-		Handler(confhandler.Respond(Delete))
+var appRoutesV2 = []respond.AppRoutes{
+	{"aggregationProfiles.list", "GET", "/aggregation_profiles", List},
+	{"aggregationProfiles.get", "GET", "/aggregation_profiles/{ID}", ListOne},
+	{"aggregationProfiles.create", "POST", "/aggregation_profiles", Create},
+	{"aggregationProfiles.update", "PUT", "/aggregation_profiles/{ID}", Update},
+	{"aggregationProfiles.delete", "DELETE", "/aggregation_profiles/{ID}", Delete},
+	{"aggregationProfiles.options", "OPTIONS", "/aggregation_profiles", Options},
+	{"aggregationProfiles.options", "OPTIONS", "/aggregation_profiles/{ID}", Options},
 }

--- a/app/factors/factorsController.go
+++ b/app/factors/factorsController.go
@@ -32,9 +32,9 @@ import (
 	"net/http"
 
 	"github.com/ARGOeu/argo-web-api/respond"
-	"github.com/ARGOeu/argo-web-api/utils/authentication"
 	"github.com/ARGOeu/argo-web-api/utils/config"
 	"github.com/ARGOeu/argo-web-api/utils/mongo"
+	"github.com/gorilla/context"
 )
 
 // List returns a list of factors (weights) per endpoint group (i.e. site)
@@ -60,13 +60,8 @@ func List(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) 
 		return code, h, output, err
 	}
 
-	tenantDbConfig, err := authentication.AuthenticateTenant(r.Header, cfg)
-
-	if err != nil {
-		code = http.StatusUnauthorized //If wrong api key is passed we return UNAUTHORIZED http status
-		output, _ = respond.MarshalContent(respond.UnauthorizedMessage, contentType, "", " ")
-		return code, h, output, err
-	}
+	// Grab Tenant DB configuration from context
+	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
 
 	session, err := mongo.OpenSession(tenantDbConfig)
 

--- a/app/factors/factors_test.go
+++ b/app/factors/factors_test.go
@@ -32,14 +32,14 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/github.com/gorilla/mux"
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/github.com/stretchr/testify/suite"
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/gopkg.in/gcfg.v1"
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/gopkg.in/mgo.v2"
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/gopkg.in/mgo.v2/bson"
 	"github.com/ARGOeu/argo-web-api/respond"
 	"github.com/ARGOeu/argo-web-api/utils/config"
 	"github.com/ARGOeu/argo-web-api/utils/mongo"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/suite"
+	"gopkg.in/gcfg.v1"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
 )
 
 // FactorsTestSuite is a utility suite struct used in tests

--- a/app/factors/routing.go
+++ b/app/factors/routing.go
@@ -23,20 +23,27 @@
 package factors
 
 import (
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/github.com/gorilla/mux"
 	"github.com/ARGOeu/argo-web-api/respond"
+	"github.com/gorilla/mux"
 )
 
 func HandleSubrouter(s *mux.Router, confhandler *respond.ConfHandler) {
 
-	s.Methods("GET").
-		Path("/factors").
-		Name("List Factors").
-		Handler(confhandler.Respond(List))
+	// s.Methods("GET").
+	// 	Path("/factors").
+	// 	Name("List Factors").
+	// 	Handler(respond.WrapAll(confhandler.Respond(List), confhandler.Config))
+	//
+	// s.Methods("OPTIONS").
+	// 	Path("/factors").
+	// 	Name("List Options of Resource").
+	// 	Handler(confhandler.Respond(Options))
 
-	s.Methods("OPTIONS").
-		Path("/factors").
-		Name("List Options of Resource").
-		Handler(confhandler.Respond(Options))
+	s = respond.PrepAppRoutes(s, confhandler, appRoutesV2)
 
+}
+
+var appRoutesV2 = []respond.AppRoutes{
+	{"factors.list", "GET", "/factors", List},
+	{"factors.options", "OPTIONS", "/factors", Options},
 }

--- a/app/metricProfiles/controller.go
+++ b/app/metricProfiles/controller.go
@@ -33,13 +33,13 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/gopkg.in/mgo.v2/bson"
+	"github.com/gorilla/context"
+	"gopkg.in/mgo.v2/bson"
 
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/github.com/gorilla/mux"
 	"github.com/ARGOeu/argo-web-api/respond"
-	"github.com/ARGOeu/argo-web-api/utils/authentication"
 	"github.com/ARGOeu/argo-web-api/utils/config"
 	"github.com/ARGOeu/argo-web-api/utils/mongo"
+	"github.com/gorilla/mux"
 )
 
 // ListOne handles the listing of one specific profile based on its given id
@@ -68,14 +68,8 @@ func ListOne(r *http.Request, cfg config.Config) (int, http.Header, []byte, erro
 		return code, h, output, err
 	}
 
-	// Tenant Authentication
-	tenantDbConfig, err := authentication.AuthenticateTenant(r.Header, cfg)
-
-	if err != nil {
-		output, _ = respond.MarshalContent(respond.UnauthorizedMessage, contentType, "", " ")
-		code = http.StatusUnauthorized //If wrong api key is passed we return UNAUTHORIZED http status
-		return code, h, output, err
-	}
+	// Grab Tenant DB configuration from context
+	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
 
 	// Open session to tenant database
 	session, err := mongo.OpenSession(tenantDbConfig)
@@ -143,14 +137,8 @@ func List(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) 
 
 	urlValues := r.URL.Query()
 
-	// Tenant Authentication
-	tenantDbConfig, err := authentication.AuthenticateTenant(r.Header, cfg)
-
-	if err != nil {
-		output, _ = respond.MarshalContent(respond.UnauthorizedMessage, contentType, "", " ")
-		code = http.StatusUnauthorized //If wrong api key is passed we return UNAUTHORIZED http status
-		return code, h, output, err
-	}
+	// Grab Tenant DB configuration from context
+	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
 
 	// Open session to tenant database
 	session, err := mongo.OpenSession(tenantDbConfig)
@@ -209,13 +197,8 @@ func Create(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 		return code, h, output, err
 	}
 
-	tenantDbConfig, err := authentication.AuthenticateTenant(r.Header, cfg)
-
-	if err != nil {
-		output, _ = respond.MarshalContent(respond.UnauthorizedMessage, contentType, "", " ")
-		code = http.StatusUnauthorized //If wrong api key is passed we return UNAUTHORIZED http status
-		return code, h, output, err
-	}
+	// Grab Tenant DB configuration from context
+	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
 
 	session, err := mongo.OpenSession(tenantDbConfig)
 	defer mongo.CloseSession(session)
@@ -277,13 +260,8 @@ func Update(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 		return code, h, output, err
 	}
 
-	tenantDbConfig, err := authentication.AuthenticateTenant(r.Header, cfg)
-
-	if err != nil {
-		output, _ = respond.MarshalContent(respond.UnauthorizedMessage, contentType, "", " ")
-		code = http.StatusUnauthorized //If wrong api key is passed we return UNAUTHORIZED http status
-		return code, h, output, err
-	}
+	// Grab Tenant DB configuration from context
+	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
 
 	incoming := MongoInterface{}
 
@@ -368,8 +346,8 @@ func Delete(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 		return code, h, output, err
 	}
 
-	// Tenant Authentication
-	tenantDbConfig, err := authentication.AuthenticateTenant(r.Header, cfg)
+	// Grab Tenant DB configuration from context
+	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
 
 	if err != nil {
 		output, _ = respond.MarshalContent(respond.UnauthorizedMessage, contentType, "", " ")

--- a/app/metricProfiles/metricProfiles_test.go
+++ b/app/metricProfiles/metricProfiles_test.go
@@ -28,13 +28,13 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/github.com/gorilla/mux"
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/github.com/stretchr/testify/suite"
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/gopkg.in/gcfg.v1"
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/gopkg.in/mgo.v2"
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/gopkg.in/mgo.v2/bson"
 	"github.com/ARGOeu/argo-web-api/respond"
 	"github.com/ARGOeu/argo-web-api/utils/config"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/suite"
+	"gopkg.in/gcfg.v1"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
 )
 
 // This is a util. suite struct used in tests (see pkg "testify")

--- a/app/metricProfiles/routing.go
+++ b/app/metricProfiles/routing.go
@@ -23,45 +23,24 @@
 package metricProfiles
 
 import (
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/github.com/gorilla/mux"
 	"github.com/ARGOeu/argo-web-api/respond"
+	"github.com/gorilla/mux"
 )
 
 // HandleSubrouter uses the subrouter for a specific calls and creates a tree of sorts
 // handling each route with a different subrouter
 func HandleSubrouter(s *mux.Router, confhandler *respond.ConfHandler) {
-	s.Methods("OPTIONS").
-		Path("/metric_profiles").
-		Name("List Options of Resource").
-		Handler(confhandler.Respond(Options))
 
-	s.Methods("GET").
-		Path("/metric_profiles").
-		Name("List Metric Profiles").
-		Handler(confhandler.Respond(List))
+	s = respond.PrepAppRoutes(s, confhandler, appRoutesV2)
 
-	s.Methods("OPTIONS").
-		Path("/metric_profiles/{ID}").
-		Name("List Options of Resource").
-		Handler(confhandler.Respond(Options))
+}
 
-	s.Methods("GET").
-		Path("/metric_profiles/{ID}").
-		Name("List One Metric Profile").
-		Handler(confhandler.Respond(ListOne))
-
-	s.Methods("POST").
-		Path("/metric_profiles").
-		Name("Create Metric Profile").
-		Handler(confhandler.Respond(Create))
-
-	s.Methods("PUT").
-		Path("/metric_profiles/{ID}").
-		Name("Update Metric Profile").
-		Handler(confhandler.Respond(Update))
-
-	s.Methods("DELETE").
-		Path("/metric_profiles/{ID}").
-		Name("Delete Metric Profile").
-		Handler(confhandler.Respond(Delete))
+var appRoutesV2 = []respond.AppRoutes{
+	{"metricProfiles.list", "GET", "/metric_profiles", List},
+	{"metricProfiles.get", "GET", "/metric_profiles/{ID}", ListOne},
+	{"metricProfiles.create", "POST", "/metric_profiles", Create},
+	{"metricProfiles.update", "PUT", "/metric_profiles/{ID}", Update},
+	{"metricProfiles.delete", "DELETE", "/metric_profiles/{ID}", Delete},
+	{"metricProfiles.options", "OPTIONS", "/metric_profiles", Options},
+	{"metricProfiles.options", "OPTIONS", "/metric_profiles/{ID}", Options},
 }

--- a/app/metricResult/controller.go
+++ b/app/metricResult/controller.go
@@ -28,11 +28,11 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/github.com/gorilla/mux"
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/gopkg.in/mgo.v2/bson"
-	"github.com/ARGOeu/argo-web-api/utils/authentication"
 	"github.com/ARGOeu/argo-web-api/utils/config"
 	"github.com/ARGOeu/argo-web-api/utils/mongo"
+	"github.com/gorilla/context"
+	"github.com/gorilla/mux"
+	"gopkg.in/mgo.v2/bson"
 )
 
 // GetMetricResult returns the detailed message from a probe
@@ -47,15 +47,8 @@ func GetMetricResult(r *http.Request, cfg config.Config) (int, http.Header, []by
 	charset := "utf-8"
 	//STANDARD DECLARATIONS END
 
-	tenantDbConfig, err := authentication.AuthenticateTenant(r.Header, cfg)
-	if err != nil {
-		if err.Error() == "Unauthorized" {
-			code = http.StatusUnauthorized
-			return code, h, output, err
-		}
-		code = http.StatusInternalServerError
-		return code, h, output, err
-	}
+	// Grab Tenant DB configuration from context
+	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
 
 	// Parse the request into the input
 	urlValues := r.URL.Query()

--- a/app/metricResult/metric_test.go
+++ b/app/metricResult/metric_test.go
@@ -28,15 +28,15 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/github.com/gorilla/mux"
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/github.com/stretchr/testify/suite"
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/gopkg.in/gcfg.v1"
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/gopkg.in/mgo.v2"
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/gopkg.in/mgo.v2/bson"
 	"github.com/ARGOeu/argo-web-api/respond"
 	"github.com/ARGOeu/argo-web-api/utils/authentication"
 	"github.com/ARGOeu/argo-web-api/utils/config"
 	"github.com/ARGOeu/argo-web-api/utils/mongo"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/suite"
+	"gopkg.in/gcfg.v1"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
 )
 
 // This is a util. suite struct used in tests (see pkg "testify")

--- a/app/metricResult/routing.go
+++ b/app/metricResult/routing.go
@@ -23,17 +23,18 @@
 package metricResult
 
 import (
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/github.com/gorilla/mux"
 	"github.com/ARGOeu/argo-web-api/respond"
+	"github.com/gorilla/mux"
 )
 
 // HandleSubrouter uses the subrouter for a specific calls and creates a tree of sorts
 // handling each route with a different subrouter
 func HandleSubrouter(s *mux.Router, confhandler *respond.ConfHandler) {
 
-	s.Path("/{endpoint_name}/{metric_name}").
-		Methods("GET").
-		Name("Metric Result").
-		Handler(confhandler.Respond(GetMetricResult))
+	s = respond.PrepAppRoutes(s, confhandler, appRoutesV2)
 
+}
+
+var appRoutesV2 = []respond.AppRoutes{
+	{"metricResult.get", "GET", "/{endpoint_name}/{metric_name}", GetMetricResult},
 }

--- a/app/operationsProfiles/controller.go
+++ b/app/operationsProfiles/controller.go
@@ -33,13 +33,13 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/gopkg.in/mgo.v2/bson"
+	"github.com/gorilla/context"
+	"gopkg.in/mgo.v2/bson"
 
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/github.com/gorilla/mux"
 	"github.com/ARGOeu/argo-web-api/respond"
-	"github.com/ARGOeu/argo-web-api/utils/authentication"
 	"github.com/ARGOeu/argo-web-api/utils/config"
 	"github.com/ARGOeu/argo-web-api/utils/mongo"
+	"github.com/gorilla/mux"
 )
 
 // ListOne handles the listing of one specific profile based on its given id
@@ -68,14 +68,8 @@ func ListOne(r *http.Request, cfg config.Config) (int, http.Header, []byte, erro
 		return code, h, output, err
 	}
 
-	// Tenant Authentication
-	tenantDbConfig, err := authentication.AuthenticateTenant(r.Header, cfg)
-
-	if err != nil {
-		output, _ = respond.MarshalContent(respond.UnauthorizedMessage, contentType, "", " ")
-		code = http.StatusUnauthorized //If wrong api key is passed we return UNAUTHORIZED http status
-		return code, h, output, err
-	}
+	// Grab Tenant DB configuration from context
+	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
 
 	// Open session to tenant database
 	session, err := mongo.OpenSession(tenantDbConfig)
@@ -143,14 +137,8 @@ func List(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) 
 
 	urlValues := r.URL.Query()
 
-	// Tenant Authentication
-	tenantDbConfig, err := authentication.AuthenticateTenant(r.Header, cfg)
-
-	if err != nil {
-		output, _ = respond.MarshalContent(respond.UnauthorizedMessage, contentType, "", " ")
-		code = http.StatusUnauthorized //If wrong api key is passed we return UNAUTHORIZED http status
-		return code, h, output, err
-	}
+	// Grab Tenant DB configuration from context
+	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
 
 	// Open session to tenant database
 	session, err := mongo.OpenSession(tenantDbConfig)
@@ -209,13 +197,8 @@ func Create(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 		return code, h, output, err
 	}
 
-	tenantDbConfig, err := authentication.AuthenticateTenant(r.Header, cfg)
-
-	if err != nil {
-		output, _ = respond.MarshalContent(respond.UnauthorizedMessage, contentType, "", " ")
-		code = http.StatusUnauthorized //If wrong api key is passed we return UNAUTHORIZED http status
-		return code, h, output, err
-	}
+	// Grab Tenant DB configuration from context
+	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
 
 	session, err := mongo.OpenSession(tenantDbConfig)
 	defer mongo.CloseSession(session)
@@ -289,13 +272,8 @@ func Update(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 		return code, h, output, err
 	}
 
-	tenantDbConfig, err := authentication.AuthenticateTenant(r.Header, cfg)
-
-	if err != nil {
-		output, _ = respond.MarshalContent(respond.UnauthorizedMessage, contentType, "", " ")
-		code = http.StatusUnauthorized //If wrong api key is passed we return UNAUTHORIZED http status
-		return code, h, output, err
-	}
+	// Grab Tenant DB configuration from context
+	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
 
 	incoming := OpsProfile{}
 
@@ -393,14 +371,8 @@ func Delete(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 		return code, h, output, err
 	}
 
-	// Tenant Authentication
-	tenantDbConfig, err := authentication.AuthenticateTenant(r.Header, cfg)
-
-	if err != nil {
-		output, _ = respond.MarshalContent(respond.UnauthorizedMessage, contentType, "", " ")
-		code = http.StatusUnauthorized //If wrong api key is passed we return UNAUTHORIZED http status
-		return code, h, output, err
-	}
+	// Grab Tenant DB configuration from context
+	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
 
 	// Open session to tenant database
 	session, err := mongo.OpenSession(tenantDbConfig)

--- a/app/operationsProfiles/operationsProfiles_test.go
+++ b/app/operationsProfiles/operationsProfiles_test.go
@@ -28,13 +28,13 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/github.com/gorilla/mux"
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/github.com/stretchr/testify/suite"
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/gopkg.in/gcfg.v1"
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/gopkg.in/mgo.v2"
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/gopkg.in/mgo.v2/bson"
 	"github.com/ARGOeu/argo-web-api/respond"
 	"github.com/ARGOeu/argo-web-api/utils/config"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/suite"
+	"gopkg.in/gcfg.v1"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
 )
 
 // This is a util. suite struct used in tests (see pkg "testify")

--- a/app/operationsProfiles/routing.go
+++ b/app/operationsProfiles/routing.go
@@ -23,46 +23,24 @@
 package operationsProfiles
 
 import (
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/github.com/gorilla/mux"
 	"github.com/ARGOeu/argo-web-api/respond"
+	"github.com/gorilla/mux"
 )
 
 // HandleSubrouter uses the subrouter for a specific calls and creates a tree of sorts
 // handling each route with a different subrouter
 func HandleSubrouter(s *mux.Router, confhandler *respond.ConfHandler) {
 
-	s.Methods("OPTIONS").
-		Path("/operations_profiles").
-		Name("List Options of Resource").
-		Handler(confhandler.Respond(Options))
+	s = respond.PrepAppRoutes(s, confhandler, appRoutesV2)
 
-	s.Methods("GET").
-		Path("/operations_profiles").
-		Name("List Operations Profiles").
-		Handler(confhandler.Respond(List))
+}
 
-	s.Methods("OPTIONS").
-		Path("/operations_profiles/{ID}").
-		Name("List Options of Resource").
-		Handler(confhandler.Respond(Options))
-
-	s.Methods("GET").
-		Path("/operations_profiles/{ID}").
-		Name("List One Operations Profile").
-		Handler(confhandler.Respond(ListOne))
-
-	s.Methods("POST").
-		Path("/operations_profiles").
-		Name("Create Operations Profile").
-		Handler(confhandler.Respond(Create))
-
-	s.Methods("PUT").
-		Path("/operations_profiles/{ID}").
-		Name("Update Operations Profile").
-		Handler(confhandler.Respond(Update))
-
-	s.Methods("DELETE").
-		Path("/operations_profiles/{ID}").
-		Name("Delete Operations Profile").
-		Handler(confhandler.Respond(Delete))
+var appRoutesV2 = []respond.AppRoutes{
+	{"operationsProfiles.list", "GET", "/operations_profiles", List},
+	{"operationsProfiles.get", "GET", "/operations_profiles/{ID}", ListOne},
+	{"operationsProfiles.create", "POST", "/operations_profiles", Create},
+	{"operationsProfiles.update", "PUT", "/operations_profiles/{ID}", Update},
+	{"operationsProfiles.delete", "DELETE", "/operations_profiles/{ID}", Delete},
+	{"operationsProfiles.options", "OPTIONS", "/operations_profiles", Options},
+	{"operationsProfiles.options", "OPTIONS", "/operations_profiles/{ID}", Options},
 }

--- a/app/recomputations2/Controller.go
+++ b/app/recomputations2/Controller.go
@@ -30,11 +30,11 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/github.com/gorilla/mux"
 	"github.com/ARGOeu/argo-web-api/respond"
-	"github.com/ARGOeu/argo-web-api/utils/authentication"
 	"github.com/ARGOeu/argo-web-api/utils/config"
 	"github.com/ARGOeu/argo-web-api/utils/mongo"
+	"github.com/gorilla/context"
+	"github.com/gorilla/mux"
 )
 
 var recomputationsColl = "recomputations"
@@ -62,13 +62,8 @@ func List(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) 
 		return code, h, output, err
 	}
 
-	tenantDbConfig, err := authentication.AuthenticateTenant(r.Header, cfg)
-
-	if err != nil {
-		output, _ = respond.MarshalContent(respond.UnauthorizedMessage, contentType, "", " ")
-		code = http.StatusUnauthorized //If wrong api key is passed we return UNAUTHORIZED http status
-		return code, h, output, err
-	}
+	// Grab Tenant DB configuration from context
+	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
 
 	filter := IncomingRecomputation{
 		StartTime: urlValues.Get("start_time"),
@@ -122,13 +117,8 @@ func ListOne(r *http.Request, cfg config.Config) (int, http.Header, []byte, erro
 		return code, h, output, err
 	}
 
-	tenantDbConfig, err := authentication.AuthenticateTenant(r.Header, cfg)
-
-	if err != nil {
-		output, _ = respond.MarshalContent(respond.UnauthorizedMessage, contentType, "", " ")
-		code = http.StatusUnauthorized //If wrong api key is passed we return UNAUTHORIZED http status
-		return code, h, output, err
-	}
+	// Grab Tenant DB configuration from context
+	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
 
 	filter := IncomingRecomputation{
 		ID: vars["ID"],
@@ -173,13 +163,8 @@ func SubmitRecomputation(r *http.Request, cfg config.Config) (int, http.Header, 
 		return code, h, output, err
 	}
 
-	tenantDbConfig, err := authentication.AuthenticateTenant(r.Header, cfg)
-
-	if err != nil {
-		output, _ = respond.MarshalContent(respond.UnauthorizedMessage, contentType, "", " ")
-		code = http.StatusUnauthorized //If wrong api key is passed we return UNAUTHORIZED http status
-		return code, h, output, err
-	}
+	// Grab Tenant DB configuration from context
+	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
 
 	session, err := mongo.OpenSession(tenantDbConfig)
 

--- a/app/recomputations2/recomputation_test.go
+++ b/app/recomputations2/recomputation_test.go
@@ -30,14 +30,14 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/github.com/gorilla/mux"
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/github.com/stretchr/testify/suite"
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/gopkg.in/gcfg.v1"
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/gopkg.in/mgo.v2"
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/gopkg.in/mgo.v2/bson"
 	"github.com/ARGOeu/argo-web-api/respond"
 	"github.com/ARGOeu/argo-web-api/utils/config"
 	"github.com/ARGOeu/argo-web-api/utils/mongo"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/suite"
+	"gopkg.in/gcfg.v1"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
 )
 
 // This is a util. suite struct used in tests (see pkg "testify")

--- a/app/recomputations2/routing.go
+++ b/app/recomputations2/routing.go
@@ -23,27 +23,20 @@
 package recomputations2
 
 import (
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/github.com/gorilla/mux"
 	"github.com/ARGOeu/argo-web-api/respond"
+	"github.com/gorilla/mux"
 )
 
 // HandleSubrouter uses the subrouter for a specific calls and creates a tree of sorts
 // handling each route with a different subrouter
 func HandleSubrouter(s *mux.Router, confhandler *respond.ConfHandler) {
-	s.Methods("GET").
-		Path("/recomputations/{ID}").
-		Name("List Single Recomputation").
-		Handler(confhandler.Respond(ListOne))
 
-	// strictRoute := s.MatcherFunc(respond.MatchRegex("^" + confhandler.Routes.V2["recomputations"] + "$")).Subrouter()
+	s = respond.PrepAppRoutes(s, confhandler, appRoutesV2)
 
-	s.Methods("GET").
-		Path("/recomputations").
-		Name("List Recomputations").
-		Handler(confhandler.Respond(List))
+}
 
-	s.Methods("POST").
-		Path("/recomputations").
-		Name("Recomputations").
-		Handler(confhandler.Respond(SubmitRecomputation))
+var appRoutesV2 = []respond.AppRoutes{
+	{"recomputations.list", "GET", "/recomputations", List},
+	{"recomputations.get", "GET", "/recomputations/{ID}", ListOne},
+	{"recomputations.submit", "POST", "/recomputations", SubmitRecomputation},
 }

--- a/app/reports/reportsController.go
+++ b/app/reports/reportsController.go
@@ -35,13 +35,13 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/gopkg.in/mgo.v2/bson"
+	"github.com/gorilla/context"
+	"gopkg.in/mgo.v2/bson"
 
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/github.com/gorilla/mux"
 	"github.com/ARGOeu/argo-web-api/respond"
-	"github.com/ARGOeu/argo-web-api/utils/authentication"
 	"github.com/ARGOeu/argo-web-api/utils/config"
 	"github.com/ARGOeu/argo-web-api/utils/mongo"
+	"github.com/gorilla/mux"
 )
 
 var reportsColl = "reports"
@@ -69,13 +69,8 @@ func Create(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 		return code, h, output, err
 	}
 
-	tenantDbConfig, err := authentication.AuthenticateTenant(r.Header, cfg)
-
-	if err != nil {
-		output, _ = respond.MarshalContent(respond.UnauthorizedMessage, contentType, "", " ")
-		code = http.StatusUnauthorized //If wrong api key is passed we return UNAUTHORIZED http status
-		return code, h, output, err
-	}
+	// Grab Tenant DB configuration from context
+	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
 
 	//Reading the json input from the request body
 	reqBody, err := ioutil.ReadAll(io.LimitReader(r.Body, cfg.Server.ReqSizeLimit))
@@ -195,13 +190,8 @@ func List(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) 
 		return code, h, output, err
 	}
 
-	tenantDbConfig, err := authentication.AuthenticateTenant(r.Header, cfg)
-
-	if err != nil {
-		output, _ = respond.MarshalContent(respond.UnauthorizedMessage, contentType, "", " ")
-		code = http.StatusUnauthorized //If wrong api key is passed we return UNAUTHORIZED http status
-		return code, h, output, err
-	}
+	// Grab Tenant DB configuration from context
+	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
 
 	// Try to open the mongo session
 	session, err := mongo.OpenSession(cfg.MongoDB)
@@ -263,13 +253,8 @@ func ListOne(r *http.Request, cfg config.Config) (int, http.Header, []byte, erro
 		return code, h, output, err
 	}
 
-	tenantDbConfig, err := authentication.AuthenticateTenant(r.Header, cfg)
-
-	if err != nil {
-		output, _ = respond.MarshalContent(respond.UnauthorizedMessage, contentType, "", " ")
-		code = http.StatusUnauthorized //If wrong api key is passed we return UNAUTHORIZED http status
-		return code, h, output, err
-	}
+	// Grab Tenant DB configuration from context
+	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
 
 	//Extracting urlvar "name" from url path
 
@@ -338,13 +323,8 @@ func Update(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 		return code, h, output, err
 	}
 
-	tenantDbConfig, err := authentication.AuthenticateTenant(r.Header, cfg)
-
-	if err != nil {
-		output, _ = respond.MarshalContent(respond.UnauthorizedMessage, contentType, "", " ")
-		code = http.StatusUnauthorized //If wrong api key is passed we return UNAUTHORIZED http status
-		return code, h, output, err
-	}
+	// Grab Tenant DB configuration from context
+	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
 
 	//Extracting report name from url
 	id := mux.Vars(r)["id"]
@@ -447,13 +427,8 @@ func Delete(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 		return code, h, output, err
 	}
 
-	tenantDbConfig, err := authentication.AuthenticateTenant(r.Header, cfg)
-
-	if err != nil {
-		output, _ = respond.MarshalContent(respond.UnauthorizedMessage, contentType, "", " ")
-		code = http.StatusUnauthorized //If wrong api key is passed we return UNAUTHORIZED http status
-		return code, h, output, err
-	}
+	// Grab Tenant DB configuration from context
+	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
 
 	//Extracting record id from url
 	id := mux.Vars(r)["id"]

--- a/app/reports/reportsModel.go
+++ b/app/reports/reportsModel.go
@@ -33,8 +33,8 @@ import (
 
 	"github.com/ARGOeu/argo-web-api/respond"
 
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/gopkg.in/mgo.v2"
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/gopkg.in/mgo.v2/bson"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
 )
 
 // MongoInterface is used as an interface to Marshal and Unmarshal from different formats

--- a/app/reports/reports_test.go
+++ b/app/reports/reports_test.go
@@ -33,15 +33,15 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/github.com/gorilla/mux"
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/github.com/stretchr/testify/suite"
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/gopkg.in/gcfg.v1"
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/gopkg.in/mgo.v2"
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/gopkg.in/mgo.v2/bson"
 	"github.com/ARGOeu/argo-web-api/respond"
 	"github.com/ARGOeu/argo-web-api/utils/authentication"
 	"github.com/ARGOeu/argo-web-api/utils/config"
 	"github.com/ARGOeu/argo-web-api/utils/mongo"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/suite"
+	"gopkg.in/gcfg.v1"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
 )
 
 // This is a util. suite struct used in tests (see pkg "testify")
@@ -1267,6 +1267,8 @@ func (suite *ReportTestSuite) TestDeleteNotFound() {
 
 func (suite *ReportTestSuite) TestOptionsReports() {
 	request, _ := http.NewRequest("OPTIONS", "/api/v2/reports", strings.NewReader(""))
+	// add the authentication token which is seeded in testdb
+	request.Header.Set("x-api-key", "C4PK3Y")
 
 	response := httptest.NewRecorder()
 

--- a/app/reports/routing.go
+++ b/app/reports/routing.go
@@ -27,18 +27,24 @@
 package reports
 
 import (
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/github.com/gorilla/mux"
 	"github.com/ARGOeu/argo-web-api/respond"
+	"github.com/gorilla/mux"
 )
 
 // HandleSubrouter uses the subrouter for a specific calls and creates a tree of sorts
 // handling each route with a different subrouter
 func HandleSubrouter(s *mux.Router, confhandler *respond.ConfHandler) {
-	s.Methods("POST").Path("/reports").Handler(confhandler.Respond(Create))
-	s.Methods("PUT").Path("/reports/{id}").Handler(confhandler.Respond(Update))
-	s.Methods("DELETE").Path("/reports/{id}").Handler(confhandler.Respond(Delete))
-	s.Methods("GET").Path("/reports/{id}").Handler(confhandler.Respond(ListOne))
-	s.Methods("GET").Path("/reports").Handler(confhandler.Respond(List))
-	s.Methods("OPTIONS").Path("/reports").Handler(confhandler.Respond(Options))
-	s.Methods("OPTIONS").Path("/reports/{id}").Handler(confhandler.Respond(Options))
+
+	s = respond.PrepAppRoutes(s, confhandler, appRoutesV2)
+
+}
+
+var appRoutesV2 = []respond.AppRoutes{
+	{"reports.list", "GET", "/reports", List},
+	{"reports.get", "GET", "/reports/{id}", ListOne},
+	{"reports.create", "POST", "/reports", Create},
+	{"reports.update", "PUT", "/reports/{id}", Update},
+	{"reports.delete", "DELETE", "/reports/{id}", Delete},
+	{"reports.options", "OPTIONS", "/reports", Options},
+	{"reports.options", "OPTIONS", "/reports/{id}", Options},
 }

--- a/app/results/Controller.go
+++ b/app/results/Controller.go
@@ -26,13 +26,13 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/github.com/gorilla/mux"
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/gopkg.in/mgo.v2/bson"
 	"github.com/ARGOeu/argo-web-api/app/reports"
 	"github.com/ARGOeu/argo-web-api/respond"
-	"github.com/ARGOeu/argo-web-api/utils/authentication"
 	"github.com/ARGOeu/argo-web-api/utils/config"
 	"github.com/ARGOeu/argo-web-api/utils/mongo"
+	"github.com/gorilla/context"
+	"github.com/gorilla/mux"
+	"gopkg.in/mgo.v2/bson"
 )
 
 // ListServiceFlavorResults is responsible for handling request to list service flavor results
@@ -59,17 +59,8 @@ func ListServiceFlavorResults(r *http.Request, cfg config.Config) (int, http.Hea
 	urlValues := r.URL.Query()
 	vars := mux.Vars(r)
 
-	tenantDbConfig, err := authentication.AuthenticateTenant(r.Header, cfg)
-	if err != nil {
-		if err.Error() == "Unauthorized" {
-			code = http.StatusUnauthorized
-			out := respond.UnauthorizedMessage
-			output = out.MarshalTo(contentType)
-			return code, h, output, err
-		}
-		code = http.StatusInternalServerError
-		return code, h, output, err
-	}
+	// Grab Tenant DB configuration from context
+	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
 
 	session, err := mongo.OpenSession(tenantDbConfig)
 	defer mongo.CloseSession(session)
@@ -204,17 +195,8 @@ func ListEndpointGroupResults(r *http.Request, cfg config.Config) (int, http.Hea
 	urlValues := r.URL.Query()
 	vars := mux.Vars(r)
 
-	tenantDbConfig, err := authentication.AuthenticateTenant(r.Header, cfg)
-	if err != nil {
-		if err.Error() == "Unauthorized" {
-			code = http.StatusUnauthorized
-			out := respond.UnauthorizedMessage
-			output = out.MarshalTo(contentType)
-			return code, h, output, err
-		}
-		code = http.StatusInternalServerError
-		return code, h, output, err
-	}
+	// Grab Tenant DB configuration from context
+	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
 
 	session, err := mongo.OpenSession(tenantDbConfig)
 	defer mongo.CloseSession(session)
@@ -343,18 +325,8 @@ func ListSuperGroupResults(r *http.Request, cfg config.Config) (int, http.Header
 	urlValues := r.URL.Query()
 	vars := mux.Vars(r)
 
-	tenantDbConfig, err := authentication.AuthenticateTenant(r.Header, cfg)
-
-	if err != nil {
-		if err.Error() == "Unauthorized" {
-			code = http.StatusUnauthorized
-			out := respond.UnauthorizedMessage
-			output = out.MarshalTo(contentType)
-			return code, h, output, err
-		}
-		code = http.StatusInternalServerError
-		return code, h, output, err
-	}
+	// Grab Tenant DB configuration from context
+	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
 
 	session, err := mongo.OpenSession(tenantDbConfig)
 	defer mongo.CloseSession(session)

--- a/app/results/Model.go
+++ b/app/results/Model.go
@@ -29,9 +29,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/gopkg.in/mgo.v2"
 	"github.com/ARGOeu/argo-web-api/app/reports"
 	"github.com/ARGOeu/argo-web-api/respond"
+	"gopkg.in/mgo.v2"
 )
 
 type list []interface{}

--- a/app/results/endpointgroup_test.go
+++ b/app/results/endpointgroup_test.go
@@ -28,13 +28,13 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/github.com/gorilla/mux"
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/github.com/stretchr/testify/suite"
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/gopkg.in/gcfg.v1"
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/gopkg.in/mgo.v2"
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/gopkg.in/mgo.v2/bson"
 	"github.com/ARGOeu/argo-web-api/respond"
 	"github.com/ARGOeu/argo-web-api/utils/config"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/suite"
+	"gopkg.in/gcfg.v1"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
 )
 
 type endpointGroupAvailabilityTestSuite struct {
@@ -340,10 +340,13 @@ func (suite *endpointGroupAvailabilityTestSuite) TestListEndpointGroupAvailabili
 
 	suite.router.ServeHTTP(response, request)
 
-	unauthorizedresponseXML := ` <root>
-   <message>Unauthorized</message>
-   <code>401</code>
- </root>`
+	unauthorizedresponseXML := `<root>
+ <status>
+  <message>Unauthorized</message>
+  <code>401</code>
+  <details>You need to provide a correct authentication token using the header &#39;x-api-key&#39;</details>
+ </status>
+</root>`
 
 	// Check that we must have a 401 Unauthorized code
 	suite.Equal(401, response.Code, "Incorrect HTTP response code")

--- a/app/results/serviceflavor_test.go
+++ b/app/results/serviceflavor_test.go
@@ -28,13 +28,13 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/github.com/gorilla/mux"
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/github.com/stretchr/testify/suite"
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/gopkg.in/gcfg.v1"
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/gopkg.in/mgo.v2"
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/gopkg.in/mgo.v2/bson"
 	"github.com/ARGOeu/argo-web-api/respond"
 	"github.com/ARGOeu/argo-web-api/utils/config"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/suite"
+	"gopkg.in/gcfg.v1"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
 )
 
 type serviceFlavorAvailabilityTestSuite struct {

--- a/app/results/supergroup_test.go
+++ b/app/results/supergroup_test.go
@@ -28,13 +28,13 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/github.com/gorilla/mux"
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/github.com/stretchr/testify/suite"
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/gopkg.in/gcfg.v1"
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/gopkg.in/mgo.v2"
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/gopkg.in/mgo.v2/bson"
 	"github.com/ARGOeu/argo-web-api/respond"
 	"github.com/ARGOeu/argo-web-api/utils/config"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/suite"
+	"gopkg.in/gcfg.v1"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
 )
 
 type SuperGroupAvailabilityTestSuite struct {

--- a/app/statusEndpointGroups/controller.go
+++ b/app/statusEndpointGroups/controller.go
@@ -26,12 +26,12 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/github.com/gorilla/mux"
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/gopkg.in/mgo.v2/bson"
 	"github.com/ARGOeu/argo-web-api/respond"
-	"github.com/ARGOeu/argo-web-api/utils/authentication"
 	"github.com/ARGOeu/argo-web-api/utils/config"
 	"github.com/ARGOeu/argo-web-api/utils/mongo"
+	"github.com/gorilla/context"
+	"github.com/gorilla/mux"
+	"gopkg.in/mgo.v2/bson"
 )
 
 // ListEndpointGroupTimelines returns a list of metric timelines
@@ -76,19 +76,9 @@ func ListEndpointGroupTimelines(r *http.Request, cfg config.Config) (int, http.H
 		contentType,
 	}
 
-	// Call authenticateTenant to check the api key and retrieve
-	// the correct tenant db conf
-	tenantDbConfig, err := authentication.AuthenticateTenant(r.Header, cfg)
-	if err != nil {
-		if err.Error() == "Unauthorized" {
-			code = http.StatusUnauthorized
-			out := respond.UnauthorizedMessage
-			output = out.MarshalTo(contentType)
-			return code, h, output, err
-		}
-		code = http.StatusInternalServerError
-		return code, h, output, err
-	}
+	// Grab Tenant DB configuration from context
+	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
+
 	// Mongo Session
 	results := []DataOutput{}
 

--- a/app/statusEndpointGroups/statusEndpointGroups_test.go
+++ b/app/statusEndpointGroups/statusEndpointGroups_test.go
@@ -28,15 +28,15 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/github.com/gorilla/mux"
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/github.com/stretchr/testify/suite"
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/gopkg.in/gcfg.v1"
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/gopkg.in/mgo.v2"
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/gopkg.in/mgo.v2/bson"
 	"github.com/ARGOeu/argo-web-api/respond"
 	"github.com/ARGOeu/argo-web-api/utils/authentication"
 	"github.com/ARGOeu/argo-web-api/utils/config"
 	"github.com/ARGOeu/argo-web-api/utils/mongo"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/suite"
+	"gopkg.in/gcfg.v1"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
 )
 
 // This is a util. suite struct used in tests (see pkg "testify")

--- a/app/statusEndpoints/statusEndpoints_test.go
+++ b/app/statusEndpoints/statusEndpoints_test.go
@@ -28,15 +28,15 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/github.com/gorilla/mux"
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/github.com/stretchr/testify/suite"
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/gopkg.in/gcfg.v1"
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/gopkg.in/mgo.v2"
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/gopkg.in/mgo.v2/bson"
 	"github.com/ARGOeu/argo-web-api/respond"
 	"github.com/ARGOeu/argo-web-api/utils/authentication"
 	"github.com/ARGOeu/argo-web-api/utils/config"
 	"github.com/ARGOeu/argo-web-api/utils/mongo"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/suite"
+	"gopkg.in/gcfg.v1"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
 )
 
 // This is a util. suite struct used in tests (see pkg "testify")

--- a/app/statusMetrics/controller.go
+++ b/app/statusMetrics/controller.go
@@ -26,12 +26,12 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/github.com/gorilla/mux"
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/gopkg.in/mgo.v2/bson"
 	"github.com/ARGOeu/argo-web-api/respond"
-	"github.com/ARGOeu/argo-web-api/utils/authentication"
 	"github.com/ARGOeu/argo-web-api/utils/config"
 	"github.com/ARGOeu/argo-web-api/utils/mongo"
+	"github.com/gorilla/context"
+	"github.com/gorilla/mux"
+	"gopkg.in/mgo.v2/bson"
 )
 
 // ListMetricTimelines returns a list of metric timelines
@@ -79,16 +79,8 @@ func ListMetricTimelines(r *http.Request, cfg config.Config) (int, http.Header, 
 		contentType,
 	}
 
-	// Call authenticateTenant to check the api key and retrieve
-	// the correct tenant db conf
-	tenantDbConfig, err := authentication.AuthenticateTenant(r.Header, cfg)
-
-	if err != nil {
-		output = []byte(http.StatusText(http.StatusUnauthorized))
-		code = http.StatusUnauthorized //If wrong api key is passed we return UNAUTHORIZED http status
-		h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
-		return code, h, output, err
-	}
+	// Grab Tenant DB configuration from context
+	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
 
 	// Mongo Session
 	results := []DataOutput{}
@@ -136,6 +128,7 @@ func prepareQuery(input InputParams, reportID string) bson.M {
 	return filter
 }
 
+// Options implements the option request on resource
 func Options(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
 
 	//STANDARD DECLARATIONS START

--- a/app/statusMetrics/routing.go
+++ b/app/statusMetrics/routing.go
@@ -27,40 +27,27 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/github.com/gorilla/mux"
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/gopkg.in/mgo.v2/bson"
 	"github.com/ARGOeu/argo-web-api/app/reports"
 	"github.com/ARGOeu/argo-web-api/respond"
-	"github.com/ARGOeu/argo-web-api/utils/authentication"
 	"github.com/ARGOeu/argo-web-api/utils/config"
 	"github.com/ARGOeu/argo-web-api/utils/mongo"
+	"github.com/gorilla/context"
+	"github.com/gorilla/mux"
+	"gopkg.in/mgo.v2/bson"
 )
 
 // HandleSubrouter contains the different paths to follow during subrouting
 func HandleSubrouter(s *mux.Router, confhandler *respond.ConfHandler) {
 
-	// eg. timelines/critical/SITE/mysite/service/apache/endpoints/apache01.host/metrics/memory_used
-	s.Path("/{report_name}/{group_type}/{group_name}/services/{service_name}/endpoints/{endpoint_name}/metrics/{metric_name}").
-		Methods("GET").
-		Name("metric name").
-		Handler(confhandler.Respond(routeCheckGroup))
+	s = respond.PrepAppRoutes(s, confhandler, appRoutesV2)
 
-	// eg. timelines/critical/SITE/mysite/service/apache/endpoints/apache01.host/metrics
-	s.Path("/{report_name}/{group_type}/{group_name}/services/{service_name}/endpoints/{endpoint_name}/metrics").
-		Methods("GET").
-		Name("all metrics").
-		Handler(confhandler.Respond(routeCheckGroup))
+}
 
-	s.Path("/{report_name}/{group_type}/{group_name}/services/{service_name}/endpoints/{endpoint_name}/metrics/{metric_name}").
-		Methods("OPTIONS").
-		Name("List options of Resource").
-		Handler(confhandler.Respond(Options))
-
-	s.Path("/{report_name}/{group_type}/{group_name}/services/{service_name}/endpoints/{endpoint_name}/metrics").
-		Methods("OPTIONS").
-		Name("List options of Resource").
-		Handler(confhandler.Respond(Options))
-
+var appRoutesV2 = []respond.AppRoutes{
+	{"status_metrics.get", "GET", "/{report_name}/{group_type}/{group_name}/services/{service_name}/endpoints/{endpoint_name}/metrics/{metric_name}", routeCheckGroup},
+	{"status_metrics.list", "GET", "/{report_name}/{group_type}/{group_name}/services/{service_name}/endpoints/{endpoint_name}/metrics", routeCheckGroup},
+	{"status_metrics.options", "OPTIONS", "/{report_name}/{group_type}/{group_name}/services/{service_name}/endpoints/{endpoint_name}/metrics/{metric_name}", Options},
+	{"status_metrics.options", "OPTIONS", "/{report_name}/{group_type}/{group_name}/services/{service_name}/endpoints/{endpoint_name}/metrics", Options},
 }
 
 func routeCheckGroup(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
@@ -82,17 +69,10 @@ func routeCheckGroup(r *http.Request, cfg config.Config) (int, http.Header, []by
 	}
 
 	vars := mux.Vars(r)
-	tenantcfg, err := authentication.AuthenticateTenant(r.Header, cfg)
-	if err != nil {
-		if err.Error() == "Unauthorized" {
-			code = http.StatusUnauthorized
-			output, _ = respond.MarshalContent(respond.UnauthorizedMessage, contentType, "", " ")
-			return code, h, output, err
-		}
-		code = http.StatusInternalServerError
-		output, _ = respond.MarshalContent(respond.InternalServerErrorMessage, contentType, "", " ")
-		return code, h, output, err
-	}
+
+	// Grab Tenant DB configuration from context
+	tenantcfg := context.Get(r, "tenant_conf").(config.MongoConfig)
+
 	session, err := mongo.OpenSession(tenantcfg)
 	defer mongo.CloseSession(session)
 	if err != nil {

--- a/app/statusMetrics/statusMetrics_test.go
+++ b/app/statusMetrics/statusMetrics_test.go
@@ -28,15 +28,15 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/github.com/gorilla/mux"
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/github.com/stretchr/testify/suite"
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/gopkg.in/gcfg.v1"
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/gopkg.in/mgo.v2"
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/gopkg.in/mgo.v2/bson"
 	"github.com/ARGOeu/argo-web-api/respond"
 	"github.com/ARGOeu/argo-web-api/utils/authentication"
 	"github.com/ARGOeu/argo-web-api/utils/config"
 	"github.com/ARGOeu/argo-web-api/utils/mongo"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/suite"
+	"gopkg.in/gcfg.v1"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
 )
 
 // This is a util. suite struct used in tests (see pkg "testify")

--- a/app/statusServices/controller.go
+++ b/app/statusServices/controller.go
@@ -26,12 +26,12 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/github.com/gorilla/mux"
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/gopkg.in/mgo.v2/bson"
 	"github.com/ARGOeu/argo-web-api/respond"
-	"github.com/ARGOeu/argo-web-api/utils/authentication"
 	"github.com/ARGOeu/argo-web-api/utils/config"
 	"github.com/ARGOeu/argo-web-api/utils/mongo"
+	"github.com/gorilla/context"
+	"github.com/gorilla/mux"
+	"gopkg.in/mgo.v2/bson"
 )
 
 // ListMetricTimelines returns a list of metric timelines
@@ -77,16 +77,8 @@ func ListServiceTimelines(r *http.Request, cfg config.Config) (int, http.Header,
 		contentType,
 	}
 
-	// Call authenticateTenant to check the api key and retrieve
-	// the correct tenant db conf
-	tenantDbConfig, err := authentication.AuthenticateTenant(r.Header, cfg)
-
-	if err != nil {
-		output = []byte(http.StatusText(http.StatusUnauthorized))
-		code = http.StatusUnauthorized //If wrong api key is passed we return UNAUTHORIZED http status
-		h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
-		return code, h, output, err
-	}
+	// Grab Tenant DB configuration from context
+	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
 
 	// Mongo Session
 	results := []DataOutput{}

--- a/app/statusServices/statusServices_test.go
+++ b/app/statusServices/statusServices_test.go
@@ -28,15 +28,15 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/github.com/gorilla/mux"
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/github.com/stretchr/testify/suite"
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/gopkg.in/gcfg.v1"
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/gopkg.in/mgo.v2"
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/gopkg.in/mgo.v2/bson"
 	"github.com/ARGOeu/argo-web-api/respond"
 	"github.com/ARGOeu/argo-web-api/utils/authentication"
 	"github.com/ARGOeu/argo-web-api/utils/config"
 	"github.com/ARGOeu/argo-web-api/utils/mongo"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/suite"
+	"gopkg.in/gcfg.v1"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
 )
 
 // This is a util. suite struct used in tests (see pkg "testify")

--- a/app/tenants/controller.go
+++ b/app/tenants/controller.go
@@ -34,13 +34,12 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/gopkg.in/mgo.v2/bson"
+	"gopkg.in/mgo.v2/bson"
 
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/github.com/gorilla/mux"
 	"github.com/ARGOeu/argo-web-api/respond"
-	"github.com/ARGOeu/argo-web-api/utils/authentication"
 	"github.com/ARGOeu/argo-web-api/utils/config"
 	"github.com/ARGOeu/argo-web-api/utils/mongo"
+	"github.com/gorilla/mux"
 )
 
 // Create function is used to implement the create tenant request.
@@ -60,15 +59,6 @@ func Create(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 	// Content Negotiation
 	contentType, err = respond.ParseAcceptHeader(r)
 	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
-
-	// if authentication procedure fails then
-	// return unauthorized http status
-	if authentication.AuthenticateAdmin(r.Header, cfg) == false {
-
-		output, _ = respond.MarshalContent(respond.UnauthorizedMessage, contentType, "", " ")
-		code = http.StatusUnauthorized //If wrong api key is passed we return UNAUTHORIZED http status
-		return code, h, output, err
-	}
 
 	// Try ingest request body
 	body, err := ioutil.ReadAll(io.LimitReader(r.Body, cfg.Server.ReqSizeLimit))
@@ -148,15 +138,6 @@ func List(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) 
 		return code, h, output, err
 	}
 
-	// if authentication procedure fails then
-	// return unauthorized http status
-	if authentication.AuthenticateAdmin(r.Header, cfg) == false {
-
-		output, _ = respond.MarshalContent(respond.UnauthorizedMessage, contentType, "", " ")
-		code = http.StatusUnauthorized //If wrong api key is passed we return UNAUTHORIZED http status
-		return code, h, output, err
-	}
-
 	// Try to open the mongo session
 	session, err := mongo.OpenSession(cfg.MongoDB)
 	defer session.Close()
@@ -212,15 +193,6 @@ func ListOne(r *http.Request, cfg config.Config) (int, http.Header, []byte, erro
 	if err != nil {
 		code = http.StatusNotAcceptable
 		output, _ = respond.MarshalContent(respond.NotAcceptableContentType, contentType, "", " ")
-		return code, h, output, err
-	}
-
-	// if authentication procedure fails then
-	// return unauthorized http status
-	if authentication.AuthenticateAdmin(r.Header, cfg) == false {
-
-		output, _ = respond.MarshalContent(respond.UnauthorizedMessage, contentType, "", " ")
-		code = http.StatusUnauthorized //If wrong api key is passed we return UNAUTHORIZED http status
 		return code, h, output, err
 	}
 
@@ -288,16 +260,6 @@ func Update(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
 
 	vars := mux.Vars(r)
-
-	// if authentication procedure fails then
-	// return unauthorized
-	if authentication.AuthenticateAdmin(r.Header, cfg) == false {
-
-		output, _ = respond.MarshalContent(respond.UnauthorizedMessage, contentType, "", " ")
-		code = http.StatusUnauthorized //If wrong api key is passed we return UNAUTHORIZED http status
-		return code, h, output, err
-
-	}
 
 	incoming := Tenant{}
 
@@ -399,15 +361,6 @@ func Delete(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
 
 	vars := mux.Vars(r)
-
-	// if authentication procedure fails then
-	// return unauthorized
-	if authentication.AuthenticateAdmin(r.Header, cfg) == false {
-
-		output, _ = respond.MarshalContent(respond.UnauthorizedMessage, contentType, "", " ")
-		code = http.StatusUnauthorized //If wrong api key is passed we return UNAUTHORIZED http status
-		return code, h, output, err
-	}
 
 	// Try to open the mongo session
 	session, err := mongo.OpenSession(cfg.MongoDB)

--- a/app/tenants/routing.go
+++ b/app/tenants/routing.go
@@ -23,45 +23,23 @@
 package tenants
 
 import (
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/github.com/gorilla/mux"
 	"github.com/ARGOeu/argo-web-api/respond"
+	"github.com/gorilla/mux"
 )
 
 // HandleSubrouter uses the subrouter for a specific calls and creates a tree of sorts
 // handling each route with a different subrouter
 func HandleSubrouter(s *mux.Router, confhandler *respond.ConfHandler) {
-	s.Methods("OPTIONS").
-		Path("/tenants").
-		Name("List Options of Resource").
-		Handler(confhandler.Respond(Options))
 
-	s.Methods("GET").
-		Path("/tenants").
-		Name("List Aggregation Profiles").
-		Handler(confhandler.Respond(List))
+	s = respond.PrepAppRoutes(s, confhandler, appRoutesV2)
+}
 
-	s.Methods("GET").
-		Path("/tenants/{ID}").
-		Name("List One Aggregation Profile").
-		Handler(confhandler.Respond(ListOne))
-
-	s.Methods("POST").
-		Path("/tenants").
-		Name("Create Aggregation Profile").
-		Handler(confhandler.Respond(Create))
-
-	s.Methods("OPTIONS").
-		Path("/tenants/{ID}").
-		Name("List Options of Resource").
-		Handler(confhandler.Respond(Options))
-
-	s.Methods("PUT").
-		Path("/tenants/{ID}").
-		Name("Update Aggregation Profile").
-		Handler(confhandler.Respond(Update))
-
-	s.Methods("DELETE").
-		Path("/tenants/{ID}").
-		Name("Delete Aggregation Profile").
-		Handler(confhandler.Respond(Delete))
+var appRoutesV2 = []respond.AppRoutes{
+	{"tenants.list", "GET", "/tenants", List},
+	{"tenants.get", "GET", "/tenants/{ID}", ListOne},
+	{"tenants.create", "POST", "/tenants", Create},
+	{"tenants.update", "PUT", "/tenants/{ID}", Update},
+	{"tenants.delete", "DELETE", "/tenants/{ID}", Delete},
+	{"tenants.options", "OPTIONS", "/tenants", Options},
+	{"tenants.options", "OPTIONS", "/tenants/{ID}", Options},
 }

--- a/app/tenants/tenants_test.go
+++ b/app/tenants/tenants_test.go
@@ -32,14 +32,14 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/github.com/gorilla/mux"
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/github.com/stretchr/testify/suite"
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/gopkg.in/gcfg.v1"
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/gopkg.in/mgo.v2"
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/gopkg.in/mgo.v2/bson"
 	"github.com/ARGOeu/argo-web-api/respond"
 	"github.com/ARGOeu/argo-web-api/utils/config"
 	"github.com/ARGOeu/argo-web-api/utils/mongo"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/suite"
+	"gopkg.in/gcfg.v1"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
 )
 
 // This is a util. suite struct used in tests (see pkg "testify")

--- a/init.go
+++ b/init.go
@@ -33,8 +33,8 @@ import (
 	"runtime"
 	"runtime/pprof"
 
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/github.com/ARGOeu/go-lru-cache"
 	"github.com/ARGOeu/argo-web-api/utils/config"
+	"github.com/ARGOeu/go-lru-cache"
 )
 
 var httpcache *cache.LRUCache

--- a/main.go
+++ b/main.go
@@ -33,8 +33,8 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/github.com/gorilla/handlers"
 	"github.com/ARGOeu/argo-web-api/routing"
+	"github.com/gorilla/handlers"
 )
 
 func main() {

--- a/respond/respond.go
+++ b/respond/respond.go
@@ -35,16 +35,37 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/github.com/gorilla/mux"
 	"github.com/ARGOeu/argo-web-api/utils/caches"
 	"github.com/ARGOeu/argo-web-api/utils/config"
 	"github.com/ARGOeu/argo-web-api/utils/logging"
+	"github.com/gorilla/context"
+	"github.com/gorilla/mux"
 )
+
+// AppRoutes holds
+type AppRoutes struct {
+	Name             string
+	Verb             string
+	Path             string
+	SubrouterHandler func(r *http.Request, cfg config.Config) (int, http.Header, []byte, error)
+}
 
 type list []interface{}
 
 const zuluForm = "2006-01-02T15:04:05Z"
 const ymdForm = "20060102"
+
+//ErrEnum used as type for enumerations of errors
+type ErrEnum int
+
+const (
+	//ErrAuthen is Error during authentication
+	ErrAuthen ErrEnum = iota
+	//ErrAuthor is Error during authorization
+	ErrAuthor
+	//ErrValid is Error during validation
+	ErrValid
+)
 
 // ConfHandler Keeps all the configuration/variables required by all the requests
 type ConfHandler struct {
@@ -71,6 +92,64 @@ type ErrorResponse struct {
 	Message string `xml:"message,omitempty" json:"message,omitempty"`
 	Code    string `xml:"code,omitempty" json:"code,omitempty"`
 	Details string `xml:"details,omitempty" json:"details,omitempty"`
+}
+
+// PrepAppRoutes is used in apps to prepare app's routes
+func PrepAppRoutes(s *mux.Router, confHandler *ConfHandler, routes []AppRoutes) *mux.Router {
+	for _, route := range routes {
+		// prepare handle wrappers
+		var handler http.HandlerFunc
+
+		handler = confHandler.Respond(route.SubrouterHandler)
+		handler = WrapValidate(handler)
+		if route.Verb != "OPTIONS" {
+			handler = WrapAuthorize(handler)
+			handler = WrapAuthenticate(handler, confHandler.Config, route.Name)
+		}
+		s.Methods(route.Verb).
+			Path(route.Path).
+			Handler(context.ClearHandler(handler))
+	}
+
+	return s
+
+}
+
+// Error responds immediately when errors arise in handler chain
+func Error(w http.ResponseWriter, r *http.Request, errType ErrEnum, cfg config.Config) {
+	//Add headers
+
+	var msg ResponseMessage
+	var code int
+	header := r.Header
+
+	switch errType {
+	case ErrAuthen:
+		msg = UnauthorizedMessage
+		code = http.StatusUnauthorized
+	default:
+		msg = InternalServerErrorMessage
+		code = http.StatusInternalServerError
+	}
+
+	contentType, _ := ParseAcceptHeader(r)
+	output, _ := MarshalContent(msg, contentType, "", " ")
+	header.Set("Content-Length", fmt.Sprintf("%d", len(output)))
+
+	if cfg.Server.EnableCors {
+		header.Set("Access-Control-Allow-Origin", "*")
+		header.Set("Access-Control-Allow-Headers", "Content-Type, Accept, x-api-key")
+		header.Set("Access-Control-Allow-Methods", "GET, POST, DELETE, PUT, OPTIONS")
+	}
+
+	for name, values := range header {
+		for _, value := range values {
+			w.Header().Add(name, value)
+		}
+	}
+
+	w.WriteHeader(code)
+	w.Write(output)
 }
 
 // Respond will be called to answer to http requests to the PI
@@ -130,9 +209,10 @@ func ParseAcceptHeader(r *http.Request) (string, error) {
 		return "application/xml", nil
 	} else if strings.Contains(contentType, "*/*") {
 		return "application/json", nil
-	} else {
-		return defaultContentType, errors.New("Not Acceptable ContentType")
 	}
+
+	return defaultContentType, errors.New("Not Acceptable ContentType")
+
 }
 
 // MarshalContent marshals content using the marshaler that corresponds to the contentType parameter
@@ -165,7 +245,7 @@ func ResetCache(w http.ResponseWriter, r *http.Request, cfg config.Config) []byt
 	return []byte(answer)
 }
 
-// SelfRefence struct for self referencing resource after they are created
+// SelfReference struct for self referencing resource after they are created
 type SelfReference struct {
 	ID    string    `xml:"id" json:"id" bson:"id,omitempty"`
 	Links SelfLinks `xml:"links" json:"links"`

--- a/respond/wrappers.go
+++ b/respond/wrappers.go
@@ -1,0 +1,83 @@
+package respond
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/ARGOeu/argo-web-api/utils/authentication"
+	"github.com/ARGOeu/argo-web-api/utils/config"
+	"github.com/gorilla/context"
+)
+
+// // WrapAll Wraps all wrap handlers. Note: Precedence is inversed
+// func WrapAll(handler http.Handler, cfg config.Config) http.Handler {
+//
+// 	handler = WrapValidate(handler)
+// 	handler = WrapAuthorize(handler)
+// 	handler = WrapAuthenticate(handler, cfg)
+//
+// 	return handler
+// }
+
+func needsAPIAdmin(routeName string) bool {
+	if strings.Split(routeName, ".")[0] == "tenants" {
+		return true
+	}
+
+	return false
+}
+
+// WrapAuthenticate handle wrapper to apply authentication
+func WrapAuthenticate(hfn http.Handler, cfg config.Config, routeName string) http.HandlerFunc {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		// check if api admin authentication is needed (for tenants etc...)
+		if needsAPIAdmin(routeName) {
+
+			// Authenticate admin api and check
+			if (authentication.AuthenticateAdmin(r.Header, cfg)) == false {
+				// Because not authenticated respond with error
+				Error(w, r, ErrAuthen, cfg)
+				return
+			}
+			// admin api authenticated so continue serving
+			context.Set(r, "authen", true)
+
+			hfn.ServeHTTP(w, r)
+
+		} else {
+
+			// authenticate tenant user
+			tenantConf, tErr := authentication.AuthenticateTenant(r.Header, cfg)
+			// If tenant user not authenticated respond with  error
+			if tErr != nil {
+				Error(w, r, ErrAuthen, cfg)
+				return
+			}
+
+			context.Set(r, "tenant_conf", tenantConf)
+			context.Set(r, "authen", true)
+			hfn.ServeHTTP(w, r)
+
+		}
+
+	})
+}
+
+// WrapAuthorize handle wrapper to apply authorization
+func WrapAuthorize(hfn http.Handler) http.HandlerFunc {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		// log.Printf(" >> Authorization takes place here...")
+		hfn.ServeHTTP(w, r)
+	})
+}
+
+// WrapValidate handle wrapper to apply validation
+func WrapValidate(hfn http.Handler) http.HandlerFunc {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		// log.Printf(" >> Validation takes place here...")
+		hfn.ServeHTTP(w, r)
+	})
+}

--- a/routing/router.go
+++ b/routing/router.go
@@ -32,7 +32,7 @@ import (
 	"github.com/ARGOeu/argo-web-api/respond"
 	"github.com/ARGOeu/argo-web-api/utils/config"
 
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/github.com/gorilla/mux"
+	"github.com/gorilla/mux"
 )
 
 // RouteV2 represents the new style of routes that are handled by each package respectively
@@ -46,6 +46,7 @@ type RouteV2 struct {
 func NewRouter(cfg config.Config) *mux.Router {
 
 	confhandler := respond.ConfHandler{Config: cfg}
+
 	router := mux.NewRouter().StrictSlash(false)
 
 	for _, subroute := range routesV2 {

--- a/utils/authentication/authenticate.go
+++ b/utils/authentication/authenticate.go
@@ -30,9 +30,9 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/gopkg.in/mgo.v2/bson"
 	"github.com/ARGOeu/argo-web-api/utils/config"
 	"github.com/ARGOeu/argo-web-api/utils/mongo"
+	"gopkg.in/mgo.v2/bson"
 )
 
 type Auth struct {

--- a/utils/authentication/authenticate_test.go
+++ b/utils/authentication/authenticate_test.go
@@ -31,12 +31,12 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/github.com/stretchr/testify/suite"
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/gopkg.in/gcfg.v1"
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/gopkg.in/mgo.v2"
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/gopkg.in/mgo.v2/bson"
 	"github.com/ARGOeu/argo-web-api/utils/config"
 	"github.com/ARGOeu/argo-web-api/utils/mongo"
+	"github.com/stretchr/testify/suite"
+	"gopkg.in/gcfg.v1"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
 )
 
 // AuthenticationProfileTestSuite is a utility suite struct used in tests

--- a/utils/caches/handleCache.go
+++ b/utils/caches/handleCache.go
@@ -29,8 +29,8 @@ package caches
 import (
 	"fmt"
 
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/github.com/ARGOeu/go-lru-cache"
 	"github.com/ARGOeu/argo-web-api/utils/config"
+	"github.com/ARGOeu/go-lru-cache"
 )
 
 var httpcache *cache.LRUCache

--- a/utils/config/config.go
+++ b/utils/config/config.go
@@ -30,7 +30,7 @@ import (
 	"flag"
 	"os"
 
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/gopkg.in/gcfg.v1"
+	"gopkg.in/gcfg.v1"
 )
 
 //All the flags that can be added when starting the PI

--- a/utils/mongo/mongoConnect.go
+++ b/utils/mongo/mongoConnect.go
@@ -29,8 +29,8 @@ package mongo
 import (
 	"fmt"
 
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/gopkg.in/mgo.v2"
 	"github.com/ARGOeu/argo-web-api/utils/config"
+	"gopkg.in/mgo.v2"
 )
 
 // OpenSession to mongodb

--- a/utils/mongo/mongoQuery.go
+++ b/utils/mongo/mongoQuery.go
@@ -31,9 +31,9 @@ import (
 	"log"
 	"reflect"
 
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/github.com/twinj/uuid"
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/gopkg.in/mgo.v2"
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/gopkg.in/mgo.v2/bson"
+	"github.com/twinj/uuid"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
 )
 
 type Id struct {

--- a/utils/mongo/mongo_test.go
+++ b/utils/mongo/mongo_test.go
@@ -29,11 +29,11 @@ package mongo
 import (
 	"testing"
 
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/github.com/stretchr/testify/suite"
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/gopkg.in/gcfg.v1"
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/gopkg.in/mgo.v2"
-	"github.com/ARGOeu/argo-web-api/Godeps/_workspace/src/gopkg.in/mgo.v2/bson"
 	"github.com/ARGOeu/argo-web-api/utils/config"
+	"github.com/stretchr/testify/suite"
+	"gopkg.in/gcfg.v1"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
 )
 
 // This is a utility suite struct used in tests (see pkg "testify")


### PR DESCRIPTION
### Goal 
Implement central authentication handling 

### Challenges 
 - Main routing + subrouting declaration on each package
 - Respond Handler not robust enough to create a handler chain 
 - Authentication calls on all HandleFunctions in all packages 
 - After tenant user authentication, tenantDBConfiguration must be forwared down the handler chain
 - Each package has repeating method declarations on subrouters. Needs to be automated in order to be able to easily use WrapHandlers in one place (and not on each route declaration)
 - To achieve the above Routing on ./app/ packages needs to be refactored
 
## Design

#### App package Routing refactoring
 - Declare AppRoute util structure centrally to describe app subroutes 
 - Declare PrepAppRoutes func centrally to use it to automatically build subrouters
  - PrepAppRoutes gets a mux.router + a list of AppRoutes and prepares a subrouter
 - Replace explicit subroute definitions with automatic subrouter creation on all App packages (reports,profiles,results,statuses,recomputations,tenants etc...)

#### Central Authentication 
 - Use a WrapAuthentication handle wrapper 
 - Check if request needs API Admin auth or TENANT User auth and act accordingly 
 - Use context to forward tenant db configuration in handler chain 
 - If authentication problem immediately call respond.Error handle func wich actually handles error responses in one place. Use error enumerations to quickly reference and create error responses

#### Implementation Details

- [x] Introduce boilerplate handle wrappers in `./respond/wrappers.go`
 - [x] wrapper placeholder for authentication
 - [x] wrapper placeholder for authorization
 - [x] wrapper placeholder for validation
- [x] Introduce WrapAll to wrap all available handle wrappers at once (forming a chain)
- [x] Use WrapAll in `reports`,`aggregationProfiles`,`metricProfiles`,`operationsProfiles` pkg routings
- [x] Move tenant authentication logic inside WrapAuthentication
- [x] Use central tenant authentication on all packages
- [x] Use admin central authentication on tenant package 
- [x] Refactor Subrouting in packages
 - [x] use AppRoutes and PrepAppRoutes to automatically define subrouters
 - [x] Replace routing definitions on all packages