### PR TITLE
ARGO-591 Enables logging to syslog

### DIFF
--- a/argo-web-api.conf
+++ b/argo-web-api.conf
@@ -33,7 +33,7 @@ start on startup
 
 script
 # Start up script just executes the api on call.
-   exec /var/www/argo-web-api/argo-web-api -conf=/etc/argo-web-api.conf
+   exec /var/www/argo-web-api/argo-web-api -conf=/etc/argo-web-api.conf | logger -t argo-web-api
 # create a custom event in case we want to chain later
    emit argo-web-api_running
 end script


### PR DESCRIPTION
The web api writes its event stream, unbuffered, to stdout, following
the twelve-factor methodology. This commit changes the init script to
pipe stdout to logger.