### PR TITLE
ARGO-1964 Return all daily metric data for specific host and date

### DIFF
--- a/app/metricResult/controller.go
+++ b/app/metricResult/controller.go
@@ -35,6 +35,55 @@ import (
 	"gopkg.in/mgo.v2/bson"
 )
 
+// GetMultipleMetricResults returns the detailed message from a probe
+func GetMultipleMetricResults(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
+
+	//STANDARD DECLARATIONS START
+	code := http.StatusOK
+	h := http.Header{}
+	output := []byte("")
+	err := error(nil)
+	charset := "utf-8"
+	//STANDARD DECLARATIONS END
+
+	// Set Content-Type response Header value
+	contentType := r.Header.Get("Accept")
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+
+	// Grab Tenant DB configuration from context
+	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
+
+	vars := mux.Vars(r)
+	urlValues := r.URL.Query()
+
+	input := metricResultQuery{
+		EndpointName: vars["endpoint_name"],
+		ExecTime:     urlValues.Get("exec_time"),
+	}
+
+	session, err := mongo.OpenSession(tenantDbConfig)
+	defer mongo.CloseSession(session)
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	results := []metricResultOutput{}
+
+	// Query the detailed metric results
+	err = mongo.Pipe(session, tenantDbConfig.Db, "status_metrics", prepMultipleQuery(input), &results)
+
+	output, err = createMultipleMetricResultsView(results, contentType)
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	return code, h, output, err
+}
+
 // GetMetricResult returns the detailed message from a probe
 func GetMetricResult(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
 
@@ -105,6 +154,55 @@ func prepQuery(input metricResultQuery) bson.M {
 		"host":         input.EndpointName,
 		"metric":       input.MetricName,
 		"time_integer": tsInt,
+	}
+
+	return query
+
+}
+
+func prepMultipleQuery(input metricResultQuery) []bson.M {
+
+	//Time Related
+	const zuluForm = "2006-01-02T15:04:05Z"
+	const ymdForm = "20060102"
+
+	ts, _ := time.Parse(zuluForm, input.ExecTime)
+	tsYMD, _ := strconv.Atoi(ts.Format(ymdForm))
+
+	filter := bson.M{
+		"date_integer": tsYMD,
+		"host":         input.EndpointName,
+	}
+
+	query := []bson.M{
+		{"$match": filter},
+		{"$group": bson.M{
+			"_id": bson.M{
+				"host":      "$host",
+				"service":   "$service",
+				"metric":    "$metric",
+				"timestamp": "$timestamp",
+				"message":   "$message",
+				"summary":   "$summary",
+				"status":    "$status"},
+		},
+		},
+		{"$project": bson.M{
+			"_id":       0,
+			"host":      "$_id.host",
+			"metric":    "$_id.metric",
+			"service":   "$_id.service",
+			"timestamp": "$_id.timestamp",
+			"status":    "$_id.status",
+			"summary":   "$_id.summary",
+			"message":   "$_id.message"},
+		},
+		{"$sort": bson.D{
+			{"service", 1},
+			{"metric", 1},
+			{"timestamp", 1},
+		},
+		},
 	}
 
 	return query

--- a/app/metricResult/metric_test.go
+++ b/app/metricResult/metric_test.go
@@ -261,6 +261,54 @@ func (suite *metricResultTestSuite) TestReadStatusDetail() {
 
 }
 
+func (suite *metricResultTestSuite) TestMultipleMetricResults() {
+
+	respJSON := `{
+   "root": [
+     {
+       "Name": "cream01.afroditi.gr",
+       "Metrics": [
+         {
+           "Name": "emi.cream.CREAMCE-JobSubmit",
+           "Service": "CREAM-CE",
+           "Details": [
+             {
+               "Timestamp": "2015-05-01T00:00:00Z",
+               "Value": "OK",
+               "Summary": "Cream status is ok",
+               "Message": "Cream job submission test return value of ok"
+             },
+             {
+               "Timestamp": "2015-05-01T01:00:00Z",
+               "Value": "CRITICAL",
+               "Summary": "Cream status is CRITICAL",
+               "Message": "Cream job submission test failed"
+             },
+             {
+               "Timestamp": "2015-05-01T05:00:00Z",
+               "Value": "OK",
+               "Summary": "Cream status is ok",
+               "Message": "Cream job submission test return value of ok"
+             }
+           ]
+         }
+       ]
+     }
+   ]
+ }`
+
+	request, _ := http.NewRequest("GET", "/api/v2/metric_result/cream01.afroditi.gr?exec_time=2015-05-01T00:00:00Z", strings.NewReader(""))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+	response := httptest.NewRecorder()
+	suite.router.ServeHTTP(response, request)
+	// Check that we must have a 200 ok code
+	suite.Equal(200, response.Code, "Incorrect HTTP response code")
+	// Compare the expected and actual xml response
+	suite.Equal(respJSON, response.Body.String(), "Response body mismatch")
+
+}
+
 // TestOptionsMetricResult is used to test the OPTIONS response
 func (suite *metricResultTestSuite) TestOptionsMetricResult() {
 

--- a/app/metricResult/model.go
+++ b/app/metricResult/model.go
@@ -34,6 +34,7 @@ type metricResultQuery struct {
 type metricResultOutput struct {
 	Timestamp string `bson:"timestamp"`
 	Hostname  string `bson:"host"`
+	Service   string `bson:"service"`
 	Metric    string `bson:"metric"`
 	Status    string `bson:"status"`
 	Summary   string `bson:"summary"`
@@ -51,6 +52,7 @@ type HostXML struct {
 type MetricXML struct {
 	XMLName xml.Name `xml:"metric" json:"-"`
 	Name    string   `xml:"name,attr"`
+	Service string   `xml:"service,attr,omitempty" json:"Service,omitempty"`
 	Details []*StatusXML
 }
 

--- a/app/metricResult/routing.go
+++ b/app/metricResult/routing.go
@@ -37,5 +37,7 @@ func HandleSubrouter(s *mux.Router, confhandler *respond.ConfHandler) {
 
 var appRoutesV2 = []respond.AppRoutes{
 	{"metricResult.get", "GET", "/{endpoint_name}/{metric_name}", GetMetricResult},
+	{"metricResult.get", "GET", "/{endpoint_name}", GetMultipleMetricResults},
 	{"metricResult.options", "OPTIONS", "/{endpoint_name}/{metric_name}", Options},
+	{"metricResult.options", "OPTIONS", "/{endpoint_name}", Options},
 }

--- a/app/metricResult/view.go
+++ b/app/metricResult/view.go
@@ -29,6 +29,71 @@ import (
 	"strings"
 )
 
+func createMultipleMetricResultsView(results []metricResultOutput, format string) ([]byte, error) {
+
+	docRoot := &root{}
+
+	// Exit here in case result is empty
+	if len(results) == 0 {
+		output, err := xml.MarshalIndent(docRoot, "", "")
+		return output, err
+	}
+
+	hostname := &HostXML{
+		Name: results[0].Hostname,
+	}
+	docRoot.Result = append(docRoot.Result, hostname)
+
+	prevMetric := ""
+	prevService := ""
+
+	metric := &MetricXML{
+		Name:    "",
+		Service: "",
+	}
+
+	for i, result := range results {
+		if i == 0 {
+			prevMetric = result.Metric
+			prevService = result.Service
+
+			metric.Name = result.Metric
+			metric.Service = result.Service
+		}
+
+		if result.Metric != prevMetric || result.Service != prevService {
+			hostname.Metrics = append(hostname.Metrics, metric)
+
+			metric = &MetricXML{
+				Name:    result.Metric,
+				Service: result.Service,
+			}
+		}
+
+		// we append the detailed results
+		metric.Details = append(metric.Details,
+			&StatusXML{
+				Timestamp: fmt.Sprintf("%s", result.Timestamp),
+				Value:     fmt.Sprintf("%s", result.Status),
+				Summary:   fmt.Sprintf("%s", result.Summary),
+				Message:   fmt.Sprintf("%s", result.Message),
+			})
+
+		prevMetric = result.Metric
+		prevService = result.Service
+
+	}
+
+	hostname.Metrics = append(hostname.Metrics, metric)
+
+	if strings.ToLower(format) == "application/json" {
+		return json.MarshalIndent(docRoot, " ", "  ")
+	}
+
+	return xml.MarshalIndent(docRoot, " ", "  ")
+
+}
+
 func createMetricResultView(result metricResultOutput, format string) ([]byte, error) {
 
 	docRoot := &root{}
@@ -60,8 +125,8 @@ func createMetricResultView(result metricResultOutput, format string) ([]byte, e
 
 	if strings.ToLower(format) == "application/json" {
 		return json.MarshalIndent(docRoot, " ", "  ")
-	} else {
-		return xml.MarshalIndent(docRoot, " ", "  ")
 	}
+
+	return xml.MarshalIndent(docRoot, " ", "  ")
 
 }

--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -1709,6 +1709,40 @@ paths:
           $ref: "#/responses/422"
         500:
           $ref: "#/responses/ServerError"
+          
+  /metric_result/{endpoint}:
+    get:
+      summary: Retrieve a list of all metric results for a specific day and a specific host
+      description: Retrieve a list with  the full output of all metric results for a specific date
+      tags:
+        - MetricResult
+      produces:
+        - "application/json"
+        - "application/xml"
+      parameters:
+        - $ref: "#/parameters/apiKey"
+        - name: "endpoint"
+          in: path
+          description: "The fqdn of the monitored host"
+          required: true
+          type: string
+        - $ref: "#/parameters/execDate"
+      responses:
+        200:
+          description: "Successful retrieval of multiple metric results"
+          schema:
+            $ref: "#/definitions/MultipleMetricResults"
+        400:
+          $ref: "#/responses/404"
+        401:
+          $ref: "#/responses/Unauthorized"
+        406:
+          $ref: "#/responses/406"
+        422:
+          $ref: "#/responses/422"
+        500:
+          $ref: "#/responses/ServerError"
+
 
   /metric_result/{endpoint}/{metric_name}:
     get:
@@ -2835,6 +2869,47 @@ definitions:
         type: string
       code:
         type: string
+        
+        
+  MultipleMetricResults:
+    type: object
+    properties:
+      root:
+        type: array
+        items:
+          type: object
+          properties:
+            Name:
+              type: string
+              description: "The fqdn of the monitored endpoint"
+            Metrics:
+              type: array
+              items:
+                type: object
+                properties:
+                  Name:
+                    type: string
+                    description: "The name of the probe (metric)"
+                  Service:
+                    type: string
+                    description: "Name of the corresponding service type"
+                  Details:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        Timestamp:
+                          type: string
+                          description: "The execution time of the probe (metric)"
+                        Value:
+                          type: string
+                          description: "The resulting state of the probe (metric)"
+                        Summary:
+                          type: string
+                          description: "A summary of the metric result"
+                        Message:
+                          type: string
+                          description: "The detailed output message of the probe (metric)"
 
   MetricResult:
     type: object

--- a/doc/v2/docs/metrics.md
+++ b/doc/v2/docs/metrics.md
@@ -59,15 +59,142 @@ Status: 200 OK
 ```
 Reponse body:
 ```
- <root>
-   <host name="www.example.com">
-     <metric name="httpd_check">
-       <status timestamp="2015-06-20T12:00:00Z" value="CRITICAL">
-	 <summary>httpd status is CRITICAL</summary>
-	 <message>httpd service seems down. Failed to connect to port 80.</message>
-       </status>
-     </metric>
-   </host>
- </root>
+ {
+   "root": [
+     {
+       "Name": "www.example.com",
+       "Metrics": [
+         {
+           "Name": "httpd_check",
+           "Service": "httpd",
+           "Details": [
+             {
+               "Timestamp": "2015-06-20T12:00:00Z",
+               "Value": "OK",
+               "Summary": "httpd is ok",
+               "Message": "all checks ok"
+             }
+           ]
+         }
+       ]
+     }
+   ]
+ }
+ 
+```
+
+## [GET]: Multiple Metric Results for a specific host, on a specific day
+
+This method may be used to retrieve multiple service metric results for a specific host on a specific day
+
+### Input
+
+```
+/metric_result/{hostname}?[exec_time]
+```
+
+#### Path Parameters
+| Type | Description | Required | Default value |
+|------|-------------|----------|---------------|
+|`hostname`| hostname of service endpoint| YES |  |
+
+#### Url Parameters
+
+| Type | Description | Required | Default value |
+|------|-------------|----------|---------------|
+|`exec_time`| The execution date of query in zulu format - timepart is irrelevant (can be 00:00:00Z) | YES |  |
+
+___Notes___:
+`exec_time` : The specific date of query in zulu format. The time part of the date is irrelevant because all metrics of that day are returned. ( GET /status/{report_name}/{lgroup_type}/{lgroup_name}/services/{service_name}/endpoints/{endpoint_name}/metrics List)
+
+#### Headers
+```
+x-api-key: shared_key_value
+Accept: application/json or application/xml
+```
+
+#### Response Code
+```
+Status: 200 OK
+```
+
+### Response body
+
+###### Example Request:
+URL:
+```
+/api/v2/metric_result/www.example.com?exec_time=2015-06-20T00:00:00Z
+```
+Headers:
+```
+x-api-key: shared_key_value
+Accept: application/json or application/xml
+
+```
+###### Example Response:
+
+Code:
+```
+Status: 200 OK
+```
+Reponse body:
+```
+{
+   "root": [
+     {
+       "Name": "www.example.com",
+       "Metrics": [
+         {
+           "Name": "httpd_check",
+           "Service": "httpd",
+           "Details": [
+             {
+               "Timestamp": "2015-06-20T12:00:00Z",
+               "Value": "OK",
+               "Summary": "httpd is ok",
+               "Message": "all checks ok"
+             },
+              {
+               "Timestamp": "2015-06-20T18:00:00Z",
+               "Value": "OK",
+               "Summary": "httpd is ok",
+               "Message": "all checks ok"
+             },
+              {
+               "Timestamp": "2015-06-20T23:00:00Z",
+               "Value": "OK",
+               "Summary": "httpd is ok",
+               "Message": "all checks ok"
+             }
+           ]
+         },
+         {
+           "Name": "httpd_memory",
+           "Service": "httpd",
+           "Details": [
+             {
+               "Timestamp": "2015-06-20T06:00:00Z",
+               "Value": "OK",
+               "Summary": "memcheck ok",
+               "Message": "memory under 20%"
+             },
+             {
+               "Timestamp": "2015-06-20T09:00:00Z",
+               "Value": "OK",
+               "Summary": "memcheck ok",
+               "Message": "memory under 20%"
+             },
+             {
+               "Timestamp": "2015-06-20T18:00:00Z",
+               "Value": "OK",
+               "Summary": "memcheck ok",
+               "Message": "memory under 20%"
+             },
+           ]
+         }
+       ]
+     }
+   ]
+ }
 ```
 

--- a/utils/mongo/mongoQuery.go
+++ b/utils/mongo/mongoQuery.go
@@ -51,7 +51,6 @@ func openCollection(session *mgo.Session, dbName string, collectionName string) 
 }
 
 func Pipe(session *mgo.Session, dbName string, collectionName string, query []bson.M, results interface{}) error {
-
 	c := openCollection(session, dbName, collectionName)
 	err := c.Pipe(query).All(results)
 	return err


### PR DESCRIPTION
# Goal 
Give the ability to query all daily metric data results for a specific host in a single request

# Implementation
in pkg `metricResult`:
- Create `GetMultipleMetricResults` handler 
- Create a mongo aggregation query in method `prepareMultipleQuery`
- Create new view for multiple metric results
- Update routing to use the pattern `/metric_result/{hostname}?exec_time={date_param}`
- Update swagger
- Update docs