### PR TITLE
ARGO-1435 Fix configuration_profile json field in tenant status call

### DIFF
--- a/app/tenants/model.go
+++ b/app/tenants/model.go
@@ -61,7 +61,7 @@ type DetailsHDFS struct {
 type SyncDataHDFS struct {
 	AggregationProf bool `bson:"aggregation_profile" json:"aggregation_profile"`
 	Recomp          bool `bson:"blank_recomputation" json:"blank_recomputation"`
-	ConfigProf      bool `bson:"configuration_profile" json: "configuration_profile"`
+	ConfigProf      bool `bson:"configuration_profile" json:"configuration_profile"`
 	Donwtimes       bool `bson:"downtimes" json:"downtimes"`
 	GroupEndpoints  bool `bson:"group_endpoints" json:"group_endpoints"`
 	GroupGroups     bool `bson:"group_groups" json:"group_groups"`

--- a/app/tenants/tenants_test.go
+++ b/app/tenants/tenants_test.go
@@ -726,7 +726,7 @@ func (suite *TenantTestSuite) TestUpdateTenantStatus() {
       "Critical": {
        "aggregation_profile": true,
        "blank_recomputation": false,
-       "ConfigProf": false,
+       "configuration_profile": false,
        "downtimes": true,
        "group_endpoints": true,
        "group_groups": true,


### PR DESCRIPTION
Fix annotation typo so the json field is exported as `configuration_profile` and not as `ConfigProf`