### PR TITLE
ARGO-1680 serve endpoint a/r results

### DIFF
--- a/app/results/Controller.go
+++ b/app/results/Controller.go
@@ -35,6 +35,215 @@ import (
 	"gopkg.in/mgo.v2/bson"
 )
 
+// ListEndpointResults is responsible for handling request to list service flavor results
+func ListEndpointResults(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
+	//STANDARD DECLARATIONS START
+	code := http.StatusOK
+	h := http.Header{}
+	output := []byte("")
+	err := error(nil)
+	charset := "utf-8"
+	//STANDARD DECLARATIONS END
+
+	// Set Content-Type response Header value
+	contentType := r.Header.Get("Accept")
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+
+	// Parse the request into the input
+	urlValues := r.URL.Query()
+	vars := mux.Vars(r)
+
+	// Grab Tenant DB configuration from context
+	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
+
+	session, err := mongo.OpenSession(tenantDbConfig)
+	defer mongo.CloseSession(session)
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	report := reports.MongoInterface{}
+	err = mongo.FindOne(session, tenantDbConfig.Db, "reports", bson.M{"info.name": vars["report_name"]}, &report)
+
+	if err != nil {
+		code = http.StatusNotFound
+		message := "The report with the name " + vars["report_name"] + " does not exist"
+		output, err := createErrorMessage(message, code, contentType) //Render the response into XML or JSON
+		return code, h, output, err
+	}
+
+	input := endpointResultQuery{
+		basicQuery: basicQuery{
+			Name: vars["endpoint_name"],
+
+			Granularity: urlValues.Get("granularity"),
+			Format:      contentType,
+			StartTime:   urlValues.Get("start_time"),
+			EndTime:     urlValues.Get("end_time"),
+			Report:      report,
+			Vars:        vars,
+		},
+		EndpointGroup: vars["lgroup_name"],
+		Service:       vars["service_type"],
+	}
+
+	tenantDB := session.DB(tenantDbConfig.Db)
+	errs := input.Validate(tenantDB)
+	if len(errs) > 0 {
+		out := respond.BadRequestSimple
+		out.Errors = errs
+		output = out.MarshalTo(contentType)
+		code = 400
+		return code, h, output, err
+	}
+
+	if vars["lgroup_type"] != report.GetEndpointGroupType() {
+		code = http.StatusNotFound
+		message := "The report " + vars["report_name"] + " does not define endpoint group type: " + vars["lgroup_type"] + ". Try using " + report.GetEndpointGroupType() + " instead."
+		output, err := createErrorMessage(message, code, contentType) //Render the response into XML or JSON
+		return code, h, output, err
+	}
+
+	results := []EndpointInterface{}
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	// Construct the query to mongodb based on the input
+	filter := bson.M{
+		"date":   bson.M{"$gte": input.StartTimeInt, "$lte": input.EndTimeInt},
+		"report": report.ID,
+	}
+
+	if input.Name != "" {
+		filter["name"] = input.Name
+	}
+
+	if input.EndpointGroup != "" {
+		filter["supergroup"] = input.EndpointGroup
+	}
+
+	if input.Service != "" {
+		filter["service"] = input.Service
+	}
+
+	// Select the granularity of the search daily/monthly
+	if input.Granularity == "daily" {
+		customForm[0] = "20060102"
+		customForm[1] = "2006-01-02"
+		query := DailyEndpoint(filter)
+		err = mongo.Pipe(session, tenantDbConfig.Db, "endpoint_ar", query, &results)
+	} else if input.Granularity == "monthly" {
+		customForm[0] = "200601"
+		customForm[1] = "2006-01"
+		query := MonthlyEndpoint(filter)
+		err = mongo.Pipe(session, tenantDbConfig.Db, "endpoint_ar", query, &results)
+	}
+
+	// mongo.Find(session, tenantDbConfig.Db, "endpoint_group_ar", bson.M{}, "_id", &results)
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	if len(results) == 0 {
+		code = http.StatusNotFound
+		message := "No results found for given query"
+		output, err = createErrorMessage(message, code, contentType)
+		return code, h, output, err
+	}
+
+	output, err = createEndpointResultView(results, report, input.Format)
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	return code, h, output, err
+
+}
+
+// DailyEndpoint query to aggregate daily endpoint a/r results from mongoDB
+func DailyEndpoint(filter bson.M) []bson.M {
+	query := []bson.M{
+		{"$match": filter},
+		{"$group": bson.M{
+			"_id": bson.M{
+				"date":         bson.D{{"$substr", list{"$date", 0, 8}}},
+				"name":         "$name",
+				"supergroup":   "$supergroup",
+				"service":      "$service",
+				"availability": "$availability",
+				"reliability":  "$reliability",
+				"unknown":      "$unknown",
+				"up":           "$up",
+				"down":         "$down",
+				"report":       "$report"}}},
+		{"$project": bson.M{
+			"date":         "$_id.date",
+			"name":         "$_id.name",
+			"availability": "$_id.availability",
+			"reliability":  "$_id.reliability",
+			"unknown":      "$_id.unknown",
+			"up":           "$_id.up",
+			"down":         "$_id.down",
+			"supergroup":   "$_id.supergroup",
+			"service":      "$_id.service",
+			"report":       "$_id.report"}},
+		{"$sort": bson.D{
+			{"supergroup", 1},
+			{"service", 1},
+			{"name", 1},
+			{"date", 1}}}}
+
+	return query
+}
+
+// MonthlyEndpoint query to aggregate monthly a/r results from mongoDB
+func MonthlyEndpoint(filter bson.M) []bson.M {
+	query := []bson.M{
+		{"$match": filter},
+		{"$group": bson.M{
+			"_id": bson.M{
+				"date":       bson.D{{"$substr", list{"$date", 0, 6}}},
+				"name":       "$name",
+				"supergroup": "$supergroup",
+				"service":    "$service",
+				"report":     "$report"},
+			"avgup":      bson.M{"$avg": "$up"},
+			"avgunknown": bson.M{"$avg": "$unknown"},
+			"avgdown":    bson.M{"$avg": "$down"}}},
+		{"$project": bson.M{
+			"date":       "$_id.date",
+			"name":       "$_id.name",
+			"supergroup": "$_id.supergroup",
+			"service":    "$_id.service",
+			"report":     "$_id.report",
+			"unknown":    "$avgunknown",
+			"up":         "$avgup",
+			"down":       "$avgdown",
+			"availability": bson.M{
+				"$multiply": list{
+					bson.M{"$divide": list{
+						"$avgup", bson.M{"$subtract": list{1.00000001, "$avgunknown"}}}},
+					100}},
+			"reliability": bson.M{
+				"$multiply": list{
+					bson.M{"$divide": list{
+						"$avgup", bson.M{"$subtract": list{bson.M{"$subtract": list{1.00000001, "$avgunknown"}}, "$avgdown"}}}},
+					100}}}},
+		{"$sort": bson.D{
+			{"supergroup", 1},
+			{"name", 1},
+			{"date", 1}}}}
+	return query
+}
+
 // ListServiceFlavorResults is responsible for handling request to list service flavor results
 func ListServiceFlavorResults(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
 	//STANDARD DECLARATIONS START

--- a/app/results/Model.go
+++ b/app/results/Model.go
@@ -67,6 +67,12 @@ type endpointGroupResultQuery struct {
 	Group string `bson:"supergroup"`
 }
 
+type endpointResultQuery struct {
+	basicQuery
+	EndpointGroup string `bson:"supergroup"`
+	Service       string `bson:"service"`
+}
+
 // ReportInterface for mongodb object exchanging
 // type ReportInterface struct {
 // 	Name              string `bson:"name"`
@@ -74,6 +80,21 @@ type endpointGroupResultQuery struct {
 // 	EndpointGroupType string `bson:"endpoint_group"`
 // 	SuperGroupType    string `bson:"group_of_groups"`
 // }
+
+//EndpointInterface for mongodb object exchanging
+type EndpointInterface struct {
+	Name         string  `bson:"name"`
+	Report       string  `bson:"report"`
+	Date         string  `bson:"date"`
+	Type         string  `bson:"type"`
+	Up           float64 `bson:"up"`
+	Down         float64 `bson:"down"`
+	Unknown      float64 `bson:"unknown"`
+	Availability float64 `bson:"availability"`
+	Reliability  float64 `bson:"reliability"`
+	SuperGroup   string  `bson:"supergroup"`
+	Service      string  `bson:"service"`
+}
 
 // ServiceFlavorInterface for mongodb object exchanging
 type ServiceFlavorInterface struct {
@@ -127,6 +148,22 @@ type Availability struct {
 	Unknown      string   `xml:"unknown,attr,omitempty" json:"unknown,omitempty"`
 	Uptime       string   `xml:"uptime,attr,omitempty" json:"uptime,omitempty"`
 	Downtime     string   `xml:"downtime,attr,omitempty" json:"downtime,omitempty"`
+}
+
+// ServuceEndpointGroup struct listing included endpoints in a service for formating xml/json
+type ServiceEndpointGroup struct {
+	XMLName   xml.Name      `xml:"group" json:"-"`
+	Name      string        `xml:"name,attr" json:"name"`
+	Type      string        `xml:"type,attr" json:"type"`
+	Endpoints []interface{} `json:"endpoints"`
+}
+
+// Endpoint A/R struct for formating xml/json
+type Endpoint struct {
+	XMLName      xml.Name      `xml:"group" json:"-"`
+	Name         string        `xml:"name,attr" json:"name"`
+	Type         string        `xml:"type,attr" json:"type"`
+	Availability []interface{} `json:"results"`
 }
 
 // ServiceFlavor struct for formating xml/json

--- a/app/results/endpoint_test.go
+++ b/app/results/endpoint_test.go
@@ -1,0 +1,734 @@
+/*
+ * Copyright (c) 2015 GRNET S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS
+ * IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ *
+ * The views and conclusions contained in the software and
+ * documentation are those of the authors and should not be
+ * interpreted as representing official policies, either expressed
+ * or implied, of GRNET S.A.
+ *
+ */
+
+package results
+
+import (
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/ARGOeu/argo-web-api/respond"
+	"github.com/ARGOeu/argo-web-api/utils/config"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/suite"
+	"gopkg.in/gcfg.v1"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+)
+
+type endpointAvailabilityTestSuite struct {
+	suite.Suite
+	cfg             config.Config
+	router          *mux.Router
+	confHandler     respond.ConfHandler
+	tenantDbConf    config.MongoConfig
+	tenantpassword  string
+	tenantusername  string
+	tenantstorename string
+	clientkey       string
+}
+
+// Setup the Test Environment
+func (suite *endpointAvailabilityTestSuite) SetupSuite() {
+
+	const testConfig = `
+	 [server]
+	 bindip = ""
+	 port = 8080
+	 maxprocs = 4
+	 cache = false
+	 lrucache = 700000000
+	 gzip = true
+	 [mongodb]
+	 host = "127.0.0.1"
+	 port = 27017
+	 db = "ARGO_test_endpoint_availability"
+	 `
+
+	_ = gcfg.ReadStringInto(&suite.cfg, testConfig)
+
+	suite.tenantDbConf.Db = "ARGO_test_endpoint_availability_tenant"
+	suite.tenantDbConf.Password = "h4shp4ss"
+	suite.tenantDbConf.Username = "dbuser"
+	suite.tenantDbConf.Store = "ar"
+	suite.clientkey = "secretkey"
+
+	// Create router and confhandler for test
+	suite.confHandler = respond.ConfHandler{suite.cfg}
+	suite.router = mux.NewRouter().StrictSlash(false).PathPrefix("/api/v2/results").Subrouter()
+	HandleSubrouter(suite.router, &suite.confHandler)
+}
+
+// This function runs before any test and setups the environment
+func (suite *endpointAvailabilityTestSuite) SetupTest() {
+
+	log.SetOutput(ioutil.Discard)
+
+	// seed mongo
+	session, err := mgo.Dial(suite.cfg.MongoDB.Host)
+	if err != nil {
+		panic(err)
+	}
+	defer session.Close()
+
+	// Seed database with tenants
+	//TODO: move tests to
+	c := session.DB(suite.cfg.MongoDB.Db).C("tenants")
+	c.Insert(
+		bson.M{"name": "Westeros",
+			"db_conf": []bson.M{
+
+				bson.M{
+					"server":   "localhost",
+					"port":     27017,
+					"database": "argo_Westeros1",
+				},
+				bson.M{
+					"server":   "localhost",
+					"port":     27017,
+					"database": "argo_Westeros2",
+				},
+			},
+			"users": []bson.M{
+
+				bson.M{
+					"name":    "John Snow",
+					"email":   "J.Snow@brothers.wall",
+					"api_key": "wh1t3_w@lk3rs",
+					"roles":   []string{"viewer"},
+				},
+				bson.M{
+					"name":    "King Joffrey",
+					"email":   "g0dk1ng@kingslanding.gov",
+					"api_key": "sansa <3",
+					"roles":   []string{"viewer"},
+				},
+			}})
+	c.Insert(
+		bson.M{"name": "EGI",
+			"db_conf": []bson.M{
+
+				bson.M{
+					"server":   "localhost",
+					"port":     27017,
+					"database": suite.tenantDbConf.Db,
+					"username": suite.tenantDbConf.Username,
+					"password": suite.tenantDbConf.Password,
+				},
+				bson.M{
+					"server":   "localhost",
+					"port":     27017,
+					"database": "argo_wrong_db_serviceflavoravailability",
+				},
+			},
+			"users": []bson.M{
+
+				bson.M{
+					"name":    "Joe Complex",
+					"email":   "C.Joe@egi.eu",
+					"api_key": suite.clientkey,
+					"roles":   []string{"viewer"},
+				},
+				bson.M{
+					"name":    "Josh Plain",
+					"email":   "P.Josh@egi.eu",
+					"api_key": "itsamysterytoyou",
+					"roles":   []string{"viewer"},
+				},
+			}})
+
+	c = session.DB(suite.cfg.MongoDB.Db).C("roles")
+	c.Insert(
+		bson.M{
+			"resource": "results.list",
+			"roles":    []string{"editor", "viewer"},
+		})
+	c.Insert(
+		bson.M{
+			"resource": "results.get",
+			"roles":    []string{"editor", "viewer"},
+		})
+
+	c = session.DB(suite.tenantDbConf.Db).C("endpoint_ar")
+
+	// Insert seed data
+	c.Insert(
+		bson.M{
+			"report":       "eba61a9e-22e9-4521-9e47-ecaa4a49436",
+			"date":         20150622,
+			"name":         "e01",
+			"supergroup":   "ST01",
+			"service":      "service_a",
+			"up":           0.98264,
+			"down":         0,
+			"unknown":      0,
+			"availability": 98.26389,
+			"reliability":  98.26389,
+			"tags": []bson.M{
+				bson.M{
+					"name":  "production",
+					"value": "Y",
+				},
+			},
+		},
+		bson.M{
+			"report":       "eba61a9e-22e9-4521-9e47-ecaa4a49436",
+			"date":         20150622,
+			"name":         "e02",
+			"supergroup":   "ST01",
+			"service":      "service_a",
+			"up":           0.96875,
+			"down":         0,
+			"unknown":      0,
+			"availability": 96.875,
+			"reliability":  96.875,
+			"tags": []bson.M{
+				bson.M{
+					"name":  "production",
+					"value": "Y",
+				},
+			},
+		},
+		bson.M{
+			"report":       "eba61a9e-22e9-4521-9e47-ecaa4a49436",
+			"date":         20150622,
+			"name":         "e03",
+			"supergroup":   "ST02",
+			"service":      "service_b",
+			"up":           0.96875,
+			"down":         0,
+			"unknown":      0,
+			"availability": 96.875,
+			"reliability":  96.875,
+			"tags": []bson.M{
+				bson.M{
+					"name":  "production",
+					"value": "Y",
+				},
+			},
+		},
+		bson.M{
+			"report":       "eba61a9e-22e9-4521-9e47-ecaa4a49436",
+			"date":         20150623,
+			"name":         "e01",
+			"supergroup":   "ST01",
+			"service":      "service_a",
+			"up":           0.53472,
+			"down":         0.33333,
+			"unknown":      0.01042,
+			"availability": 54.03509,
+			"reliability":  81.48148,
+			"tags": []bson.M{
+				bson.M{
+					"name":  "production",
+					"value": "Y",
+				},
+			},
+		},
+		bson.M{
+			"report":       "eba61a9e-22e9-4521-9e47-ecaa4a49436",
+			"date":         20150623,
+			"name":         "e02",
+			"supergroup":   "ST01",
+			"service":      "service_a",
+			"up":           1,
+			"down":         0,
+			"unknown":      0,
+			"availability": 100,
+			"reliability":  100,
+			"tags": []bson.M{
+				bson.M{
+					"name":  "production",
+					"value": "Y",
+				},
+			},
+		})
+
+	c = session.DB(suite.tenantDbConf.Db).C("reports")
+
+	c.Insert(bson.M{
+		"id": "eba61a9e-22e9-4521-9e47-ecaa4a49436",
+		"info": bson.M{
+			"name":        "Report_A",
+			"description": "lalalallala",
+		},
+		"topology_schema": bson.M{
+			"group": bson.M{
+				"type": "GROUP",
+				"group": bson.M{
+					"type": "SITE",
+				},
+			},
+		},
+		"profiles": []bson.M{
+			bson.M{
+				"type": "metric",
+				"name": "ch.cern.SAM.ROC_CRITICAL"},
+		},
+		"filter_tags": []bson.M{
+			bson.M{
+				"name":  "name1",
+				"value": "value1"},
+			bson.M{
+				"name":  "name2",
+				"value": "value2"},
+		}})
+}
+
+// TestListEndpointAvailabilityMonthly tests if monthly results are returned correctly
+func (suite *endpointAvailabilityTestSuite) TestListEndpointAvailabilityMonthly() {
+
+	request, _ := http.NewRequest("GET", "/api/v2/results/Report_A/SITE/ST01/services/service_a/endpoints?start_time=2015-06-22T00:00:00Z&end_time=2015-06-23T23:59:59Z&granularity=monthly", strings.NewReader(""))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/xml")
+
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+	responseBody := response.Body.String()
+	endpointAvailabilityXML := ` <root>
+   <group name="ST01" type="SITE">
+     <group name="service_a" type="service">
+       <group name="e01" type="endpoint">
+         <results timestamp="2015-06" availability="76.26534166743393" reliability="91.61418757296076" unknown="0.00521" uptime="0.75868" downtime="0.166665"></results>
+       </group>
+       <group name="e02" type="endpoint">
+         <results timestamp="2015-06" availability="98.43749901562502" reliability="98.43749901562502" unknown="0" uptime="0.984375" downtime="0"></results>
+       </group>
+     </group>
+   </group>
+ </root>`
+
+	// Check that we must have a 200 ok code
+	suite.Equal(200, response.Code, "Incorrect HTTP response code")
+	// Compare the expected and actual xml response
+	suite.Equal(endpointAvailabilityXML, responseBody, "Response body mismatch")
+
+	request, _ = http.NewRequest("GET", "/api/v2/results/Report_A/SITE/ST01/services/service_a/endpoints?start_time=2015-06-22T00:00:00Z&end_time=2015-06-23T23:59:59Z&granularity=monthly", strings.NewReader(""))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+
+	response = httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+	responseBody = response.Body.String()
+
+	endpointAvailabilityJSON := `{
+   "results": [
+     {
+       "name": "ST01",
+       "type": "SITE",
+       "serviceflavors": [
+         {
+           "name": "service_a",
+           "type": "service",
+           "endpoints": [
+             {
+               "name": "e01",
+               "type": "endpoint",
+               "results": [
+                 {
+                   "timestamp": "2015-06",
+                   "availability": "76.26534166743393",
+                   "reliability": "91.61418757296076",
+                   "unknown": "0.00521",
+                   "uptime": "0.75868",
+                   "downtime": "0.166665"
+                 }
+               ]
+             },
+             {
+               "name": "e02",
+               "type": "endpoint",
+               "results": [
+                 {
+                   "timestamp": "2015-06",
+                   "availability": "98.43749901562502",
+                   "reliability": "98.43749901562502",
+                   "unknown": "0",
+                   "uptime": "0.984375",
+                   "downtime": "0"
+                 }
+               ]
+             }
+           ]
+         }
+       ]
+     }
+   ]
+ }`
+
+	// Check that we must have a 200 ok code
+	suite.Equal(200, response.Code, "Incorrect HTTP response code")
+	// Compare the expected and actual xml response
+	suite.Equal(endpointAvailabilityJSON, responseBody, "Response body mismatch")
+
+	// Test the quick path to site endpoint a/r
+	request, _ = http.NewRequest("GET", "/api/v2/results/Report_A/SITE/ST01/endpoints?start_time=2015-06-22T00:00:00Z&end_time=2015-06-23T23:59:59Z&granularity=monthly", strings.NewReader(""))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+
+	response = httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+	responseBody = response.Body.String()
+
+	// Check that we must have a 200 ok code
+	suite.Equal(200, response.Code, "Incorrect HTTP response code")
+	// Compare the expected and actual xml response
+	suite.Equal(endpointAvailabilityJSON, responseBody, "Response body mismatch")
+
+}
+
+// TestListServiceFlavorAvailabilityDaily tests if daily results are returned correctly
+func (suite *endpointAvailabilityTestSuite) TestListEndpointAvailabilityDaily() {
+
+	request, _ := http.NewRequest("GET", "/api/v2/results/Report_A/SITE/ST01/services/service_a/endpoints?start_time=2015-06-22T00:00:00Z&end_time=2015-06-23T23:59:59Z", strings.NewReader(""))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/xml")
+
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	endpointAvailabilityXML := ` <root>
+   <group name="ST01" type="SITE">
+     <group name="service_a" type="service">
+       <group name="e01" type="endpoint">
+         <results timestamp="2015-06-22" availability="98.26389" reliability="98.26389" unknown="0" uptime="0.98264" downtime="0"></results>
+         <results timestamp="2015-06-23" availability="54.03509" reliability="81.48148" unknown="0.01042" uptime="0.53472" downtime="0.33333"></results>
+       </group>
+       <group name="e02" type="endpoint">
+         <results timestamp="2015-06-22" availability="96.875" reliability="96.875" unknown="0" uptime="0.96875" downtime="0"></results>
+         <results timestamp="2015-06-23" availability="100" reliability="100" unknown="0" uptime="1" downtime="0"></results>
+       </group>
+     </group>
+   </group>
+ </root>`
+
+	// Check that we must have a 200 ok code
+	suite.Equal(200, response.Code, "Incorrect HTTP response code")
+	// Compare the expected and actual xml response
+	suite.Equal(endpointAvailabilityXML, response.Body.String(), "Response body mismatch")
+
+	request, _ = http.NewRequest("GET", "/api/v2/results/Report_A/SITE/ST01/services/service_a/endpoints?start_time=2015-06-22T00:00:00Z&end_time=2015-06-23T23:59:59Z", strings.NewReader(""))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+
+	response = httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	serviceFlavorAvailabilityJSON := `{
+   "results": [
+     {
+       "name": "ST01",
+       "type": "SITE",
+       "serviceflavors": [
+         {
+           "name": "service_a",
+           "type": "service",
+           "endpoints": [
+             {
+               "name": "e01",
+               "type": "endpoint",
+               "results": [
+                 {
+                   "timestamp": "2015-06-22",
+                   "availability": "98.26389",
+                   "reliability": "98.26389",
+                   "unknown": "0",
+                   "uptime": "0.98264",
+                   "downtime": "0"
+                 },
+                 {
+                   "timestamp": "2015-06-23",
+                   "availability": "54.03509",
+                   "reliability": "81.48148",
+                   "unknown": "0.01042",
+                   "uptime": "0.53472",
+                   "downtime": "0.33333"
+                 }
+               ]
+             },
+             {
+               "name": "e02",
+               "type": "endpoint",
+               "results": [
+                 {
+                   "timestamp": "2015-06-22",
+                   "availability": "96.875",
+                   "reliability": "96.875",
+                   "unknown": "0",
+                   "uptime": "0.96875",
+                   "downtime": "0"
+                 },
+                 {
+                   "timestamp": "2015-06-23",
+                   "availability": "100",
+                   "reliability": "100",
+                   "unknown": "0",
+                   "uptime": "1",
+                   "downtime": "0"
+                 }
+               ]
+             }
+           ]
+         }
+       ]
+     }
+   ]
+ }`
+
+	// Check that we must have a 200 ok code
+	suite.Equal(200, response.Code, "Incorrect HTTP response code")
+	// Compare the expected and actual xml response
+	suite.Equal(serviceFlavorAvailabilityJSON, response.Body.String(), "Response body mismatch")
+
+	request, _ = http.NewRequest("GET", "/api/v2/results/Report_A/SITE/ST01/services?start_time=2015-06-22T00:00:00Z&end_time=2015-06-23T23:59:59Z", strings.NewReader(""))
+	request.Header.Set("x-api-key", "AWRONGKEY")
+	request.Header.Set("Accept", "application/xml")
+
+	response = httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	// Check that we must have a 401 Unauthorized code
+	suite.Equal(401, response.Code, "Incorrect HTTP response code")
+
+}
+
+// TestListServiceFlavorAvailabilityErrors tests if errors/exceptions are returned correctly
+func (suite *endpointAvailabilityTestSuite) TestListEndpointAvailabilityErrors() {
+
+	reportErrorXML := ` <root>
+   <message>The report with the name Report_B does not exist</message>
+   <code>404</code>
+ </root>`
+
+	typeErrorXML := `<root>
+ <status>
+  <message>Bad Request</message>
+  <code>400</code>
+ </status>
+ <errors>
+  <error>
+   <message>Endpoint Group type not in report</message>
+   <code>400</code>
+   <details>Endpoint Group type Site not present in report Report_A. Try using SITE instead</details>
+  </error>
+ </errors>
+</root>`
+
+	typeError1XML := ` <root>
+   <message>No results found for given query</message>
+   <code>404</code>
+ </root>`
+
+	typeError1JSON := `{
+   "message": "No results found for given query",
+   "code": 404
+ }`
+
+	request, _ := http.NewRequest("GET", "/api/v2/results/Report_B/SITE/ST01/services/service_a/endpoints?start_time=2015-06-22T00:00:00Z&end_time=2015-06-23T23:59:59Z", strings.NewReader(""))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/xml")
+
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	// Check that we must have a 404 not found code
+	suite.Equal(404, response.Code, "Incorrect HTTP response code")
+	// Compare the expected and actual xml response
+	suite.Equal(reportErrorXML, response.Body.String(), "Response body mismatch")
+
+	request, _ = http.NewRequest("GET", "/api/v2/results/Report_A/Site/ST01/services/service_a/endpoints?start_time=2015-06-22T00:00:00Z&end_time=2015-06-23T23:59:59Z", strings.NewReader(""))
+	request.Header.Set("Accept", "application/xml")
+	request.Header.Set("x-api-key", suite.clientkey)
+
+	response = httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+	output := response.Body.String()
+
+	// Check that we must have a 400 bad request code
+	suite.Equal(400, response.Code, "Incorrect HTTP response code")
+	// Compare the expected and actual xml response
+	suite.Equal(typeErrorXML, output, "Response body mismatch")
+
+	request, _ = http.NewRequest("GET", "/api/v2/results/Report_A/SITE/ST01/services?start_time=2025-06-22T00:00:00Z&end_time=2025-06-23T23:59:59Z", strings.NewReader(""))
+	request.Header.Set("Accept", "application/xml")
+	request.Header.Set("x-api-key", suite.clientkey)
+
+	response = httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+	output = response.Body.String()
+
+	// Check that we must have a 404 not found code
+	suite.Equal(404, response.Code, "Incorrect HTTP response code")
+	// Compare the expected and actual xml response
+	suite.Equal(typeError1XML, output, "Response body mismatch")
+
+	request, _ = http.NewRequest("GET", "/api/v2/results/Report_A/SITE/ST01/services?start_time=2025-06-22T00:00:00Z&end_time=2025-06-23T23:59:59Z", strings.NewReader(""))
+	request.Header.Set("Accept", "application/json")
+	request.Header.Set("x-api-key", suite.clientkey)
+
+	response = httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+	output = response.Body.String()
+
+	// Check that we must have a 404 not found code
+	suite.Equal(404, response.Code, "Incorrect HTTP response code")
+	// Compare the expected and actual xml response
+	suite.Equal(typeError1JSON, output, "Response body mismatch")
+
+}
+
+// TestOptionsServiceFlavor tests responses in case the OPTIONS http verb is used
+func (suite *endpointAvailabilityTestSuite) TestOptionsServiceFlavor() {
+
+	request, _ := http.NewRequest("OPTIONS", "/api/v2/results/Report_A/SITE/ST01/services/service_a/endpoints", strings.NewReader(""))
+
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code := response.Code
+	output := response.Body.String()
+	headers := response.HeaderMap
+
+	suite.Equal(200, code, "Error in response code")
+	suite.Equal("", output, "Expected empty response body")
+	suite.Equal("GET, OPTIONS", headers.Get("Allow"), "Error in Allow header response (supported resource verbs of resource)")
+	suite.Equal("text/plain; charset=utf-8", headers.Get("Content-Type"), "Error in Content-Type header response")
+
+	request, _ = http.NewRequest("OPTIONS", "/api/v2/results/Report_A/SITE/ST01/services/service_a/endpoints/e01", strings.NewReader(""))
+
+	response = httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code = response.Code
+	output = response.Body.String()
+	headers = response.HeaderMap
+
+	suite.Equal(200, code, "Error in response code")
+	suite.Equal("", output, "Expected empty response body")
+	suite.Equal("GET, OPTIONS", headers.Get("Allow"), "Error in Allow header response (supported resource verbs of resource)")
+	suite.Equal("text/plain; charset=utf-8", headers.Get("Content-Type"), "Error in Content-Type header response")
+
+	request, _ = http.NewRequest("OPTIONS", "/api/v2/results/Report_A/GROUP/GROUP_A/SITE/ST01/services/service_a/endpoints", strings.NewReader(""))
+
+	response = httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code = response.Code
+	output = response.Body.String()
+	headers = response.HeaderMap
+
+	suite.Equal(200, code, "Error in response code")
+	suite.Equal("", output, "Expected empty response body")
+	suite.Equal("GET, OPTIONS", headers.Get("Allow"), "Error in Allow header response (supported resource verbs of resource)")
+	suite.Equal("text/plain; charset=utf-8", headers.Get("Content-Type"), "Error in Content-Type header response")
+
+	request, _ = http.NewRequest("OPTIONS", "/api/v2/results/Report_A/GROUP/GROUP_A/SITE/ST01/services/service_a/endpoints/e01", strings.NewReader(""))
+
+	response = httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code = response.Code
+	output = response.Body.String()
+	headers = response.HeaderMap
+
+	suite.Equal(200, code, "Error in response code")
+	suite.Equal("", output, "Expected empty response body")
+	suite.Equal("GET, OPTIONS", headers.Get("Allow"), "Error in Allow header response (supported resource verbs of resource)")
+	suite.Equal("text/plain; charset=utf-8", headers.Get("Content-Type"), "Error in Content-Type header response")
+
+}
+
+// TestStrictSlashServiceFlavorResults test if not found responses are returned correctly
+func (suite *endpointAvailabilityTestSuite) TestStrictSlashServiceFlavorResults() {
+
+	request, _ := http.NewRequest("GET", "/api/v2/results/Report_A/SITE/ST01/services/SF01/endpoints/?start_time=2015-06-22T00:00:00Z&end_time=2015-06-23T23:59:59Z&granularity=monthly", strings.NewReader(""))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/xml")
+	response := httptest.NewRecorder()
+	suite.router.ServeHTTP(response, request)
+	suite.Equal(404, response.Code, "Incorrect HTTP response code")
+
+	request, _ = http.NewRequest("GET", "/api/v2/results/Report_A/SITE/ST01/services/SF01/endpoints/e01/?start_time=2015-06-22T00:00:00Z&end_time=2015-06-23T23:59:59Z&granularity=monthly", strings.NewReader(""))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/xml")
+	response = httptest.NewRecorder()
+	suite.router.ServeHTTP(response, request)
+	suite.Equal(404, response.Code, "Incorrect HTTP response code")
+
+}
+
+//TearDownTest to tear down every test
+func (suite *endpointAvailabilityTestSuite) TearDownTest() {
+
+	session, err := mgo.Dial(suite.cfg.MongoDB.Host)
+	if err != nil {
+		panic(err)
+	}
+
+	tenantDB := session.DB(suite.tenantDbConf.Db)
+	mainDB := session.DB(suite.cfg.MongoDB.Db)
+
+	cols, err := tenantDB.CollectionNames()
+	for _, col := range cols {
+		tenantDB.C(col).RemoveAll(nil)
+	}
+
+	cols, err = mainDB.CollectionNames()
+	for _, col := range cols {
+		mainDB.C(col).RemoveAll(nil)
+	}
+
+}
+
+//TearDownTest to tear down every test
+func (suite *endpointAvailabilityTestSuite) TearDownSuite() {
+
+	session, err := mgo.Dial(suite.cfg.MongoDB.Host)
+	if err != nil {
+		panic(err)
+	}
+	session.DB(suite.tenantDbConf.Db).DropDatabase()
+	session.DB(suite.cfg.MongoDB.Db).DropDatabase()
+}
+
+// TestEndpointAvailabilityTestSuite is responsible for calling the tests
+func TestEndpointAvailabilityTestSuite(t *testing.T) {
+	suite.Run(t, new(endpointAvailabilityTestSuite))
+}

--- a/app/results/routing.go
+++ b/app/results/routing.go
@@ -39,6 +39,10 @@ import (
 // handling each route with a different subrouter
 func HandleSubrouter(s *mux.Router, confhandler *respond.ConfHandler) {
 
+	// Routes for serving endpoint a/r results under services
+	endpointSubrouter := s.StrictSlash(false).PathPrefix("/{report_name}").Subrouter()
+	endpointSubrouter = respond.PrepAppRoutes(endpointSubrouter, confhandler, appEndpointRoutes)
+
 	serviceSubrouter := s.StrictSlash(false).PathPrefix("/{report_name}").Subrouter()
 	serviceSubrouter = respond.PrepAppRoutes(serviceSubrouter, confhandler, appServiceRoutes)
 
@@ -46,6 +50,20 @@ func HandleSubrouter(s *mux.Router, confhandler *respond.ConfHandler) {
 	groupSubrouter = respond.PrepAppRoutes(groupSubrouter, confhandler, appGroupRoutes)
 
 	s = respond.PrepAppRoutes(s, confhandler, appRoutesV2)
+}
+
+var appEndpointRoutes = []respond.AppRoutes{
+	{"results.get", "GET", "/{group_type}/{group_name}/{lgroup_type}/{lgroup_name}/services/{service_type}/endpoints/{endpoint_name}", ListEndpointResults},
+	{"results.get", "GET", "/{group_type}/{group_name}/{lgroup_type}/{lgroup_name}/services/{service_type}/endpoints", ListEndpointResults},
+	{"results.get", "GET", "/{lgroup_type}/{lgroup_name}/services/{service_type}/endpoints/{endpoint_name}", ListEndpointResults},
+	{"results.get", "GET", "/{lgroup_type}/{lgroup_name}/services/{service_type}/endpoints", ListEndpointResults},
+	//routes to quickly get endpoints included in an endpoint group without specifing service
+	{"results.get", "GET", "/{group_type}/{group_name}/{lgroup_type}/{lgroup_name}/endpoints/{endpoint_name}", ListEndpointResults},
+	{"results.get", "GET", "/{group_type}/{group_name}/{lgroup_type}/{lgroup_name}/endpoints", ListEndpointResults},
+	{"results.get", "GET", "/{lgroup_type}/{lgroup_name}/endpoints/{endpoint_name}", ListEndpointResults},
+	{"results.get", "GET", "/{lgroup_type}/{lgroup_name}/endpoints", ListEndpointResults},
+	// normal routes to get endpoints included in a service
+
 }
 
 var appServiceRoutes = []respond.AppRoutes{
@@ -67,11 +85,19 @@ var appRoutesV2 = []respond.AppRoutes{
 	{"results.options", "OPTIONS", "/{report_name}/{group_type}", Options},
 	{"results.options", "OPTIONS", "/{report_name}/{group_type}/{group_name}/{lgroup_type}", Options},
 	{"results.options", "OPTIONS", "/{report_name}/{group_type}/{group_name}/{lgroup_type}/{lgroup_name}", Options},
+	{"results.options", "OPTIONS", "/{report_name}/{group_type}/{group_name}/{lgroup_type}/{lgroup_name}/endpoints", Options},
+	{"results.options", "OPTIONS", "/{report_name}/{group_type}/{group_name}/{lgroup_type}/{lgroup_name}/endpoints/{endpoint_name}", Options},
 	{"results.options", "OPTIONS", "/{report_name}/{group_type}/{group_name}/{lgroup_type}/{lgroup_name}/services", Options},
 	{"results.options", "OPTIONS", "/{report_name}/{group_type}/{group_name}/{lgroup_type}/{lgroup_name}/services/{service_name}", Options},
+	{"results.options", "OPTIONS", "/{report_name}/{group_type}/{group_name}/{lgroup_type}/{lgroup_name}/services/{service_name}/endpoints", Options},
+	{"results.options", "OPTIONS", "/{report_name}/{group_type}/{group_name}/{lgroup_type}/{lgroup_name}/services/{service_name}/endpoints/{endpoint_name}", Options},
 	{"results.options", "OPTIONS", "/{report_name}/{lgroup_type}/{lgroup_name}", Options},
+	{"results.options", "OPTIONS", "/{report_name}/{lgroup_type}/{lgroup_name}/endpoints", Options},
+	{"results.options", "OPTIONS", "/{report_name}/{lgroup_type}/{lgroup_name}/endpoints/{endpoint_name}", Options},
 	{"results.options", "OPTIONS", "/{report_name}/{lgroup_type}/{lgroup_name}/services", Options},
 	{"results.options", "OPTIONS", "/{report_name}/{lgroup_type}/{lgroup_name}/services/{service_name}", Options},
+	{"results.options", "OPTIONS", "/{report_name}/{lgroup_type}/{lgroup_name}/services/{service_name}/endpoints", Options},
+	{"results.options", "OPTIONS", "/{report_name}/{lgroup_type}/{lgroup_name}/services/{service_name}/endpoints/{endpoint_name}", Options},
 }
 
 func routeGroup(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {

--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -1849,6 +1849,294 @@ paths:
           $ref: "#/responses/422"
         500:
           $ref: "#/responses/ServerError"
+  
+  /results/{report_name}/{group_type}/{group_name}/{lgroup_type}/{lgroup_name}/services/{service_name}/endpoints:
+    get:
+      summary: "List A/R results of all endpoints (under a given service)"
+      description: "This method retrieves the results of specified service's endpoints that where computed based on a given report. Results can be retrieved on daily or monthly granularity."
+      operationId: resultsGroupServiceEndpoints
+      tags:
+        - Results
+      produces:
+        - "application/json"
+        - "application/xml"
+      parameters:
+        - $ref: "#/parameters/apiKey"
+        - $ref: "#/parameters/reportName"
+        - $ref: "#/parameters/groupType"
+        - $ref: "#/parameters/groupName"
+        - $ref: "#/parameters/lgroupType"
+        - $ref: "#/parameters/lgroupName"
+        - $ref: "#/parameters/startDate"
+        - $ref: "#/parameters/endDate"
+        - $ref: "#/parameters/Granularity"
+        - $ref: "#/parameters/service_name"
+      responses:
+        200:
+          description: "Successful retrieval of results"
+          schema:
+            $ref: "#/definitions/EndpointResultsResponse"
+        400:
+          $ref: "#/responses/404"
+        401:
+          $ref: "#/responses/Unauthorized"
+        406:
+          $ref: "#/responses/406"
+        422:
+          $ref: "#/responses/422"
+        500:
+          $ref: "#/responses/ServerError"
+
+  /results/{report_name}/{group_type}/{group_name}/{lgroup_type}/{lgroup_name}/services/{service_name}/endpoints/{endpoint_name}:
+    get:
+      summary: "List A/R results of a given endpoint (under a given service)"
+      description: "This method retrieves the results of a specified endpoint that where computed based on a given report. Results can be retrieved on daily or monthly granularity."
+      operationId: resultsGroupServiceEndpoint
+      tags:
+        - Results
+      produces:
+        - "application/json"
+        - "application/xml"
+      parameters:
+        - $ref: "#/parameters/apiKey"
+        - $ref: "#/parameters/reportName"
+        - $ref: "#/parameters/groupType"
+        - $ref: "#/parameters/groupName"
+        - $ref: "#/parameters/lgroupType"
+        - $ref: "#/parameters/lgroupName"
+        - $ref: "#/parameters/service_name"
+        - $ref: "#/parameters/startDate"
+        - $ref: "#/parameters/endDate"
+        - $ref: "#/parameters/Granularity"
+        - $ref: "#/parameters/endpoint_name"
+      responses:
+        200:
+          description: "Successful retrieval of results"
+          schema:
+            $ref: "#/definitions/EndpointResultsResponse"
+        400:
+          $ref: "#/responses/404"
+        401:
+          $ref: "#/responses/Unauthorized"
+        406:
+          $ref: "#/responses/406"
+        422:
+          $ref: "#/responses/422"
+        500:
+          $ref: "#/responses/ServerError"
+
+  /results/{report_name}/{lgroup_type}/{lgroup_name}/services/{service_name}/endpoints:
+    get:
+      summary: "List A/R results of all endpoints (under a given service)"
+      description: "This method retrieves the results of endpoints under a specific service that where computed based on a given report. Results can be retrieved on daily or monthly granularity."
+      operationId: resultsServiceEndpoints
+      tags:
+        - Results
+      produces:
+        - "application/json"
+        - "application/xml"
+      parameters:
+        - $ref: "#/parameters/apiKey"
+        - $ref: "#/parameters/reportName"
+        - $ref: "#/parameters/lgroupType"
+        - $ref: "#/parameters/lgroupName"
+        - $ref: "#/parameters/startDate"
+        - $ref: "#/parameters/endDate"
+        - $ref: "#/parameters/Granularity"
+        - $ref: "#/parameters/service_name"
+      responses:
+        200:
+          description: "Successful retrieval of results"
+          schema:
+            $ref: "#/definitions/EndpointResultsResponse"
+        400:
+          $ref: "#/responses/404"
+        401:
+          $ref: "#/responses/Unauthorized"
+        406:
+          $ref: "#/responses/406"
+        422:
+          $ref: "#/responses/422"
+        500:
+          $ref: "#/responses/ServerError"
+  /results/{report_name}/{lgroup_type}/{lgroup_name}/services/{service_name}/endpoints/{endpoint_name}:
+    get:
+      summary: "List A/R results of a given endpoint (under a given service)"
+      description: "This method retrieves the results of a specified endpoint that where computed based on a given report. Results can be retrieved on daily or monthly granularity."
+      operationId: resultsServiceEndpoint
+      tags:
+        - Results
+      produces:
+        - "application/json"
+        - "application/xml"
+      parameters:
+        - $ref: "#/parameters/apiKey"
+        - $ref: "#/parameters/reportName"
+        - $ref: "#/parameters/lgroupType"
+        - $ref: "#/parameters/lgroupName"
+        - $ref: "#/parameters/service_name"
+        - $ref: "#/parameters/startDate"
+        - $ref: "#/parameters/endDate"
+        - $ref: "#/parameters/Granularity"
+        - $ref: "#/parameters/endpoint_name"
+      responses:
+        200:
+          description: "Successful retrieval of results"
+          schema:
+            $ref: "#/definitions/EndpointResultsResponse"
+        400:
+          $ref: "#/responses/404"
+        401:
+          $ref: "#/responses/Unauthorized"
+        406:
+          $ref: "#/responses/406"
+        422:
+          $ref: "#/responses/422"
+        500:
+          $ref: "#/responses/ServerError"
+  
+  /results/{report_name}/{group_type}/{group_name}/{lgroup_type}/{lgroup_name}/endpoints:
+    get:
+      summary: "List A/R results of all endpoints (under a given group)"
+      description: "This method retrieves the results of specified group's endpoints that where computed based on a given report. Results can be retrieved on daily or monthly granularity."
+      operationId: resultsGroupEndpoints
+      tags:
+        - Results
+      produces:
+        - "application/json"
+        - "application/xml"
+      parameters:
+        - $ref: "#/parameters/apiKey"
+        - $ref: "#/parameters/reportName"
+        - $ref: "#/parameters/groupType"
+        - $ref: "#/parameters/groupName"
+        - $ref: "#/parameters/lgroupType"
+        - $ref: "#/parameters/lgroupName"
+        - $ref: "#/parameters/startDate"
+        - $ref: "#/parameters/endDate"
+        - $ref: "#/parameters/Granularity"
+        
+      responses:
+        200:
+          description: "Successful retrieval of results"
+          schema:
+            $ref: "#/definitions/EndpointResultsResponse"
+        400:
+          $ref: "#/responses/404"
+        401:
+          $ref: "#/responses/Unauthorized"
+        406:
+          $ref: "#/responses/406"
+        422:
+          $ref: "#/responses/422"
+        500:
+          $ref: "#/responses/ServerError"
+
+  /results/{report_name}/{group_type}/{group_name}/{lgroup_type}/{lgroup_name}/endpoints/{endpoint_name}:
+    get:
+      summary: "List A/R results of a given endpoint (under a given group)"
+      description: "This method retrieves the results of a specified endpoint that where computed based on a given report. Results can be retrieved on daily or monthly granularity."
+      operationId: resultsGroupEndpoint
+      tags:
+        - Results
+      produces:
+        - "application/json"
+        - "application/xml"
+      parameters:
+        - $ref: "#/parameters/apiKey"
+        - $ref: "#/parameters/reportName"
+        - $ref: "#/parameters/groupType"
+        - $ref: "#/parameters/groupName"
+        - $ref: "#/parameters/lgroupType"
+        - $ref: "#/parameters/lgroupName"
+        - $ref: "#/parameters/service_name"
+        - $ref: "#/parameters/startDate"
+        - $ref: "#/parameters/endDate"
+        - $ref: "#/parameters/Granularity"
+        - $ref: "#/parameters/endpoint_name"
+      responses:
+        200:
+          description: "Successful retrieval of results"
+          schema:
+            $ref: "#/definitions/EndpointResultsResponse"
+        400:
+          $ref: "#/responses/404"
+        401:
+          $ref: "#/responses/Unauthorized"
+        406:
+          $ref: "#/responses/406"
+        422:
+          $ref: "#/responses/422"
+        500:
+          $ref: "#/responses/ServerError"
+
+  /results/{report_name}/{lgroup_type}/{lgroup_name}/endpoints:
+    get:
+      summary: "List A/R results of all endpoints (under a given group)"
+      description: "This method retrieves the results of endpoints under a specific group that where computed based on a given report. Results can be retrieved on daily or monthly granularity."
+      operationId: resultsEndpoints
+      tags:
+        - Results
+      produces:
+        - "application/json"
+        - "application/xml"
+      parameters:
+        - $ref: "#/parameters/apiKey"
+        - $ref: "#/parameters/reportName"
+        - $ref: "#/parameters/lgroupType"
+        - $ref: "#/parameters/lgroupName"
+        - $ref: "#/parameters/startDate"
+        - $ref: "#/parameters/endDate"
+        - $ref: "#/parameters/Granularity"
+      responses:
+        200:
+          description: "Successful retrieval of results"
+          schema:
+            $ref: "#/definitions/EndpointResultsResponse"
+        400:
+          $ref: "#/responses/404"
+        401:
+          $ref: "#/responses/Unauthorized"
+        406:
+          $ref: "#/responses/406"
+        422:
+          $ref: "#/responses/422"
+        500:
+          $ref: "#/responses/ServerError"
+  /results/{report_name}/{lgroup_type}/{lgroup_name}/endpoints/{endpoint_name}:
+    get:
+      summary: "List A/R results of a given endpoint (under a given group)"
+      description: "This method retrieves the results of a specified endpoint that where computed based on a given report. Results can be retrieved on daily or monthly granularity."
+      operationId: resultsEndpoint
+      tags:
+        - Results
+      produces:
+        - "application/json"
+        - "application/xml"
+      parameters:
+        - $ref: "#/parameters/apiKey"
+        - $ref: "#/parameters/reportName"
+        - $ref: "#/parameters/lgroupType"
+        - $ref: "#/parameters/lgroupName"
+        - $ref: "#/parameters/startDate"
+        - $ref: "#/parameters/endDate"
+        - $ref: "#/parameters/Granularity"
+        - $ref: "#/parameters/endpoint_name"
+      responses:
+        200:
+          description: "Successful retrieval of results"
+          schema:
+            $ref: "#/definitions/EndpointResultsResponse"
+        400:
+          $ref: "#/responses/404"
+        401:
+          $ref: "#/responses/Unauthorized"
+        406:
+          $ref: "#/responses/406"
+        422:
+          $ref: "#/responses/422"
+        500:
+          $ref: "#/responses/ServerError"
 
   /results/{report_name}/{group_type}/{group_name}/{lgroup_type}/{lgroup_name}:
     get:
@@ -2375,7 +2663,39 @@ definitions:
                     type: string
                   results:
                     $ref: "#/definitions/results"
-
+  
+  EndpointResultsResponse:
+    type: object
+    properties:
+      root:
+        type: array
+        items:
+          type: object
+          properties:
+            name:
+              type: string
+            type:
+              type: string
+            serviceflavors:
+              type: array
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  type:
+                    type: string
+                  endpoints:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        type:
+                          type: string
+                        results:
+                          $ref: "#/definitions/results"
 
 
   StatusEndpointResponse:

--- a/doc/v2/docs/results.md
+++ b/doc/v2/docs/results.md
@@ -132,6 +132,89 @@ Status: 200 OK
 
 <a id="3"></a>
 
+# [GET]: List Availabilities and Reliabilities for Endpoints
+The following methods can be used to obtain a tenant's Availability and Reliability result metrics for endpoints under a specific service or group. The api authenticates the tenant using the api-key within the x-api-key header. The user can specify time granularity (`monthly` or `daily`) for retrieved results and also format using the `Accept` header. Depending on the form of the request the user can request a single service flavor results or a bulk of endpoint results.
+
+## [GET] Endpoints A/R
+### Input
+
+Request endpoint a/r under specific service:
+```
+/results/{report_name}/{group_type}/{group_name}/{endpoint_group_type}/{endpoint_group_name}/services/{service_name}/endpoints?[start_time]&[end_time]&[granularity]
+or
+/results/{report_name}/{group_type}/{group_name}/{endpoint_group_type}/{endpoint_group_name}/services/{service_name}/endpoints/{endpoint_name}?[start_time]&[end_time]&[granularity]
+or
+/results/{report_name}/{endpoint_group_type}/{endpoint_group_name}/services/{service_name}/endpoints?[start_time]&[end_time]&[granularity]
+or
+/results/{report_name}/{endpoint_group_type}/{endpoint_group_name}/services/{service_name}/endpoints/{endpoint_name}?[start_time]&[end_time]&[granularity]
+```
+Request endpoint a/r under specific endpoint group:
+```
+/results/{report_name}/{group_type}/{group_name}/{endpoint_group_type}/{endpoint_group_name}/endpoints?[start_time]&[end_time]&[granularity]
+or
+/results/{report_name}/{group_type}/{group_name}/{endpoint_group_type}/{endpoint_group_name}/endpoints/{endpoint_name}?[start_time]&[end_time]&[granularity]
+or
+/results/{report_name}/{endpoint_group_type}/{endpoint_group_name}/endpoints?[start_time]&[end_time]&[granularity]
+or
+/results/{report_name}/{endpoint_group_type}/{endpoint_group_name}/endpoints/{endpoint_name}?[start_time]&[end_time]&[granularity]
+```
+
+#### Query Parameters
+
+Type            | Description                                                                                     | Required | Default value
+--------------- | ----------------------------------------------------------------------------------------------- | -------- | -------------
+`[start_time]`  | UTC time in W3C format                                                                          | YES      |
+`[end_time]`    | UTC time in W3C format                                                                          | YES      |
+`[granularity]` | Granularity of time that will be used to present data. Possible values are `monthly` or `daily` | NO       | `daily`
+
+#### Path Parameters
+
+Name                    | Description                                                                                                                           | Required | Default value
+----------------------- | ------------------------------------------------------------------------------------------------------------------------------------- | -------- | -------------
+`{report_name}`         | Name of the report that contains all the information about the profile, filter tags, group types etc.                                 | YES      |
+`{group_type}`          | Type of the Group of Endpoint Groups.                                                                                                 | NO       |
+`{group_name}`          | Name of the Group of Endpoint Groups.                                                                                                 | NO       |
+`{endpoint_group_type}` | Type of the the Endpoint Group.                                                                                                       | YES      |
+`{endpoint_group_name}` | Name of the the Endpoint Group.                                                                                                       | YES      |
+`{service_name}` | Name of the specific service. | NO       |
+`{endpoint_name}` | Name of the specific endpoint. | NO       |
+
+#### Headers
+##### Request
+
+```
+x-api-key: "tenant_key_value"
+Accept: "application/xml" or "application/json"
+```
+
+##### Response
+
+```
+Status: 200 OK
+```
+
+#### URL
+`/api/v2/results/Report_A/SITE/ST01/services/service_a/endpoints?start_time=2015-06-22T00:00:00Z&end_time=2015-06-23T23:23:59Z&granularity=daily`
+
+#### Response Body
+
+```
+<root>
+  <group name="ST01" type="SITE">
+    <group name="SF01" type="service">
+      <results timestamp="2015-06-22" availability="98.26389" reliability="98.26389" unknown="0" uptime="0.98264" downtime="0"></results>
+      <results timestamp="2015-06-23" availability="54.03509" reliability="81.48148" unknown="0.01042" uptime="0.53472" downtime="0.33333"></results>
+    </group>
+    <group name="SF02" type="service">
+      <results timestamp="2015-06-22" availability="96.875" reliability="96.875" unknown="0" uptime="0.96875" downtime="0"></results>
+      <results timestamp="2015-06-23" availability="100" reliability="100" unknown="0" uptime="1" downtime="0"></results>
+    </group>
+  </group>
+</root>
+```
+
+
+
 # [GET]: List Availabilities and Reliabilities for Service Flavors
 The following methods can be used to obtain a tenant's Availability and Reliability result metrics per given Service Flavor(s). The api authenticates the tenant using the api-key within the x-api-key header. The user can specify time granularity (`monthly` or `daily`) for retrieved results and also format using the `Accept` header. Depending on the form of the request the user can request a single service flavor results or a bulk of service flavor results.
 
@@ -181,22 +264,191 @@ Accept: "application/xml" or "application/json"
 Status: 200 OK
 ```
 
+## Request endpoint a/r under service: `service_a`
+
 #### URL
-`/api/v2/results/Report_A/SITE/ST01/services?start_time=2015-06-22T00:00:00Z&end_time=2015-06-23T23:23:59Z&granularity=daily`
+`/api/v2/results/Report_A/SITE/ST01/services/service_a/endpoints?start_time=2015-06-22T00:00:00Z&end_time=2015-06-23T23:23:59Z&granularity=daily`
 
 #### Response Body
 
 ```
-<root>
-  <group name="ST01" type="SITE">
-    <group name="SF01" type="service">
-      <results timestamp="2015-06-22" availability="98.26389" reliability="98.26389" unknown="0" uptime="0.98264" downtime="0"></results>
-      <results timestamp="2015-06-23" availability="54.03509" reliability="81.48148" unknown="0.01042" uptime="0.53472" downtime="0.33333"></results>
-    </group>
-    <group name="SF02" type="service">
-      <results timestamp="2015-06-22" availability="96.875" reliability="96.875" unknown="0" uptime="0.96875" downtime="0"></results>
-      <results timestamp="2015-06-23" availability="100" reliability="100" unknown="0" uptime="1" downtime="0"></results>
-    </group>
-  </group>
-</root>
+{
+   "results": [
+     {
+       "name": "ST01",
+       "type": "SITE",
+       "serviceflavors": [
+         {
+           "name": "service_a",
+           "type": "service",
+           "endpoints": [
+             {
+               "name": "e01",
+               "type": "endpoint",
+               "results": [
+                 {
+                   "timestamp": "2015-06-22",
+                   "availability": "98.26389",
+                   "reliability": "98.26389",
+                   "unknown": "0",
+                   "uptime": "0.98264",
+                   "downtime": "0"
+                 },
+                 {
+                   "timestamp": "2015-06-23",
+                   "availability": "54.03509",
+                   "reliability": "81.48148",
+                   "unknown": "0.01042",
+                   "uptime": "0.53472",
+                   "downtime": "0.33333"
+                 }
+               ]
+             },
+             {
+               "name": "e02",
+               "type": "endpoint",
+               "results": [
+                 {
+                   "timestamp": "2015-06-22",
+                   "availability": "96.875",
+                   "reliability": "96.875",
+                   "unknown": "0",
+                   "uptime": "0.96875",
+                   "downtime": "0"
+                 },
+                 {
+                   "timestamp": "2015-06-23",
+                   "availability": "100",
+                   "reliability": "100",
+                   "unknown": "0",
+                   "uptime": "1",
+                   "downtime": "0"
+                 }
+               ]
+             }
+           ]
+         }
+       ]
+     }
+   ]
+ }
 ```
+
+## Request endpoint a/r under endpoint group: `ST01`
+
+#### URL
+`/api/v2/results/Report_A/SITE/ST01/endpoints?start_time=2015-06-22T00:00:00Z&end_time=2015-06-23T23:23:59Z&granularity=daily`
+
+#### Response Body
+
+```
+{
+   "results": [
+     {
+       "name": "ST01",
+       "type": "SITE",
+       "serviceflavors": [
+         {
+           "name": "service_a",
+           "type": "service",
+           "endpoints": [
+             {
+               "name": "e01",
+               "type": "endpoint",
+               "results": [
+                 {
+                   "timestamp": "2015-06-22",
+                   "availability": "98.26389",
+                   "reliability": "98.26389",
+                   "unknown": "0",
+                   "uptime": "0.98264",
+                   "downtime": "0"
+                 },
+                 {
+                   "timestamp": "2015-06-23",
+                   "availability": "54.03509",
+                   "reliability": "81.48148",
+                   "unknown": "0.01042",
+                   "uptime": "0.53472",
+                   "downtime": "0.33333"
+                 }
+               ]
+             },
+             {
+               "name": "e02",
+               "type": "endpoint",
+               "results": [
+                 {
+                   "timestamp": "2015-06-22",
+                   "availability": "96.875",
+                   "reliability": "96.875",
+                   "unknown": "0",
+                   "uptime": "0.96875",
+                   "downtime": "0"
+                 },
+                 {
+                   "timestamp": "2015-06-23",
+                   "availability": "100",
+                   "reliability": "100",
+                   "unknown": "0",
+                   "uptime": "1",
+                   "downtime": "0"
+                 }
+               ]
+             }
+           ]
+         }
+       ]
+     }
+   ]
+ }
+```
+
+## Request endpoint a/r for specific endpoint `e01` under endpoint group: `ST01`
+
+#### URL
+`/api/v2/results/Report_A/SITE/ST01/services/service_a/endpoints/e01?start_time=2015-06-22T00:00:00Z&end_time=2015-06-23T23:23:59Z&granularity=daily`
+
+#### Response Body
+
+```
+{
+   "results": [
+     {
+       "name": "ST01",
+       "type": "SITE",
+       "serviceflavors": [
+         {
+           "name": "service_a",
+           "type": "service",
+           "endpoints": [
+             {
+               "name": "e01",
+               "type": "endpoint",
+               "results": [
+                 {
+                   "timestamp": "2015-06-22",
+                   "availability": "98.26389",
+                   "reliability": "98.26389",
+                   "unknown": "0",
+                   "uptime": "0.98264",
+                   "downtime": "0"
+                 },
+                 {
+                   "timestamp": "2015-06-23",
+                   "availability": "54.03509",
+                   "reliability": "81.48148",
+                   "unknown": "0.01042",
+                   "uptime": "0.53472",
+                   "downtime": "0.33333"
+                 }
+               ]
+             }
+           ]
+         }
+       ]
+     }
+   ]
+ }
+```
+


### PR DESCRIPTION
### Task
Compute engine calculates a/r scores on endpoint level. Argo web-api should expose those results. Extend current results path to be able to drill down to endpoint results:

- Current results path example:
`/v2/api/results/{REPORT}/{group_type}/{group_name}/services/{service}`
- Extended path variations for endpoint results:
 `/v2/api/results/{REPORT}/{group_type}/{group_name}/services/{service}/endpoints`
 `/v2/api/results/{REPORT}/{group_type}/{group_name}/services/{service}/endpoints/{endpoint_name}`
 and provide also a direct shortcut to get endpoint a/r results under a group: 
  `/v2/api/results/{REPORT}/{group_type}/{group_name}/endpoints`
 `/v2/api/results/{REPORT}/{group_type}/{group_name}/endpoints/{endpoint_name}`

### Implementation 
- [x] Add New Controller method in results package to serve Endpoint AR results
- [x] Add Endpoint A/R related models in results package
- [x] Add New View for displaying endpoint a/r result data 
- [x] Add New routes for endpoint results and connect them to the specific Endpoint controller method
- [x] Add unit tests for endpoint a/r functionality
- [x] Update swagger definitions
- [x] Update mkdocs