### PR TITLE
[Proposed] Support OPTIONS verb under metricResult resource

### DIFF
--- a/app/metricResult/controller.go
+++ b/app/metricResult/controller.go
@@ -117,3 +117,21 @@ func prepQuery(input metricResultQuery) bson.M {
 	return query
 
 }
+
+// Options implements the option request on resource
+func Options(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
+
+	//STANDARD DECLARATIONS START
+	code := http.StatusOK
+	h := http.Header{}
+	output := []byte("")
+	err := error(nil)
+	contentType := "text/plain"
+	charset := "utf-8"
+	//STANDARD DECLARATIONS END
+
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+	h.Set("Allow", fmt.Sprintf("GET, OPTIONS"))
+	return code, h, output, err
+
+}

--- a/app/metricResult/metric_test.go
+++ b/app/metricResult/metric_test.go
@@ -248,6 +248,24 @@ func (suite *metricResultTestSuite) TestReadStatusDetail() {
 
 }
 
+// TestOptionsMetricResult is used to test the OPTIONS response
+func (suite *metricResultTestSuite) TestOptionsMetricResult() {
+
+	request, _ := http.NewRequest("OPTIONS", "/api/v2/metric_result/cream01.afroditi.gr/emi.cream.CREAMCE-JobSubmit", strings.NewReader(""))
+	response := httptest.NewRecorder()
+	suite.router.ServeHTTP(response, request)
+
+	code := response.Code
+	output := response.Body.String()
+	headers := response.HeaderMap
+
+	suite.Equal(200, code, "Error in response code")
+	suite.Equal("", output, "Expected empty response body")
+	suite.Equal("GET, OPTIONS", headers.Get("Allow"), "Error in Allow header response (supported resource verbs of resource)")
+	suite.Equal("text/plain; charset=utf-8", headers.Get("Content-Type"), "Error in Content-Type header response")
+
+}
+
 // This function is actually called in the end of all tests
 // and clears the test environment.
 // Mainly it's purpose is to drop the testdb

--- a/app/metricResult/routing.go
+++ b/app/metricResult/routing.go
@@ -37,4 +37,5 @@ func HandleSubrouter(s *mux.Router, confhandler *respond.ConfHandler) {
 
 var appRoutesV2 = []respond.AppRoutes{
 	{"metricResult.get", "GET", "/{endpoint_name}/{metric_name}", GetMetricResult},
+	{"metricResult.options", "OPTIONS", "/{endpoint_name}/{metric_name}", Options},
 }

--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -32,6 +32,8 @@ tags:
     description: Availability/Reliability in numbers
   - name: Status
     description: Status results in detail
+  - name: MetricResult
+    description: Retrieve the full output of a  metric result
 paths:
   /admin/tenants/{TENANT_ID}:
     get:
@@ -1287,6 +1289,44 @@ paths:
         500:
           $ref: "#/responses/ServerError"
 
+  /metric_result/{endpoint}/{metric_name}:
+    get:
+      summary: Retrieve the full output of a metric result
+      description: Retrieve the full output of a metric result
+      tags:
+        - MetricResult
+      produces:
+        - "application/json"
+        - "application/xml"
+      parameters:
+        - $ref: "#/parameters/apiKey"
+        - name: "endpoint"
+          in: path
+          description: "The fqdn of the monitored host"
+          required: true
+          type: string
+        - name: "metric_name"
+          in: path
+          description: "The name of the probe (metric)"
+          required: true
+          type: string
+        - $ref: "#/parameters/execDate"
+      responses:
+        200:
+          description: "Successful retrieval of results"
+          schema:
+            $ref: "#/definitions/MetricResult"
+        400:
+          $ref: "#/responses/404"
+        401:
+          $ref: "#/responses/Unauthorized"
+        406:
+          $ref: "#/responses/406"
+        422:
+          $ref: "#/responses/422"
+        500:
+          $ref: "#/responses/ServerError"
+
   /results/{report_name}/{group_type}/{group_name}/{lgroup_type}/{lgroup_name}/services:
     get:
       summary: "List A/R results of all services (under a given endpoint group)"
@@ -1708,6 +1748,13 @@ parameters:
     required: false
     type: string
     default: "daily"
+  execDate:
+    name: exec_time
+    in: query
+    description: "execution date of query in zulu format"
+    required: true
+    type: string
+    default: "2006-01-01T00:04:05Z"
 
 responses:
   Unauthorized:
@@ -1982,6 +2029,43 @@ definitions:
         type: string
       code:
         type: string
+
+  MetricResult:
+    type: object
+    properties:
+      root:
+        type: array
+        items:
+          type: object
+          properties:
+            Name:
+              type: string
+              description: "The fqdn of the monitored endpoint"
+            Metrics:
+              type: array
+              items:
+                type: object
+                properties:
+                  Name:
+                    type: string
+                    description: "The name of the probe (metric)"
+                  Details:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        Timestamp:
+                          type: string
+                          description: "The execution time of the probe (metric)"
+                        Value:
+                          type: string
+                          description: "The resulting state of the probe (metric)"
+                        Summary:
+                          type: string
+                          description: "A summary of the metric result"
+                        Message:
+                          type: string
+                          description: "The detailed output message of the probe (metric)"
 
   Self_reference:
     type: object


### PR DESCRIPTION
Description

While working on central validation task (ARGO-405) I noticed the OPTIONS verb was
not supported under the /api/v2/metric_result resource. This proposed PR adds this
functionality on the given resource and also adds the underlying signature and response
schemas into the swagger yaml definition file.