### PR TITLE
ARGO-1268 Serve topology statistics per report

### DIFF
--- a/app/topology/controller.go
+++ b/app/topology/controller.go
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2018 GRNET S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS
+ * IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ *
+ * The views and conclusions contained in the software and
+ * documentation are those of the authors and should not be
+ * interpreted as representing official policies, either expressed
+ * or implied, of GRNET S.A.
+ *
+ */
+
+package topology
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/ARGOeu/argo-web-api/utils/config"
+	"github.com/ARGOeu/argo-web-api/utils/mongo"
+	"github.com/gorilla/context"
+	"github.com/gorilla/mux"
+	"gopkg.in/mgo.v2/bson"
+)
+
+// ListTopoStats list statistics about the topology used in the report
+func ListTopoStats(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
+
+	//STANDARD DECLARATIONS START
+	code := http.StatusOK
+	h := http.Header{}
+	output := []byte("")
+	err := error(nil)
+	charset := "utf-8"
+	//STANDARD DECLARATIONS END
+
+	// Set Content-Type response Header value
+	contentType := r.Header.Get("Accept")
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+
+	// Grab Tenant DB configuration from context
+	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
+	groupType := context.Get(r, "group_type").(string)
+	egroupType := context.Get(r, "endpoint_group_type").(string)
+
+	// Parse the request into the input
+	urlValues := r.URL.Query()
+	vars := mux.Vars(r)
+
+	report_name := vars["report_name"]
+	//Time Related
+	dateStr := urlValues.Get("date")
+
+	const zuluForm = "2006-01-02"
+	const ymdForm = "20060102"
+
+	ts := time.Now().UTC()
+	if dateStr != "" {
+		ts, _ = time.Parse(zuluForm, dateStr)
+	}
+
+	tsYMD, _ := strconv.Atoi(ts.Format(ymdForm))
+
+	session, err := mongo.OpenSession(tenantDbConfig)
+	defer mongo.CloseSession(session)
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	// find the report id first
+	reportID, err := mongo.GetReportID(session, tenantDbConfig.Db, report_name)
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	var serviceResults []string
+	var egroupResults []string
+	var groupResults []string
+
+	serviceCol := session.DB(tenantDbConfig.Db).C("service_ar")
+	eGroupCol := session.DB(tenantDbConfig.Db).C("endpoint_group_ar")
+
+	err = serviceCol.Find(bson.M{"report": reportID, "date": tsYMD}).Distinct("name", &serviceResults)
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+	err = eGroupCol.Find(bson.M{"report": reportID, "date": tsYMD}).Distinct("name", &egroupResults)
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+	err = eGroupCol.Find(bson.M{"report": reportID, "date": tsYMD}).Distinct("supergroup", &groupResults)
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	// fill the topology JSON struct
+	result := Topology{}
+	result.GroupCount = len(groupResults)
+	result.GroupType = groupType
+	result.GroupList = groupResults
+	result.EndGroupCount = len(egroupResults)
+	result.EndGroupType = egroupType
+	result.EndGroupList = egroupResults
+	result.ServiceCount = len(serviceResults)
+	result.ServiceList = serviceResults
+
+	output, err = createTopoView(result, contentType, http.StatusOK)
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	return code, h, output, err
+}
+
+// Options implements the option request on resource
+func Options(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
+
+	//STANDARD DECLARATIONS START
+	code := http.StatusOK
+	h := http.Header{}
+	output := []byte("")
+	err := error(nil)
+	contentType := "text/plain"
+	charset := "utf-8"
+	//STANDARD DECLARATIONS END
+
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+	h.Set("Allow", fmt.Sprintf("GET, OPTIONS"))
+	return code, h, output, err
+
+}

