### PR TITLE
ARGO-417 Implement Authorization logic using roles

### DIFF
--- a/app/aggregationProfiles/aggregationProfiles_test.go
+++ b/app/aggregationProfiles/aggregationProfiles_test.go
@@ -97,7 +97,37 @@ func (suite *AggregationProfilesTestSuite) SetupTest() {
 
 	// Seed database with tenants
 	//TODO: move tests to
-	c := session.DB(suite.cfg.MongoDB.Db).C("tenants")
+
+	//seed roles
+	// Seed database with metric profiles
+	c := session.DB(suite.cfg.MongoDB.Db).C("roles")
+	c.Insert(
+		bson.M{
+			"resource": "aggregationProfiles.list",
+			"roles":    []string{"editor", "viewer"},
+		})
+	c.Insert(
+		bson.M{
+			"resource": "aggregationProfiles.get",
+			"roles":    []string{"editor", "viewer"},
+		})
+	c.Insert(
+		bson.M{
+			"resource": "aggregationProfiles.create",
+			"roles":    []string{"editor"},
+		})
+	c.Insert(
+		bson.M{
+			"resource": "aggregationProfiles.delete",
+			"roles":    []string{"editor"},
+		})
+	c.Insert(
+		bson.M{
+			"resource": "aggregationProfiles.update",
+			"roles":    []string{"editor"},
+		})
+
+	c = session.DB(suite.cfg.MongoDB.Db).C("tenants")
 	c.Insert(
 		bson.M{"id": "6ac7d684-1f8e-4a02-a502-720e8f11e50c",
 			"info": bson.M{
@@ -125,11 +155,13 @@ func (suite *AggregationProfilesTestSuite) SetupTest() {
 					"name":    "user1",
 					"email":   "user1@email.com",
 					"api_key": "USER1KEY",
+					"roles":   []string{"editor"},
 				},
 				bson.M{
 					"name":    "user2",
 					"email":   "user2@email.com",
 					"api_key": "USER2KEY",
+					"roles":   []string{"editor"},
 				},
 			}})
 	c.Insert(
@@ -162,11 +194,13 @@ func (suite *AggregationProfilesTestSuite) SetupTest() {
 					"name":    "user3",
 					"email":   "user3@email.com",
 					"api_key": suite.clientkey,
+					"roles":   []string{"editor"},
 				},
 				bson.M{
 					"name":    "user4",
 					"email":   "user4@email.com",
-					"api_key": "USER4KEY",
+					"api_key": "VIEWERKEY",
+					"roles":   []string{"viewer"},
 				},
 			}})
 	// Seed database with metric profiles
@@ -553,6 +587,88 @@ func (suite *AggregationProfilesTestSuite) TestListOne() {
 	// Compare the expected and actual json response
 	suite.Equal(profileJSON, output, "Response body mismatch")
 
+}
+
+func (suite *AggregationProfilesTestSuite) TestCreateForbidViewer() {
+
+	jsonInput := `{
+  "name": "test_profile",
+  "namespace [
+    `
+
+	jsonOutput := `{
+ "status": {
+  "message": "Access to the resource is Forbidden",
+  "code": "403"
+ }
+}`
+
+	request, _ := http.NewRequest("POST", "/api/v2/aggregation_profiles", strings.NewReader(jsonInput))
+	request.Header.Set("x-api-key", "VIEWERKEY")
+	request.Header.Set("Accept", "application/json")
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code := response.Code
+	output := response.Body.String()
+	// Check that we must have a 200 ok code
+	suite.Equal(403, code, "Internal Server Error")
+	// Compare the expected and actual json response
+
+	suite.Equal(jsonOutput, output, "Response body mismatch")
+}
+
+func (suite *AggregationProfilesTestSuite) TestUpdateForbidViewer() {
+
+	jsonInput := `{}`
+
+	jsonOutput := `{
+ "status": {
+  "message": "Access to the resource is Forbidden",
+  "code": "403"
+ }
+}`
+
+	request, _ := http.NewRequest("PUT", "/api/v2/aggregation_profiles/6ac7d684-1f8e-4a02-a502-720e8f11e007", strings.NewReader(jsonInput))
+	request.Header.Set("x-api-key", "VIEWERKEY")
+	request.Header.Set("Accept", "application/json")
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code := response.Code
+	output := response.Body.String()
+	// Check that we must have a 200 ok code
+	suite.Equal(403, code, "Internal Server Error")
+	// Compare the expected and actual json response
+
+	suite.Equal(jsonOutput, output, "Response body mismatch")
+
+}
+
+func (suite *AggregationProfilesTestSuite) TestDeleteForbidViewer() {
+
+	request, _ := http.NewRequest("DELETE", "/api/v2/aggregation_profiles/6ac7d684-1f8e-4a02-a502-720e8f11e50b", strings.NewReader(""))
+	request.Header.Set("x-api-key", "VIEWERKEY")
+	request.Header.Set("Accept", "application/json")
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code := response.Code
+	output := response.Body.String()
+
+	metricProfileJSON := `{
+ "status": {
+  "message": "Access to the resource is Forbidden",
+  "code": "403"
+ }
+}`
+	// Check that we must have a 200 ok code
+	suite.Equal(403, code, "Internal Server Error")
+	// Compare the expected and actual json response
+	suite.Equal(metricProfileJSON, output, "Response body mismatch")
 }
 
 func (suite *AggregationProfilesTestSuite) TestCreateBadJson() {

--- a/app/factors/factors_test.go
+++ b/app/factors/factors_test.go
@@ -106,7 +106,7 @@ func (suite *FactorsTestSuite) SetupTest() {
 	// Add authentication token to mongo coredb
 	seedAuth := bson.M{"name": "TEST",
 		"db_conf": []bson.M{bson.M{"server": "127.0.0.1", "port": 27017, "database": "AR_test"}},
-		"users":   []bson.M{bson.M{"name": "Jack Doe", "email": "jack.doe@example.com", "api_key": "secret"}}}
+		"users":   []bson.M{bson.M{"name": "Jack Doe", "email": "jack.doe@example.com", "api_key": "secret", "roles": []string{"viewer"}}}}
 	_ = mongo.Insert(session, suite.cfg.MongoDB.Db, "tenants", seedAuth)
 
 	// Add a few factors in collection
@@ -114,6 +114,13 @@ func (suite *FactorsTestSuite) SetupTest() {
 	c.Insert(bson.M{"hepspec": 14595, "name": "CIEMAT-LCG2"})
 	c.Insert(bson.M{"hepspec": 1019, "name": "CFP-IST"})
 	c.Insert(bson.M{"hepspec": 5406, "name": "CETA-GRID"})
+
+	c = session.DB(suite.cfg.MongoDB.Db).C("roles")
+	c.Insert(
+		bson.M{
+			"resource": "factors.list",
+			"roles":    []string{"editor", "viewer"},
+		})
 
 }
 

--- a/app/metricResult/metric_test.go
+++ b/app/metricResult/metric_test.go
@@ -99,6 +99,7 @@ func (suite *metricResultTestSuite) SetupTest() {
 	defer session.Close()
 
 	// seed a tenant to use
+
 	c := session.DB(suite.cfg.MongoDB.Db).C("tenants")
 	c.Insert(bson.M{
 		"id": "6ac7d684-1f8e-4a02-a502-720e8f11e50c",
@@ -121,8 +122,16 @@ func (suite *metricResultTestSuite) SetupTest() {
 			bson.M{
 				"name":    "egi_user",
 				"email":   "egi_user@email.com",
+				"roles":   []string{"viewer"},
 				"api_key": "KEY1"},
 		}})
+
+	c = session.DB(suite.cfg.MongoDB.Db).C("roles")
+	c.Insert(
+		bson.M{
+			"resource": "metricResult.get",
+			"roles":    []string{"editor", "viewer"},
+		})
 
 	// get dbconfiguration based on the tenant
 	// Prepare the request object

--- a/app/operationsProfiles/operationsProfiles_test.go
+++ b/app/operationsProfiles/operationsProfiles_test.go
@@ -126,11 +126,13 @@ func (suite *OperationsProfilesTestSuite) SetupTest() {
 					"name":    "user1",
 					"email":   "user1@email.com",
 					"api_key": "USER1KEY",
+					"roles":   []string{"editor"},
 				},
 				bson.M{
 					"name":    "user2",
 					"email":   "user2@email.com",
 					"api_key": "USER2KEY",
+					"roles":   []string{"editor"},
 				},
 			}})
 	c.Insert(
@@ -163,13 +165,43 @@ func (suite *OperationsProfilesTestSuite) SetupTest() {
 					"name":    "user3",
 					"email":   "user3@email.com",
 					"api_key": suite.clientkey,
+					"roles":   []string{"editor"},
 				},
 				bson.M{
 					"name":    "user4",
 					"email":   "user4@email.com",
-					"api_key": "USER4KEY",
+					"api_key": "VIEWERKEY",
+					"roles":   []string{"viewer"},
 				},
 			}})
