### PR TITLE
ARGO-541 Fix MonthlySupergroup avail/rel aggregation bug

### DIFF
--- a/app/results/Controller.go
+++ b/app/results/Controller.go
@@ -604,23 +604,38 @@ func DailySuperGroup(filter bson.M) []bson.M {
 
 // MonthlySuperGroup function to build the MongoDB aggregation query for monthly calculations
 func MonthlySuperGroup(filter bson.M) []bson.M {
-	filter["availability"] = bson.M{"$gte": 0}
-	filter["reliability"] = bson.M{"$gte": 0}
-	// Mongo aggregation pipeline
-	// Select all the records that match q
-	// Project the results to add 1 to every weights to avoid having 0 as a weights
-	// Group them by the first 8 digits of datetime (YYYYMMDD) and each group find
-	// availability = sum(availability*weights)
-	// reliability = sum(reliability*weights)
-	// weights = sum(weights)
-	// Project to a better format and do these computations
-	// availability = availability/weights
-	// reliability = reliability/weights
-	// Group by the first 6 digits of the datetime (YYYYMM) and by ngi,site,profile and for each group find
-	// availability = average(availability)
-	// reliability = average(reliability)
-	// Project the results to a better format
-	// Sort by namespace->report->supergroup->datetime
+
+	// The following aggregation query consists of 5 grand steps
+	// 1. Match   : records for the specific date and report and supergroup(optional)
+	// 2. Project : all necessary fields (date,availability,reliability,report) etc but also
+	//              if avail >= 0 set an availability-weigh = weight + 1, else = 0
+	//							if rel >=0 set a reliability-weight = weight + 1, else = 0
+	//              keep also weight = weight + 1 (to compensate for zero values)
+	//
+	//              Keeping two extra weights (a/r) has the following result:
+	//               - If an item has undef availab. then it will have an weightAv=0 and will not affect sums
+	//                    for eg. avg_daily_supergroup_availability = (av1*w1 + av2*w2 + undefAv3*0) / (w1 + w1 + 0)
+	//               - If an item has undef reliab. then it will have an weightRel=0 and will not affect sums
+	//                    for eg. avg_daily_supergroup_reliability = (rel1*w2 + rel2*w2 + undefRel3*0) / (w1 + w1 + 0)
+	//
+	// 3. Group   : by supergroup and day and calculate the sum of weighted daily availabilites (and reliabilities also)
+	//              - availability(weighted_sum) = av1*w1 + av2*w2 + undefAv3*0 etc...
+	//              - reliability(weighted_sum) = rel1*w1 + rel2*w2 + undefRel3*0 etc...
+	//
+	// 4. Match   : assertion step - keep only items that have a valid weight > 0
+	// 5. Project : the previous results and try to find the weighted average of daily avail. and reliability by:
+	//              - divide the previous sum of weighted availabilities by the total weightAv
+	//                SPECIAL CASE: If total weightAv remains : 0 that means that total daily supergroup avail = undef
+	//                              so instead of a numeric value, add a "nan" string (will not be counted in monthly average)
+	//              - divide the previous sum of weighted availabilities by the total weightAv
+	//								SPECIAL CASE: If total weightRem remains : 0 that means that total daily supergroup rel = undef
+	//                              so instead of a numeric value, add a "nan" string (will not be counted in monthly average)
+	// 6. Group   : by first date part (month, eg: 201608) to calculate monthly average avail and rel.
+	//							- monthly availability avg = avg(daily_availabilities) ~ but items with "nan" values will be neglected
+	//						  - monthly reliability avg = avg(daily_reliabilities) ~ but items with "nan" values will be neglected
+	//
+	// 7. Project : the relevant fields to form the appropriate final response (date,supergroup,report,avail,rel)
+	// 8. Sort    : the final results by report, supergroup and then date
 
 	query := []bson.M{
 		{"$match": filter},
@@ -630,6 +645,8 @@ func MonthlySuperGroup(filter bson.M) []bson.M {
 			"reliability":  1,
 			"report":       1,
 			"supergroup":   1,
+			"weightAv":     bson.M{"$cond": list{bson.M{"$gte": list{"$availability", 0}}, bson.M{"$add": list{"$weight", 1}}, 0}},
+			"weightRel":    bson.M{"$cond": list{bson.M{"$gte": list{"$reliability", 0}}, bson.M{"$add": list{"$weight", 1}}, 0}},
 			"weight": bson.M{
 				"$add": list{"$weight", 1}}},
 		},
@@ -638,8 +655,10 @@ func MonthlySuperGroup(filter bson.M) []bson.M {
 				"date":       bson.D{{"$substr", list{"$date", 0, 8}}},
 				"supergroup": "$supergroup",
 				"report":     "$report"},
-			"availability": bson.M{"$sum": bson.M{"$multiply": list{"$availability", "$weight"}}},
-			"reliability":  bson.M{"$sum": bson.M{"$multiply": list{"$reliability", "$weight"}}},
+			"availability": bson.M{"$sum": bson.M{"$multiply": list{"$availability", "$weightAv"}}},
+			"reliability":  bson.M{"$sum": bson.M{"$multiply": list{"$reliability", "$weightRel"}}},
+			"weightAv":     bson.M{"$sum": "$weightAv"},
+			"weightRel":    bson.M{"$sum": "$weightRel"},
 			"weight":       bson.M{"$sum": "$weight"}},
 		},
 		{"$match": bson.M{
@@ -649,8 +668,8 @@ func MonthlySuperGroup(filter bson.M) []bson.M {
 			"date":         "$_id.date",
 			"supergroup":   "$_id.supergroup",
 			"report":       "$_id.report",
-			"availability": bson.M{"$divide": list{"$availability", "$weight"}},
-			"reliability":  bson.M{"$divide": list{"$reliability", "$weight"}}},
+			"availability": bson.M{"$cond": list{bson.M{"$gt": list{"$weightAv", 0}}, bson.M{"$divide": list{"$availability", "$weightAv"}}, "nan"}},
+			"reliability":  bson.M{"$cond": list{bson.M{"$gt": list{"$weightRel", 0}}, bson.M{"$divide": list{"$reliability", "$weightRel"}}, "nan"}}},
 		},
 		{"$group": bson.M{
 			"_id": bson.M{


### PR DESCRIPTION
### Issue 
The web-api monthly supergroup aggregation contained a bug which in the monthly availability calculation excluded (wrongly) days that had undefined reliabilities but well definied availabilities. The error was in a mongo query which computes the results on the fly and responds.

### Fix 
In order not to break the query to multiple ones and cause refactoring changes to surrounding objects a single query remained *but* with the following changes:
- Since monthly av/rel figures are produced with weighted averages each item gets two new weights (weightAv and weightRel). 
- If item's availability is undefined then the corresponding weight (weightAv) will be set to 0 so as not to affect the sums/averages
- If item's reliability is undefined then the corresponding weight (weightRel) will be set to 0 so as not to affect sums/averages
 - To calculate the daily supergroup availability results only the weightAv values are taken into account
 - To calculate the daily supergroup reliability results only the weightRev values are taken into account
- In the edge cases where the total daily avail. remains undefined, then the value is replaced with a "nan" string so as to be excluded in the final monthly average (same for total daily reliability values)