--- a/app/topology/model.go
+++ b/app/topology/model.go
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2018 GRNET S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS
+ * IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ *
+ * The views and conclusions contained in the software and
+ * documentation are those of the authors and should not be
+ * interpreted as representing official policies, either expressed
+ * or implied, of GRNET S.A.
+ *
+ */
+
+package topology
+
+import "encoding/xml"
+
+// MongoInterface to retrieve and insert metricProfiles in mongo
+// type MongoInterface struct {
+// 	ID       string    `bson:"id" json:"id"`
+// 	Name     string    `bson:"name" json:"name"`
+// 	Services []Serv `bson:"services" json:"services"`
+// }
+
+// Topology struct to represent topology statistics
+type Topology struct {
+	GroupCount    int      `json:"group_count"`
+	GroupType     string   `json:"group_type"`
+	GroupList     []string `json:"group_list"`
+	EndGroupCount int      `json:"endpoint_group_count"`
+	EndGroupType  string   `json:"endpoint_group_type"`
+	EndGroupList  []string `json:"endpoint_group_list"`
+	ServiceCount  int      `json:"service_count"`
+	ServiceList   []string `json:"service_list"`
+}
+
+// Message struct to hold the json/xml response
+type messageOUT struct {
+	XMLName xml.Name `xml:"root" json:"-"`
+	Message string   `xml:"message" json:"message"`
+	Code    string   `xml:"code,omitempty" json:"code,omitempty"`
+}

--- a/app/topology/routing.go
+++ b/app/topology/routing.go
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2018 GRNET S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS
+ * IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ *
+ * The views and conclusions contained in the software and
+ * documentation are those of the authors and should not be
+ * interpreted as representing official policies, either expressed
+ * or implied, of GRNET S.A.
+ *
+ */
+
+package topology
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/ARGOeu/argo-web-api/app/reports"
+	"github.com/ARGOeu/argo-web-api/respond"
+	"github.com/ARGOeu/argo-web-api/utils/config"
+	"github.com/ARGOeu/argo-web-api/utils/mongo"
+	"github.com/gorilla/context"
+	"github.com/gorilla/mux"
+	"gopkg.in/mgo.v2/bson"
+)
+
+// HandleSubrouter uses the subrouter for a specific calls and creates a tree of sorts
+// handling each route with a different subrouter
+func HandleSubrouter(s *mux.Router, confhandler *respond.ConfHandler) {
+
+	s = respond.PrepAppRoutes(s, confhandler, appRoutesV2)
+
+}
+
+var appRoutesV2 = []respond.AppRoutes{
+	{"topology.list", "GET", "/{report_name}", routeCheckGroup},
+	{"topology.options", "OPTIONS", "/{report_name}", Options},
+}
+
+func routeCheckGroup(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
+
+	//STANDARD DECLARATIONS START
+	code := http.StatusOK
+	h := http.Header{}
+	output := []byte("group check")
+	err := error(nil)
+	charset := "utf-8"
+	//STANDARD DECLARATIONS END
+
+	// Handle response format based on Accept Header
+	contentType := r.Header.Get("Accept")
+
+	vars := mux.Vars(r)
+
+	// Grab Tenant DB configuration from context
+	tenantcfg := context.Get(r, "tenant_conf").(config.MongoConfig)
+
+	session, err := mongo.OpenSession(tenantcfg)
+	defer mongo.CloseSession(session)
+	if err != nil {
+		code = http.StatusInternalServerError
+		output, _ = respond.MarshalContent(respond.InternalServerErrorMessage, contentType, "", " ")
+		return code, h, output, err
+	}
+	result := reports.MongoInterface{}
+	err = mongo.FindOne(session, tenantcfg.Db, "reports", bson.M{"info.name": vars["report_name"]}, &result)
+	if err != nil {
+		code = http.StatusNotFound
+		message := "The report with the name " + vars["report_name"] + " does not exist"
+		output, err := createMessageOUT(message, code, contentType) //Render the response into XML or JSON
+		h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+		return code, h, output, err
+	}
+	// default generic group names
+	group_type := "group"
+	endpoint_group_type := "endpoint_group"
+
+	// if specific group names are available in report use them
+	if result.Topology.Group != nil {
+		group_type = result.Topology.Group.Type
+		if result.Topology.Group.Group != nil {
+			endpoint_group_type = result.Topology.Group.Group.Type
+		}
+	}
+
+	// set group names as part of the context
+	context.Set(r, "group_type", group_type)
+	context.Set(r, "endpoint_group_type", endpoint_group_type)
+	return ListTopoStats(r, cfg)
+
+}

