### PR TITLE
ARGO-1958 Fix add end of day point in multiple status timelines

### DIFF
--- a/app/statusEndpointGroups/controller.go
+++ b/app/statusEndpointGroups/controller.go
@@ -102,7 +102,7 @@ func ListEndpointGroupTimelines(r *http.Request, cfg config.Config) (int, http.H
 		doResults := hbaseToDataOutput(hbResults)
 
 		// Render the reults into xml
-		output, errHb = createView(doResults, input) //Render the results into XML format
+		output, errHb = createView(doResults, input, urlValues.Get("end_time")) //Render the results into JSON/XML format
 
 		h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
 		return code, h, output, errHb
@@ -148,9 +148,7 @@ func ListEndpointGroupTimelines(r *http.Request, cfg config.Config) (int, http.H
 		}
 	}
 
-	// close the timeline by adding a final status point at the end of the day or at the current time
-	results = closeTimeline(results, urlValues.Get("end_time"))
-	output, err = createView(results, input) //Render the results into JSON/XML format
+	output, err = createView(results, input, urlValues.Get("end_time")) //Render the results into JSON/XML format
 
 	return code, h, output, err
 }
@@ -168,6 +166,7 @@ func prepareQuery(input InputParams, reportID string) bson.M {
 	return filter
 }
 
+//Options responds to an OPTIONS request
 func Options(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
 
 	//STANDARD DECLARATIONS START

--- a/app/statusEndpointGroups/statusEndpointGroups_test.go
+++ b/app/statusEndpointGroups/statusEndpointGroups_test.go
@@ -233,6 +233,27 @@ func (suite *StatusEndpointGroupsTestSuite) SetupTest() {
 		"endpoint_group": "HG-03-AUTH",
 		"status":         "OK",
 	})
+	c.Insert(bson.M{
+		"report":         "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date_integer":   20150501,
+		"timestamp":      "2015-05-01T00:00:00Z",
+		"endpoint_group": "HG-02-AUTH",
+		"status":         "OK",
+	})
+	c.Insert(bson.M{
+		"report":         "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date_integer":   20150501,
+		"timestamp":      "2015-05-01T03:00:00Z",
+		"endpoint_group": "HG-02-AUTH",
+		"status":         "WARNING",
+	})
+	c.Insert(bson.M{
+		"report":         "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date_integer":   20150501,
+		"timestamp":      "2015-05-01T17:53:00Z",
+		"endpoint_group": "HG-02-AUTH",
+		"status":         "CRITICAL",
+	})
 
 	// get dbconfiguration based on the tenant
 	// Prepare the request object
@@ -566,6 +587,77 @@ func (suite *StatusEndpointGroupsTestSuite) TestLatestResults() {
 	suite.Equal(200, response2.Code, "Internal Server Error")
 	// Compare the expected and actual xml response
 	suite.Equal(respJSON1, response2.Body.String(), "Response body mismatch")
+
+}
+
+func (suite *StatusEndpointGroupsTestSuite) TestMultipleItems() {
+
+	fullurl1 := "/api/v2/status/Report_A/SITES" +
+		"?start_time=2015-05-01T00:00:00Z&end_time=2015-05-01T23:00:00Z"
+
+	respJSON1 := `{
+ "groups": [
+  {
+   "name": "HG-03-AUTH",
+   "type": "SITES",
+   "statuses": [
+    {
+     "timestamp": "2015-05-01T00:00:00Z",
+     "value": "OK"
+    },
+    {
+     "timestamp": "2015-05-01T01:00:00Z",
+     "value": "CRITICAL"
+    },
+    {
+     "timestamp": "2015-05-01T05:00:00Z",
+     "value": "OK"
+    },
+    {
+     "timestamp": "2015-05-01T23:59:59Z",
+     "value": "OK"
+    }
+   ]
+  },
+  {
+   "name": "HG-02-AUTH",
+   "type": "SITES",
+   "statuses": [
+    {
+     "timestamp": "2015-05-01T00:00:00Z",
+     "value": "OK"
+    },
+    {
+     "timestamp": "2015-05-01T03:00:00Z",
+     "value": "WARNING"
+    },
+    {
+     "timestamp": "2015-05-01T17:53:00Z",
+     "value": "CRITICAL"
+    },
+    {
+     "timestamp": "2015-05-01T23:59:59Z",
+     "value": "CRITICAL"
+    }
+   ]
+  }
+ ]
+}`
+
+	// init the response placeholder
+	response := httptest.NewRecorder()
+	// Prepare the request object for second tenant
+	request, _ := http.NewRequest("GET", fullurl1, strings.NewReader(""))
+	// add json accept header
+	request.Header.Set("Accept", "application/json")
+	// add the authentication token which is seeded in testdb
+	request.Header.Set("x-api-key", "KEY1")
+	// Serve the http request
+	suite.router.ServeHTTP(response, request)
+	// Check that we must have a 200 ok code
+	suite.Equal(200, response.Code, "Internal Server Error")
+	// Compare the expected and actual xml response
+	suite.Equal(respJSON1, response.Body.String(), "Response body mismatch")
 
 }
 

