### PR TITLE
ARGO-451 Close status timelines with latest daily result

### DIFF
--- a/app/statusEndpointGroups/controller.go
+++ b/app/statusEndpointGroups/controller.go
@@ -148,6 +148,8 @@ func ListEndpointGroupTimelines(r *http.Request, cfg config.Config) (int, http.H
 		}
 	}
 
+	// close the timeline by adding a final status point at the end of the day or at the current time
+	results = closeTimeline(results, urlValues.Get("end_time"))
 	output, err = createView(results, input) //Render the results into JSON/XML format
 
 	return code, h, output, err

--- a/app/statusEndpointGroups/statusEndpointGroups_test.go
+++ b/app/statusEndpointGroups/statusEndpointGroups_test.go
@@ -317,6 +317,7 @@ func (suite *StatusEndpointGroupsTestSuite) TestListStatusEndpointGroups() {
   <status timestamp="2015-05-01T00:00:00Z" value="OK"></status>
   <status timestamp="2015-05-01T01:00:00Z" value="CRITICAL"></status>
   <status timestamp="2015-05-01T05:00:00Z" value="OK"></status>
+  <status timestamp="2015-05-01T23:59:59Z" value="OK"></status>
  </group>
 </root>`
 
@@ -325,6 +326,7 @@ func (suite *StatusEndpointGroupsTestSuite) TestListStatusEndpointGroups() {
   <status timestamp="2015-05-01T00:00:00Z" value="OK"></status>
   <status timestamp="2015-05-01T01:00:00Z" value="CRITICAL"></status>
   <status timestamp="2015-05-01T05:00:00Z" value="OK"></status>
+  <status timestamp="2015-05-01T23:59:59Z" value="OK"></status>
  </group>
 </root>`
 
@@ -344,6 +346,10 @@ func (suite *StatusEndpointGroupsTestSuite) TestListStatusEndpointGroups() {
     },
     {
      "timestamp": "2015-05-01T05:00:00Z",
+     "value": "OK"
+    },
+    {
+     "timestamp": "2015-05-01T23:59:59Z",
      "value": "OK"
     }
    ]
@@ -366,6 +372,10 @@ func (suite *StatusEndpointGroupsTestSuite) TestListStatusEndpointGroups() {
     },
     {
      "timestamp": "2015-05-01T05:00:00Z",
+     "value": "OK"
+    },
+    {
+     "timestamp": "2015-05-01T23:59:59Z",
      "value": "OK"
     }
    ]
@@ -512,6 +522,10 @@ func (suite *StatusEndpointGroupsTestSuite) TestLatestResults() {
     },
     {
      "timestamp": "2015-05-01T05:00:00Z",
+     "value": "OK"
+    },
+    {
+     "timestamp": "2015-05-01T23:59:59Z",
      "value": "OK"
     }
    ]

--- a/app/statusEndpointGroups/view.go
+++ b/app/statusEndpointGroups/view.go
@@ -27,6 +27,7 @@ import (
 	"encoding/xml"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/ARGOeu/argo-web-api/respond"
 	"github.com/ARGOeu/argo-web-api/utils/hbase"
@@ -49,6 +50,28 @@ func hbaseToDataOutput(hResults []*hrpc.Result) []DataOutput {
 	}
 
 	return dResult
+}
+
+// closeTimeline accepts a list of status item and an endDate parameter
+// and tries to close the status timeline by providing a final status item
+// at the end of the date (if the endDate parameter refers to a past date)
+// or at the current time (if the endDate parameter refers to the current date)
+func closeTimeline(results []DataOutput, endDate string) []DataOutput {
+	if len(results) == 0 {
+		return results
+	}
+
+	extra := results[len(results)-1]
+	tsNow := time.Now().UTC()
+	today := tsNow.Format("2006-01-02")
+	if strings.Split(endDate, "T")[0] == today {
+		extra.Timestamp = tsNow.Format(zuluForm)
+	} else {
+		extra.Timestamp = strings.Split(extra.Timestamp, "T")[0] + "T23:59:59Z"
+	}
+
+	results = append(results, extra)
+	return results
 }
 
 func createView(results []DataOutput, input InputParams) ([]byte, error) {

--- a/app/statusEndpoints/controller.go
+++ b/app/statusEndpoints/controller.go
@@ -144,7 +144,8 @@ func ListEndpointTimelines(r *http.Request, cfg config.Config) (int, http.Header
 			return code, h, output, err
 		}
 	}