+
+	c = session.DB(suite.cfg.MongoDB.Db).C("roles")
+	c.Insert(
+		bson.M{
+			"resource": "operationsProfiles.list",
+			"roles":    []string{"editor", "viewer"},
+		})
+	c.Insert(
+		bson.M{
+			"resource": "operationsProfiles.get",
+			"roles":    []string{"editor", "viewer"},
+		})
+	c.Insert(
+		bson.M{
+			"resource": "operationsProfiles.create",
+			"roles":    []string{"editor"},
+		})
+	c.Insert(
+		bson.M{
+			"resource": "operationsProfiles.delete",
+			"roles":    []string{"editor"},
+		})
+	c.Insert(
+		bson.M{
+			"resource": "operationsProfiles.update",
+			"roles":    []string{"editor"},
+		})
+
 	// Seed database with operations profiles
 	c = session.DB(suite.tenantDbConf.Db).C("operations_profiles")
 	c.Insert(
@@ -1412,6 +1444,88 @@ func (suite *OperationsProfilesTestSuite) TestOptionsOperationsProfiles() {
 	suite.Equal("GET, POST, DELETE, PUT, OPTIONS", headers.Get("Allow"), "Error in Allow header response (supported resource verbs of resource)")
 	suite.Equal("text/plain; charset=utf-8", headers.Get("Content-Type"), "Error in Content-Type header response")
 
+}
+
+func (suite *OperationsProfilesTestSuite) TestCreateForbidViewer() {
+
+	jsonInput := `{
+  "name": "test_profile",
+  "namespace [
+    `
+
+	jsonOutput := `{
+ "status": {
+  "message": "Access to the resource is Forbidden",
+  "code": "403"
+ }
+}`
+
+	request, _ := http.NewRequest("POST", "/api/v2/operations_profiles", strings.NewReader(jsonInput))
+	request.Header.Set("x-api-key", "VIEWERKEY")
+	request.Header.Set("Accept", "application/json")
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code := response.Code
+	output := response.Body.String()
+	// Check that we must have a 200 ok code
+	suite.Equal(403, code, "Internal Server Error")
+	// Compare the expected and actual json response
+
+	suite.Equal(jsonOutput, output, "Response body mismatch")
+}
+
+func (suite *OperationsProfilesTestSuite) TestUpdateForbidViewer() {
+
+	jsonInput := `{}`
+
+	jsonOutput := `{
+ "status": {
+  "message": "Access to the resource is Forbidden",
+  "code": "403"
+ }
+}`
+
+	request, _ := http.NewRequest("PUT", "/api/v2/operations_profiles/6ac7d684-1f8e-4a02-a502-720e8f11e007", strings.NewReader(jsonInput))
+	request.Header.Set("x-api-key", "VIEWERKEY")
+	request.Header.Set("Accept", "application/json")
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code := response.Code
+	output := response.Body.String()
+	// Check that we must have a 200 ok code
+	suite.Equal(403, code, "Internal Server Error")
+	// Compare the expected and actual json response
+
+	suite.Equal(jsonOutput, output, "Response body mismatch")
+
+}
+
+func (suite *OperationsProfilesTestSuite) TestDeleteForbidViewer() {
+
+	request, _ := http.NewRequest("DELETE", "/api/v2/operations_profiles/6ac7d684-1f8e-4a02-a502-720e8f11e50b", strings.NewReader(""))
+	request.Header.Set("x-api-key", "VIEWERKEY")
+	request.Header.Set("Accept", "application/json")
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code := response.Code
+	output := response.Body.String()
+
+	metricProfileJSON := `{
+ "status": {
+  "message": "Access to the resource is Forbidden",
+  "code": "403"
+ }
+}`
+	// Check that we must have a 200 ok code
+	suite.Equal(403, code, "Internal Server Error")
+	// Compare the expected and actual json response
+	suite.Equal(metricProfileJSON, output, "Response body mismatch")
 }
 
 //TearDownTest to tear down every test

--- a/app/recomputations2/recomputation_test.go
+++ b/app/recomputations2/recomputation_test.go
@@ -133,11 +133,13 @@ func (suite *RecomputationsProfileTestSuite) SetupTest() {
 					"name":    "John Snow",
 					"email":   "J.Snow@brothers.wall",
 					"api_key": "wh1t3_w@lk3rs",
+					"roles":   []string{"editor"},
 				},
 				bson.M{
 					"name":    "King Joffrey",
 					"email":   "g0dk1ng@kingslanding.gov",
 					"api_key": "sansa <3",
+					"roles":   []string{"editor"},
 				},
 			}})
 	c.Insert(
@@ -170,13 +172,32 @@ func (suite *RecomputationsProfileTestSuite) SetupTest() {
 					"name":    "Joe Complex",
 					"email":   "C.Joe@egi.eu",
 					"api_key": suite.clientkey,
+					"roles":   []string{"editor"},
 				},
 				bson.M{
 					"name":    "Josh Plain",
 					"email":   "P.Josh@egi.eu",
-					"api_key": "itsamysterytoyou",
+					"api_key": "VIEWERKEY",
+					"roles":   []string{"viewer"},
 				},
 			}})
