### PR TITLE
ARGO-1260 Implement CRUD on threshold profiles resource

### DIFF
--- a/app/thresholdsProfiles/controller.go
+++ b/app/thresholdsProfiles/controller.go
@@ -1,0 +1,399 @@
+/*
+ * Copyright (c) 2018 GRNET S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS
+ * IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ *
+ * The views and conclusions contained in the software and
+ * documentation are those of the authors and should not be
+ * interpreted as representing official policies, either expressed
+ * or implied, of GRNET S.A.
+ *
+ */
+
+package thresholdsProfiles
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/gorilla/context"
+	"gopkg.in/mgo.v2/bson"
+
+	"github.com/ARGOeu/argo-web-api/respond"
+	"github.com/ARGOeu/argo-web-api/utils/config"
+	"github.com/ARGOeu/argo-web-api/utils/mongo"
+	"github.com/gorilla/mux"
+)
+
+// ListOne handles the listing of one specific profile based on its given id
+func ListOne(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
+
+	//STANDARD DECLARATIONS START
+	code := http.StatusOK
+	h := http.Header{}
+	output := []byte("")
+	err := error(nil)
+	charset := "utf-8"
+	//STANDARD DECLARATIONS END
+
+	// Set Content-Type response Header value
+	contentType := r.Header.Get("Accept")
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+
+	vars := mux.Vars(r)
+
+	// Grab Tenant DB configuration from context
+	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
+
+	// Open session to tenant database
+	session, err := mongo.OpenSession(tenantDbConfig)
+	defer mongo.CloseSession(session)
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	filter := bson.M{"id": vars["ID"]}
+
+	// Retrieve Results from database
+	results := []ThresholdsProfile{}
+	err = mongo.Find(session, tenantDbConfig.Db, "thresholds_profiles", filter, "name", &results)
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	// Check if nothing found
+	if len(results) < 1 {
+		output, _ = respond.MarshalContent(respond.NotFound, contentType, "", " ")
+		code = 404
+		return code, h, output, err
+	}
+
+	// Create view of the results
+	output, err = createListView(results, "Success", code) //Render the results into JSON
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+	return code, h, output, err
+}
+
+// List the existing metric profiles for the tenant making the request
+// Also there is an optional url param "name" to filter results by
+func List(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
+
+	//STANDARD DECLARATIONS START
+
+	code := http.StatusOK
+	h := http.Header{}
+	output := []byte("")
+	err := error(nil)
+	charset := "utf-8"
+
+	//STANDARD DECLARATIONS END
+
+	// Set Content-Type response Header value
+	contentType := r.Header.Get("Accept")
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+
+	urlValues := r.URL.Query()
+
+	// Grab Tenant DB configuration from context
+	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
+
+	// Open session to tenant database
+	session, err := mongo.OpenSession(tenantDbConfig)
+	defer mongo.CloseSession(session)
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	// Retrieve Results from database
+
+	var filter interface{}
+	if len(urlValues["name"]) > 0 {
+		filter = bson.M{"name": urlValues["name"][0]}
+	} else {
+		filter = nil
+	}
+
+	results := []ThresholdsProfile{}
+	err = mongo.Find(session, tenantDbConfig.Db, "thresholds_profiles", filter, "name", &results)
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	// Create view of the results
+	output, err = createListView(results, "Success", code) //Render the results into JSON
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+	return code, h, output, err
+}
+
+//Create a new metric profile
+func Create(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
+	//STANDARD DECLARATIONS START
+	code := http.StatusOK
+	h := http.Header{}
+	output := []byte("")
+	err := error(nil)
+	charset := "utf-8"
+	//STANDARD DECLARATIONS END
+
+	// Set Content-Type response Header value
+	contentType := r.Header.Get("Accept")
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+
+	// Grab Tenant DB configuration from context
+	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
+
+	session, err := mongo.OpenSession(tenantDbConfig)
+	defer mongo.CloseSession(session)
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	incoming := ThresholdsProfile{}
+
+	// Try ingest request body
+	body, err := ioutil.ReadAll(io.LimitReader(r.Body, cfg.Server.ReqSizeLimit))
+	if err != nil {
+		panic(err)
+	}
+	if err := r.Body.Close(); err != nil {
+		panic(err)
+	}
+
+	// Parse body json
+	if err := json.Unmarshal(body, &incoming); err != nil {
+		output, _ = respond.MarshalContent(respond.BadRequestBadJSON, contentType, "", " ")
+		code = 400
+		return code, h, output, err
+	}
+
+	// Validate States
+	var errList []string
+	errList = append(errList, incoming.Validate()...)
+
+	if len(errList) > 0 {
+		output, err = createErrView("Validation Error", 422, errList)
+		code = 422
+		return code, h, output, err
+	}
+
+	// Generate new id
+	incoming.ID = mongo.NewUUID()
+	err = mongo.Insert(session, tenantDbConfig.Db, "thresholds_profiles", incoming)
+
+	if err != nil {
+		panic(err)
+	}
+
+	// Create view of the results
+	output, err = createRefView(incoming, "Thresholds Profile successfully created", 201, r) //Render the results into JSON
+	code = 201
+	return code, h, output, err
+}
+
+//Update function to update contents of an existing metric profile
+func Update(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
+	//STANDARD DECLARATIONS START
+	code := http.StatusOK
+	h := http.Header{}
+	output := []byte("")
+	err := error(nil)
+	charset := "utf-8"
+	//STANDARD DECLARATIONS END
+
+	vars := mux.Vars(r)
+
+	// Set Content-Type response Header value
+	contentType := r.Header.Get("Accept")
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+
+	// Grab Tenant DB configuration from context
+	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
+
+	incoming := ThresholdsProfile{}
+
+	// ingest body data
+	body, err := ioutil.ReadAll(io.LimitReader(r.Body, cfg.Server.ReqSizeLimit))
+	if err != nil {
+		panic(err)
+	}
+	if err := r.Body.Close(); err != nil {
+		panic(err)
+	}
+	// parse body json
+	if err := json.Unmarshal(body, &incoming); err != nil {
+		output, _ = respond.MarshalContent(respond.BadRequestBadJSON, contentType, "", " ")
+		code = 400
+		return code, h, output, err
+	}
+
+	session, err := mongo.OpenSession(tenantDbConfig)
+	defer mongo.CloseSession(session)
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	// create filter to retrieve specific profile with id
+	filter := bson.M{"id": vars["ID"]}
+
+	incoming.ID = vars["ID"]
+
+	// Retrieve Results from database
+	results := []ThresholdsProfile{}
+	err = mongo.Find(session, tenantDbConfig.Db, "thresholds_profiles", filter, "name", &results)
+
+	if err != nil {
+		panic(err)
+	}
+
+	// Check if nothing found
+	if len(results) < 1 {
+		output, _ = respond.MarshalContent(respond.NotFound, contentType, "", " ")
+		code = 404
+		return code, h, output, err
+	}
+
+	// Validate States
+	var errList []string
+	errList = append(errList, incoming.Validate()...)
+
+	if len(errList) > 0 {
+		output, err = createErrView("Validation Error", 422, errList)
+		code = 422
+		return code, h, output, err
+	}
+
+	// run the update query
+	err = mongo.Update(session, tenantDbConfig.Db, "thresholds_profiles", filter, incoming)
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	// Create view for response message
+	output, err = createMsgView("Thresholds Profile successfully updated", 200) //Render the results into JSON
+	code = 200
+	return code, h, output, err
+}
+
+//Delete metric profile based on id
+func Delete(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
+
+	//STANDARD DECLARATIONS START
+
+	code := http.StatusOK
+	h := http.Header{}
+	output := []byte("")
+	err := error(nil)
+	charset := "utf-8"
+
+	//STANDARD DECLARATIONS END
+
+	// Set Content-Type response Header value
+	contentType := r.Header.Get("Accept")
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+
+	vars := mux.Vars(r)
+
+	// Grab Tenant DB configuration from context
+	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
+
+	// Open session to tenant database
+	session, err := mongo.OpenSession(tenantDbConfig)
+	defer mongo.CloseSession(session)
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	filter := bson.M{"id": vars["ID"]}
+
+	// Retrieve Results from database
+	results := []ThresholdsProfile{}
+	err = mongo.Find(session, tenantDbConfig.Db, "thresholds_profiles", filter, "name", &results)
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	// Check if nothing found
+	if len(results) < 1 {
+		output, _ = respond.MarshalContent(respond.NotFound, contentType, "", " ")
+		code = 404
+		return code, h, output, err
+	}
+
+	mongo.Remove(session, tenantDbConfig.Db, "thresholds_profiles", filter)
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	// Create view of the results
+	output, err = createMsgView("Thresholds Profile Successfully Deleted", 200) //Render the results into JSON
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+	return code, h, output, err
+}
+
+func Options(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
+
+	//STANDARD DECLARATIONS START
+
+	code := http.StatusOK
+	h := http.Header{}
+	output := []byte("")
+	err := error(nil)
+	contentType := "text/plain"
+	charset := "utf-8"
+
+	//STANDARD DECLARATIONS END
+
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+	h.Set("Allow", fmt.Sprintf("GET, POST, DELETE, PUT, OPTIONS"))
+	return code, h, output, err
+
+}

