### PR TITLE
ARGO-1099 Add read-only super-admin

### DIFF
--- a/app/tenants/model.go
+++ b/app/tenants/model.go
@@ -31,8 +31,8 @@ package tenants
 type Tenant struct {
 	ID     string         `bson:"id" json:"id"`
 	Info   TenantInfo     `bson:"info" json:"info"`
-	DbConf []TenantDbConf `bson:"db_conf" json:"db_conf"`
-	Users  []TenantUser   `bson:"users" json:"users"`
+	DbConf []TenantDbConf `bson:"db_conf" json:"db_conf,omitempty"`
+	Users  []TenantUser   `bson:"users" json:"users,omitempty"`
 }
 
 // TenantInfo struct holds information about tenant name, contact details

--- a/doc/v2/docs/tenants.md
+++ b/doc/v2/docs/tenants.md
@@ -20,6 +20,9 @@ DELETE: Delete a tenant |This method can be used to delete an existing tenant | 
 ## [GET]: List Tenants
 This method can be used to retrieve a list of current tenants
 
+__Note__: This method restricts tenant database and user information when the x-api-key token holder is a __restricted__ super admin
+
+
 ### Input
 
 ```
@@ -37,7 +40,7 @@ Accept: application/json
 ### Response
 Headers: `Status: 200 OK`
 
-#### Response body
+#### Response body for super admin users
 Json Response
 
 ```json
@@ -126,6 +129,40 @@ Json Response
      "api_key": "ST4RL0RDK3Y"
     }
    ]
+  }
+ ]
+}
+```
+
+#### Response body for restricted super admin users:
+Json Response
+
+```json
+{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50b",
+   "info": {
+    "name": "Tenant1",
+    "email": "email1@tenant1.com",
+    "website": "www.tenant1.com",
+    "created": "2015-10-20 02:08:04",
+    "updated": "2015-10-20 02:08:04"
+   }
+  },
+  {
+   "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50c",
+   "info": {
+    "name": "tenant2",
+    "email": "tenant2@email.com",
+    "website": "www.tenant2.com",
+    "created": "2015-10-20 02:08:04",
+    "updated": "2015-10-20 02:08:04"
+   }
   }
  ]
 }

--- a/respond/wrappers.go
+++ b/respond/wrappers.go
@@ -37,15 +37,22 @@ func WrapAuthenticate(hfn http.Handler, cfg config.Config, routeName string) htt
 		// check if api admin authentication is needed (for tenants etc...)
 		if needsAPIAdmin(routeName) {
 
-			// Authenticate admin api and check
 			if (authentication.AuthenticateAdmin(r.Header, cfg)) == false {
 				// Because not authenticated respond with error
 				Error(w, r, ErrAuthen, cfg, errs)
 				return
 			}
+
 			// admin api authenticated so continue serving
 			context.Set(r, "authen", true)
-			context.Set(r, "roles", []string{"super_admin"})
+			// Add admin restricted or not information -- used in get tenants
+
+			// Check if admin is restricted
+			if authentication.IsAdminRestricted(r.Header, cfg) {
+				context.Set(r, "roles", []string{"super_admin_restricted"})
+			} else {
+				context.Set(r, "roles", []string{"super_admin"})
+			}
 
 			hfn.ServeHTTP(w, r)
 

--- a/scripts/mongodb/populate_default_roles.js
+++ b/scripts/mongodb/populate_default_roles.js
@@ -46,7 +46,7 @@ function populate_default_roles()
   {"resource" : "status.list", "roles" : [ "admin", "editor","viewer" ]},
   {"resource" : "factors.list", "roles" : [ "admin", "editor","viewer"] },
   {"resource" : "tenants.get", "roles" : [ "super_admin"] },
-  {"resource" : "tenants.list", "roles" : [ "super_admin" ]},
+  {"resource" : "tenants.list", "roles" : [ "super_admin", "super_admin_restricted" ]},
   {"resource" : "tenants.create", "roles" : [ "super_admin" ] },
   {"resource" : "tenants.delete", "roles" : [ "super_admin" ] },
   {"resource" : "tenants.update", "roles" : [ "super_admin" ] },


### PR DESCRIPTION
# Issue 
Super admins are the only users that have access to tenant information. They also have CRUD authorization. There are cases that client need access to tenant info for read-only purposes. 

# Solution
Implement a super_admin_restricted user that will have read-only access to list of tenants. Hide some internal tenant information (like tenant's db conf and tenant's user list) from restricted super admin 

# Implementation
- [x] Refactor super_admin model to support restricted bool flag (yes/no)
- [x] Refactor authN to check if super_admin is restricted
- [x] Refactor authZ to check if user is super_admin_restricted 
- [x] Refactor TenantList function to minimize output (to just tenant info) when accessed by a restricted super admin
- [x] Add unit test
- [x] update docs