--- a/app/topology/topology_test.go
+++ b/app/topology/topology_test.go
@@ -1,0 +1,530 @@
+/*
+ * Copyright (c) 2015 GRNET S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS
+ * IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ *
+ * The views and conclusions contained in the software and
+ * documentation are those of the authors and should not be
+ * interpreted as representing official policies, either expressed
+ * or implied, of GRNET S.A.
+ *
+ */
+
+package topology
+
+import (
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/ARGOeu/argo-web-api/respond"
+	"github.com/ARGOeu/argo-web-api/utils/config"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/suite"
+	"gopkg.in/gcfg.v1"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+)
+
+type topologyTestSuite struct {
+	suite.Suite
+	cfg             config.Config
+	router          *mux.Router
+	confHandler     respond.ConfHandler
+	tenantDbConf    config.MongoConfig
+	tenantpassword  string
+	tenantusername  string
+	tenantstorename string
+	clientkey       string
+}
+
+// Setup the Test Environment
+func (suite *topologyTestSuite) SetupSuite() {
+
+	const testConfig = `
+	[server]
+	bindip = ""
+	port = 8080
+	maxprocs = 4
+	cache = false
+	lrucache = 700000000
+	gzip = true
+	[mongodb]
+	host = "127.0.0.1"
+	port = 27017
+	db = "ARGO_test_serviceFlavor_availability"
+	`
+
+	_ = gcfg.ReadStringInto(&suite.cfg, testConfig)
+
+	suite.tenantDbConf.Db = "ARGO_test_topology_tenant"
+	suite.tenantDbConf.Password = "h4shp4ss"
+	suite.tenantDbConf.Username = "dbuser"
+	suite.tenantDbConf.Store = "ar"
+	suite.clientkey = "secretkey"
+
+	// Create router and confhandler for test
+	suite.confHandler = respond.ConfHandler{suite.cfg}
+	suite.router = mux.NewRouter().StrictSlash(false).PathPrefix("/api/v2/topology").Subrouter()
+	HandleSubrouter(suite.router, &suite.confHandler)
+}
+
+// This function runs before any test and setups the environment
+func (suite *topologyTestSuite) SetupTest() {
+
+	log.SetOutput(ioutil.Discard)
+
+	// seed mongo
+	session, err := mgo.Dial(suite.cfg.MongoDB.Host)
+	if err != nil {
+		panic(err)
+	}
+	defer session.Close()
+
+	// Seed database with tenants
+	//TODO: move tests to
+	c := session.DB(suite.cfg.MongoDB.Db).C("tenants")
+	c.Insert(
+		bson.M{"name": "Westeros",
+			"db_conf": []bson.M{
+
+				bson.M{
+					"server":   "localhost",
+					"port":     27017,
+					"database": "argo_Westeros1",
+				},
+				bson.M{
+					"server":   "localhost",
+					"port":     27017,
+					"database": "argo_Westeros2",
+				},
+			},
+			"users": []bson.M{
+
+				bson.M{
+					"name":    "John Snow",
+					"email":   "J.Snow@brothers.wall",
+					"api_key": "wh1t3_w@lk3rs",
+					"roles":   []string{"viewer"},
+				},
+				bson.M{
+					"name":    "King Joffrey",
+					"email":   "g0dk1ng@kingslanding.gov",
+					"api_key": "sansa <3",
+					"roles":   []string{"viewer"},
+				},
+			}})
+	c.Insert(
+		bson.M{"name": "EGI",
+			"db_conf": []bson.M{
+
+				bson.M{
+					"server":   "localhost",
+					"port":     27017,
+					"database": suite.tenantDbConf.Db,
+					"username": suite.tenantDbConf.Username,
+					"password": suite.tenantDbConf.Password,
+				},
+				bson.M{
+					"server":   "localhost",
+					"port":     27017,
+					"database": "argo_wrong_db_serviceflavoravailability",
+				},
+			},
+			"users": []bson.M{
+
+				bson.M{
+					"name":    "Joe Complex",
+					"email":   "C.Joe@egi.eu",
+					"api_key": suite.clientkey,
+					"roles":   []string{"viewer"},
+				},
+				bson.M{
+					"name":    "Josh Plain",
+					"email":   "P.Josh@egi.eu",
+					"api_key": "itsamysterytoyou",
+					"roles":   []string{"viewer"},
+				},
+			}})
+
+	c = session.DB(suite.cfg.MongoDB.Db).C("roles")
+	c.Insert(
+		bson.M{
+			"resource": "topology.list",
+			"roles":    []string{"editor", "viewer"},
+		})
+	c.Insert(
+		bson.M{
+			"resource": "results.get",
+			"roles":    []string{"editor", "viewer"},
+		})
+	// Seed database with recomputations
+	c = session.DB(suite.tenantDbConf.Db).C("service_ar")
+
+	// Insert seed data
+	c.Insert(
+		bson.M{
+			"report":       "eba61a9e-22e9-4521-9e47-ecaa4a49436",
+			"date":         20150622,
+			"name":         "SF01",
+			"supergroup":   "ST01",
+			"up":           0.98264,
+			"down":         0,
+			"unknown":      0,
+			"availability": 98.26389,
+			"reliability":  98.26389,
+			"tags": []bson.M{
+				bson.M{
+					"name":  "production",
+					"value": "Y",
+				},
+			},
+		},
+		bson.M{
+			"report":       "eba61a9e-22e9-4521-9e47-ecaa4a49436",
+			"date":         20150622,
+			"name":         "SF02",
+			"supergroup":   "ST01",
+			"up":           0.96875,
+			"down":         0,
+			"unknown":      0,
+			"availability": 96.875,
+			"reliability":  96.875,
+			"tags": []bson.M{
+				bson.M{
+					"name":  "production",
+					"value": "Y",
+				},
+			},
+		},
+		bson.M{
+			"report":       "eba61a9e-22e9-4521-9e47-ecaa4a49436",
+			"date":         20150622,
+			"name":         "SF03",
+			"supergroup":   "ST02",
+			"up":           0.96875,
+			"down":         0,
+			"unknown":      0,
+			"availability": 96.875,
+			"reliability":  96.875,
+			"tags": []bson.M{
+				bson.M{
+					"name":  "production",
+					"value": "Y",
+				},
+			},
+		},
+		bson.M{
+			"report":       "eba61a9e-22e9-4521-9e47-ecaa4a49436",
+			"date":         20150622,
+			"name":         "SF01",
+			"supergroup":   "ST01",
+			"up":           0.53472,
+			"down":         0.33333,
+			"unknown":      0.01042,
+			"availability": 54.03509,
+			"reliability":  81.48148,
+			"tags": []bson.M{
+				bson.M{
+					"name":  "production",
+					"value": "Y",
+				},
+			},
+		},
+		bson.M{
+			"report":       "eba61a9e-22e9-4521-9e47-ecaa4a49436",
+			"date":         20150622,
+			"name":         "SF02",
+			"supergroup":   "ST01",
+			"up":           1,
+			"down":         0,
+			"unknown":      0,
+			"availability": 100,
+			"reliability":  100,
+			"tags": []bson.M{
+				bson.M{
+					"name":  "production",
+					"value": "Y",
+				},
+			},
+		})
+
+	// Seed database with recomputations
+	c = session.DB(suite.tenantDbConf.Db).C("endpoint_group_ar")
+
+	// Insert seed data
+	c.Insert(
+		bson.M{
+			"report":       "eba61a9e-22e9-4521-9e47-ecaa4a49436",
+			"date":         20150622,
+			"name":         "ST01",
+			"supergroup":   "GROUP_A",
+			"up":           1,
+			"down":         0,
+			"unknown":      0,
+			"availability": 66.7,
+			"reliability":  54.6,
+			"weight":       5634,
+			"tags": []bson.M{
+				bson.M{
+					"name":  "",
+					"value": "",
+				},
+			},
+		},
+		bson.M{
+			"report":       "eba61a9e-22e9-4521-9e47-ecaa4a49436",
+			"date":         20150622,
+			"name":         "ST02",
+			"supergroup":   "GROUP_A",
+			"up":           1,
+			"down":         0,
+			"unknown":      0,
+			"availability": 70,
+			"reliability":  45,
+			"weight":       4356,
+			"tags": []bson.M{
+				bson.M{
+					"name":  "",
+					"value": "",
+				},
+			},
+		},
+		bson.M{
+			"report":       "eba61a9e-22e9-4521-9e47-ecaa4a49436",
+			"date":         20150622,
+			"name":         "ST01",
+			"supergroup":   "GROUP_A",
+			"up":           1,
+			"down":         0,
+			"unknown":      0,
+			"availability": 100,
+			"reliability":  100,
+			"weight":       5634,
+			"tags": []bson.M{
+				bson.M{
+					"name":  "",
+					"value": "",
+				},
+			},
+		},
+		bson.M{
+			"report":       "eba61a9e-22e9-4521-9e47-ecaa4a49436",
+			"date":         20150622,
+			"name":         "ST04",
+			"supergroup":   "GROUP_B",
+			"up":           1,
+			"down":         0,
+			"unknown":      0,
+			"availability": 30,
+			"reliability":  100,
+			"weight":       5344,
+			"tags": []bson.M{
+				bson.M{
+					"name":  "",
+					"value": "",
+				},
+			},
+		},
+		bson.M{
+			"report":       "eba61a9e-22e9-4521-9e47-ecaa4a49436",
+			"date":         20150622,
+			"name":         "ST05",
+			"supergroup":   "GROUP_B",
+			"up":           0,
+			"down":         0,
+			"unknown":      1,
+			"availability": 90,
+			"reliability":  100,
+			"weight":       5634,
+			"tags": []bson.M{
+				bson.M{
+					"name":  "",
+					"value": "",
+				},
+			},
+		},
+		bson.M{
+			"report":       "eba61a9e-22e9-4521-9e47-ecaa4a49436",
+			"date":         20150624,
+			"name":         "ST05",
+			"supergroup":   "GROUP_B",
+			"up":           1,
+			"down":         0,
+			"unknown":      0,
+			"availability": 40,
+			"reliability":  70,
+			"weight":       5634,
+			"tags": []bson.M{
+				bson.M{
+					"name":  "",
+					"value": "",
+				},
+			},
+		},
+		bson.M{
+			"report":       "eba61a9e-22e9-4521-9e47-ecaa4a49436",
+			"date":         20150625,
+			"name":         "ST05",
+			"supergroup":   "GROUP_B",
+			"up":           1,
+			"down":         0,
+			"unknown":      0,
+			"availability": 40,
+			"reliability":  70,
+			"weight":       5634,
+			"tags": []bson.M{
+				bson.M{
+					"name":  "",
+					"value": "",
+				},
+			},
+		},
+		bson.M{
+			"report":       "eba61a9e-22e9-4521-9e47-ecaa4a49436",
+			"date":         20150622,
+			"name":         "ST02",
+			"supergroup":   "GROUP_A",
+			"up":           1,
+			"down":         0,
+			"unknown":      0,
+			"availability": 43.5,
+			"reliability":  56,
+			"weight":       4356,
+			"tags": []bson.M{
+				bson.M{
+					"name":  "",
+					"value": "",
+				},
+			},
+		})
+	c = session.DB(suite.tenantDbConf.Db).C("reports")
+
+	c.Insert(bson.M{
+		"id": "eba61a9e-22e9-4521-9e47-ecaa4a49436",
+		"info": bson.M{
+			"name":        "Critical",
+			"description": "lalalallala",
+		},
+		"topology_schema": bson.M{
+			"group": bson.M{
+				"type": "GROUP",
+				"group": bson.M{
+					"type": "SITE",
+				},
+			},
+		},
+		"profiles": []bson.M{
+			bson.M{
+				"type": "metric",
+				"name": "ch.cern.SAM.ROC_CRITICAL"},
+		},
+		"filter_tags": []bson.M{
+			bson.M{
+				"name":  "name1",
+				"value": "value1"},
+			bson.M{
+				"name":  "name2",
+				"value": "value2"},
+		}})
+}
+
+// TestListServiceFlavorAvailabilityMonthly tests if daily results are returned correctly
+func (suite *topologyTestSuite) TestListServiceFlavorAvailabilityMonthly() {
+
+	expJSON := `{
+ "status": {
+  "message": "application/json",
+  "code": "200"
+ },
+ "data": {
+  "group_count": 2,
+  "group_type": "GROUP",
+  "group_list": [
+   "GROUP_A",
+   "GROUP_B"
+  ],
+  "endpoint_group_count": 4,
+  "endpoint_group_type": "SITE",
+  "endpoint_group_list": [
+   "ST01",
+   "ST02",
+   "ST04",
+   "ST05"
+  ],
+  "service_count": 3,
+  "service_list": [
+   "SF01",
+   "SF02",
+   "SF03"
+  ]
+ }
+}`
+
+	request, _ := http.NewRequest("GET", "/api/v2/topology/Critical?date=2015-06-22", strings.NewReader(""))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+	responseBody := response.Body.String()
+
+	// Check that we must have a 200 ok code
+	suite.Equal(200, response.Code, "Incorrect HTTP response code")
+	// Compare the expected and actual xml response
+	suite.Equal(expJSON, responseBody, "Response body mismatch")
+
+}
+
+//TearDownTest to tear down every test
+func (suite *topologyTestSuite) TearDownTest() {
+
+	session, err := mgo.Dial(suite.cfg.MongoDB.Host)
+	if err != nil {
+		panic(err)
+	}
+
+	tenantDB := session.DB(suite.tenantDbConf.Db)
+	mainDB := session.DB(suite.cfg.MongoDB.Db)
+
+	cols, err := tenantDB.CollectionNames()
+	for _, col := range cols {
+		tenantDB.C(col).RemoveAll(nil)
+	}
+
+	cols, err = mainDB.CollectionNames()
+	for _, col := range cols {
+		mainDB.C(col).RemoveAll(nil)
+	}
+
+}
+
+//TearDownTest to tear down every test
+func (suite *topologyTestSuite) TearDownSuite() {
+
+	session, err := mgo.Dial(suite.cfg.MongoDB.Host)
+	if err != nil {
+		panic(err)
+	}
+	session.DB(suite.tenantDbConf.Db).DropDatabase()
+	session.DB(suite.cfg.MongoDB.Db).DropDatabase()
+}
+
+// TestTopologyTestSuite is responsible for calling the tests
+func TestTopologyTestSuite(t *testing.T) {
+	suite.Run(t, new(topologyTestSuite))
+}