-
+	// close the timeline by adding a final status point at the end of the day or at the current time
+	results = closeTimeline(results, urlValues.Get("end_time"))
 	output, err = createView(results, input) //Render the results into XML format
 
 	return code, h, output, err

--- a/app/statusEndpoints/statusEndpoints_test.go
+++ b/app/statusEndpoints/statusEndpoints_test.go
@@ -334,6 +334,7 @@ func (suite *StatusEndpointsTestSuite) TestListStatusEndpoints() {
     <status timestamp="2015-05-01T00:00:00Z" value="OK"></status>
     <status timestamp="2015-05-01T01:00:00Z" value="CRITICAL"></status>
     <status timestamp="2015-05-01T05:00:00Z" value="OK"></status>
+    <status timestamp="2015-05-01T23:59:59Z" value="OK"></status>
    </endpoint>
   </group>
  </group>
@@ -346,6 +347,7 @@ func (suite *StatusEndpointsTestSuite) TestListStatusEndpoints() {
     <status timestamp="2015-05-01T00:00:00Z" value="OK"></status>
     <status timestamp="2015-05-01T01:00:00Z" value="CRITICAL"></status>
     <status timestamp="2015-05-01T05:00:00Z" value="OK"></status>
+    <status timestamp="2015-05-01T23:59:59Z" value="OK"></status>
    </endpoint>
   </group>
  </group>
@@ -374,6 +376,10 @@ func (suite *StatusEndpointsTestSuite) TestListStatusEndpoints() {
         },
         {
          "timestamp": "2015-05-01T05:00:00Z",
+         "value": "OK"
+        },
+        {
+         "timestamp": "2015-05-01T23:59:59Z",
          "value": "OK"
         }
        ]
@@ -407,6 +413,10 @@ func (suite *StatusEndpointsTestSuite) TestListStatusEndpoints() {
         },
         {
          "timestamp": "2015-05-01T05:00:00Z",
+         "value": "OK"
+        },
+        {
+         "timestamp": "2015-05-01T23:59:59Z",
          "value": "OK"
         }
        ]
@@ -549,6 +559,10 @@ func (suite *StatusEndpointsTestSuite) TestLatestResults() {
         },
         {
          "timestamp": "2015-05-01T05:00:00Z",
+         "value": "OK"
+        },
+        {
+         "timestamp": "2015-05-01T23:59:59Z",
          "value": "OK"
         }
        ]

--- a/app/statusMetrics/controller.go
+++ b/app/statusMetrics/controller.go
@@ -147,7 +147,8 @@ func ListMetricTimelines(r *http.Request, cfg config.Config) (int, http.Header, 
 			return code, h, output, err
 		}
 	}
-
+	// close the timeline by adding a final status point at the end of the day or at the current time
+	results = closeTimeline(results, urlValues.Get("end_time"))
 	output, err = createView(results, input) //Render the results into XML format
 
 	return code, h, output, err

--- a/app/statusMetrics/statusMetrics_test.go
+++ b/app/statusMetrics/statusMetrics_test.go
@@ -373,6 +373,7 @@ func (suite *StatusMetricsTestSuite) TestListStatusMetrics() {
      <status timestamp="2015-05-01T00:00:00Z" value="OK"></status>
      <status timestamp="2015-05-01T01:00:00Z" value="CRITICAL"></status>
      <status timestamp="2015-05-01T05:00:00Z" value="OK"></status>
+     <status timestamp="2015-05-01T23:59:59Z" value="OK"></status>
     </metric>
    </endpoint>
   </group>
@@ -388,6 +389,7 @@ func (suite *StatusMetricsTestSuite) TestListStatusMetrics() {
      <status timestamp="2015-05-01T00:00:00Z" value="OK"></status>
      <status timestamp="2015-05-01T01:00:00Z" value="CRITICAL"></status>
      <status timestamp="2015-05-01T05:00:00Z" value="OK"></status>
+     <status timestamp="2015-05-01T23:59:59Z" value="OK"></status>
     </metric>
    </endpoint>
   </group>
@@ -424,6 +426,10 @@ func (suite *StatusMetricsTestSuite) TestListStatusMetrics() {
           },
           {
            "timestamp": "2015-05-01T05:00:00Z",
+           "value": "OK"
+          },
+          {
+           "timestamp": "2015-05-01T23:59:59Z",
            "value": "OK"
           }
          ]
@@ -467,6 +473,10 @@ func (suite *StatusMetricsTestSuite) TestListStatusMetrics() {
           },
           {
            "timestamp": "2015-05-01T05:00:00Z",
+           "value": "OK"
+          },
+          {
+           "timestamp": "2015-05-01T23:59:59Z",
            "value": "OK"
           }
          ]