+
+	c = session.DB(suite.cfg.MongoDB.Db).C("roles")
+	c.Insert(
+		bson.M{
+			"resource": "recomputations.list",
+			"roles":    []string{"editor", "viewer"},
+		})
+	c.Insert(
+		bson.M{
+			"resource": "recomputations.get",
+			"roles":    []string{"editor", "viewer"},
+		})
+	c.Insert(
+		bson.M{
+			"resource": "recomputations.submit",
+			"roles":    []string{"editor"},
+		})
 	// Seed database with recomputations
 	c = session.DB(suite.tenantDbConf.Db).C("recomputations")
 	c.Insert(
@@ -442,6 +463,35 @@ func (suite *RecomputationsProfileTestSuite) TearDownTest() {
 		mainDB.C(col).RemoveAll(nil)
 	}
 
+}
+
+func (suite *RecomputationsProfileTestSuite) TestSubmitForbidViewer() {
+
+	jsonInput := `{
+  "name": "test",
+  }`
+
+	jsonOutput := `{
+ "status": {
+  "message": "Access to the resource is Forbidden",
+  "code": "403"
+ }
+}`
+
+	request, _ := http.NewRequest("POST", "/api/v2/recomputations", strings.NewReader(jsonInput))
+	request.Header.Set("x-api-key", "VIEWERKEY")
+	request.Header.Set("Accept", "application/json")
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code := response.Code
+	output := response.Body.String()
+	// Check that we must have a 200 ok code
+	suite.Equal(403, code, "Internal Server Error")
+	// Compare the expected and actual json response
+
+	suite.Equal(jsonOutput, output, "Response body mismatch")
 }
 
 //TearDownTest to tear down every test

--- a/app/results/endpointgroup_test.go
+++ b/app/results/endpointgroup_test.go
@@ -114,11 +114,13 @@ func (suite *endpointGroupAvailabilityTestSuite) SetupTest() {
 					"name":    "John Snow",
 					"email":   "J.Snow@brothers.wall",
 					"api_key": "wh1t3_w@lk3rs",
+					"roles":   []string{"viewer"},
 				},
 				bson.M{
 					"name":    "King Joffrey",
 					"email":   "g0dk1ng@kingslanding.gov",
 					"api_key": "sansa <3",
+					"roles":   []string{"viewer"},
 				},
 			}})
 	c.Insert(
@@ -144,14 +146,27 @@ func (suite *endpointGroupAvailabilityTestSuite) SetupTest() {
 					"name":    "Joe Complex",
 					"email":   "C.Joe@egi.eu",
 					"api_key": suite.clientkey,
+					"roles":   []string{"viewer"},
 				},
 				bson.M{
 					"name":    "Josh Plain",
 					"email":   "P.Josh@egi.eu",
 					"api_key": "itsamysterytoyou",
+					"roles":   []string{"viewer"},
 				},
 			}})
 
+	c = session.DB(suite.cfg.MongoDB.Db).C("roles")
+	c.Insert(
+		bson.M{
+			"resource": "results.list",
+			"roles":    []string{"editor", "viewer"},
+		})
+	c.Insert(
+		bson.M{
+			"resource": "results.get",
+			"roles":    []string{"editor", "viewer"},
+		})
 	// Seed tenant database with data
 	c = session.DB(suite.tenantDbConf.Db).C("endpoint_group_ar")
 