--- a/app/topology/view.go
+++ b/app/topology/view.go
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2018 GRNET S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS
+ * IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ *
+ * The views and conclusions contained in the software and
+ * documentation are those of the authors and should not be
+ * interpreted as representing official policies, either expressed
+ * or implied, of GRNET S.A.
+ *
+ */
+
+package topology
+
+import (
+	"encoding/json"
+	"strconv"
+
+	"github.com/ARGOeu/argo-web-api/respond"
+)
+
+func createTopoView(results Topology, msg string, code int) ([]byte, error) {
+
+	docRoot := &respond.ResponseMessage{
+		Status: respond.StatusResponse{
+			Message: msg,
+			Code:    strconv.Itoa(code),
+		},
+	}
+	docRoot.Data = results
+
+	output, err := json.MarshalIndent(docRoot, "", " ")
+	return output, err
+
+}
+
+func createMessageOUT(message string, code int, format string) ([]byte, error) {
+
+	output := []byte("message placeholder")
+	err := error(nil)
+	docRoot := &messageOUT{}
+
+	docRoot.Message = message
+	docRoot.Code = strconv.Itoa(code)
+	output, err = respond.MarshalContent(docRoot, format, "", " ")
+	return output, err
+}

--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -1305,6 +1305,36 @@ paths:
           schema:
             $ref: '#/definitions/Status_error'
 