--- a/app/thresholdsProfiles/model.go
+++ b/app/thresholdsProfiles/model.go
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2018 GRNET S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS
+ * IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ *
+ * The views and conclusions contained in the software and
+ * documentation are those of the authors and should not be
+ * interpreted as representing official policies, either expressed
+ * or implied, of GRNET S.A.
+ *
+ */
+
+package thresholdsProfiles
+
+import (
+	"log"
+	"regexp"
+)
+
+// ThresholdsProfile struct that holds information about threshold rules
+type ThresholdsProfile struct {
+	ID    string `bson:"id" json:"id"`
+	Name  string `bson:"name" json:"name"`
+	Rules []Rule `bson:"rules" json:"rules"`
+}
+
+// Rule represents a thresholds rule that must be applied to a metric and then optionally to a host and/or endpoint group
+type Rule struct {
+	EndpointGroup string `bson:"endpoint_group" json:"endpoint_group,omitempty"`
+	Host          string `bson:"host" json:"host,omitempty"`
+	Metric        string `bson:"metric" json:"metric"`
+	Thresholds    string `bson:"thresholds" json:"thresholds"`
+}
+
+// SelfReference to hold links and id
+type SelfReference struct {
+	ID    string `json:"id" bson:"id,omitempty"`
+	Links Links  `json:"links"`
+}
+
+// Links struct to hold links
+type Links struct {
+	Self string `json:"self"`
+}
+
+// ValidateRule takes a thresholds rule declaration and validates it against it standar format
+func validateRule(rule string) bool {
+	// Threshold rule validation regexp
+	r, err := regexp.Compile(`^([a-zA-Z][\w]+=-?\d+(\.\d+)*(s|us|ms|%|B|KB|MB|TB|c)?(;(-?\d+(\.\d+)*|(~|-?\d+(\.\d+)*):(-?\d+(\.\d+)*)?)?){0,2}(;(-?\d+(\.\d+)*)?){0,2}(;|\s)*)+$`)
+	if err != nil {
+		log.Println(err)
+		return false
+	}
+
+	return r.MatchString(rule)
+}
+
+// Validate validates all threshold rules of a thresholds profile
+func (tprof *ThresholdsProfile) Validate() []string {
+
+	var errList []string
+
+	for _, rule := range tprof.Rules {
+		if !validateRule(rule.Thresholds) {
+			errList = append(errList, "Invalid threshold: "+rule.Thresholds)
+		}
+	}
+
+	return errList
+
+}

--- a/app/thresholdsProfiles/routing.go
+++ b/app/thresholdsProfiles/routing.go
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2018 GRNET S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS
+ * IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ *
+ * The views and conclusions contained in the software and
+ * documentation are those of the authors and should not be
+ * interpreted as representing official policies, either expressed
+ * or implied, of GRNET S.A.
+ *
+ */
+
+package thresholdsProfiles
+
+import (
+	"github.com/ARGOeu/argo-web-api/respond"
+	"github.com/gorilla/mux"
+)
+
+// HandleSubrouter uses the subrouter for a specific calls and creates a tree of sorts
+// handling each route with a different subrouter
+func HandleSubrouter(s *mux.Router, confhandler *respond.ConfHandler) {
+
+	s = respond.PrepAppRoutes(s, confhandler, appRoutesV2)
+
+}
+
+var appRoutesV2 = []respond.AppRoutes{
+	{"thresholdsProfiles.list", "GET", "/thresholds_profiles", List},
+	{"thresholdsProfiles.get", "GET", "/thresholds_profiles/{ID}", ListOne},
+	{"thresholdsProfiles.create", "POST", "/thresholds_profiles", Create},
+	{"thresholdsProfiles.update", "PUT", "/thresholds_profiles/{ID}", Update},
+	{"thresholdsProfiles.delete", "DELETE", "/thresholds_profiles/{ID}", Delete},
+	{"thresholdsProfiles.options", "OPTIONS", "/thresholds_profiles", Options},
+	{"thresholdsProfiles.options", "OPTIONS", "/thresholds_profiles/{ID}", Options},
+}