--- a/app/statusEndpointGroups/view.go
+++ b/app/statusEndpointGroups/view.go
@@ -52,29 +52,19 @@ func hbaseToDataOutput(hResults []*hrpc.Result) []DataOutput {
 	return dResult
 }
 
-// closeTimeline accepts a list of status item and an endDate parameter
-// and tries to close the status timeline by providing a final status item
-// at the end of the date (if the endDate parameter refers to a past date)
-// or at the current time (if the endDate parameter refers to the current date)
-func closeTimeline(results []DataOutput, endDate string) []DataOutput {
-	if len(results) == 0 {
-		return results
-	}
+func createView(results []DataOutput, input InputParams, endDate string) ([]byte, error) {
 
-	extra := results[len(results)-1]
+	// calculate part of the timestamp that closes the timeline of each item
+	var extraTS string
+
 	tsNow := time.Now().UTC()
 	today := tsNow.Format("2006-01-02")
+
 	if strings.Split(endDate, "T")[0] == today {
-		extra.Timestamp = tsNow.Format(zuluForm)
+		extraTS = "T" + strings.Split(tsNow.Format(zuluForm), "T")[1]
 	} else {
-		extra.Timestamp = strings.Split(extra.Timestamp, "T")[0] + "T23:59:59Z"
+		extraTS = "T23:59:59Z"
 	}
-
-	results = append(results, extra)
-	return results
-}
-
-func createView(results []DataOutput, input InputParams) ([]byte, error) {
 
 	output := []byte("reponse output")
 	err := error(nil)
@@ -97,6 +87,15 @@ func createView(results []DataOutput, input InputParams) ([]byte, error) {
 	for _, row := range results {
 
 		if row.EndpointGroup != prevEndpointGroup && row.EndpointGroup != "" {
+			// close the status timeline by adding a new status item at 23:59 or at current time
+			if ppEndpointGroup != nil {
+				eStatus := &statusOUT{}
+				latestStatus := ppEndpointGroup.Statuses[len(ppEndpointGroup.Statuses)-1]
+				eStatus.Timestamp = strings.Split(latestStatus.Timestamp, "T")[0] + extraTS
+				eStatus.Value = latestStatus.Value
+				ppEndpointGroup.Statuses = append(ppEndpointGroup.Statuses, eStatus)
+			}
+
 			endpointGroup := &endpointGroupOUT{}
 			endpointGroup.Name = row.EndpointGroup
 			endpointGroup.GroupType = input.groupType
@@ -110,6 +109,15 @@ func createView(results []DataOutput, input InputParams) ([]byte, error) {
 		status.Value = row.Status
 		ppEndpointGroup.Statuses = append(ppEndpointGroup.Statuses, status)
 
+	}
+
+	// close the status timeline of the last item by adding a new status item at 23:59 or at current time
+	if ppEndpointGroup != nil {
+		eStatus := &statusOUT{}
+		latestStatus := ppEndpointGroup.Statuses[len(ppEndpointGroup.Statuses)-1]
+		eStatus.Timestamp = strings.Split(latestStatus.Timestamp, "T")[0] + extraTS
+		eStatus.Value = latestStatus.Value
+		ppEndpointGroup.Statuses = append(ppEndpointGroup.Statuses, eStatus)
 	}
 
 	output, err = respond.MarshalContent(docRoot, input.format, "", " ")

--- a/app/statusEndpoints/controller.go
+++ b/app/statusEndpoints/controller.go
@@ -101,7 +101,7 @@ func ListEndpointTimelines(r *http.Request, cfg config.Config) (int, http.Header
 		// Convert hbase results to data output format
 		doResults := hbaseToDataOutput(hbResults)
 		// Render the reults into xml
-		output, err = createView(doResults, input) //Render the results into XML format
+		output, err = createView(doResults, input, urlValues.Get("end_time")) //Render the results into JSON/XML format
 
 		h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
 		return code, h, output, errHb
@@ -144,9 +144,8 @@ func ListEndpointTimelines(r *http.Request, cfg config.Config) (int, http.Header
 			return code, h, output, err
 		}
 	}
-	// close the timeline by adding a final status point at the end of the day or at the current time
-	results = closeTimeline(results, urlValues.Get("end_time"))
-	output, err = createView(results, input) //Render the results into XML format
+
+	output, err = createView(results, input, urlValues.Get("end_time")) //Render the results into JSON/XML format
 
 	return code, h, output, err
 }

--- a/app/statusEndpoints/statusEndpoints_test.go
+++ b/app/statusEndpoints/statusEndpoints_test.go
@@ -239,6 +239,66 @@ func (suite *StatusEndpointsTestSuite) SetupTest() {
 		"metric":         "emi.cream.CREAMCE-JobSubmit",
 		"status":         "OK",
 	})
+	c.Insert(bson.M{
+		"report":         "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date_integer":   20150501,
+		"timestamp":      "2015-05-01T00:00:00Z",
+		"endpoint_group": "HG-03-AUTH",
+		"service":        "CREAM-CE",
+		"host":           "cream02.afroditi.gr",
+		"metric":         "emi.cream.CREAMCE-JobSubmit",
+		"status":         "OK",
+	})
+	c.Insert(bson.M{
+		"report":         "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date_integer":   20150501,
+		"timestamp":      "2015-05-01T08:47:00Z",
+		"endpoint_group": "HG-03-AUTH",
+		"service":        "CREAM-CE",
+		"host":           "cream02.afroditi.gr",
+		"metric":         "emi.cream.CREAMCE-JobSubmit",
+		"status":         "WARNING",
+	})
+	c.Insert(bson.M{
+		"report":         "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date_integer":   20150501,
+		"timestamp":      "2015-05-01T12:00:00Z",
+		"endpoint_group": "HG-03-AUTH",
+		"service":        "CREAM-CE",
+		"host":           "cream02.afroditi.gr",
+		"metric":         "emi.cream.CREAMCE-JobSubmit",
+		"status":         "OK",
+	})
+	c.Insert(bson.M{
+		"report":         "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date_integer":   20150501,
+		"timestamp":      "2015-05-01T00:00:00Z",
+		"endpoint_group": "HG-03-AUTH",
+		"service":        "CREAM-CE",
+		"host":           "cream03.afroditi.gr",
+		"metric":         "emi.cream.CREAMCE-JobSubmit",
+		"status":         "OK",
+	})
+	c.Insert(bson.M{
+		"report":         "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date_integer":   20150501,
+		"timestamp":      "2015-05-01T04:40:00Z",
+		"endpoint_group": "HG-03-AUTH",
+		"service":        "CREAM-CE",
+		"host":           "cream03.afroditi.gr",
+		"metric":         "emi.cream.CREAMCE-JobSubmit",
+		"status":         "UNKNOWN",
+	})
+	c.Insert(bson.M{
+		"report":         "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date_integer":   20150501,
+		"timestamp":      "2015-05-01T06:00:00Z",
+		"endpoint_group": "HG-03-AUTH",
+		"service":        "CREAM-CE",
+		"host":           "cream03.afroditi.gr",
+		"metric":         "emi.cream.CREAMCE-JobSubmit",
+		"status":         "CRITICAL",
+	})
 
 	// get dbconfiguration based on the tenant
 	// Prepare the request object
@@ -607,6 +667,109 @@ func (suite *StatusEndpointsTestSuite) TestLatestResults() {
 	suite.Equal(200, response2.Code, "Internal Server Error")
 	// Compare the expected and actual xml response
 	suite.Equal(respJSON1, response2.Body.String(), "Response body mismatch")
+
+}
+
+func (suite *StatusEndpointsTestSuite) TestMultipleItems() {
+
+	fullurl1 := "/api/v2/status/Report_A/SITES/HG-03-AUTH" +
+		"/services/CREAM-CE/endpoints" +
+		"?start_time=2015-05-01T00:00:00Z&end_time=2015-05-01T23:00:00Z"
+
+	respJSON1 := `{
+ "groups": [
+  {
+   "name": "HG-03-AUTH",
+   "type": "SITES",
+   "services": [
+    {
+     "name": "CREAM-CE",
+     "type": "service",
+     "endpoints": [
+      {
+       "name": "cream01.afroditi.gr",
+       "statuses": [
+        {
+         "timestamp": "2015-05-01T00:00:00Z",
+         "value": "OK"
+        },
+        {
+         "timestamp": "2015-05-01T01:00:00Z",
+         "value": "CRITICAL"
+        },
+        {
+         "timestamp": "2015-05-01T05:00:00Z",
+         "value": "OK"
+        },
+        {
+         "timestamp": "2015-05-01T23:59:59Z",
+         "value": "OK"
+        }
+       ]
+      },
+      {
+       "name": "cream02.afroditi.gr",
+       "statuses": [
+        {
+         "timestamp": "2015-05-01T00:00:00Z",
+         "value": "OK"
+        },
+        {
+         "timestamp": "2015-05-01T08:47:00Z",
+         "value": "WARNING"
+        },
+        {
+         "timestamp": "2015-05-01T12:00:00Z",
+         "value": "OK"
+        },
+        {
+         "timestamp": "2015-05-01T23:59:59Z",
+         "value": "OK"
+        }
+       ]
+      },
+      {
+       "name": "cream03.afroditi.gr",
+       "statuses": [
+        {
+         "timestamp": "2015-05-01T00:00:00Z",
+         "value": "OK"
+        },
+        {
+         "timestamp": "2015-05-01T04:40:00Z",
+         "value": "UNKNOWN"
+        },
+        {
+         "timestamp": "2015-05-01T06:00:00Z",
+         "value": "CRITICAL"
+        },
+        {
+         "timestamp": "2015-05-01T23:59:59Z",
+         "value": "CRITICAL"
+        }
+       ]
+      }
+     ]
+    }
+   ]
+  }
+ ]
+}`
+
+	// init the response placeholder
+	response := httptest.NewRecorder()
+	// Prepare the request object for second tenant
+	request, _ := http.NewRequest("GET", fullurl1, strings.NewReader(""))
+	// add json accept header
+	request.Header.Set("Accept", "application/json")
+	// add the authentication token which is seeded in testdb
+	request.Header.Set("x-api-key", "KEY1")
+	// Serve the http request
+	suite.router.ServeHTTP(response, request)
+	// Check that we must have a 200 ok code
+	suite.Equal(200, response.Code, "Internal Server Error")
+	// Compare the expected and actual xml response
+	suite.Equal(respJSON1, response.Body.String(), "Response body mismatch")
 
 }
 

--- a/app/statusEndpoints/view.go
+++ b/app/statusEndpoints/view.go
@@ -55,29 +55,19 @@ func hbaseToDataOutput(hResults []*hrpc.Result) []DataOutput {
 	return dResult
 }
 
-// closeTimeline accepts a list of status item and an endDate parameter
-// and tries to close the status timeline by providing a final status item
-// at the end of the date (if the endDate parameter refers to a past date)
-// or at the current time (if the endDate parameter refers to the current date)
-func closeTimeline(results []DataOutput, endDate string) []DataOutput {
-	if len(results) == 0 {
-		return results
-	}
+func createView(results []DataOutput, input InputParams, endDate string) ([]byte, error) {
 
-	extra := results[len(results)-1]
+	// calculate part of the timestamp that closes the timeline of each item
+	var extraTS string
+
 	tsNow := time.Now().UTC()
 	today := tsNow.Format("2006-01-02")
+
 	if strings.Split(endDate, "T")[0] == today {
-		extra.Timestamp = tsNow.Format(zuluForm)
+		extraTS = "T" + strings.Split(tsNow.Format(zuluForm), "T")[1]
 	} else {
-		extra.Timestamp = strings.Split(extra.Timestamp, "T")[0] + "T23:59:59Z"
+		extraTS = "T23:59:59Z"
 	}
-
-	results = append(results, extra)
-	return results
-}
-
-func createView(results []DataOutput, input InputParams) ([]byte, error) {
 
 	output := []byte("reponse output")
 	err := error(nil)
@@ -123,6 +113,15 @@ func createView(results []DataOutput, input InputParams) ([]byte, error) {
 		}
 
 		if row.Hostname != prevHostname && row.Hostname != "" {
+			// close the status timeline of item by adding a new status item at 23:59 or at current time
+			if ppHost != nil {
+				eStatus := &statusOUT{}
+				latestStatus := ppHost.Statuses[len(ppHost.Statuses)-1]
+				eStatus.Timestamp = strings.Split(latestStatus.Timestamp, "T")[0] + extraTS
+				eStatus.Value = latestStatus.Value
+				ppHost.Statuses = append(ppHost.Statuses, eStatus)
+			}
+
 			host := &endpointOUT{} //create new host
 			host.Name = row.Hostname
 			ppService.Endpoints = append(ppService.Endpoints, host)
@@ -135,6 +134,14 @@ func createView(results []DataOutput, input InputParams) ([]byte, error) {
 		status.Value = row.Status
 		ppHost.Statuses = append(ppHost.Statuses, status)
 
+	}
+	// close the status timeline of the last item by adding a new status item at 23:59 or at current time
+	if ppHost != nil {
+		eStatus := &statusOUT{}
+		latestStatus := ppHost.Statuses[len(ppHost.Statuses)-1]
+		eStatus.Timestamp = strings.Split(latestStatus.Timestamp, "T")[0] + extraTS
+		eStatus.Value = latestStatus.Value
+		ppHost.Statuses = append(ppHost.Statuses, eStatus)
 	}
 
 	output, err = respond.MarshalContent(docRoot, input.format, "", " ")

--- a/app/statusMetrics/controller.go
+++ b/app/statusMetrics/controller.go
@@ -104,7 +104,7 @@ func ListMetricTimelines(r *http.Request, cfg config.Config) (int, http.Header, 
 		// Convert hbase results to data output format
 		doResults := hbaseToDataOutput(hbResults)
 		// Render the reults into xml
-		output, err = createView(doResults, input) //Render the results into XML format
+		output, err = createView(doResults, input, urlValues.Get("end_time")) //Render the results into XML format
 
 		h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
 		return code, h, output, errHb
@@ -147,9 +147,8 @@ func ListMetricTimelines(r *http.Request, cfg config.Config) (int, http.Header, 
 			return code, h, output, err
 		}
 	}
-	// close the timeline by adding a final status point at the end of the day or at the current time
-	results = closeTimeline(results, urlValues.Get("end_time"))
-	output, err = createView(results, input) //Render the results into XML format
+
+	output, err = createView(results, input, urlValues.Get("end_time")) //Render the results into XML format
 
 	return code, h, output, err
 }

--- a/app/statusMetrics/statusMetrics_test.go
+++ b/app/statusMetrics/statusMetrics_test.go
@@ -258,6 +258,54 @@ func (suite *StatusMetricsTestSuite) SetupTest() {
 		"summary":            "Cream status is ok",
 		"message":            "Cream job submission test return value of ok",
 	})
+	c.Insert(bson.M{
+		"report":             "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"monitoring_box":     "nagios3.hellasgrid.gr",
+		"date_integer":       20150501,
+		"timestamp":          "2015-05-01T00:00:00Z",
+		"service":            "CREAM-CE",
+		"host":               "cream01.afroditi.gr",
+		"endpoint_group":     "HG-03-AUTH",
+		"metric":             "emi.cream.CREAMCE-JobCancel",
+		"status":             "OK",
+		"time_integer":       0,
+		"previous_state":     "OK",
+		"previous_timestamp": "2015-04-30T23:59:00Z",
+		"summary":            "Cream status is ok",
+		"message":            "Cream job submission test return value of ok",
+	})
+	c.Insert(bson.M{
+		"report":             "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"monitoring_box":     "nagios3.hellasgrid.gr",
+		"date_integer":       20150501,
+		"timestamp":          "2015-05-01T01:00:00Z",
+		"service":            "CREAM-CE",
+		"host":               "cream01.afroditi.gr",
+		"endpoint_group":     "HG-03-AUTH",
+		"metric":             "emi.cream.CREAMCE-JobCancel",
+		"status":             "CRITICAL",
+		"time_integer":       10000,
+		"previous_state":     "OK",
+		"previous_timestamp": "2015-05-01T00:00:00Z",
+		"summary":            "Cream status is CRITICAL",
+		"message":            "Cream job submission test failed",
+	})
+	c.Insert(bson.M{
+		"report":             "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"monitoring_box":     "nagios3.hellasgrid.gr",
+		"date_integer":       20150501,
+		"timestamp":          "2015-05-01T05:00:00Z",
+		"service":            "CREAM-CE",
+		"host":               "cream01.afroditi.gr",
+		"endpoint_group":     "HG-03-AUTH",
+		"metric":             "emi.cream.CREAMCE-JobCancel",
+		"status":             "OK",
+		"time_integer":       50000,
+		"previous_state":     "CRITICAL",
+		"previous_timestamp": "2015-05-01T01:00:00Z",
+		"summary":            "Cream status is ok",
+		"message":            "Cream job submission test return value of ok",
+	})
 
 	// get dbconfiguration based on the tenant
 	// Prepare the request object
@@ -698,6 +746,101 @@ func (suite *StatusMetricsTestSuite) TestLatestResults() {
 	suite.Equal(200, response2.Code, "Internal Server Error")
 	// Compare the expected and actual xml response
 	suite.Equal(respJSON1, response2.Body.String(), "Response body mismatch")
+
+}
+
+func (suite *StatusMetricsTestSuite) TestMultipleItems() {
+
+	fullurl1 := "/api/v2/status/Report_A/SITES/HG-03-AUTH" +
+		"/services/CREAM-CE/endpoints/cream01.afroditi.gr/metrics" +
+		"?start_time=2015-05-01T00:00:00Z&end_time=2015-05-01T23:00:00Z"
+
+	respJSON1 := `{
+ "groups": [
+  {
+   "name": "HG-03-AUTH",
+   "type": "SITES",
+   "services": [
+    {
+     "name": "CREAM-CE",
+     "type": "service",
+     "endpoints": [
+      {
+       "name": "cream01.afroditi.gr",
+       "metrics": [
+        {
+         "name": "emi.cream.CREAMCE-JobSubmit",
+         "statuses": [
+          {
+           "timestamp": "2015-04-30T23:59:00Z",
+           "value": "OK"
+          },
+          {
+           "timestamp": "2015-05-01T00:00:00Z",
+           "value": "OK"
+          },
+          {
+           "timestamp": "2015-05-01T01:00:00Z",
+           "value": "CRITICAL"
+          },
+          {
+           "timestamp": "2015-05-01T05:00:00Z",
+           "value": "OK"
+          },
+          {
+           "timestamp": "2015-05-01T23:59:59Z",
+           "value": "OK"
+          }
+         ]
+        },
+        {
+         "name": "emi.cream.CREAMCE-JobCancel",
+         "statuses": [
+          {
+           "timestamp": "2015-04-30T23:59:00Z",
+           "value": "OK"
+          },
+          {
+           "timestamp": "2015-05-01T00:00:00Z",
+           "value": "OK"
+          },
+          {
+           "timestamp": "2015-05-01T01:00:00Z",
+           "value": "CRITICAL"
+          },
+          {
+           "timestamp": "2015-05-01T05:00:00Z",
+           "value": "OK"
+          },
+          {
+           "timestamp": "2015-05-01T23:59:59Z",
+           "value": "OK"
+          }
+         ]
+        }
+       ]
+      }
+     ]
+    }
+   ]
+  }
+ ]
+}`
+
+	// init the response placeholder
+	response := httptest.NewRecorder()
+	// Prepare the request object for second tenant
+	request, _ := http.NewRequest("GET", fullurl1, strings.NewReader(""))
+	// add json accept header
+	request.Header.Set("Accept", "application/json")
+	// add the authentication token which is seeded in testdb
+	request.Header.Set("x-api-key", "KEY1")
+	// Serve the http request
+	suite.router.ServeHTTP(response, request)
+	// Check that we must have a 200 ok code
+	suite.Equal(200, response.Code, "Internal Server Error")
+	// Compare the expected and actual xml response
+	suite.Equal(respJSON1, response.Body.String(), "Response body mismatch")
 
 }
 

--- a/app/statusServices/controller.go
+++ b/app/statusServices/controller.go
@@ -49,7 +49,7 @@ func getPrevDay(dateStr string) (int, error) {
 	return strconv.Atoi(prevTime.Format(ymdForm))
 }
 
-// ListMetricTimelines returns a list of metric timelines
+// ListServiceTimelines returns a list of service timelines
 func ListServiceTimelines(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
 
 	//STANDARD DECLARATIONS START
@@ -100,7 +100,7 @@ func ListServiceTimelines(r *http.Request, cfg config.Config) (int, http.Header,
 		// Convert hbase results to data output format
 		doResults := hbaseToDataOutput(hbResults)
 		// Render the reults into xml
-		output, err = createView(doResults, input) //Render the results into XML format
+		output, err = createView(doResults, input, urlValues.Get("end_time")) //Render the results into XML format
 
 		h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
 		return code, h, output, errHb
@@ -143,9 +143,8 @@ func ListServiceTimelines(r *http.Request, cfg config.Config) (int, http.Header,
 			return code, h, output, err
 		}
 	}
-	// close the timeline by adding a final status point at the end of the day or at the current time
-	results = closeTimeline(results, urlValues.Get("end_time"))
-	output, err = createView(results, input) //Render the results into XML format
+
+	output, err = createView(results, input, urlValues.Get("end_time")) //Render the results into XML format
 
 	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
 	return code, h, output, err

--- a/app/statusServices/statusServices_test.go
+++ b/app/statusServices/statusServices_test.go
@@ -233,6 +233,30 @@ func (suite *StatusServicesTestSuite) SetupTest() {
 		"service":        "CREAM-CE",
 		"status":         "OK",
 	})
+	c.Insert(bson.M{
+		"report":         "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date_integer":   20150501,
+		"timestamp":      "2015-05-01T00:00:00Z",
+		"endpoint_group": "HG-03-AUTH",
+		"service":        "SRM",
+		"status":         "WARNING",
+	})
+	c.Insert(bson.M{
+		"report":         "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date_integer":   20150501,
+		"timestamp":      "2015-05-01T01:00:00Z",
+		"endpoint_group": "HG-03-AUTH",
+		"service":        "SRM",
+		"status":         "OK",
+	})
+	c.Insert(bson.M{
+		"report":         "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date_integer":   20150501,
+		"timestamp":      "2015-05-01T05:00:00Z",
+		"endpoint_group": "HG-03-AUTH",
+		"service":        "SRM",
+		"status":         "UNKNOWN",
+	})
 
 	// get dbconfiguration based on the tenant
 	// Prepare the request object
@@ -597,6 +621,83 @@ func (suite *StatusServicesTestSuite) TestLatestResults() {
 	suite.Equal(200, response2.Code, "Internal Server Error")
 	// Compare the expected and actual xml response
 	suite.Equal(respJSON1, response2.Body.String(), "Response body mismatch")
+}
+
+func (suite *StatusServicesTestSuite) TestMultipleItems() {
+
+	fullurl1 := "/api/v2/status/Report_A/SITES/HG-03-AUTH" +
+		"/services" +
+		"?start_time=2015-05-01T00:00:00Z&end_time=2015-05-01T23:00:00Z"
+
+	respJSON1 := `{
+ "groups": [
+  {
+   "name": "HG-03-AUTH",
+   "type": "SITES",
+   "services": [
+    {
+     "name": "CREAM-CE",
+     "type": "service",
+     "statuses": [
+      {
+       "timestamp": "2015-05-01T00:00:00Z",
+       "value": "OK"
+      },
+      {
+       "timestamp": "2015-05-01T01:00:00Z",
+       "value": "CRITICAL"
+      },
+      {
+       "timestamp": "2015-05-01T05:00:00Z",
+       "value": "OK"
+      },
+      {
+       "timestamp": "2015-05-01T23:59:59Z",
+       "value": "OK"
+      }
+     ]
+    },
+    {
+     "name": "SRM",
+     "type": "service",
+     "statuses": [
+      {
+       "timestamp": "2015-05-01T00:00:00Z",
+       "value": "WARNING"
+      },
+      {
+       "timestamp": "2015-05-01T01:00:00Z",
+       "value": "OK"
+      },
+      {
+       "timestamp": "2015-05-01T05:00:00Z",
+       "value": "UNKNOWN"
+      },
+      {
+       "timestamp": "2015-05-01T23:59:59Z",
+       "value": "UNKNOWN"
+      }
+     ]
+    }
+   ]
+  }
+ ]
+}`
+
+	// init the response placeholder
+	response := httptest.NewRecorder()
+	// Prepare the request object for second tenant
+	request, _ := http.NewRequest("GET", fullurl1, strings.NewReader(""))
+	// add json accept header
+	request.Header.Set("Accept", "application/json")
+	// add the authentication token which is seeded in testdb
+	request.Header.Set("x-api-key", "KEY1")
+	// Serve the http request
+	suite.router.ServeHTTP(response, request)
+	// Check that we must have a 200 ok code
+	suite.Equal(200, response.Code, "Internal Server Error")
+	// Compare the expected and actual xml response
+	suite.Equal(respJSON1, response.Body.String(), "Response body mismatch")
 
 }
 


### PR DESCRIPTION
# Issue 
When asking for multime status timelines at once, only the last one gets an end of day status point that closes the timeline

# Fix 
- Refactor create view at statusEndpointGroups package to fix the issue
- Refactor create view at statusServices package to fix the issue
- Refactor create view at statusEndpoints package to fix the issue
- Refactor create view at statusMetrics package to fix the issue
- Remove closeTimeline function
- Refactor controllers