@@ -638,6 +648,10 @@ func (suite *StatusMetricsTestSuite) TestLatestResults() {
           },
           {
            "timestamp": "2015-05-01T05:00:00Z",
+           "value": "OK"
+          },
+          {
+           "timestamp": "2015-05-01T23:59:59Z",
            "value": "OK"
           }
          ]

--- a/app/statusMetrics/view.go
+++ b/app/statusMetrics/view.go
@@ -27,6 +27,7 @@ import (
 	"encoding/xml"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/ARGOeu/argo-web-api/respond"
 	"github.com/ARGOeu/argo-web-api/utils/hbase"
@@ -54,6 +55,28 @@ func hbaseToDataOutput(hResults []*hrpc.Result) []DataOutput {
 	}
 
 	return dResult
+}
+
+// closeTimeline accepts a list of status item and an endDate parameter
+// and tries to close the status timeline by providing a final status item
+// at the end of the date (if the endDate parameter refers to a past date)
+// or at the current time (if the endDate parameter refers to the current date)
+func closeTimeline(results []DataOutput, endDate string) []DataOutput {
+	if len(results) == 0 {
+		return results
+	}
+
+	extra := results[len(results)-1]
+	tsNow := time.Now().UTC()
+	today := tsNow.Format("2006-01-02")
+	if strings.Split(endDate, "T")[0] == today {
+		extra.Timestamp = tsNow.Format(zuluForm)
+	} else {
+		extra.Timestamp = strings.Split(extra.Timestamp, "T")[0] + "T23:59:59Z"
+	}
+
+	results = append(results, extra)
+	return results
 }
 
 func createView(results []DataOutput, input InputParams) ([]byte, error) {

--- a/app/statusServices/controller.go
+++ b/app/statusServices/controller.go
@@ -143,7 +143,8 @@ func ListServiceTimelines(r *http.Request, cfg config.Config) (int, http.Header,
 			return code, h, output, err
 		}
 	}
-
+	// close the timeline by adding a final status point at the end of the day or at the current time
+	results = closeTimeline(results, urlValues.Get("end_time"))
 	output, err = createView(results, input) //Render the results into XML format
 
 	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))

--- a/app/statusServices/statusServices_test.go
+++ b/app/statusServices/statusServices_test.go
@@ -321,6 +321,7 @@ func (suite *StatusServicesTestSuite) TestListStatusServices() {
    <status timestamp="2015-05-01T00:00:00Z" value="OK"></status>
    <status timestamp="2015-05-01T01:00:00Z" value="CRITICAL"></status>
    <status timestamp="2015-05-01T05:00:00Z" value="OK"></status>
+   <status timestamp="2015-05-01T23:59:59Z" value="OK"></status>
   </group>
  </group>
 </root>`
@@ -331,6 +332,7 @@ func (suite *StatusServicesTestSuite) TestListStatusServices() {
    <status timestamp="2015-05-01T00:00:00Z" value="OK"></status>
    <status timestamp="2015-05-01T01:00:00Z" value="CRITICAL"></status>
    <status timestamp="2015-05-01T05:00:00Z" value="OK"></status>
+   <status timestamp="2015-05-01T23:59:59Z" value="OK"></status>
   </group>
  </group>
 </root>`
@@ -355,6 +357,10 @@ func (suite *StatusServicesTestSuite) TestListStatusServices() {
       },
       {
        "timestamp": "2015-05-01T05:00:00Z",
+       "value": "OK"
+      },
+      {
+       "timestamp": "2015-05-01T23:59:59Z",
        "value": "OK"
       }
      ]
