### PR TITLE
ARGO-1298 Show/Update tenant's argo-engine status

### DIFF
--- a/app/tenants/model.go
+++ b/app/tenants/model.go
@@ -35,6 +35,48 @@ type Tenant struct {
 	Users  []TenantUser   `bson:"users" json:"users,omitempty"`
 }
 
+type TenantStatus struct {
+	ID     string       `bson:"id" json:"id"`
+	Info   TenantInfo   `bson:"info" json:"info"`
+	Status StatusDetail `bson:"status" json:"status,omitempty"`
+}
+
+type StatusDetail struct {
+	AMS          DetailsAMS  `bson:"ams" json:"ams"`
+	HDFS         DetailsHDFS `bson:"hdfs" json:"hdfs"`
+	EngineConfig bool        `bson:"engine_config" json:"engine_config"`
+	LastCheck    string      `bson:"last_check" json:"last_check"`
+}
+
+type DetailsAMS struct {
+	MetricData NodeAMS `bson:"metric_data" json:"metric_data"`
+	SyncData   NodeAMS `bson:"sync_data" json:"sync_data"`
+}
+
+type DetailsHDFS struct {
+	MetricData bool                    `bson:"metric_data" json:"metric_data"`
+	SyncData   map[string]SyncDataHDFS `bson:"sync_data" json:"sync_data,omitempty"`
+}
+
+type SyncDataHDFS struct {
+	AggregationProf bool `bson:"aggregation_profile" json:"aggregation_profile"`
+	Recomp          bool `bson:"blank_recomputation" json:"blank_recomputation"`
+	ConfigProf      bool `bson:"configuration_profile" json: "configuration_profile"`
+	Donwtimes       bool `bson:"downtimes" json:"downtimes"`
+	GroupEndpoints  bool `bson:"group_endpoints" json:"group_endpoints"`
+	GroupGroups     bool `bson:"group_groups" json:"group_groups"`
+	MetricProf      bool `bson:"metric_profile" json:"metric_profile"`
+	OpsProf         bool `bson:"operations_profile" json:"operations_profile"`
+	Weight          bool `bson:"weights" json:"weights"`
+}
+
+type NodeAMS struct {
+	Ingestion       bool  `bson:"ingestion" json:"ingestion"`
+	Publishing      bool  `bson:"publishing" json:"publishing"`
+	StatusStreaming bool  `bson:"status_streaming" json:"status_streaming"`
+	MsgArrived      int64 `bson:"messages_arrived" json:"messages_arrived"`
+}
+
 // TenantInfo struct holds information about tenant name, contact details
 type TenantInfo struct {
 	Name    string `bson:"name" json:"name"`

--- a/app/tenants/routing.go
+++ b/app/tenants/routing.go
@@ -36,8 +36,10 @@ func HandleSubrouter(s *mux.Router, confhandler *respond.ConfHandler) {
 
 var appRoutesV2 = []respond.AppRoutes{
 	{"tenants.list", "GET", "/tenants", List},
+	{"tenants.get_status", "GET", "/tenants/{ID}/status", ListStatus},
 	{"tenants.get", "GET", "/tenants/{ID}", ListOne},
 	{"tenants.create", "POST", "/tenants", Create},
+	{"tenants.update_status", "PUT", "/tenants/{ID}/status", UpdateStatus},
 	{"tenants.update", "PUT", "/tenants/{ID}", Update},
 	{"tenants.delete", "DELETE", "/tenants/{ID}", Delete},
 	{"tenants.options", "OPTIONS", "/tenants", Options},

--- a/app/tenants/view.go
+++ b/app/tenants/view.go
@@ -35,6 +35,22 @@ import (
 )
 
 // createListView constructs the list response template and exports it as json
+func createStatusView(results []TenantStatus, msg string, code int) ([]byte, error) {
+
+	docRoot := &respond.ResponseMessage{
+		Status: respond.StatusResponse{
+			Message: msg,
+			Code:    strconv.Itoa(code),
+		},
+	}
+	docRoot.Data = results
+
+	output, err := json.MarshalIndent(docRoot, "", " ")
+	return output, err
+
+}
+
+// createListView constructs the list response template and exports it as json
 func createListView(results []Tenant, msg string, code int) ([]byte, error) {
 
 	docRoot := &respond.ResponseMessage{

--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -35,6 +35,8 @@ tags:
   - name: MetricResult
     description: Retrieve the full output of a  metric result
 paths:
+
+
   /admin/tenants/{TENANT_ID}:
     get:
       summary: List a specific tenant
@@ -218,6 +220,96 @@ paths:
             $ref: '#/definitions/Status_error'
         '401':
           description: Unauthorized user
+          schema:
+            $ref: '#/definitions/Status_error'
+        '406':
+          description: Content Not acceptable
+          schema:
+            $ref: '#/definitions/Status_error'
+        '422':
+          description: Validation Error
+          schema:
+            $ref: '#/definitions/Status_error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Status_error'
+
+  /admin/tenants/{TENANT_ID}/status:
+    get:
+      summary: List a specific tenant's argo-engine status
+      operationId: tenants.ListStatus
+      description: List one specific tenant's status designated by its unique id
+      tags:
+        - Tenants
+      produces:
+        - "application/json"
+      parameters:
+        - name: "TENANT_ID"
+          in: "path"
+          description: "id of the tenant"
+          required: true
+          type: string
+        - $ref: "#/parameters/apiKey"
+      responses:
+        '200':
+          description: A list with one tenant's argo-engine status
+          schema:
+            $ref: '#/definitions/Tenant_status_list'
+        '401':
+          description: Unauthorized user
+          schema:
+            $ref: '#/definitions/Status_error'
+        '404':
+          description: Item not found
+          schema:
+            $ref: '#/definitions/Status_error'
+        '406':
+          description: Content Not acceptable
+          schema:
+            $ref: '#/definitions/Status_error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Status_error'
+    put:
+      summary: Update a tenant's status
+      operationId: tenants.UpdateStatus
+      description: update information on a specific tenant's argo-engine status definition
+      tags:
+        - Tenants
+      consumes:
+        - "application/json"
+      produces:
+        - "application/json"
+      parameters:
+        - name: "TENANT_ID"
+          in: "path"
+          description: "id of the tenant"
+          required: true
+          type: string
+        - $ref: "#/parameters/apiKey"
+        - name: "tenant"
+          in: "body"
+          description: "Json description of tenant's argo-engine status definition to be updated"
+          required: true
+          schema:
+            $ref: '#/definitions/Tenant_status'
+      responses:
+        '201':
+          description: Tenant's status definition updated
+          schema:
+            $ref: '#/definitions/Status'
+        '400':
+          description: Bad request due to malformed JSON in put body
+          schema:
+            $ref: '#/definitions/Status_error'
+        '401':
+          description: Unauthorized user
+          schema:
+            $ref: '#/definitions/Status_error'
+        '404':
+          description: Item not found
           schema:
             $ref: '#/definitions/Status_error'
         '406':
@@ -2574,6 +2666,96 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/Operations_profile'
+
+  Tenant_status_list:
+    type: object
+    properties:
+      status:
+       $ref: '#/definitions/Status'
+      data:
+        type: array
+        items:
+          $ref: '#/definitions/Tenant_status'
+
+  Tenant_status:
+    type: object
+    properties:
+      ams:
+        type: object
+        properties:
+          metric_data:
+            type: object
+            properties:
+              ingestion:
+                type: boolean
+              publishing:
+                type: boolean
+              status_streaming:
+                type: boolean
+              messages_arrived:
+                type: integer
+          sync_data:
+            type: object
+            properties:
+              ingestion:
+                type: boolean
+              publishing:
+                type: boolean
+              status_streaming:
+                type: boolean
+              messages_arrived:
+                type: integer
+      hdfs:
+        type: object
+        properties:
+          metric_data:
+            type: boolean
+          sync_data:
+            type: object
+            additionalProperties:
+              type: object
+              properties:
+                downtimes:
+                  type: boolean
+                group_endpoints:
+                  type: boolean
+                blank_recomputation:
+                  type: boolean
+                group_groups:
+                  type: boolean
+                weights:
+                  type: boolean
+                operations_profile:
+                  type: boolean
+                metric_profile:
+                  type: boolean
+                aggregation_profile:
+                  type: boolean
+
+      engine_config:
+        type: boolean
+      last_check:
+        type: string
+
+      name:
+        type: string
+      available_states:
+        type: array
+        items:
+          type: string
+      defaults:
+        type: object
+        properties:
+          down:
+            type: string
+          missing:
+            type: string
+          unknown:
+            type: string
+      operations:
+        type: array
+        items:
+          $ref: '#/definitions/Operation'
 
   Operations_profile:
     type: object

--- a/doc/v2/docs/tenants.md
+++ b/doc/v2/docs/tenants.md
@@ -14,7 +14,8 @@ GET: List a specific tenant         | This method can be used to retrieve a spec
 POST: Create a new tenant  | This method can be used to create a new tenant | [ Description](#3)
 PUT: Update a tenant |This method can be used to update information on an existing tenant | [ Description](#4)
 DELETE: Delete a tenant |This method can be used to delete an existing tenant | [ Description](#5)
-
+GET: Get a tenant's arg engine status |This method can be used to get status for a specific tenant | [ Description](#6)
+PUT: Update a tenant's engine status |This method can be used to update argo engine status information for a specific tenant | [ Description](#7)
 <a id='1'></a>
 
 ## [GET]: List Tenants
@@ -462,6 +463,146 @@ Json Response
 {
  "status": {
   "message": "Tenant Successfully Deleted",
+  "code": "200"
+ }
+}
+```
+
+<a id='6'></a>
+
+## [GET]: List A Specific tenant's argo-engine status
+This method can be used to retrieve specific tenant's status based on its id
+
+### Input
+
+```
+GET /admin/tenants/{ID}/status
+```
+
+#### Request headers
+
+```
+x-api-key: shared_key_value
+Accept: application/json
+```
+
+### Response
+Headers: `Status: 200 OK`
+
+#### Response body
+Json Response
+
+```json
+{
+"status": {
+"message": "Success",
+"code": "200"
+},
+"data": [
+{
+ "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50b",
+ "info": {
+  "name": "tenant1",
+  "email": "email1@tenant1.com",
+  "website": "www.tenant1.com",
+  "created": "2015-10-20 02:08:04",
+  "updated": "2015-10-20 02:08:04"
+ },
+ "status": {
+  "ams": {
+   "metric_data": {
+    "ingestion": false,
+    "publishing": false,
+    "status_streaming": false,
+    "messages_arrived": 0
+   },
+   "sync_data": {
+    "ingestion": false,
+    "publishing": false,
+    "status_streaming": false,
+    "messages_arrived": 0
+   }
+  },
+  "hdfs": {
+   "metric_data": false
+  },
+  "engine_config": false,
+  "last_check": ""
+ }
+}
+]
+}
+```
+
+<a id='7'></a>
+
+## [PUT]: Update argo-engine status information on an existing tenant
+This method can be used to update status information on an existing tenant
+
+### Input
+
+```
+PUT /admin/tenants/{ID}/status
+```
+
+#### Request headers
+
+```
+x-api-key: shared_key_value
+Accept: application/json
+```
+
+#### PUT BODY
+
+```json
+{
+    "ams": {
+        "metric_data": {
+            "ingestion": true,
+            "publishing": true,
+            "status_streaming": false,
+            "messages_arrived": 100
+        },
+        "sync_data": {
+            "ingestion": true,
+            "publishing": false,
+            "status_streaming": true,
+            "messages_arrived": 200
+        }
+    },
+    "hdfs": {
+        "metric_data": true,
+        "sync_data": {
+          "Critical": {
+              "downtimes": true,
+              "group_endpoints": true,
+              "blank_recompuation": true,
+              "group_groups": true,
+              "weights": true,
+              "operations_profile": true,
+              "metric_profile": true,
+              "aggregation_profile": true
+
+          }
+          }
+
+    },
+    "engine_config": true,
+    "last_check": "2018-08-10T12:32:45Z"
+
+}
+```
+
+### Response
+Headers: `Status: 200 OK`
+
+#### Response body
+Json Response
+
+```json
+{
+ "status": {
+  "message": "Tenant successfully updated",
   "code": "200"
  }
 }


### PR DESCRIPTION
# Task 
Related to: https://github.com/ARGOeu/argo-streaming/pull/88
Show tenant's argo-engine status through api call
  - signature: `GET /api/v2/admin/tenants/{tenant_id}/status` 

Update tenant's argo-engine status through api call
  - signature: `PUT /api/v2/admin/tenants/{tenant_id}/status` 


# Implementation
- [x] In package tenants implement Tenant show status method
- [x] In package tenants implement Tenant update status method
- [x] Add unit tests
- [x] Update swagger
- [x] Update mkdocs