--- a/app/results/routing.go
+++ b/app/results/routing.go
@@ -50,28 +50,28 @@ func HandleSubrouter(s *mux.Router, confhandler *respond.ConfHandler) {
 }
 
 var appServiceRoutes = []respond.AppRoutes{
-	{"results.services.get", "GET", "/{group_type}/{group_name}/{lgroup_type}/{lgroup_name}/services/{service_type}", ListServiceFlavorResults},
-	{"results.services.list", "GET", "/{group_type}/{group_name}/{lgroup_type}/{lgroup_name}/services", ListServiceFlavorResults},
-	{"reports.services.get", "GET", "/{lgroup_type}/{lgroup_name}/services/{service_type}", ListServiceFlavorResults},
-	{"reports.services.list", "GET", "/{lgroup_type}/{lgroup_name}/services", ListServiceFlavorResults},
+	{"results.get", "GET", "/{group_type}/{group_name}/{lgroup_type}/{lgroup_name}/services/{service_type}", ListServiceFlavorResults},
+	{"results.list", "GET", "/{group_type}/{group_name}/{lgroup_type}/{lgroup_name}/services", ListServiceFlavorResults},
+	{"results.get", "GET", "/{lgroup_type}/{lgroup_name}/services/{service_type}", ListServiceFlavorResults},
+	{"results.list", "GET", "/{lgroup_type}/{lgroup_name}/services", ListServiceFlavorResults},
 }
 
 var appGroupRoutes = []respond.AppRoutes{
-	{"results.endpoint_groups.get", "GET", "/{group_type}/{group_name}/{lgroup_type}/{lgroup_name}", ListEndpointGroupResults},
-	{"reports.endpoint_groups.list", "GET", "/{group_type}/{group_name}/{lgroup_type}", ListEndpointGroupResults},
-	{"reports.groups.get", "GET", "/{group_type}/{group_name}", routeGroup},
-	{"reports.groups.list", "GET", "/{group_type}", routeGroup},
+	{"results.get", "GET", "/{group_type}/{group_name}/{lgroup_type}/{lgroup_name}", ListEndpointGroupResults},
+	{"results.list", "GET", "/{group_type}/{group_name}/{lgroup_type}", ListEndpointGroupResults},
+	{"results.get", "GET", "/{group_type}/{group_name}", routeGroup},
+	{"results.list", "GET", "/{group_type}", routeGroup},
 }
 
 var appRoutesV2 = []respond.AppRoutes{
-	{"results.groups.options", "OPTIONS", "/{report_name}/{group_type}", Options},
-	{"results.endpoint_groups.options", "OPTIONS", "/{report_name}/{group_type}/{group_name}/{lgroup_type}", Options},
-	{"results.groups.options", "OPTIONS", "/{report_name}/{group_type}/{group_name}/{lgroup_type}/{lgroup_name}", Options},
-	{"results.services.options", "OPTIONS", "/{report_name}/{group_type}/{group_name}/{lgroup_type}/{lgroup_name}/services", Options},
-	{"results.services.options", "OPTIONS", "/{report_name}/{group_type}/{group_name}/{lgroup_type}/{lgroup_name}/services/{service_name}", Options},
-	{"results.endpoint_groups.options", "OPTIONS", "/{report_name}/{lgroup_type}/{lgroup_name}", Options},
-	{"results.services.options", "OPTIONS", "/{report_name}/{lgroup_type}/{lgroup_name}/services", Options},
-	{"results.services.options", "OPTIONS", "/{report_name}/{lgroup_type}/{lgroup_name}/services/{service_name}", Options},
+	{"results.options", "OPTIONS", "/{report_name}/{group_type}", Options},
+	{"results.options", "OPTIONS", "/{report_name}/{group_type}/{group_name}/{lgroup_type}", Options},
+	{"results.options", "OPTIONS", "/{report_name}/{group_type}/{group_name}/{lgroup_type}/{lgroup_name}", Options},
+	{"results.options", "OPTIONS", "/{report_name}/{group_type}/{group_name}/{lgroup_type}/{lgroup_name}/services", Options},
+	{"results.options", "OPTIONS", "/{report_name}/{group_type}/{group_name}/{lgroup_type}/{lgroup_name}/services/{service_name}", Options},
+	{"results.options", "OPTIONS", "/{report_name}/{lgroup_type}/{lgroup_name}", Options},
+	{"results.options", "OPTIONS", "/{report_name}/{lgroup_type}/{lgroup_name}/services", Options},
+	{"results.options", "OPTIONS", "/{report_name}/{lgroup_type}/{lgroup_name}/services/{service_name}", Options},
 }
 
 func routeGroup(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {

--- a/app/results/serviceflavor_test.go
+++ b/app/results/serviceflavor_test.go
@@ -114,11 +114,13 @@ func (suite *serviceFlavorAvailabilityTestSuite) SetupTest() {
 					"name":    "John Snow",
 					"email":   "J.Snow@brothers.wall",
 					"api_key": "wh1t3_w@lk3rs",
+					"roles":   []string{"viewer"},
 				},
 				bson.M{
 					"name":    "King Joffrey",
 					"email":   "g0dk1ng@kingslanding.gov",
 					"api_key": "sansa <3",
+					"roles":   []string{"viewer"},
 				},
 			}})
 	c.Insert(
@@ -144,13 +146,27 @@ func (suite *serviceFlavorAvailabilityTestSuite) SetupTest() {
 					"name":    "Joe Complex",
 					"email":   "C.Joe@egi.eu",
 					"api_key": suite.clientkey,
+					"roles":   []string{"viewer"},
 				},
 				bson.M{
 					"name":    "Josh Plain",
 					"email":   "P.Josh@egi.eu",
 					"api_key": "itsamysterytoyou",
+					"roles":   []string{"viewer"},
 				},
 			}})
+
+	c = session.DB(suite.cfg.MongoDB.Db).C("roles")
+	c.Insert(
+		bson.M{
+			"resource": "results.list",
+			"roles":    []string{"editor", "viewer"},
+		})
+	c.Insert(
+		bson.M{
+			"resource": "results.get",
+			"roles":    []string{"editor", "viewer"},
+		})
 	// Seed database with recomputations
 	c = session.DB(suite.tenantDbConf.Db).C("service_ar")
 