+  /topology/{report_name}:
+    get:
+      summary: "List topology statistics for a specific report"
+      description: "This request lists number of groups and services contained in the report"
+      operationId: topology
+      tags:
+        - Topology
+      produces:
+        - "application/json"
+      parameters:
+        - $ref: "#/parameters/apiKey"
+        - $ref: "#/parameters/reportName"
+        - $ref: "#/parameters/topoDate"
+
+      responses:
+        200:
+          description: "Successful retrieval of latest metric data"
+          schema:
+            $ref: "#/definitions/TopologyResponse"
+        400:
+          $ref: "#/responses/404"
+        401:
+          $ref: "#/responses/Unauthorized"
+        406:
+          $ref: "#/responses/406"
+        422:
+          $ref: "#/responses/422"
+        500:
+          $ref: "#/responses/ServerError"
+
   /latest/{report_name}/{lgroup_type}:
     get:
       summary: "List latest metric data for available in a specific report"
@@ -1314,7 +1344,6 @@ paths:
         - Latest
       produces:
         - "application/json"
-        - "application/xml"
       parameters:
         - $ref: "#/parameters/apiKey"
         - $ref: "#/parameters/reportName"
@@ -1350,7 +1379,6 @@ paths:
         - Latest
       produces:
         - "application/json"