@@ -384,6 +390,10 @@ func (suite *StatusServicesTestSuite) TestListStatusServices() {
       },
       {
        "timestamp": "2015-05-01T05:00:00Z",
+       "value": "OK"
+      },
+      {
+       "timestamp": "2015-05-01T23:59:59Z",
        "value": "OK"
       }
      ]
@@ -508,6 +518,7 @@ func (suite *StatusServicesTestSuite) TestListStatusServices() {
 	suite.Equal(401, response.Code, "Response code mismatch")
 	// Compare the expected and actual xml response
 	suite.Equal(respUnauthorized, response.Body.String(), "Response body mismatch")
+
 }
 
 func (suite *StatusServicesTestSuite) TestLatestResults() {
@@ -540,6 +551,10 @@ func (suite *StatusServicesTestSuite) TestLatestResults() {
       },
       {
        "timestamp": "2015-05-01T05:00:00Z",
+       "value": "OK"
+      },
+      {
+       "timestamp": "2015-05-01T23:59:59Z",
        "value": "OK"
       }
      ]

--- a/app/statusServices/view.go
+++ b/app/statusServices/view.go
@@ -27,6 +27,7 @@ import (
 	"encoding/xml"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/ARGOeu/argo-web-api/respond"
 	"github.com/ARGOeu/argo-web-api/utils/hbase"
@@ -50,6 +51,28 @@ func hbaseToDataOutput(hResults []*hrpc.Result) []DataOutput {
 	}
 
 	return dResult
+}
+
+// closeTimeline accepts a list of status item and an endDate parameter
+// and tries to close the status timeline by providing a final status item
+// at the end of the date (if the endDate parameter refers to a past date)
+// or at the current time (if the endDate parameter refers to the current date)
+func closeTimeline(results []DataOutput, endDate string) []DataOutput {
+	if len(results) == 0 {
+		return results
+	}
+
+	extra := results[len(results)-1]
+	tsNow := time.Now().UTC()
+	today := tsNow.Format("2006-01-02")
+	if strings.Split(endDate, "T")[0] == today {
+		extra.Timestamp = tsNow.Format(zuluForm)
+	} else {
+		extra.Timestamp = strings.Split(extra.Timestamp, "T")[0] + "T23:59:59Z"
+	}
+
+	results = append(results, extra)
+	return results
 }
 
 func createView(results []DataOutput, input InputParams) ([]byte, error) {

--- a/doc/v2/docs/status.md
+++ b/doc/v2/docs/status.md
@@ -78,7 +78,7 @@ Code:
 ```
 Status: 200 OK
 ```
-Reponse body:
+Response body (XML):
 ```
 <root>
 	<group name="HG-03-AUTH" type="SITES">
@@ -88,11 +88,13 @@ Reponse body:
 					<status timestamp="2015-04-30T23:59:00Z" status="OK"></status>
 					<status timestamp="2015-05-01T01:00:00Z" status="CRITICAL"></status>
 					<status timestamp="2015-05-01T02:00:00Z" status="OK"></status>
+					<status timestamp="2015-05-01T23:59:59Z" status="OK"></status>
 				</metric>
 				<metric name="emi.wn.WN-Bi">
 					<status timestamp="2015-04-30T22:59:00Z" status="OK"></status>
 					<status timestamp="2015-05-01T02:00:00Z" status="OK"></status>
 					<status timestamp="2015-05-01T03:00:00Z" status="OK"></status>
+					<status timestamp="2015-05-01T23:59:59Z" status="OK"></status>
 				</metric>
 			</endpoint>
 		</group>
@@ -100,8 +102,74 @@ Reponse body:
 </root>
 ```
 
+Response body (JSON):
+```
+{
+  "groups": [
+    {
+      "name": "HG-03-AUTH",
+      "type": "SITES",
+      "services": [
+        {
+          "name": "CREAM-CE",
+          "type": "service",
+          "endpoints": [
+            {
+              "name": "cream01.afroditi.gr",
+              "metrics": [
+                {
+                  "name": "emi.cream.CREAMCE-JobSubmit",
+                  "statuses": [
+                    {
+                      "timestamp": "2015-04-30T23:59:00Z",
+                      "value": "OK"
+                    },
+                    {
+                      "timestamp": "2015-05-01T01:00:00Z",
+                      "value": "CRITICAL"
+                    },
+                    {
+                      "timestamp": "2015-05-01T02:00:00Z",
+                      "value": "OK"
+                    },
+                    {
+                      "timestamp": "2015-05-01T23:59:59Z",
+                      "value": "OK"
+                    }
+                  ]
+                },
+                {
+                  "name": "emi.wn.WN-Bi",
+                  "statuses": [
+                    {
+                      "timestamp": "2015-04-30T22:59:00Z",
+                      "value": "OK"
+                    },
+                    {
+                      "timestamp": "2015-05-02T00:00:00Z",
+                      "value": "OK"
+                    },
+                    {
+                      "timestamp": "2015-05-03T01:00:00Z",
+                      "value": "OK"
+                    },
+                    {
+                      "timestamp": "2015-05-01T23:59:59Z",
+                      "value": "OK"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
 
-#### List specific metric 
+#### List specific metric
 (`metric_name=emi.cream.CREAM-CE-JobSubmit`):
 
 ##### Example Request:
@@ -120,7 +188,7 @@ Code:
 ```
 Status: 200 OK
 ```
-Reponse body:
+Response body (XML):
 
 ```
 <root>
@@ -131,11 +199,58 @@ Reponse body:
 					<status timestamp="2015-04-30T23:59:00Z" status="OK"></status>
 					<status timestamp="2015-05-01T01:00:00Z" status="CRITICAL"></status>
 					<status timestamp="2015-05-01T02:00:00Z" status="OK"></status>
+					<status timestamp="2015-05-01T23:59:59Z" status="OK"></status>
 				</metric>
 			</endpoint>
 		</group>
 	</group>
 </root>
+```
+
+Response body (JSON):
+```
+{
+  "groups": [
+    {
+      "name": "HG-03-AUTH",
+      "type": "SITES",
+      "services": [
+        {
+          "name": "CREAM-CE",
+          "type": "service",
+          "endpoints": [
+            {
+              "name": "cream01.afroditi.gr",
+              "metrics": [
+                {
+                  "name": "emi.cream.CREAMCE-JobSubmit",
+                  "statuses": [
+                    {
+                      "timestamp": "2015-04-30T23:59:00Z",
+                      "value": "OK"
+                    },
+                    {
+                      "timestamp": "2015-05-01T01:00:00Z",
+                      "value": "CRITICAL"
+                    },
+                    {
+                      "timestamp": "2015-05-02T01:00:00Z",
+                      "value": "OK"
+                    },
+                    {
+                      "timestamp": "2015-05-01T23:59:59Z",
+                      "value": "OK"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
 ```
 
 <a id="2"></a>
@@ -206,7 +321,7 @@ Code:
 ```
 Status: 200 OK
 ```
-Reponse body:
+Response body (XML):
 ```
 <root>
 	<group name="HG-03-AUTH" type="SITES">
@@ -215,15 +330,79 @@ Reponse body:
 				<status timestamp="2015-04-30T23:59:00Z" status="OK"></status>
 				<status timestamp="2015-05-01T01:00:00Z" status="CRITICAL"></status>
 				<status timestamp="2015-05-01T02:00:00Z" status="OK"></status>
+				<status timestamp="2015-05-01T23:59:59Z" status="OK"></status>
 			</endpoint>
 			<endpoint name="cream02.afroditi.gr">
 				<status timestamp="2015-04-30T23:59:00Z" status="OK"></status>
 				<status timestamp="2015-05-01T01:00:00Z" status="CRITICAL"></status>
 				<status timestamp="2015-05-01T02:00:00Z" status="OK"></status>
+				<status timestamp="2015-05-01T23:59:59Z" status="OK"></status>
 			</endpoint>
 		</group>
 	</group>
 </root>
+```
+
+Response body (JSON):
+```
+{
+  "groups": [
+    {
+      "name": "HG-03-AUTH",
+      "type": "SITES",
+      "services": [
+        {
+          "name": "CREAM-CE",
+          "type": "service",
+          "endpoints": [
+            {
+              "name": "cream01.afroditi.gr",
+              "statuses": [
+                {
+                  "timestamp": "2015-04-30T23:59:00Z",
+                  "value": "OK"
+                },
+                {
+                  "timestamp": "2015-05-01T01:00:00Z",
+                  "value": "CRITICAL"
+                },
+                {
+                  "timestamp": "2015-05-01T02:00:00Z",
+                  "value": "OK"
+                },
+                {
+                  "timestamp": "2015-05-01T23:59:59Z",
+                  "value": "OK"
+                }
+              ]
+            },
+                        {
+              "name": "cream02.afroditi.gr",
+              "statuses": [
+                {
+                  "timestamp": "2015-04-30T23:59:00Z",
+                  "value": "OK"
+                },
+                {
+                  "timestamp": "2015-05-01T01:00:00Z",
+                  "value": "CRITICAL"
+                },
+                {
+                  "timestamp": "2015-05-01T02:00:00Z",
+                  "value": "OK"
+                },
+                {
+                  "timestamp": "2015-05-01T23:59:59Z",
+                  "value": "OK"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
 ```
 
 
@@ -246,7 +425,7 @@ Code:
 ```
 Status: 200 OK
 ```
-Reponse body:
+Response body (XML):
 
 ```
 <root>
@@ -256,12 +435,53 @@ Reponse body:
 				<status timestamp="2015-04-30T23:59:00Z" status="OK"></status>
 				<status timestamp="2015-05-01T01:00:00Z" status="CRITICAL"></status>
 				<status timestamp="2015-05-01T02:00:00Z" status="OK"></status>
+				<status timestamp="2015-05-01T23:59:59Z" status="OK"></status>
 			</endpoint>
 		</group>
 	</group>
 </root>
 ```
 
+Response body (JSON):
+```
+{
+  "groups": [
+    {
+      "name": "HG-03-AUTH",
+      "type": "SITES",
+      "services": [
+        {
+          "name": "CREAM-CE",
+          "type": "service",
+          "endpoints": [
+            {
+              "name": "cream01.afroditi.gr",
+              "statuses": [
+                {
+                  "timestamp": "2015-04-30T23:59:00Z",
+                  "value": "OK"
+                },
+                {
+                  "timestamp": "2015-05-01T01:00:00Z",
+                  "value": "CRITICAL"
+                },
+                {
+                  "timestamp": "2015-05-01T02:00:00Z",
+                  "value": "OK"
+                },
+                {
+                  "timestamp": "2015-05-01T23:59:59Z",
+                  "value": "OK"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
 
 
 
@@ -332,7 +552,7 @@ Code:
 ```
 Status: 200 OK
 ```
-Reponse body:
+Response body (XML):
 ```
 <root>
 	<group name="HG-03-AUTH" type="SITES">
@@ -340,18 +560,78 @@ Reponse body:
 			<status timestamp="2015-04-30T23:59:00Z" status="OK"></status>
 			<status timestamp="2015-05-01T01:00:00Z" status="CRITICAL"></status>
 			<status timestamp="2015-05-01T02:00:00Z" status="OK"></status>
+			<status timestamp="2015-05-01T23:59:59Z" status="OK"></status>
 		</group>
 		<group name="SRMv2" type="service">
 			<status timestamp="2015-04-30T23:59:00Z" status="OK"></status>
 			<status timestamp="2015-05-01T01:00:00Z" status="CRITICAL"></status>
 			<status timestamp="2015-05-01T02:00:00Z" status="OK"></status>
+			<status timestamp="2015-05-01T23:59:59Z" status="OK"></status>
 		</group>
 	</group>
 </root>
 ```
 
+Response body (JSON):
+```
+{
+  "groups": [
+    {
+      "name": "HG-03-AUTH",
+      "type": "SITES",
+      "services": [
+        {
+          "name": "CREAM-CE",
+          "type": "service",
+          "statuses": [
+            {
+              "timestamp": "2015-04-30T23:59:00Z",
+              "value": "OK"
+            },
+            {
+              "timestamp": "2015-05-01T01:00:00Z",
+              "value": "CRITICAL"
+            },
+            {
+              "timestamp": "2015-05-01T02:00:00Z",
+              "value": "OK"
+            },
+            {
+              "timestamp": "2015-05-01T23:59:59Z",
+              "value": "OK"
+            }
+          ]
+        },
+        {
+          "name": "SRMv2",
+          "type": "service",
+          "statuses": [
+            {
+              "timestamp": "2015-04-30T23:59:00Z",
+              "value": "OK"
+            },
+            {
+              "timestamp": "2015-05-01T01:00:00Z",
+              "value": "CRITICAL"
+            },
+            {
+              "timestamp": "2015-05-01T02:00:00Z",
+              "value": "OK"
+            },
+            {
+              "timestamp": "2015-05-01T23:59:59Z",
+              "value": "OK"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
 
-##### List specific service type 
+
+##### List specific service type
 (`service_type=CREAM-CE`):
 
 ###### Example Request:
@@ -370,7 +650,7 @@ Code:
 ```
 Status: 200 OK
 ```
-Reponse body:
+Response body (XML):
 
 ```
 <root>
@@ -379,9 +659,46 @@ Reponse body:
 			<status timestamp="2015-04-30T23:59:00Z" status="OK"></status>
 			<status timestamp="2015-05-01T01:00:00Z" status="CRITICAL"></status>
 			<status timestamp="2015-05-01T02:00:00Z" status="OK"></status>
+			<status timestamp="2015-05-01T23:59:59Z" status="OK"></status>
 		</group>
 	</group>
 </root>
+```
+
+Response body (JSON):
+```
+{
+  "groups": [
+    {
+      "name": "HG-03-AUTH",
+      "type": "SITES",
+      "services": [
+        {
+          "name": "CREAM-CE",
+          "type": "service",
+          "statuses": [
+            {
+              "timestamp": "2015-04-30T23:59:00Z",
+              "value": "OK"
+            },
+            {
+              "timestamp": "2015-05-01T01:00:00Z",
+              "value": "CRITICAL"
+            },
+            {
+              "timestamp": "2015-05-01T02:00:00Z",
+              "value": "OK"
+            },
+            {
+              "timestamp": "2015-05-01T23:59:59Z",
+              "value": "OK"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
 ```
 
 <a id="4"></a>
@@ -450,24 +767,78 @@ Code:
 ```
 Status: 200 OK
 ```
-Reponse body:
+Response body (XML):
 ```
 <root>
 	<group name="HG-03-AUTH" type="SITES">
-		<status timestamp="2015-05-01T01:00:00Z" status="CRITICAL"></status>
-		<status timestamp="2015-05-01T02:00:00Z" status="OK"></status>
+		<status timestamp="2015-05-01T00:00:00Z" status="CRITICAL"></status>
+		<status timestamp="2015-05-01T01:00:00Z" status="WARNING"></status>
 		<status timestamp="2015-05-01T05:00:00Z" status="OK"></status>
+		<status timestamp="2015-05-01T23:59:59Z" status="OK"></status>
 	</group>
 	<group name="HG-01-AUTH" type="SITES">
-		<status timestamp="2015-05-01T01:00:00Z" status="CRITICAL"></status>
-		<status timestamp="2015-05-01T02:00:00Z" status="OK"></status>
+		<status timestamp="2015-05-01T00:00:00Z" status="CRITICAL"></status>
+		<status timestamp="2015-05-01T02:00:00Z" status="UNKNOWN"></status>
 		<status timestamp="2015-05-01T05:00:00Z" status="OK"></status>
+		<status timestamp="2015-05-01T23:59:59Z" status="OK"></status>
 	</group>
 </root>
 ```
 
+Response body (JSON):
+```
+{
+  "groups": [
+    {
+      "name": "HG-03-AUTH",
+      "type": "SITES",
+      "statuses": [
+        {
+          "timestamp": "2015-05-01T00:00:00Z",
+          "value": "CRITICAL"
+        },
+        {
+          "timestamp": "2015-05-01T01:00:00Z",
+          "value": "WARNING"
+        },
+        {
+          "timestamp": "2015-05-01T05:00:00Z",
+          "value": "OK"
+        },
+        {
+          "timestamp": "2015-05-01T23:59:59Z",
+          "value": "OK"
+        }
+      ]
+    },
+    {
+      "name": "HG-01-AUTH",
+      "type": "SITES",
+      "statuses": [
+        {
+          "timestamp": "2015-05-01T00:00:00Z",
+          "value": "CRITICAL"
+        },
+        {
+          "timestamp": "2015-05-01T02:00:00Z",
+          "value": "UNKNOWN"
+        },
+        {
+          "timestamp": "2015-05-01T05:00:00Z",
+          "value": "OK"
+        },
+        {
+          "timestamp": "2015-05-01T23:59:59Z",
+          "value": "OK"
+        }
+      ]
+    }
+  ]
+}
+```
 
-##### List specific endpoint group 
+
+##### List specific endpoint group
 (`group_name=HG-03-AUTH`):
 
 ###### Example Request:
@@ -486,16 +857,47 @@ Code:
 ```
 Status: 200 OK
 ```
-Reponse body:
+Response body (XML):
 
 ```
 <root>
 	<group name="HG-03-AUTH" type="SITES">
-		<status timestamp="2015-05-01T01:00:00Z" status="CRITICAL"></status>
-		<status timestamp="2015-05-01T02:00:00Z" status="OK"></status>
+		<status timestamp="2015-05-01T00:00:00Z" status="CRITICAL"></status>
+		<status timestamp="2015-05-01T02:00:00Z" status="WARNING"></status>
 		<status timestamp="2015-05-01T05:00:00Z" status="OK"></status>
+		<status timestamp="2015-05-01T23:59:59Z" status="OK"></status>
 	</group>
 </root>
+```
+
+Response body (JSON):
+```
+{
+  "groups": [
+    {
+      "name": "HG-03-AUTH",
+      "type": "SITES",
+      "statuses": [
+        {
+          "timestamp": "2015-05-01T00:00:00Z",
+          "value": "CRITICAL"
+        },
+        {
+          "timestamp": "2015-05-01T02:00:00Z",
+          "value": "WARNING"
+        },
+        {
+          "timestamp": "2015-05-01T05:00:00Z",
+          "value": "OK"
+        },
+        {
+          "timestamp": "2015-05-01T23:59:59Z",
+          "value": "OK"
+        }
+      ]
+    }
+  ]
+}
 ```
 
 <a id="5"></a>
@@ -555,7 +957,7 @@ Code:
 ```
 Status: 200 OK
 ```
-Reponse body:
+Response body (XML):
 ```
  <root>
    <host name="www.example.com">
@@ -569,4 +971,26 @@ Reponse body:
  </root>
 ```
 
-
+Response body (JSON):
+```
+{
+  "root": [
+    {
+      "Name": "www.example.com",
+      "Metrics": [
+        {
+          "Name": "httpd_check",
+          "Details": [
+            {
+              "Timestamp": "2015-06-20T12:00:00Z",
+              "Value": "CRITICAL",
+              "Summary": "httpd status is CRITICAL",
+              "Message": "httpd service seems down. Failed to connect to port 80."
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```


### PR DESCRIPTION
# Task
When presenting a status timeline go the extra mile and display the last point in the timeline even if the status doesn't change

for e.g. from:
```
{
    "groups": [
        {
            "name": "FOO",
            "type": "SITES",
            "statuses": [
                {
                    "timestamp": "2018-06-22T00:00:00Z",
                    "value": "OK"
                }
            ]
        }
    ]
}
```
go to:
```
{
    "groups": [
        {
            "name": "FOO",
            "type": "SITES",
            "statuses": [
                {
                    "timestamp": "2018-06-22T00:00:00Z",
                    "value": "OK"
                },
                {
                    "timestamp": "2018-06-22T23:59:59Z",
                    "value": "OK"
                }
            ]
        }
    ]
}
```