--- a/app/thresholdsProfiles/thresholdsProfiles_test.go
+++ b/app/thresholdsProfiles/thresholdsProfiles_test.go
@@ -1,0 +1,998 @@
+/*
+ * Copyright (c) 2018 GRNET S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS
+ * IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ *
+ * The views and conclusions contained in the software and
+ * documentation are those of the authors and should not be
+ * interpreted as representing official policies, either expressed
+ * or implied, of GRNET S.A.
+ *
+ */
+
+package thresholdsProfiles
+
+import (
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/ARGOeu/argo-web-api/respond"
+	"github.com/ARGOeu/argo-web-api/utils/config"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/suite"
+	"gopkg.in/gcfg.v1"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+)
+
+// This is a util. suite struct used in tests (see pkg "testify")
+type ThresholdsProfilesTestSuite struct {
+	suite.Suite
+	cfg                       config.Config
+	router                    *mux.Router
+	confHandler               respond.ConfHandler
+	tenantDbConf              config.MongoConfig
+	clientkey                 string
+	respRecomputationsCreated string
+	respUnauthorized          string
+}
+
+// Setup the Test Environment
+func (suite *ThresholdsProfilesTestSuite) SetupSuite() {
+
+	log.SetOutput(ioutil.Discard)
+
+	const testConfig = `
+	    [server]
+	    bindip = ""
+	    port = 8080
+	    maxprocs = 4
+	    cache = false
+	    lrucache = 700000000
+	    gzip = true
+		reqsizelimit = 1073741824
+
+	    [mongodb]
+	    host = "127.0.0.1"
+	    port = 27017
+	    db = "AR_test_op_profiles"
+	    `
+
+	_ = gcfg.ReadStringInto(&suite.cfg, testConfig)
+
+	suite.respUnauthorized = "Unauthorized"
+	suite.tenantDbConf = config.MongoConfig{
+		Host:     "localhost",
+		Port:     27017,
+		Db:       "AR_test_thresholds_profiles_tenant",
+		Password: "pass",
+		Username: "dbuser",
+		Store:    "ar",
+	}
+	suite.clientkey = "123456"
+
+	suite.confHandler = respond.ConfHandler{suite.cfg}
+	suite.router = mux.NewRouter().StrictSlash(false).PathPrefix("/api/v2").Subrouter()
+	HandleSubrouter(suite.router, &suite.confHandler)
+}
+
+// This function runs before any test and setups the environment
+func (suite *ThresholdsProfilesTestSuite) SetupTest() {
+
+	// seed mongo
+	session, err := mgo.Dial(suite.cfg.MongoDB.Host)
+	if err != nil {
+		panic(err)
+	}
+	defer session.Close()
+
+	// Seed database with tenants
+	//TODO: move tests to
+	c := session.DB(suite.cfg.MongoDB.Db).C("tenants")
+	c.Insert(
+		bson.M{"id": "6ac7d684-1f8e-4a02-a502-720e8f11e50c",
+			"info": bson.M{
+				"name":    "GUARDIANS",
+				"email":   "email@something2",
+				"website": "www.gotg.com",
+				"created": "2015-10-20 02:08:04",
+				"updated": "2015-10-20 02:08:04"},
+			"db_conf": []bson.M{
+
+				bson.M{
+					"server":   "localhost",
+					"port":     27017,
+					"database": "argo_FOO",
+				},
+				bson.M{
+					"server":   "localhost",
+					"port":     27017,
+					"database": "argo_FOO",
+				},
+			},
+			"users": []bson.M{
+
+				bson.M{
+					"name":    "user1",
+					"email":   "user1@email.com",
+					"api_key": "USER1KEY",
+					"roles":   []string{"editor"},
+				},
+				bson.M{
+					"name":    "user2",
+					"email":   "user2@email.com",
+					"api_key": "USER2KEY",
+					"roles":   []string{"editor"},
+				},
+			}})
+	c.Insert(
+		bson.M{"id": "6ac7d684-1f8e-4a02-a502-720e8f11e50d",
+			"info": bson.M{
+				"name":    "AVENGERS",
+				"email":   "email@something2",
+				"website": "www.gotg.com",
+				"created": "2015-10-20 02:08:04",
+				"updated": "2015-10-20 02:08:04"},
+			"db_conf": []bson.M{
+
+				bson.M{
+					// "store":    "ar",
+					"server":   suite.tenantDbConf.Host,
+					"port":     suite.tenantDbConf.Port,
+					"database": suite.tenantDbConf.Db,
+					"username": suite.tenantDbConf.Username,
+					"password": suite.tenantDbConf.Password,
+				},
+				bson.M{
+					"server":   suite.tenantDbConf.Host,
+					"port":     suite.tenantDbConf.Port,
+					"database": suite.tenantDbConf.Db,
+				},
+			},
+			"users": []bson.M{
+
+				bson.M{
+					"name":    "user3",
+					"email":   "user3@email.com",
+					"api_key": suite.clientkey,
+					"roles":   []string{"editor"},
+				},
+				bson.M{
+					"name":    "user4",
+					"email":   "user4@email.com",
+					"api_key": "VIEWERKEY",
+					"roles":   []string{"viewer"},
+				},
+			}})
+
+	c = session.DB(suite.cfg.MongoDB.Db).C("roles")
+	c.Insert(
+		bson.M{
+			"resource": "thresholdsProfiles.list",
+			"roles":    []string{"editor", "viewer"},
+		})
+	c.Insert(
+		bson.M{
+			"resource": "thresholdsProfiles.get",
+			"roles":    []string{"editor", "viewer"},
+		})
+	c.Insert(
+		bson.M{
+			"resource": "thresholdsProfiles.create",
+			"roles":    []string{"editor"},
+		})
+	c.Insert(
+		bson.M{
+			"resource": "thresholdsProfiles.delete",
+			"roles":    []string{"editor"},
+		})
+	c.Insert(
+		bson.M{
+			"resource": "thresholdsProfiles.update",
+			"roles":    []string{"editor"},
+		})
+
+	// Seed database with thresholds profiles
+	c = session.DB(suite.tenantDbConf.Db).C("thresholds_profiles")
+	c.Insert(
+		bson.M{
+			"id":   "6ac7d684-1f8e-4a02-a502-720e8f11e50b",
+			"name": "thr01",
+			"rules": []bson.M{bson.M{
+				"host":       "hostFoo",
+				"metric":     "metricA",
+				"thresholds": "freshnesss=1s;10;9:;0;25 entries=1;3;2:0;10",
+			}},
+		})
+
+	c.Insert(
+		bson.M{
+			"id":   "6ac7d222-1f8e-4a02-a502-720e8f11e50b",
+			"name": "thr02",
+			"rules": []bson.M{bson.M{
+				"host":       "hostFoo",
+				"metric":     "metricA",
+				"thresholds": "freshness=1s;10;9:;0;25 entries=1;3;2:0;10",
+			}},
+		})
+
+	c.Insert(
+		bson.M{
+			"id":   "6ac7d555-1f8e-4a02-a502-720e8f11e50b",
+			"name": "thr03",
+			"rules": []bson.M{bson.M{
+				"host":       "hostFoo",
+				"metric":     "metricA",
+				"thresholds": "freshness=1s;10;9:;0;25 entries=1;3;2:0;10",
+			}},
+		})
+}
+
+func (suite *ThresholdsProfilesTestSuite) TestList() {
+
+	request, _ := http.NewRequest("GET", "/api/v2/thresholds_profiles", strings.NewReader(""))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code := response.Code
+	output := response.Body.String()
+
+	profileJSON := `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50b",
+   "name": "thr01",
+   "rules": [
+    {
+     "host": "hostFoo",
+     "metric": "metricA",
+     "thresholds": "freshnesss=1s;10;9:;0;25 entries=1;3;2:0;10"
+    }
+   ]
+  },
+  {
+   "id": "6ac7d222-1f8e-4a02-a502-720e8f11e50b",
+   "name": "thr02",
+   "rules": [
+    {
+     "host": "hostFoo",
+     "metric": "metricA",
+     "thresholds": "freshness=1s;10;9:;0;25 entries=1;3;2:0;10"
+    }
+   ]
+  },
+  {
+   "id": "6ac7d555-1f8e-4a02-a502-720e8f11e50b",
+   "name": "thr03",
+   "rules": [
+    {
+     "host": "hostFoo",
+     "metric": "metricA",
+     "thresholds": "freshness=1s;10;9:;0;25 entries=1;3;2:0;10"
+    }
+   ]
+  }
+ ]
+}`
+	// Check that we must have a 200 ok code
+	suite.Equal(200, code, "Internal Server Error")
+	// Compare the expected and actual json response
+	suite.Equal(profileJSON, output, "Response body mismatch")
+
+}
+
+func (suite *ThresholdsProfilesTestSuite) TestListQueryName() {
+
+	request, _ := http.NewRequest("GET", "/api/v2/thresholds_profiles?name=thr02", strings.NewReader(""))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code := response.Code
+	output := response.Body.String()
+
+	profileJSON := `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "id": "6ac7d222-1f8e-4a02-a502-720e8f11e50b",
+   "name": "thr02",
+   "rules": [
+    {
+     "host": "hostFoo",
+     "metric": "metricA",
+     "thresholds": "freshness=1s;10;9:;0;25 entries=1;3;2:0;10"
+    }
+   ]
+  }
+ ]
+}`
+	// Check that we must have a 200 ok code
+	suite.Equal(200, code, "Internal Server Error")
+	// Compare the expected and actual json response
+	suite.Equal(profileJSON, output, "Response body mismatch")
+
+}
+
+func (suite *ThresholdsProfilesTestSuite) TestListOneNotFound() {
+
+	jsonInput := `{}`
+
+	jsonOutput := `{
+ "status": {
+  "message": "Not Found",
+  "code": "404",
+  "details": "item with the specific ID was not found on the server"
+ }
+}`
+
+	request, _ := http.NewRequest("GET", "/api/v2/thresholds_profiles/wrong-id", strings.NewReader(jsonInput))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code := response.Code
+	output := response.Body.String()
+	// Check that we must have a 200 ok code
+	suite.Equal(404, code, "Internal Server Error")
+	// Compare the expected and actual json response
+
+	suite.Equal(jsonOutput, output, "Response body mismatch")
+
+}
+
+func (suite *ThresholdsProfilesTestSuite) TestListOne() {
+
+	request, _ := http.NewRequest("GET", "/api/v2/thresholds_profiles/6ac7d222-1f8e-4a02-a502-720e8f11e50b", strings.NewReader(""))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code := response.Code
+	output := response.Body.String()
+
+	profileJSON := `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "id": "6ac7d222-1f8e-4a02-a502-720e8f11e50b",
+   "name": "thr02",
+   "rules": [
+    {
+     "host": "hostFoo",
+     "metric": "metricA",
+     "thresholds": "freshness=1s;10;9:;0;25 entries=1;3;2:0;10"
+    }
+   ]
+  }
+ ]
+}`
+	// Check that we must have a 200 ok code
+	suite.Equal(200, code, "Internal Server Error")
+	// Compare the expected and actual json response
+	suite.Equal(profileJSON, output, "Response body mismatch")
+
+}
+
+func (suite *ThresholdsProfilesTestSuite) TestCreateBadJson() {
+
+	jsonInput := `{
+  "name": "test_profile",
+  "namespace [
+    `
+
+	jsonOutput := `{
+ "status": {
+  "message": "Bad Request",
+  "code": "400",
+  "details": "Request Body contains malformed JSON, thus rendering the Request Bad"
+ }
+}`
+
+	request, _ := http.NewRequest("POST", "/api/v2/thresholds_profiles", strings.NewReader(jsonInput))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code := response.Code
+	output := response.Body.String()
+	// Check that we must have a 200 ok code
+	suite.Equal(400, code, "Internal Server Error")
+	// Compare the expected and actual json response
+
+	suite.Equal(jsonOutput, output, "Response body mismatch")
+
+}
+
+func (suite *ThresholdsProfilesTestSuite) TestCreate() {
+
+	jsonInput := `{
+  "name" : "thr04",
+  "rules": [
+    {
+      "metric": "metricB",
+      "thresholds": "time=1s;10;9:30;0;30"
+    }
+  ]
+}`
+
+	jsonOutput := `{
+ "status": {
+  "message": "Thresholds Profile successfully created",
+  "code": "201"
+ },
+ "data": {
+  "id": "{{ID}}",
+  "links": {
+   "self": "https:///api/v2/thresholds_profiles/{{ID}}"
+  }
+ }
+}`
+
+	jsonCreated := `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "id": "{{ID}}",
+   "name": "thr04",
+   "rules": [
+    {
+     "metric": "metricB",
+     "thresholds": "time=1s;10;9:30;0;30"
+    }
+   ]
+  }
+ ]
+}`
+
+	request, _ := http.NewRequest("POST", "/api/v2/thresholds_profiles", strings.NewReader(jsonInput))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code := response.Code
+	output := response.Body.String()
+
+	// Check that we must have a 200 ok code
+	suite.Equal(201, code, "Internal Server Error")
+	// Compare the expected and actual json response
+
+	// Grab ID from mongodb
+	session, err := mgo.Dial(suite.cfg.MongoDB.Host)
+	defer session.Close()
+	if err != nil {
+		panic(err)
+	}
+
+	// Retrieve id from database
+	var result map[string]interface{}
+	c := session.DB(suite.tenantDbConf.Db).C("thresholds_profiles")
+
+	c.Find(bson.M{"name": "thr04"}).One(&result)
+	id := result["id"].(string)
+
+	// Apply id to output template and check
+	suite.Equal(strings.Replace(jsonOutput, "{{ID}}", id, 2), output, "Response body mismatch")
+
+	// Check that actually the item has been created
+	// Call List one with the specific ID
+	request2, _ := http.NewRequest("GET", "/api/v2/thresholds_profiles/"+id, strings.NewReader(jsonInput))
+	request2.Header.Set("x-api-key", suite.clientkey)
+	request2.Header.Set("Accept", "application/json")
+	response2 := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response2, request2)
+
+	code2 := response2.Code
+	output2 := response2.Body.String()
+
+	// Check that we must have a 200 ok code
+	suite.Equal(200, code2, "Internal Server Error")
+	// Compare the expected and actual json response
+	suite.Equal(strings.Replace(jsonCreated, "{{ID}}", id, 1), output2, "Response body mismatch")
+}
+
+func (suite *ThresholdsProfilesTestSuite) TestUpdateBadJson() {
+
+	jsonInput := `{
+   "name": "yolo",
+   "namespace": "testin
+    `
+
+	jsonOutput := `{
+ "status": {
+  "message": "Bad Request",
+  "code": "400",
+  "details": "Request Body contains malformed JSON, thus rendering the Request Bad"
+ }
+}`
+
+	request, _ := http.NewRequest("PUT", "/api/v2/thresholds_profiles/6ac7d684-1f8e-4a02-a502-720e8f11e50c", strings.NewReader(jsonInput))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code := response.Code
+	output := response.Body.String()
+	// Check that we must have a 200 ok code
+	suite.Equal(400, code, "Internal Server Error")
+	// Compare the expected and actual json response
+
+	suite.Equal(jsonOutput, output, "Response body mismatch")
+
+}
+
+func (suite *ThresholdsProfilesTestSuite) TestUpdateNotFound() {
+
+	jsonInput := `{}`
+
+	jsonOutput := `{
+ "status": {
+  "message": "Not Found",
+  "code": "404",
+  "details": "item with the specific ID was not found on the server"
+ }
+}`
+
+	request, _ := http.NewRequest("PUT", "/api/v2/thresholds_profiles/wrong-id", strings.NewReader(jsonInput))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code := response.Code
+	output := response.Body.String()
+	// Check that we must have a 200 ok code
+	suite.Equal(404, code, "Internal Server Error")
+	// Compare the expected and actual json response
+
+	suite.Equal(jsonOutput, output, "Response body mismatch")
+
+}
+
+func (suite *ThresholdsProfilesTestSuite) TestUpdate() {
+
+	jsonInput := `{
+  "name" : "thr04",
+  "rules": [
+    {
+      "metric": "metricB",
+      "thresholds": "time=2s;10;9:30;0;30"
+    }
+  ]
+}`
+
+	jsonOutput := `{
+ "status": {
+  "message": "Thresholds Profile successfully updated",
+  "code": "200"
+ }
+}`
+
+	jsonUpdated := `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "id": "6ac7d555-1f8e-4a02-a502-720e8f11e50b",
+   "name": "thr04",
+   "rules": [
+    {
+     "metric": "metricB",
+     "thresholds": "time=2s;10;9:30;0;30"
+    }
+   ]
+  }
+ ]
+}`
+
+	request, _ := http.NewRequest("PUT", "/api/v2/thresholds_profiles/6ac7d555-1f8e-4a02-a502-720e8f11e50b", strings.NewReader(jsonInput))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code := response.Code
+	output := response.Body.String()
+
+	// Check that we must have a 200 ok code
+	suite.Equal(200, code, "Internal Server Error")
+	// Compare the expected and actual json response
+
+	// Apply id to output template and check
+	suite.Equal(jsonOutput, output, "Response body mismatch")
+
+	// Check that the item has actually updated
+	// run a list specific
+	request2, _ := http.NewRequest("GET", "/api/v2/thresholds_profiles/6ac7d555-1f8e-4a02-a502-720e8f11e50b", strings.NewReader(jsonInput))
+	request2.Header.Set("x-api-key", suite.clientkey)
+	request2.Header.Set("Accept", "application/json")
+	response2 := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response2, request2)
+
+	code2 := response2.Code
+	output2 := response2.Body.String()
+	// Check that we must have a 200 ok code
+	suite.Equal(200, code2, "Internal Server Error")
+	// Compare the expected and actual json response
+	suite.Equal(jsonUpdated, output2, "Response body mismatch")
+
+}
+
+func (suite *ThresholdsProfilesTestSuite) TestDeleteNotFound() {
+
+	jsonInput := `{}`
+
+	jsonOutput := `{
+ "status": {
+  "message": "Not Found",
+  "code": "404",
+  "details": "item with the specific ID was not found on the server"
+ }
+}`
+
+	request, _ := http.NewRequest("DELETE", "/api/v2/thresholds_profiles/wrong-id", strings.NewReader(jsonInput))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code := response.Code
+	output := response.Body.String()
+	// Check that we must have a 200 ok code
+	suite.Equal(404, code, "Internal Server Error")
+	// Compare the expected and actual json response
+
+	suite.Equal(jsonOutput, output, "Response body mismatch")
+
+}
+
+func (suite *ThresholdsProfilesTestSuite) TestDelete() {
+
+	request, _ := http.NewRequest("DELETE", "/api/v2/thresholds_profiles/6ac7d684-1f8e-4a02-a502-720e8f11e50b", strings.NewReader(""))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code := response.Code
+	output := response.Body.String()
+
+	metricProfileJSON := `{
+ "status": {
+  "message": "Thresholds Profile Successfully Deleted",
+  "code": "200"
+ }
+}`
+	// Check that we must have a 200 ok code
+	suite.Equal(200, code, "Internal Server Error")
+	// Compare the expected and actual json response
+	suite.Equal(metricProfileJSON, output, "Response body mismatch")
+
+	// check that the element has actually been Deleted
+	// connect to mongodb
+	session, err := mgo.Dial(suite.cfg.MongoDB.Host)
+	defer session.Close()
+	if err != nil {
+		panic(err)
+	}
+	// try to retrieve item
+	var result map[string]interface{}
+	c := session.DB(suite.tenantDbConf.Db).C("thresholds_profiles")
+	err = c.Find(bson.M{"id": "6ac7d684-1f8e-4a02-a502-720e8f11e50b"}).One(&result)
+
+	suite.NotEqual(err, nil, "No not found error")
+	suite.Equal(err.Error(), "not found", "No not found error")
+}
+
+func (suite *ThresholdsProfilesTestSuite) TestOptionsOperationsProfiles() {
+	request, _ := http.NewRequest("OPTIONS", "/api/v2/thresholds_profiles", strings.NewReader(""))
+
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code := response.Code
+	output := response.Body.String()
+	headers := response.HeaderMap
+
+	suite.Equal(200, code, "Error in response code")
+	suite.Equal("", output, "Expected empty response body")
+	suite.Equal("GET, POST, DELETE, PUT, OPTIONS", headers.Get("Allow"), "Error in Allow header response (supported resource verbs of resource)")
+	suite.Equal("text/plain; charset=utf-8", headers.Get("Content-Type"), "Error in Content-Type header response")
+
+	request, _ = http.NewRequest("OPTIONS", "/api/v2/thresholds_profiles/6ac7d684-1f8e-4a02-a502-720e8f11e50b", strings.NewReader(""))
+
+	response = httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code = response.Code
+	output = response.Body.String()
+	headers = response.HeaderMap
+
+	suite.Equal(200, code, "Error in response code")
+	suite.Equal("", output, "Expected empty response body")
+	suite.Equal("GET, POST, DELETE, PUT, OPTIONS", headers.Get("Allow"), "Error in Allow header response (supported resource verbs of resource)")
+	suite.Equal("text/plain; charset=utf-8", headers.Get("Content-Type"), "Error in Content-Type header response")
+
+}
+
+func (suite *ThresholdsProfilesTestSuite) TestCreateForbidViewer() {
+
+	jsonInput := `{
+  "name": "test_profile",
+  "namespace [
+    `
+
+	jsonOutput := `{
+ "status": {
+  "message": "Access to the resource is Forbidden",
+  "code": "403"
+ }
+}`
+
+	request, _ := http.NewRequest("POST", "/api/v2/thresholds_profiles", strings.NewReader(jsonInput))
+	request.Header.Set("x-api-key", "VIEWERKEY")
+	request.Header.Set("Accept", "application/json")
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code := response.Code
+	output := response.Body.String()
+	// Check that we must have a 200 ok code
+	suite.Equal(403, code, "Internal Server Error")
+	// Compare the expected and actual json response
+
+	suite.Equal(jsonOutput, output, "Response body mismatch")
+}
+
+func (suite *ThresholdsProfilesTestSuite) TestUpdateForbidViewer() {
+
+	jsonInput := `{}`
+
+	jsonOutput := `{
+ "status": {
+  "message": "Access to the resource is Forbidden",
+  "code": "403"
+ }
+}`
+
+	request, _ := http.NewRequest("PUT", "/api/v2/thresholds_profiles/6ac7d684-1f8e-4a02-a502-720e8f11e007", strings.NewReader(jsonInput))
+	request.Header.Set("x-api-key", "VIEWERKEY")
+	request.Header.Set("Accept", "application/json")
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code := response.Code
+	output := response.Body.String()
+	// Check that we must have a 200 ok code
+	suite.Equal(403, code, "Internal Server Error")
+	// Compare the expected and actual json response
+
+	suite.Equal(jsonOutput, output, "Response body mismatch")
+
+}
+
+func (suite *ThresholdsProfilesTestSuite) TestDeleteForbidViewer() {
+
+	request, _ := http.NewRequest("DELETE", "/api/v2/thresholds_profiles/6ac7d684-1f8e-4a02-a502-720e8f11e50b", strings.NewReader(""))
+	request.Header.Set("x-api-key", "VIEWERKEY")
+	request.Header.Set("Accept", "application/json")
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code := response.Code
+	output := response.Body.String()
+
+	metricProfileJSON := `{
+ "status": {
+  "message": "Access to the resource is Forbidden",
+  "code": "403"
+ }
+}`
+	// Check that we must have a 200 ok code
+	suite.Equal(403, code, "Internal Server Error")
+	// Compare the expected and actual json response
+	suite.Equal(metricProfileJSON, output, "Response body mismatch")
+}
+
+func (suite *ThresholdsProfilesTestSuite) TestInvalidCreate() {
+
+	jsonInput := `{
+			"name":"test-invalid-01",
+			"rules":[
+				{"thresholds":"bad01=33;33s"},
+				{"thresholds":"good01=33s;33 good02=1s;~:10;9:;-20;30"},
+				{"thresholds":"bad02=33sbad03=1s;~~:10;9:;-20;30"},
+				{"thresholds":"33;33 bad04=33s;33 -20;30"},
+				{"thresholds":"good01=2KB;0:3;2:10;0;20 good02=1c;~:10;9:30;-30;30"}
+			]
+		}`
+
+	jsonOutput := `{
+ "status": {
+  "message": "Validation Error",
+  "code": "422"
+ },
+ "errors": [
+  {
+   "message": "Validation Failed",
+   "code": "422",
+   "details": "Invalid threshold: bad01=33;33s"
+  },
+  {
+   "message": "Validation Failed",
+   "code": "422",
+   "details": "Invalid threshold: bad02=33sbad03=1s;~~:10;9:;-20;30"
+  },
+  {
+   "message": "Validation Failed",
+   "code": "422",
+   "details": "Invalid threshold: 33;33 bad04=33s;33 -20;30"
+  }
+ ]
+}`
+
+	request, _ := http.NewRequest("POST", "/api/v2/thresholds_profiles", strings.NewReader(jsonInput))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code := response.Code
+	output := response.Body.String()
+	// Check that we must have a 200 ok code
+	suite.Equal(422, code, "Internal Server Error")
+
+	// Apply id to output template and check
+	suite.Equal(jsonOutput, output, "Response body mismatch")
+
+}
+
+func (suite *ThresholdsProfilesTestSuite) TestInvalidUpdate() {
+
+	jsonInput := `{
+			"name":"test-invalid-01",
+			"rules":[
+				{"thresholds":"bad01=33;33s"},
+				{"thresholds":"good01=33s;33 good02=1s;~:10;9:;-20;30"},
+				{"thresholds":"bad02=33sbad03=1s;~~:10;9:;-20;30"},
+				{"thresholds":"33;33 bad04=33s;33 -20;30"},
+				{"thresholds":"good01=2KB;0:3;2:10;0;20 good02=1c;~:10;9:30;-30;30"}
+			]
+		}`
+
+	jsonOutput := `{
+ "status": {
+  "message": "Validation Error",
+  "code": "422"
+ },
+ "errors": [
+  {
+   "message": "Validation Failed",
+   "code": "422",
+   "details": "Invalid threshold: bad01=33;33s"
+  },
+  {
+   "message": "Validation Failed",
+   "code": "422",
+   "details": "Invalid threshold: bad02=33sbad03=1s;~~:10;9:;-20;30"
+  },
+  {
+   "message": "Validation Failed",
+   "code": "422",
+   "details": "Invalid threshold: 33;33 bad04=33s;33 -20;30"
+  }
+ ]
+}`
+
+	request, _ := http.NewRequest("PUT", "/api/v2/thresholds_profiles/6ac7d555-1f8e-4a02-a502-720e8f11e50b", strings.NewReader(jsonInput))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code := response.Code
+	output := response.Body.String()
+
+	// Check that we must have a 200 ok code
+	suite.Equal(422, code, "Internal Server Error")
+	// Compare the expected and actual json response
+
+	// Apply id to output template and check
+	suite.Equal(jsonOutput, output, "Response body mismatch")
+
+}
+
+//TearDownTest to tear down every test
+func (suite *ThresholdsProfilesTestSuite) TearDownTest() {
+
+	session, err := mgo.Dial(suite.cfg.MongoDB.Host)
+	if err != nil {
+		panic(err)
+	}
+
+	tenantDB := session.DB(suite.tenantDbConf.Db)
+	mainDB := session.DB(suite.cfg.MongoDB.Db)
+
+	cols, err := tenantDB.CollectionNames()
+	for _, col := range cols {
+		tenantDB.C(col).RemoveAll(nil)
+	}
+
+	cols, err = mainDB.CollectionNames()
+	for _, col := range cols {
+		mainDB.C(col).RemoveAll(nil)
+	}
+
+}
+
+//TearDownTest to tear down every test
+func (suite *ThresholdsProfilesTestSuite) TearDownSuite() {
+
+	session, err := mgo.Dial(suite.cfg.MongoDB.Host)
+	if err != nil {
+		panic(err)
+	}
+	session.DB(suite.tenantDbConf.Db).DropDatabase()
+	session.DB(suite.cfg.MongoDB.Db).DropDatabase()
+}
+
+func TestThresholdsProfilesTestSuite(t *testing.T) {
+	suite.Run(t, new(ThresholdsProfilesTestSuite))
+}