--- a/app/results/supergroup_test.go
+++ b/app/results/supergroup_test.go
@@ -120,11 +120,13 @@ func (suite *SuperGroupAvailabilityTestSuite) SetupTest() {
 					"name":    "John Snow",
 					"email":   "J.Snow@brothers.wall",
 					"api_key": "wh1t3_w@lk3rs",
+					"roles":   []string{"viewer"},
 				},
 				bson.M{
 					"name":    "King Joffrey",
 					"email":   "g0dk1ng@kingslanding.gov",
 					"api_key": "sansa <3",
+					"roles":   []string{"viewer"},
 				},
 			}})
 	c.Insert(
@@ -156,13 +158,27 @@ func (suite *SuperGroupAvailabilityTestSuite) SetupTest() {
 					"name":    "Joe Complex",
 					"email":   "C.Joe@egi.eu",
 					"api_key": suite.clientkey,
+					"roles":   []string{"viewer"},
 				},
 				bson.M{
 					"name":    "Josh Plain",
 					"email":   "P.Josh@egi.eu",
 					"api_key": "itsamysterytoyou",
+					"roles":   []string{"viewer"},
 				},
 			}})
+
+	c = session.DB(suite.cfg.MongoDB.Db).C("roles")
+	c.Insert(
+		bson.M{
+			"resource": "results.list",
+			"roles":    []string{"editor", "viewer"},
+		})
+	c.Insert(
+		bson.M{
+			"resource": "results.get",
+			"roles":    []string{"editor", "viewer"},
+		})
 	// Seed database with recomputations
 	c = session.DB(suite.tenantDbConf.Db).C("endpoint_group_ar")
 

--- a/app/statusEndpointGroups/routing.go
+++ b/app/statusEndpointGroups/routing.go
@@ -44,10 +44,10 @@ func HandleSubrouter(s *mux.Router, confhandler *respond.ConfHandler) {
 }
 
 var appRoutesV2 = []respond.AppRoutes{
-	{"status_endpoint_groups.get", "GET", "/{report_name}/{group_type}/{group_name}", routeCheckGroup},
-	{"status_endpoint_groups.list", "GET", "/{report_name}/{group_type}", routeCheckGroup},
-	{"status_endpoint_groups.options", "OPTIONS", "/{report_name}/{group_type}/{group_name}", Options},
-	{"status_endpoint_groups.options", "OPTIONS", "/{report_name}/{group_type}", Options},
+	{"status.get", "GET", "/{report_name}/{group_type}/{group_name}", routeCheckGroup},
+	{"status.list", "GET", "/{report_name}/{group_type}", routeCheckGroup},
+	{"status.options", "OPTIONS", "/{report_name}/{group_type}/{group_name}", Options},
+	{"status.options", "OPTIONS", "/{report_name}/{group_type}", Options},
 }
 
 func routeCheckGroup(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {

--- a/app/statusEndpointGroups/statusEndpointGroups_test.go
+++ b/app/statusEndpointGroups/statusEndpointGroups_test.go
@@ -114,6 +114,7 @@ func (suite *StatusEndpointGroupsTestSuite) SetupTest() {
 			bson.M{
 				"name":    "egi_user",
 				"email":   "egi_user@email.com",
+				"roles":   []string{"viewer"},
 				"api_key": "KEY1"},
 		}})
 
@@ -138,9 +139,20 @@ func (suite *StatusEndpointGroupsTestSuite) SetupTest() {
 			bson.M{
 				"name":    "eudat_user",
 				"email":   "eudat_user@email.com",
+				"roles":   []string{"viewer"},
 				"api_key": "KEY2"},
 		}})
-
+	c = session.DB(suite.cfg.MongoDB.Db).C("roles")
+	c.Insert(
+		bson.M{
+			"resource": "status.list",
+			"roles":    []string{"editor", "viewer"},
+		})
+	c.Insert(
+		bson.M{
+			"resource": "status.get",
+			"roles":    []string{"editor", "viewer"},
+		})
 	// get dbconfiguration based on the tenant
 	// Prepare the request object
 	request, _ := http.NewRequest("GET", "", strings.NewReader(""))

--- a/app/statusEndpoints/routing.go
+++ b/app/statusEndpoints/routing.go
@@ -43,10 +43,10 @@ func HandleSubrouter(s *mux.Router, confhandler *respond.ConfHandler) {
 }
 
 var appRoutesV2 = []respond.AppRoutes{
-	{"status_endpoints.get", "GET", "/{report_name}/{group_type}/{group_name}/services/{service_name}/endpoints/{endpoint_name}", routeCheckGroup},
-	{"status_endpoints.list", "GET", "/{report_name}/{group_type}/{group_name}/services/{service_name}/endpoints", routeCheckGroup},
-	{"status_endpoints.options", "OPTIONS", "/{report_name}/{group_type}/{group_name}/services/{service_name}/endpoints/{endpoint_name}", Options},
-	{"status_endpoints.options", "OPTIONS", "/{report_name}/{group_type}/{group_name}/services/{service_name}/endpoints", Options},
+	{"status.get", "GET", "/{report_name}/{group_type}/{group_name}/services/{service_name}/endpoints/{endpoint_name}", routeCheckGroup},
+	{"status.list", "GET", "/{report_name}/{group_type}/{group_name}/services/{service_name}/endpoints", routeCheckGroup},
+	{"status.options", "OPTIONS", "/{report_name}/{group_type}/{group_name}/services/{service_name}/endpoints/{endpoint_name}", Options},
+	{"status.options", "OPTIONS", "/{report_name}/{group_type}/{group_name}/services/{service_name}/endpoints", Options},
 }
 
 func routeCheckGroup(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {

--- a/app/statusEndpoints/statusEndpoints_test.go
+++ b/app/statusEndpoints/statusEndpoints_test.go
@@ -114,6 +114,7 @@ func (suite *StatusEndpointsTestSuite) SetupTest() {
 			bson.M{
 				"name":    "egi_user",
 				"email":   "egi_user@email.com",
+				"roles":   []string{"viewer"},
 				"api_key": "KEY1"},
 		}})
 
