### PR TITLE
ARGO-1438 Implement tenant general status

### DIFF
--- a/app/tenants/controller.go
+++ b/app/tenants/controller.go
@@ -48,6 +48,67 @@ func isAdminRestricted(roles []string) bool {
 	return len(roles) > 0 && roles[0] == "super_admin_restricted"
 }
 
+// Provides a global tenant status (true/false) based on tenant's status details
+func calcTotalStatus(details StatusDetail) bool {
+	// Check first tenant configuration in argo-engine
+	if details.EngineConfig == false {
+		return false
+	}
+	// Check tenant configuration statuses regarding AMS service
+	if details.AMS.MetricData.Ingestion == false {
+		return false
+	}
+	if details.AMS.MetricData.Publishing == false {
+		return false
+	}
+	if details.AMS.MetricData.StatusStreaming == false {
+		return false
+	}
+	if details.AMS.SyncData.Ingestion == false {
+		return false
+	}
+	if details.AMS.SyncData.Publishing == false {
+		return false
+	}
+	if details.AMS.SyncData.StatusStreaming == false {
+		return false
+	}
+	// Check tenant configuration statuses regarding HDFS
+	if details.HDFS.MetricData == false {
+		return false
+	}
+	for _, item := range details.HDFS.SyncData {
+		if item.AggregationProf == false {
+			return false
+		}
+		if item.ConfigProf == false {
+			return false
+		}
+		if item.Donwtimes == false {
+			return false
+		}
+		if item.GroupEndpoints == false {
+			return false
+		}
+		if item.GroupGroups == false {
+			return false
+		}
+		if item.MetricProf == false {
+			return false
+		}
+		if item.OpsProf == false {
+			return false
+		}
+		if item.Recomp == false {
+			return false
+		}
+		if item.Weight == false {
+			return false
+		}
+	}
+	return true
+}
+
 func restrictTenantOutput(results []Tenant) []Tenant {
 	restricted := []Tenant{}
 	for _, tenant := range results {
@@ -237,6 +298,8 @@ func ListStatus(r *http.Request, cfg config.Config) (int, http.Header, []byte, e
 		code = http.StatusNotFound
 		return code, h, output, err
 	}
+
+	results[0].Status.TotalStatus = calcTotalStatus(results[0].Status)
 
 	// After successfully retrieving the db results
 	// call the createView function to render them into idented xml

--- a/app/tenants/model.go
+++ b/app/tenants/model.go
@@ -42,6 +42,7 @@ type TenantStatus struct {
 }
 
 type StatusDetail struct {
+	TotalStatus  bool        `json:"total_status"`
 	AMS          DetailsAMS  `bson:"ams" json:"ams"`
 	HDFS         DetailsHDFS `bson:"hdfs" json:"hdfs"`
 	EngineConfig bool        `bson:"engine_config" json:"engine_config"`

--- a/app/tenants/tenants_test.go
+++ b/app/tenants/tenants_test.go
@@ -651,12 +651,12 @@ func (suite *TenantTestSuite) TestUpdateTenantStatus() {
           "metric_data": {
               "ingestion": true,
               "publishing": true,
-              "status_streaming": false,
+              "status_streaming": true,
               "messages_arrived": 100
           },
           "sync_data": {
               "ingestion": true,
-              "publishing": false,
+              "publishing": true,
               "status_streaming": true,
               "messages_arrived": 200
           }
@@ -667,7 +667,8 @@ func (suite *TenantTestSuite) TestUpdateTenantStatus() {
           	"Critical": {
           			"downtimes": true,
           			"group_endpoints": true,
-          			"blank_recompuation": true,
+          			"blank_recomputation": true,
+								"configuration_profile": true,
           			"group_groups": true,
           			"weights": true,
           			"operations_profile": true,
@@ -706,16 +707,17 @@ func (suite *TenantTestSuite) TestUpdateTenantStatus() {
     "updated": "2015-10-20 02:08:04"
    },
    "status": {
+    "total_status": true,
     "ams": {
      "metric_data": {
       "ingestion": true,
       "publishing": true,
-      "status_streaming": false,
+      "status_streaming": true,
       "messages_arrived": 100
      },
      "sync_data": {
       "ingestion": true,
-      "publishing": false,
+      "publishing": true,
       "status_streaming": true,
       "messages_arrived": 200
      }
@@ -725,8 +727,8 @@ func (suite *TenantTestSuite) TestUpdateTenantStatus() {
      "sync_data": {
       "Critical": {
        "aggregation_profile": true,
-       "blank_recomputation": false,
-       "configuration_profile": false,
+       "blank_recomputation": true,
+       "configuration_profile": true,
        "downtimes": true,
        "group_endpoints": true,
        "group_groups": true,
@@ -769,7 +771,6 @@ func (suite *TenantTestSuite) TestUpdateTenantStatus() {
 
 	suite.Equal(200, code2, "Wrong code in response")
 	suite.Equal(jsonUpdatedTenant, output2, "Response body mismatch")
-
 }
 
 // TestUpdateTenant function implements testing the http PUT update tenant request.
@@ -1268,6 +1269,7 @@ func (suite *TenantTestSuite) TestListTenantStatus() {
     "updated": "2015-10-20 02:08:04"
    },
    "status": {
+    "total_status": false,
     "ams": {
      "metric_data": {
       "ingestion": false,

--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -2744,6 +2744,8 @@ definitions:
   Tenant_status:
     type: object
     properties:
+      total_status:
+        type: boolean
       ams:
         type: object
         properties:

--- a/doc/v2/docs/tenants.md
+++ b/doc/v2/docs/tenants.md
@@ -509,6 +509,7 @@ Json Response
   "updated": "2015-10-20 02:08:04"
  },
  "status": {
+  "total_status": false,
   "ams": {
    "metric_data": {
     "ingestion": false,


### PR DESCRIPTION
# Goal 
admin/tenant/status request returns a detailed json about tenant's status in argo engine but instead of iterating through numerous fields, we need a quick boolean field to show us that everything is ok. 
`total_status` boolean field is added in the json body which is calculated on the fly from the values of the other specific status fields

example:
```json
"status": {
  "total_status": false,
  "ams": {
   "metric_data": {
    "ingestion": false,
    "publishing": false,
    "status_streaming": false,
    "messages_arrived": 0
   },
...
}
```
# Implementation
- Add TotalStatus field in tenant.StatusDetail structure
- Implement tenants.calcTotallStatus() 
- Refactor tenants.ListStatus() handler to use calcTotalStatus() method
- Update unit tests (add example with both false/true general statuses)
- Update swagger
- Update Docs