--- a/app/thresholdsProfiles/view.go
+++ b/app/thresholdsProfiles/view.go
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2018 GRNET S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS
+ * IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ *
+ * The views and conclusions contained in the software and
+ * documentation are those of the authors and should not be
+ * interpreted as representing official policies, either expressed
+ * or implied, of GRNET S.A.
+ *
+ */
+
+package thresholdsProfiles
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+
+	"github.com/ARGOeu/argo-web-api/respond"
+)
+
+// createListView constructs the list response template and exports it as json
+func createListView(results []ThresholdsProfile, msg string, code int) ([]byte, error) {
+
+	docRoot := &respond.ResponseMessage{
+		Status: respond.StatusResponse{
+			Message: msg,
+			Code:    strconv.Itoa(code),
+		},
+	}
+	docRoot.Data = results
+
+	output, err := json.MarshalIndent(docRoot, "", " ")
+	return output, err
+
+}
+
+// createListView constructs self-reference response and exports it as json
+func createRefView(inserted ThresholdsProfile, msg string, code int, r *http.Request) ([]byte, error) {
+	docRoot := &respond.ResponseMessage{
+		Status: respond.StatusResponse{
+			Message: msg,
+			Code:    strconv.Itoa(code),
+		},
+		Data: SelfReference{
+			ID:    inserted.ID,
+			Links: Links{Self: "https://" + r.Host + r.URL.Path + "/" + inserted.ID},
+		},
+	}
+
+	output, err := json.MarshalIndent(docRoot, "", " ")
+	return output, err
+}
+
+// createErrView constructs a simple message response without data
+func createErrView(msg string, code int, errList []string) ([]byte, error) {
+
+	var errRespond []respond.ErrorResponse
+
+	for _, item := range errList {
+		temp := respond.ErrorResponse{"Validation Failed", strconv.Itoa(code), item}
+		errRespond = append(errRespond, temp)
+	}
+
+	docRoot := &respond.ResponseMessage{
+		Status: respond.StatusResponse{
+			Message: msg,
+			Code:    strconv.Itoa(code),
+		},
+		Errors: errRespond,
+	}
+
+	output, err := json.MarshalIndent(docRoot, "", " ")
+	return output, err
+}
+
+// createMsgView constructs a simple message response without data
+func createMsgView(msg string, code int) ([]byte, error) {
+	docRoot := &respond.ResponseMessage{
+		Status: respond.StatusResponse{
+			Message: msg,
+			Code:    strconv.Itoa(code),
+		},
+	}
+
+	output, err := json.MarshalIndent(docRoot, "", " ")
+	return output, err
+}