@@ -138,9 +139,20 @@ func (suite *StatusEndpointsTestSuite) SetupTest() {
 			bson.M{
 				"name":    "eudat_user",
 				"email":   "eudat_user@email.com",
+				"roles":   []string{"viewer"},
 				"api_key": "KEY2"},
 		}})
-
+	c = session.DB(suite.cfg.MongoDB.Db).C("roles")
+	c.Insert(
+		bson.M{
+			"resource": "status.list",
+			"roles":    []string{"editor", "viewer"},
+		})
+	c.Insert(
+		bson.M{
+			"resource": "status.get",
+			"roles":    []string{"editor", "viewer"},
+		})
 	// get dbconfiguration based on the tenant
 	// Prepare the request object
 	request, _ := http.NewRequest("GET", "", strings.NewReader(""))

--- a/app/statusMetrics/routing.go
+++ b/app/statusMetrics/routing.go
@@ -44,10 +44,10 @@ func HandleSubrouter(s *mux.Router, confhandler *respond.ConfHandler) {
 }
 
 var appRoutesV2 = []respond.AppRoutes{
-	{"status_metrics.get", "GET", "/{report_name}/{group_type}/{group_name}/services/{service_name}/endpoints/{endpoint_name}/metrics/{metric_name}", routeCheckGroup},
-	{"status_metrics.list", "GET", "/{report_name}/{group_type}/{group_name}/services/{service_name}/endpoints/{endpoint_name}/metrics", routeCheckGroup},
-	{"status_metrics.options", "OPTIONS", "/{report_name}/{group_type}/{group_name}/services/{service_name}/endpoints/{endpoint_name}/metrics/{metric_name}", Options},
-	{"status_metrics.options", "OPTIONS", "/{report_name}/{group_type}/{group_name}/services/{service_name}/endpoints/{endpoint_name}/metrics", Options},
+	{"status.get", "GET", "/{report_name}/{group_type}/{group_name}/services/{service_name}/endpoints/{endpoint_name}/metrics/{metric_name}", routeCheckGroup},
+	{"status.list", "GET", "/{report_name}/{group_type}/{group_name}/services/{service_name}/endpoints/{endpoint_name}/metrics", routeCheckGroup},
+	{"status.options", "OPTIONS", "/{report_name}/{group_type}/{group_name}/services/{service_name}/endpoints/{endpoint_name}/metrics/{metric_name}", Options},
+	{"status.options", "OPTIONS", "/{report_name}/{group_type}/{group_name}/services/{service_name}/endpoints/{endpoint_name}/metrics", Options},
 }
 
 func routeCheckGroup(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {

--- a/app/statusMetrics/statusMetrics_test.go
+++ b/app/statusMetrics/statusMetrics_test.go
@@ -114,6 +114,7 @@ func (suite *StatusMetricsTestSuite) SetupTest() {
 			bson.M{
 				"name":    "egi_user",
 				"email":   "egi_user@email.com",
+				"roles":   []string{"viewer"},
 				"api_key": "KEY1"},
 		}})
 
@@ -138,9 +139,20 @@ func (suite *StatusMetricsTestSuite) SetupTest() {
 			bson.M{
 				"name":    "tenant2_user",
 				"email":   "tenant2_user@email.com",
+				"roles":   []string{"viewer"},
 				"api_key": "KEY2"},
 		}})
-
+	c = session.DB(suite.cfg.MongoDB.Db).C("roles")
+	c.Insert(
+		bson.M{
+			"resource": "status.list",
+			"roles":    []string{"editor", "viewer"},
+		})
+	c.Insert(
+		bson.M{
+			"resource": "status.get",
+			"roles":    []string{"editor", "viewer"},
+		})
 	// get dbconfiguration based on the tenant
 	// Prepare the request object
 	request, _ := http.NewRequest("GET", "", strings.NewReader(""))

--- a/app/statusServices/routing.go
+++ b/app/statusServices/routing.go
@@ -44,10 +44,10 @@ func HandleSubrouter(s *mux.Router, confhandler *respond.ConfHandler) {
 }
 
 var appRoutesV2 = []respond.AppRoutes{
-	{"status_services.get", "GET", "/{report_name}/{group_type}/{group_name}/services/{service_name}", routeCheckGroup},
-	{"status_services.list", "GET", "/{report_name}/{group_type}/{group_name}/services", routeCheckGroup},
-	{"status_services.options", "OPTIONS", "/{report_name}/{group_type}/{group_name}/services/{service_name}", Options},
-	{"status_services.options", "OPTIONS", "/{report_name}/{group_type}/{group_name}/services", Options},
+	{"status.get", "GET", "/{report_name}/{group_type}/{group_name}/services/{service_name}", routeCheckGroup},
+	{"status.list", "GET", "/{report_name}/{group_type}/{group_name}/services", routeCheckGroup},
+	{"status.options", "OPTIONS", "/{report_name}/{group_type}/{group_name}/services/{service_name}", Options},
+	{"status.options", "OPTIONS", "/{report_name}/{group_type}/{group_name}/services", Options},
 }
 
 func routeCheckGroup(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {

--- a/app/statusServices/statusServices_test.go
+++ b/app/statusServices/statusServices_test.go
@@ -114,6 +114,7 @@ func (suite *StatusServicesTestSuite) SetupTest() {
 			bson.M{
 				"name":    "egi_user",
 				"email":   "egi_user@email.com",
+				"roles":   []string{"viewer"},
 				"api_key": "KEY1"},
 		}})
 
@@ -138,9 +139,20 @@ func (suite *StatusServicesTestSuite) SetupTest() {
 			bson.M{
 				"name":    "eudat_user",
 				"email":   "eudat_user@email.com",
+				"roles":   []string{"viewer"},
 				"api_key": "KEY2"},
 		}})
