### PR TITLE
[Proposed] Remove duplicated definition

### DIFF
--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -1930,32 +1930,6 @@ definitions:
                           items:
                             $ref: "#/definitions/timestamp_value"
 
-  StatusMetricResponse:
-    type: object
-    properties:
-      groups:
-        type: array
-        items:
-          type: object
-          properties:
-            name:
-              type: string
-            type:
-              type: string
-            services:
-              type: array
-              items:
-                type: object
-                properties:
-                  name:
-                    type: string
-                  type:
-                    type: string
-                  statuses:
-                    type: array
-                    items:
-                      $ref: "#/definitions/timestamp_value"
-
   StatusResponse:
     type: object
     properties:


### PR DESCRIPTION
Description

This (proposed) PR removes a duplicate definition that was discovered within
the swagger yaml definitions file. Apparently after some update on the publicly
available swagger editor the duplication is caught and marked as an error. 