--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -1022,6 +1022,197 @@ paths:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Status_error'
+
+  /thresholds_profiles/{PROFILE_ID}:
+    get:
+      summary: List a specific threhsolds profile
+      operationId: thresholdsProfiles.ListOne
+      description: List one specific thresholds profile targeted by it's unique id
+      tags:
+        - Thresholds Profiles
+      produces:
+        - "application/json"
+      parameters:
+        - $ref: "#/parameters/apiKey"
+        - name: "PROFILE_ID"
+          in: "path"
+          description: "id of the thresholds profile"
+          required: true
+          type: string
+      responses:
+        '200':
+          description: A list with one thresholds profile
+          schema:
+            $ref: '#/definitions/Thresholds_profile_list'
+        '401':
+          description: Unauthorized user
+          schema:
+            $ref: '#/definitions/Status_error'
+        '404':
+          description: Item not found
+          schema:
+            $ref: '#/definitions/Status_error'
+        '406':
+          description: Content Not acceptable
+          schema:
+            $ref: '#/definitions/Status_error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Status_error'
+    put:
+      summary: update a threhsolds profile
+      operationId: threhsoldsProfiles.Update
+      description: update information on a specific thresholds Profile which is targeted by it's unique id
+      tags:
+        - Thresholds Profiles
+      consumes:
+        - "application/json"
+      produces:
+        - "application/json"
+      parameters:
+        - $ref: "#/parameters/apiKey"
+        - name: "PROFILE_ID"
+          in: "path"
+          description: "id of the thresholds profile"
+          required: true
+          type: string
+        - name: "thresholds_profile"
+          in: "body"
+          description: "Json description of the thresholds profile to be updated"
+          required: true
+          schema:
+            $ref: '#/definitions/Thresholds_profile'
+      responses:
+        '201':
+          description: Thresholds profile Updated
+          schema:
+            $ref: '#/definitions/Status'
+        '400':
+          description: Bad request due to malformed JSON in put body
+          schema:
+            $ref: '#/definitions/Status_error'
+        '401':
+          description: Unauthorized user
+          schema:
+            $ref: '#/definitions/Status_error'
+        '404':
+          description: Item not found
+          schema:
+            $ref: '#/definitions/Status_error'
+        '406':
+          description: Content Not acceptable
+          schema:
+            $ref: '#/definitions/Status_error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Status_error'
+    delete:
+      summary: Delete a thresholds profile
+      operationId: thresholdsProfiles.Delete
+      description: Delete a specific thresholds Profile which is targeted by it's unique id
+      tags:
+        - Thresholds Profiles
+      produces:
+        - "application/json"
+      parameters:
+        - $ref: "#/parameters/apiKey"
+        - name: "PROFILE_ID"
+          in: "path"
+          description: "id of the thresholds profile"
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Thresholds profile Deleted
+          schema:
+            $ref: '#/definitions/Status'
+        '401':
+          description: Unauthorized user
+          schema:
+            $ref: '#/definitions/Status_error'
+        '404':
+          description: Item not found
+          schema:
+            $ref: '#/definitions/Status_error'
+        '406':
+          description: Content Not acceptable
+          schema:
+            $ref: '#/definitions/Status_error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Status_error'
+
+  /thresholds_profiles:
+    get:
+      summary: List all threhsolds profiles
+      operationId: thresholdsProfiles.List
+      description: Thresholds profiles provide a list of threshold rules to be accounted during a computation
+      tags:
+        - Thresholds Profiles
+      produces:
+        - "application/json"
+      parameters:
+        - $ref: "#/parameters/apiKey"
+      responses:
+        '200':
+          description: A list of thresholds profiles
+          schema:
+            $ref: '#/definitions/Thresholds_profile_list'
+        '401':
+          description: Unauthorized user
+          schema:
+            $ref: '#/definitions/Status_error'
+        '406':
+          description: Content Not acceptable
+          schema:
+            $ref: '#/definitions/Status_error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Status_error'
+    post:
+      summary: Create a thresholds profile
+      operationId: thresholdsProfiles.Create
+      description: Create a new thresholds profile which includes a list of threshold ruels to be accounted during a computation
+      tags:
+        - Thresholds Profiles
+      consumes:
+        - "application/json"
+      produces:
+        - "application/json"
+      parameters:
+        - name: "thresholds_profile"
+          in: "body"
+          description: "Json description of the thresholds profile to be created"
+          required: true
+          schema:
+            $ref: '#/definitions/Thresholds_profile'
+        - $ref: "#/parameters/apiKey"
+      responses:
+        '200':
+          description: Thresholds profile Created
+          schema:
+            $ref: '#/definitions/Self_reference'
+        '400':
+          description: Bad request due to malformed JSON in post body
+          schema:
+            $ref: '#/definitions/Status_error'
+        '401':
+          description: Unauthorized user
+          schema:
+            $ref: '#/definitions/Status_error'
+        '406':
+          description: Content Not acceptable
+          schema:
+            $ref: '#/definitions/Status_error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Status_error'
+
   /status/{report_name}/{lgroup_type}/{lgroup_name}:
     get:
       summary: "List status results for a given endpoint group (i.e. Group_A)"