-
+	c = session.DB(suite.cfg.MongoDB.Db).C("roles")
+	c.Insert(
+		bson.M{
+			"resource": "status.list",
+			"roles":    []string{"editor", "viewer"},
+		})
+	c.Insert(
+		bson.M{
+			"resource": "status.get",
+			"roles":    []string{"editor", "viewer"},
+		})
 	// get dbconfiguration based on the tenant
 	// Prepare the request object
 	request, _ := http.NewRequest("GET", "", strings.NewReader(""))

--- a/app/tenants/tenants_test.go
+++ b/app/tenants/tenants_test.go
@@ -130,8 +130,35 @@ func (suite *TenantTestSuite) SetupTest() {
 	}
 	defer session.Close()
 
+	c := session.DB(suite.cfg.MongoDB.Db).C("roles")
+	c.Insert(
+		bson.M{
+			"resource": "tenants.list",
+			"roles":    []string{"super_admin"},
+		})
+	c.Insert(
+		bson.M{
+			"resource": "tenants.get",
+			"roles":    []string{"super_admin"},
+		})
+	c.Insert(
+		bson.M{
+			"resource": "tenants.create",
+			"roles":    []string{"super_admin"},
+		})
+	c.Insert(
+		bson.M{
+			"resource": "tenants.delete",
+			"roles":    []string{"super_admin"},
+		})
+	c.Insert(
+		bson.M{
+			"resource": "tenants.update",
+			"roles":    []string{"super_admin"},
+		})
+
 	// seed first tenant