-        - "application/xml"
       parameters:
         - $ref: "#/parameters/apiKey"
         - $ref: "#/parameters/reportName"
@@ -2077,6 +2105,12 @@ paths:
             $ref: '#/definitions/Status_error'
 
 parameters:
+  topoDate:
+    name: "date"
+    in: "query"
+    type: string
+    description: "target day to get latest topology statistics"
+    default: todays_date in YYYY-MM-DD format
   latestDate:
     name: "date"
     in: "query"
@@ -2341,6 +2375,8 @@ definitions:
                     type: string
                   results:
                     $ref: "#/definitions/results"
+
+
 
   StatusEndpointResponse:
     type: object
@@ -2898,6 +2934,32 @@ definitions:
               type: string
             context:
               type: string
+
+  TopologyResponse:
+    type: object
+    properties:
+      group_count:
+        type: integer
+      group_type:
+        type: string
+      group_list:
+        type: array
+        items:
+          type: string
+      endpoint_group_count:
+        type: integer
+      endpoint_group_type:
+        type: string
+      endpoint_group_list:
+        type: array
+        items:
+          type: string
+      service_count:
+        type: integer
+      service_list:
+        type: array
+        items:
+          type: string
 
   Tenant_list:
     type: object

--- a/doc/v2/docs/topology.md
+++ b/doc/v2/docs/topology.md
@@ -1,0 +1,121 @@
+#Topology Statistics
+
+API calls for retrieving topology statistics per report
+
+| Name  | Description | Shortcut |
+|-------|-------------|----------|
+| GET: List topology statistics | List number of groups, endpoint groups and services .|<a href="#1">Description</a>|
+
+
+<a id="1"></a>
+
+## [GET]: List topology statistics
+
+This method may be used to retrieve topology statistics for a specific report. Topology statistics include number of groups, endpoint groups and services included in the report
+
+### Input
+##### List All latest metric data
+```
+/topology/{report}/?[date]
+```
+
+
+#### Path Parameters
+| Type | Description | Required | Default value |
+|------|-------------|----------|---------------|
+|`report`| name of the report used | YES | |
+
+#### Url Parameters
+
+| Type | Description | Required | Default value |
+|------|-------------|----------|---------------|
+|`date`|  target a specific data | NO | today's date |
+
+
+#### Headers
+```
+x-api-key: secret_key_value
+Accept: application/json
+```
+
+#### Response Code
+```
+Status: 200 OK
+```
+
+### Response body
+```json
+{
+    "status": {
+        "message": "application/json",
+        "code": "200"
+    },
+    "data": {
+        "group_count": 1,
+        "group_type": "type of top-level groups in report",
+        "group_list": [
+          "list of top level groups"
+        ],
+        "endpoint_group_count": 1,
+        "endpoint_group_type": "type of endpoint groups in report",
+        "endpoint_group_list": [
+        "list of endpoint groups"
+        ],
+        "service_count": 1,
+        "service_list": [
+          "list of available services"
+        ]
+    }
+}
+```
+
+###### Example Request:
+URL:
+```
+latest/Report_B/?date=2015-05-01
+```
+Headers:
+```
+x-api-key: secret_key_value
+Accept: application/json
+```
+###### Example Response:
+Code:
+```
+Status: 200 OK
+```
+Response body:
+```json
+{
+    "status": {
+        "message": "application/json",
+        "code": "200"
+    },
+    "data": {
+        "group_count": 2,
+        "group_type": "PROJECTS",
+        "group_list": [
+            "PROJECT_A",
+            "PROJECT_B"
+        ],
+        "endpoint_group_count": 3,
+        "endpoint_group_type": "SERVICEGROUPS",
+        "endpoint_group_list": [
+          "SGROUP_A",
+          "SGROUP_B",
+          "SGROUP_C"
+        ],
+        "service_count": 8,
+        "service_list": [
+            "service_type_1",
+            "service_type_2",
+            "service_type_3",
+            "service_type_4",
+            "service_type_5",
+            "service_type_6",
+            "service_type_7",
+            "service_type_8"
+        ]
+    }
+}
+```