@@ -1598,7 +1789,7 @@ paths:
           $ref: "#/responses/422"
         500:
           $ref: "#/responses/ServerError"
-          
+
   /recomputations/{ID}:
     get:
       summary: "Get Recomputation details"
@@ -1843,7 +2034,7 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/recomputation'
-          
+
   timestamp_value:
     type: object
     properties:
@@ -2192,6 +2383,41 @@ definitions:
             details:
               type: string
 
+  Thresholds_profile_list:
+    type: object
+    properties:
+      status:
+       $ref: '#/definitions/Status'
+      data:
+        type: array
+        items:
+          $ref: '#/definitions/Thresholds_profile'
+
+  Thresholds_profile:
+    type: object
+    properties:
+      id:
+        type: string
+      name:
+        type: string
+      rules:
+        type: array
+        items:
+          $ref: '#/definitions/Threshold_rule'
+
+  Threshold_rule:
+    type: object
+    properties:
+      endpoint_group:
+        type: string
+      host:
+        type: string
+      metric:
+        type: string
+      threshold:
+        type: string
+
+
   Aggregation_profile_list:
     type: object
     properties:
@@ -2248,6 +2474,7 @@ definitions:
         type: string
       operation:
         type: string
+
 
   Operations_profile_list:
     type: object

--- a/doc/v2/docs/threshold_profiles.md
+++ b/doc/v2/docs/threshold_profiles.md
@@ -1,0 +1,381 @@
+---
+title: 'API documentation | ARGO'
+page_title: API - Operations Profile Requests
+font_title: fa fa-cogs
+description: API Calls for listing existing and creating new threshold profiles
+---
+
+# Description
+A Threshold profile contains a list of threshold rules. Threshold rules refer to low level monitoring numeric values
+that accompany metric data and threshold limits on those values that can deem the status 'WARNING' or 'CRITICAL'
+
+# Threshold format
+Each threhsold rule is expressed as string in the following format
+`{label}={value}[uom];{warning};{critical};{min};{max}`
+
+- `label` : can contain alphanumeric characters but must always begin with a letter
+- `value` : is a float or integer
+- `uom`   : is a string unit of measurement (accepted values: `s`,`us`,`ms`,`B`,`KB`,`MB`,`TB`,`%`,`c`)
+- `warning`: is a range defining the warning threshold limits
+- `critical`: is a range defining the critical threshold limits
+- `min`: is a float or integer defining the minimum value
+- `max`: is a float or integer defining the maximum value
+
+Note: min,max can be omitted.
+
+Ranges (`{warning}` or `{critical}`) are defined in the following format:
+`@{floor}:{ceiling}`
+-`@`: optional - negates the range (value should belong outside ranges limits)
+- `floor`: integer/float or `~` that defines negative infinity
+- `ceiling`: integer/float or empty (defining positive infinity)
+
+# Thresholds rule
+Each thresholds rule can contain multiple threshold definitions separated by space
+for e.g.
+`label01=1s;0:10;11:12 label02=1B;0:200;199:500;0;500`
+
+# Thresholds profile
+Each threhsolds profile has a name and contains a list of thresholds rules in the following json format
+Each rule must always refer to a metric. It can optionally refer to a host and an endpoint group.
+```
+{
+  "id": "68dbd3d8-c95d-41ea-b13e-7ea3644285e5",
+  "name": "example-threshold-profile-101"
+  "rules":[
+    {
+      "metric": "httpd.ResponseTime"
+      "thresholds": "response=20ms;0:300;299:1000"
+    },
+    {
+      "host": "webserver01.example.foo"
+      "metric": "httpd.ResponseTime"
+      "thresholds": "response=20ms;0:200;199:300"
+    },
+    {
+      "endpoint_group": "TEST-SITE-51"
+      "metric": "httpd.ResponseTime"
+      "thresholds": "response=20ms;0:500;499:1000"
+    }
+  ]
+}
+```
+
+
+# API Calls
+
+Name                                     | Description                                                                            | Shortcut
+---------------------------------------- | -------------------------------------------------------------------------------------- | ------------------
+GET: List Thresholds Profile Requests         | This method can be used to retrieve a list of current Thresholds profiles.          | [ Description](#1)
+GET: List a specific  Threshold profile         | This method can be used to retrieve a specific  Threshold profile based on its id.          | [ Description](#2)
+POST: Create a new  Threshold profile  | This method can be used to create a new  Threshold profile | [ Description](#3)
+PUT: Update an Threshold profile |This method can be used to update information on an existing  Threshold profile | [ Description](#4)
+DELETE: Delete an  Threshold profile |This method can be used to delete an existing Threshold profile | [ Description](#5)
+
+<a id='1'></a>
+
+## [GET]: List Threshold Profiles
+
+This method can be used to retrieve a list of current Threshold profiles
+
+### Input
+
+```
+GET /thresholds_profiles
+```
+
+#### Optional Query Parameters
+
+Type            | Description                                                                                     | Required
+--------------- | ----------------------------------------------------------------------------------------------- | --------
+`name`          | thresholds profile name to be used as query                                                     | NO      
+
+#### Request headers
+
+```
+x-api-key: shared_key_value
+Accept: application/json
+```
+
+### Response
+Headers: `Status: 200 OK`
+
+#### Response body
+Json Response
+
+```json
+{
+"status": {
+"message": "Success",
+"code": "200"
+},
+"data": [
+{
+ "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50b",
+ "name": "thr01",
+ "rules": [
+  {
+   "host": "hostFoo",
+   "metric": "metricA",
+   "thresholds": "freshnesss=1s;10;9:;0;25 entries=1;3;2:0;10"
+  }
+ ]
+},
+{
+ "id": "6ac7d222-1f8e-4a02-a502-720e8f11e50b",
+ "name": "thr02",
+ "rules": [
+  {
+   "host": "hostFoo",
+   "metric": "metricA",
+   "thresholds": "freshness=1s;10;9:;0;25 entries=1;3;2:0;10"
+  }
+ ]
+},
+{
+ "id": "6ac7d555-1f8e-4a02-a502-720e8f11e50b",
+ "name": "thr03",
+ "rules": [
+  {
+   "host": "hostFoo",
+   "metric": "metricA",
+   "thresholds": "freshness=1s;10;9:;0;25 entries=1;3;2:0;10"
+  }
+ ]
+}
+]
+}
+```
+
+<a id='2'></a>
+
+## [GET]: List A Specific Thresholds profile
+This method can be used to retrieve specific Thresholds profile based on its id
+
+### Input
+
+```
+GET /thresholds_profiles/{ID}
+```
+
+#### Request headers
+
+```
+x-api-key: shared_key_value
+Accept: application/json
+```
+
+### Response
+Headers: `Status: 200 OK`
+
+#### Response body
+Json Response
+
+```json
+{
+"status": {
+"message": "Success",
+"code": "200"
+},
+"data": [
+{
+ "id": "6ac7d222-1f8e-4a02-a502-720e8f11e50b",
+ "name": "thr02",
+ "rules": [
+  {
+   "host": "hostFoo",
+   "metric": "metricA",
+   "thresholds": "freshness=1s;10;9:;0;25 entries=1;3;2:0;10"
+  }
+ ]
+}
+]
+}
+```
+
+<a id='3'></a>
+
+## [POST]: Create a new Thresholds Profile
+This method can be used to insert a new thresholds profile
+
+### Input
+
+```
+POST /thresholds_profiles
+```
+
+#### Request headers
+
+```
+x-api-key: shared_key_value
+Accept: application/json
+```
+
+#### POST BODY
+
+```json
+{
+"name" : "thr04",
+"rules": [
+  {
+    "metric": "metricB",
+    "thresholds": "time=1s;10;9:30;0;30"
+  }
+]
+}
+```
+
+### Response
+Headers: `Status: 201 Created`
+
+#### Response body
+Json Response
+
+```json
+{
+"status": {
+"message": "Thresholds Profile successfully created",
+"code": "201"
+},
+"data": {
+"id": "{{ID}}",
+"links": {
+ "self": "https:///api/v2/thresholds_profiles/{{ID}}"
+}
+}
+}
+```
+
+<a id='4'></a>
+
+## [PUT]: Update information on an existing operations profile
+This method can be used to update information on an existing operations profile
+
+### Input
+
+```
+PUT /thresholds_profiles/{ID}
+```
+
+#### Request headers
+
+```
+x-api-key: shared_key_value
+Accept: application/json
+```
+
+#### PUT BODY
+
+```json
+{
+"name" : "thr04",
+"rules": [
+  {
+    "metric": "metricB",
+    "thresholds": "time=1s;10;9:30;0;30"
+  }
+]
+}
+```
+
+### Response
+Headers: `Status: 200 OK`
+
+#### Response body
+Json Response
+
+```json
+{
+ "status": {
+  "message": "Thresholds Profile successfully updated",
+  "code": "200"
+ }
+}
+```
+
+<a id='5'></a>
+
+## [DELETE]: Delete an existing aggregation profile
+This method can be used to delete an existing aggregation profile
+
+### Input
+
+```
+DELETE /thresholds_profiles/{ID}
+```
+
+#### Request headers
+
+```
+x-api-key: shared_key_value
+Accept: application/json
+```
+
+
+### Response
+Headers: `Status: 200 OK`
+
+#### Response body
+Json Response
+
+```json
+{
+ "status": {
+  "message": "Operations Profile Successfully Deleted",
+  "code": "200"
+ }
+}
+```
+
+## Validation Checks
+When submitting or updating a new threshold profile, validation checks are performed on json POST/PUT body for the following cases:
+  - Check if each thresholds rule is valid according to threshold specification discussed in the first paragraph
+
+When an invalid operations profile is submitted the api responds with a validation error list:
+
+#### Example invalid profile
+
+```json
+{
+    "name":"test-invalid-01",
+    "rules":[
+      {"thresholds":"bad01=33;33s"},
+      {"thresholds":"good01=33s;33 good02=1s;~:10;9:;-20;30"},
+      {"thresholds":"bad02=33sbad03=1s;~~:10;9:;-20;30"},
+      {"thresholds":"33;33 bad04=33s;33 -20;30"},
+      {"thresholds":"good01=2KB;0:3;2:10;0;20 good02=1c;~:10;9:30;-30;30"}
+    ]
+}
+  ```
+
+  Api response is the following:
+
+### Response
+Headers: `Status: 422 Unprocessable Entity`
+
+#### Response body
+
+ ```json
+ {
+  "status": {
+   "message": "Validation Error",
+   "code": "422"
+  },
+  "errors": [
+   {
+    "message": "Validation Failed",
+    "code": "422",
+    "details": "Invalid threshold: bad01=33;33s"
+   },
+   {
+    "message": "Validation Failed",
+    "code": "422",
+    "details": "Invalid threshold: bad02=33sbad03=1s;~~:10;9:;-20;30"
+   },
+   {
+    "message": "Validation Failed",
+    "code": "422",
+    "details": "Invalid threshold: 33;33 bad04=33s;33 -20;30"
+   }
+  ]
+ }
+ ```

--- a/routing/routes.go
+++ b/routing/routes.go
@@ -36,6 +36,7 @@ import (
 	"github.com/ARGOeu/argo-web-api/app/statusMetrics"
 	"github.com/ARGOeu/argo-web-api/app/statusServices"
 	"github.com/ARGOeu/argo-web-api/app/tenants"
+	"github.com/ARGOeu/argo-web-api/app/thresholdsProfiles"
 )
 
 var routesV2 = []RouteV2{
@@ -50,6 +51,7 @@ var routesV2 = []RouteV2{
 	{"Reports", "", reports.HandleSubrouter},
 	{"Aggregation Profiles", "", aggregationProfiles.HandleSubrouter},
 	{"Operations Profiles", "", operationsProfiles.HandleSubrouter},
+	{"Thresholds Profiles", "", thresholdsProfiles.HandleSubrouter},
 	{"Tenants", "/admin", tenants.HandleSubrouter},
 	{"Factors", "", factors.HandleSubrouter},
 }


### PR DESCRIPTION
# Task
Hold threhsold profile information in argo-web-api

# Implementation
- [x] Add thresholdProfiles package
- [x] Add models for threshold profiles and threshold rules
- [x] Add validation mechanism for threshold rules
- [x] Add thresholds profiles Create handler and routes
- [x] Add thresholds profiles List handler and routes
- [x] Add thresholds profiles ListOne handler and routes
- [x] Add thresholds profiles Update handler and routes
- [x] Add thresholds profiles Delete handler and routes
- [x] Add thresholds profiles unit test suite for CRUD and validation functionality
- [x] Update swagger definition
- [x] Update mkdocs