-	c := session.DB(suite.cfg.MongoDB.Db).C("tenants")
+	c = session.DB(suite.cfg.MongoDB.Db).C("tenants")
 	c.Insert(bson.M{
 		"id": "6ac7d684-1f8e-4a02-a502-720e8f11e50b",
 		"info": bson.M{

--- a/respond/respond.go
+++ b/respond/respond.go
@@ -103,7 +103,7 @@ func PrepAppRoutes(s *mux.Router, confHandler *ConfHandler, routes []AppRoutes) 
 		handler = confHandler.Respond(route.SubrouterHandler)
 		handler = WrapValidate(handler)
 		if route.Verb != "OPTIONS" {
-			handler = WrapAuthorize(handler)
+			handler = WrapAuthorize(handler, confHandler.Config, route.Name)
 			handler = WrapAuthenticate(handler, confHandler.Config, route.Name)
 		}
 		s.Methods(route.Verb).
@@ -127,6 +127,9 @@ func Error(w http.ResponseWriter, r *http.Request, errType ErrEnum, cfg config.C
 	case ErrAuthen:
 		msg = UnauthorizedMessage
 		code = http.StatusUnauthorized
+	case ErrAuthor:
+		msg = Forbidden
+		code = http.StatusForbidden
 	default:
 		msg = InternalServerErrorMessage
 		code = http.StatusInternalServerError
@@ -354,5 +357,13 @@ var InternalServerErrorMessage = ResponseMessage{
 	Status: StatusResponse{
 		Code:    "500",
 		Message: "Internal Server Error",
+	},
+}
+
+// Forbidden is used to marshal a response
+var Forbidden = ResponseMessage{
+	Status: StatusResponse{
+		Code:    "403",
+		Message: "Access to the resource is Forbidden",
 	},
 }

--- a/scripts/mongodb/populate_default_roles.js
+++ b/scripts/mongodb/populate_default_roles.js
@@ -1,0 +1,58 @@
+// Default Role definitions
+//
+// Roles are defined in 'roles' collection in argo_core database
+// Default roles include the following:
+//  - super_admin: only able to edit global tenant information (tenants/users/roles)
+//  - admin: able to view/edit all information under a tenant
+//  - editor: same as tenant admin (but not able to change privileges - future feature)
+//  - viewer: able to only view all information under a tenant (cannot edit)
+//
+// To run the script issue in mongo shell the following commands:
+//   > load('./populate_default_roles.js')
+//   true
+//   > populate_default_roles()
+//   INFO	Opened argo_core db
+//   INFO	Polulated default roles in 'roles' collection
+
+
+function populate_default_roles()
+{
+  db = db.getSiblingDB('argo_core')
+  print("INFO\tOpened argo_core db")
+  db.roles.insert([
+  {"resource" : "reports.get", "roles" : [ "admin", "editor","viewer"] },
+  {"resource" : "reports.list", "roles" : [ "admin", "editor","viewer" ]},
+  {"resource" : "reports.create", "roles" : [ "admin", "editor" ] },
+  {"resource" : "reports.delete", "roles" : [ "admin", "editor" ] },
+  {"resource" : "reports.update", "roles" : [ "admin", "editor" ] },
+  {"resource" : "metric_profiles.get", "roles" : [ "admin", "editor","viewer"] },
+  {"resource" : "metric_profiles.list", "roles" : [ "admin", "editor","viewer" ]},
+  {"resource" : "metric_profiles.create", "roles" : [ "admin", "editor" ] },
+  {"resource" : "metric_profiles.delete", "roles" : [ "admin", "editor" ] },
+  {"resource" : "metric_profiles.update", "roles" : [ "admin", "editor" ] },
+  {"resource" : "operations_profiles.get", "roles" : [ "admin", "editor","viewer"] },
+  {"resource" : "operations_profiles.list", "roles" : [ "admin", "editor","viewer" ]},
+  {"resource" : "operations_profiles.create", "roles" : [ "admin", "editor" ] },
+  {"resource" : "operations_profiles.delete", "roles" : [ "admin", "editor" ] },
+  {"resource" : "operations_profiles.update", "roles" : [ "admin", "editor" ] },
+  {"resource" : "aggregation_profiles.get", "roles" : [ "admin", "editor","viewer"] },
+  {"resource" : "aggregation_profiles.list", "roles" : [ "admin", "editor","viewer" ]},
+  {"resource" : "aggregation_profiles.create", "roles" : [ "admin", "editor" ] },
+  {"resource" : "aggregation_profiles.delete", "roles" : [ "admin", "editor" ] },
+  {"resource" : "aggregation_profiles.update", "roles" : [ "admin", "editor" ] },
+  {"resource" : "results.get", "roles" : [ "admin", "editor","viewer"] },
+  {"resource" : "results.list", "roles" : [ "admin", "editor","viewer" ]},
+  {"resource" : "status.get", "roles" : [ "admin", "editor","viewer"] },
+  {"resource" : "status.list", "roles" : [ "admin", "editor","viewer" ]},
+  {"resource" : "factors.list", "roles" : [ "admin", "editor","viewer"] },
+  {"resource" : "tenants.get", "roles" : [ "super_admin"] },
+  {"resource" : "tenants.list", "roles" : [ "super_admin" ]},
+  {"resource" : "tenants.create", "roles" : [ "super_admin" ] },
+  {"resource" : "tenants.delete", "roles" : [ "super_admin" ] },
+  {"resource" : "tenants.update", "roles" : [ "super_admin" ] },
+  {"resource" : "metric_result.get", "roles" : [ "admin", "editor","viewer" ]},
+  {"resource" : "recomputations.list", "roles" : [ "admin","editor"]},
+  {"resource" : "recomputations.get", "roles" : [ "admin","editor"]},
+  {"resource" : "recomputations.submit", "roles" : [ "admin","editor"]}]);
+  print("INFO\tPolulated default roles in \'roles\' collection")
+}

--- a/utils/authentication/authenticate.go
+++ b/utils/authentication/authenticate.go
@@ -128,6 +128,7 @@ func AuthenticateTenant(h http.Header, cfg config.Config) (config.MongoConfig, e
 		if user.ApiKey == apiKey {
 			mongoConf.User = user.User
 			mongoConf.Email = user.Email
+			mongoConf.Roles = user.Roles
 		}
 	}
 	return mongoConf, nil

--- a/utils/authorization/authorize.go
+++ b/utils/authorization/authorize.go
@@ -1,0 +1,43 @@
+package authorization
+
+import (
+	"log"
+
+	"github.com/ARGOeu/argo-web-api/utils/config"
+	"github.com/ARGOeu/argo-web-api/utils/mongo"
+
+	"gopkg.in/mgo.v2/bson"
+)
+
+// QRole holds roles resources relationships
+type QRole struct {
+	Resource string   `bson:"resource"`
+	Roles    []string `bson:"roles"`
+}
+
+// HasResourceRoles returns if a resource has the roles given
+func HasResourceRoles(cfg config.Config, resource string, roles []string) bool {
+
+	session, err := mongo.OpenSession(cfg.MongoDB)
+	defer mongo.CloseSession(session)
+
+	if err != nil {
+		panic(err)
+	}
+
+	var results []QRole
+
+	query := bson.M{"resource": resource, "roles": bson.M{"$in": roles}}
+	err = mongo.Find(session, cfg.MongoDB.Db, "roles", query, "resource", &results)
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if len(results) > 0 {
+		return true
+	}
+
+	return false
+
+}

--- a/utils/config/config.go
+++ b/utils/config/config.go
@@ -51,15 +51,16 @@ var flEnableCors = flag.String("enable-cors", "no", "specify weather to enable C
 
 // MongoConfig configuration to connect to a mongodb instance
 type MongoConfig struct {
-	User     string `bson:"name"`
-	Email    string `bson:"email"`
-	Host     string `bson:"server"`
-	Port     int    `bson:"port"`
-	Db       string `bson:"database"`
-	Username string `bson:"username"`
-	Password string `bson:"password"`
-	Store    string `bson:"store"`
-	ApiKey   string `bson:"api_key"`
+	User     string   `bson:"name"`
+	Email    string   `bson:"email"`
+	Host     string   `bson:"server"`
+	Port     int      `bson:"port"`
+	Db       string   `bson:"database"`
+	Username string   `bson:"username"`
+	Password string   `bson:"password"`
+	Store    string   `bson:"store"`
+	ApiKey   string   `bson:"api_key"`
+	Roles    []string `bson:"roles"`
 }
 
 // Config configuration for the api


### PR DESCRIPTION
## Goal
Implement authorization logic (as in argo-messaging) using roles

## Design
In argo-messaging two collections are used for auth: `users` and `roles`
In argo-web-api user information is holded in `tenants` collection. User list of roled was added as a new field for each user in `tenants` collection for eg:

```json
{
	
	"name" : "TENANT",
	"db_conf" : [
	
	],
	"users" : [
		{
			"name" : "User_admin",
			"email" : "useradmin@email.example.com",
			"api_key" : "ADMINKEY",
			"roles" : [
				"admin",
				"member"
			]
		},
		{
			"name" : "User_viewer",
			"email" : "userview@email.example.com",
			"api_key" : "VIEWERKEY",
			"roles" : [
				"viewer"
			]
		}
	]
}
```

- `roles` collection was added with permission reflection argo-web-api's routes 
for eg:
```json
[{ "resource" : "reports.get", "roles" : [ "admin", "editor", "viewer" ] },
{ "resource" : "reports.list", "roles" : [ "admin", "editor", "viewer" ] },
{ "resource" : "reports.create", "roles" : [ "admin", "editor" ] },
{ "resource" : "reports.delete", "roles" : [ "admin", "editor" ] },
{ "resource" : "reports.update", "roles" : [ "admin", "editor" ] },
{ "resource" : "metric_profiles.get", "roles" : [ "admin", "editor", "viewer" ] },
{ "resource" : "metric_profiles.list", "roles" : [ "admin", "editor", "viewer" ] }],
```
## Implementation
- [x] Add Authorization Routines
- [x] Use WrapAuthorization handler
- [x] Update each unit tests with role seeds and proper tenant configuration 
 