--- a/doc/v2/mkdocs.yml
+++ b/doc/v2/mkdocs.yml
@@ -18,5 +18,7 @@ pages:
   - Error Codes: errors.md
   - Validation Checks: validations.md
   - Metrics: metrics.md
+  - Latest results: latest.md
+  - Topology statistics: topology.md
 
 theme: readthedocs

--- a/routing/routes.go
+++ b/routing/routes.go
@@ -38,9 +38,11 @@ import (
 	"github.com/ARGOeu/argo-web-api/app/statusServices"
 	"github.com/ARGOeu/argo-web-api/app/tenants"
 	"github.com/ARGOeu/argo-web-api/app/thresholdsProfiles"
+	"github.com/ARGOeu/argo-web-api/app/topology"
 )
 
 var routesV2 = []RouteV2{
+	{"Topology", "/topology", topology.HandleSubrouter},
 	{"Latest", "/latest", latest.HandleSubrouter},
 	{"Results", "/results", results.HandleSubrouter},
 	{"Metric Result", "/metric_result", metricResult.HandleSubrouter},

--- a/scripts/mongodb/populate_default_roles.js
+++ b/scripts/mongodb/populate_default_roles.js
@@ -20,6 +20,7 @@ function populate_default_roles()
   db = db.getSiblingDB('argo_core')
   print("INFO\tOpened argo_core db")
   db.roles.insert([
+  {"resource" : "topology.list", "roles": ["admin", "editor", "viewer"]},
   {"resource" : "latest.get", "roles": ["admin", "editor", "viewer"]},
   {"resource" : "reports.get", "roles" : [ "admin", "editor","viewer"] },
   {"resource" : "reports.list", "roles" : [ "admin", "editor","viewer" ]},


### PR DESCRIPTION
# Task 
Per report, serve topology details for groups, services included in the report 

# Implementation
Implement the following method with request signature 
`GET /api/v2/topology/{report_name}?date=2018-06-02`

which responds with in the following style:
```
```json
{
    "status": {
        "message": "application/json",
        "code": "200"
    },
    "data": {
        "group_count": 2,
        "group_type": "PROJECTS",
        "group_list": [
            "PROJECT_A",
            "PROJECT_B"
        ],
        "endpoint_group_count": 3,
        "endpoint_group_type": "SERVICEGROUPS",
        "endpoint_group_list": [
          "SGROUP_A",
          "SGROUP_B",
          "SGROUP_C"
        ],
        "service_count": 8,
        "service_list": [
            "service_type_1",
            "service_type_2",
            "service_type_3",
            "service_type_4",
            "service_type_5",
            "service_type_6",
            "service_type_7",
            "service_type_8"
        ]
    }
}
```
which includes 
- count numbers for groups, endpoint groups and services
- types of groups and endpoint groups as defined in report
- the raw list with all the available items on the report

- [x] Implemented topology package
- [x] Updated routing with topology route
- [x] Added unit tests
- [x] Updated swagger
- [x] Updated mkdocs