### PR TITLE
ARGO-1983 Add filter param to return metric result list

### DIFF
--- a/app/metricResult/metric_test.go
+++ b/app/metricResult/metric_test.go
@@ -309,6 +309,138 @@ func (suite *metricResultTestSuite) TestMultipleMetricResults() {
 
 }
 
+func (suite *metricResultTestSuite) TestMultipleMetricResultsNonOK() {
+
+	respJSON := `{
+   "root": [
+     {
+       "Name": "cream01.afroditi.gr",
+       "Metrics": [
+         {
+           "Name": "emi.cream.CREAMCE-JobSubmit",
+           "Service": "CREAM-CE",
+           "Details": [
+             {
+               "Timestamp": "2015-05-01T01:00:00Z",
+               "Value": "CRITICAL",
+               "Summary": "Cream status is CRITICAL",
+               "Message": "Cream job submission test failed"
+             }
+           ]
+         }
+       ]
+     }
+   ]
+ }`
+
+	request, _ := http.NewRequest("GET", "/api/v2/metric_result/cream01.afroditi.gr?exec_time=2015-05-01T00:00:00Z&filter=non-ok", strings.NewReader(""))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+	response := httptest.NewRecorder()
+	suite.router.ServeHTTP(response, request)
+	// Check that we must have a 200 ok code
+	suite.Equal(200, response.Code, "Incorrect HTTP response code")
+	// Compare the expected and actual xml response
+	suite.Equal(respJSON, response.Body.String(), "Response body mismatch")
+
+}
+
+func (suite *metricResultTestSuite) TestMultipleMetricResultsCritical() {
+
+	respJSON := `{
+   "root": [
+     {
+       "Name": "cream01.afroditi.gr",
+       "Metrics": [
+         {
+           "Name": "emi.cream.CREAMCE-JobSubmit",
+           "Service": "CREAM-CE",
+           "Details": [
+             {
+               "Timestamp": "2015-05-01T01:00:00Z",
+               "Value": "CRITICAL",
+               "Summary": "Cream status is CRITICAL",
+               "Message": "Cream job submission test failed"
+             }
+           ]
+         }
+       ]
+     }
+   ]
+ }`
+
+	request, _ := http.NewRequest("GET", "/api/v2/metric_result/cream01.afroditi.gr?exec_time=2015-05-01T00:00:00Z&filter=critical", strings.NewReader(""))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+	response := httptest.NewRecorder()
+	suite.router.ServeHTTP(response, request)
+	// Check that we must have a 200 ok code
+	suite.Equal(200, response.Code, "Incorrect HTTP response code")
+	// Compare the expected and actual xml response
+	suite.Equal(respJSON, response.Body.String(), "Response body mismatch")
+
+}
+
+func (suite *metricResultTestSuite) TestMultipleMetricResultsWarning() {
+
+	respJSON := `{
+   "root": []
+ }`
+
+	request, _ := http.NewRequest("GET", "/api/v2/metric_result/cream01.afroditi.gr?exec_time=2015-05-01T00:00:00Z&filter=warning", strings.NewReader(""))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+	response := httptest.NewRecorder()
+	suite.router.ServeHTTP(response, request)
+	// Check that we must have a 200 ok code
+	suite.Equal(200, response.Code, "Incorrect HTTP response code")
+	// Compare the expected and actual xml response
+	suite.Equal(respJSON, response.Body.String(), "Response body mismatch")
+
+}
+
+func (suite *metricResultTestSuite) TestMultipleMetricResultsOK() {
+
+	respJSON := `{
+   "root": [
+     {
+       "Name": "cream01.afroditi.gr",
+       "Metrics": [
+         {
+           "Name": "emi.cream.CREAMCE-JobSubmit",
+           "Service": "CREAM-CE",
+           "Details": [
+             {
+               "Timestamp": "2015-05-01T00:00:00Z",
+               "Value": "OK",
+               "Summary": "Cream status is ok",
+               "Message": "Cream job submission test return value of ok"
+             },
+             {
+               "Timestamp": "2015-05-01T05:00:00Z",
+               "Value": "OK",
+               "Summary": "Cream status is ok",
+               "Message": "Cream job submission test return value of ok"
+             }
+           ]
+         }
+       ]
+     }
+   ]
+ }`
+
+	request, _ := http.NewRequest("GET", "/api/v2/metric_result/cream01.afroditi.gr?exec_time=2015-05-01T00:00:00Z&filter=ok", strings.NewReader(""))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+	response := httptest.NewRecorder()
+	suite.router.ServeHTTP(response, request)
+	// Check that we must have a 200 ok code
+	suite.Equal(200, response.Code, "Incorrect HTTP response code")
+	// Compare the expected and actual xml response
+	suite.Equal(respJSON, response.Body.String(), "Response body mismatch")
+
+}
+
 // TestOptionsMetricResult is used to test the OPTIONS response
 func (suite *metricResultTestSuite) TestOptionsMetricResult() {
 

--- a/app/metricResult/model.go
+++ b/app/metricResult/model.go
@@ -66,6 +66,6 @@ type StatusXML struct {
 }
 
 type root struct {
-	XMLName xml.Name      `xml:"root" json:"-"`
-	Result  []interface{} `json:"root"`
+	XMLName xml.Name   `xml:"root" json:"-"`
+	Result  []*HostXML `json:"root"`
 }

--- a/app/metricResult/view.go
+++ b/app/metricResult/view.go
@@ -35,8 +35,12 @@ func createMultipleMetricResultsView(results []metricResultOutput, format string
 
 	// Exit here in case result is empty
 	if len(results) == 0 {
-		output, err := xml.MarshalIndent(docRoot, "", "")
-		return output, err
+
+		docRoot.Result = []*HostXML{}
+		if strings.ToLower(format) == "application/json" {
+			return json.MarshalIndent(docRoot, " ", "  ")
+		}
+		return xml.MarshalIndent(docRoot, "", "")
 	}
 
 	hostname := &HostXML{

--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -1727,6 +1727,7 @@ paths:
           required: true
           type: string
         - $ref: "#/parameters/execDate"
+        - $ref: "#/parameters/latestFilter"
       responses:
         200:
           description: "Successful retrieval of multiple metric results"

--- a/doc/v2/docs/metrics.md
+++ b/doc/v2/docs/metrics.md
@@ -103,6 +103,7 @@ This method may be used to retrieve multiple service metric results for a specif
 | Type | Description | Required | Default value |
 |------|-------------|----------|---------------|
 |`exec_time`| The execution date of query in zulu format - timepart is irrelevant (can be 00:00:00Z) | YES |  |
+|`filter`| Filter metric results by statuses: non-ok, ok, critical, warning | NO |  |
 
 ___Notes___:
 `exec_time` : The specific date of query in zulu format. The time part of the date is irrelevant because all metrics of that day are returned. ( GET /status/{report_name}/{lgroup_type}/{lgroup_name}/services/{service_name}/endpoints/{endpoint_name}/metrics List)
@@ -156,9 +157,9 @@ Reponse body:
              },
               {
                "Timestamp": "2015-06-20T18:00:00Z",
-               "Value": "OK",
-               "Summary": "httpd is ok",
-               "Message": "all checks ok"
+               "Value": "CRITICAL",
+               "Summary": "httpd is critical",
+               "Message": "some checks failed"
              },
               {
                "Timestamp": "2015-06-20T23:00:00Z",
@@ -198,3 +199,116 @@ Reponse body:
  }
 ```
 
+###### Example Request with filter parameter set to `non-ok`:
+URL:
+```
+/api/v2/metric_result/www.example.com?exec_time=2015-06-20T00:00:00Z&filter=non-ok
+```
+Headers:
+```
+x-api-key: shared_key_value
+Accept: application/json or application/xml
+
+```
+###### Example Response using fitler parameter set to `non-ok`:
+
+Code:
+```
+Status: 200 OK
+```
+Reponse body:
+```
+{
+   "root": [
+     {
+       "Name": "www.example.com",
+       "Metrics": [
+         {
+           "Name": "httpd_check",
+           "Service": "httpd",
+           "Details": [
+              {
+               "Timestamp": "2015-06-20T18:00:00Z",
+               "Value": "CRITICAL",
+               "Summary": "httpd is critical",
+               "Message": "some checks failed"
+              }
+           ]
+         }
+       ]
+     }
+   ]
+ }
+```
+
+###### Example Request with filter parameter set to `ok`:
+URL:
+```
+/api/v2/metric_result/www.example.com?exec_time=2015-06-20T00:00:00Z&filter=ok
+```
+Headers:
+```
+x-api-key: shared_key_value
+Accept: application/json or application/xml
+
+```
+###### Example Response using fitler parameter set to `ok`:
+
+Code:
+```
+Status: 200 OK
+```
+Reponse body:
+```
+{
+   "root": [
+     {
+       "Name": "www.example.com",
+       "Metrics": [
+         {
+           "Name": "httpd_check",
+           "Service": "httpd",
+           "Details": [
+             {
+               "Timestamp": "2015-06-20T12:00:00Z",
+               "Value": "OK",
+               "Summary": "httpd is ok",
+               "Message": "all checks ok"
+             },
+             {
+               "Timestamp": "2015-06-20T23:00:00Z",
+               "Value": "OK",
+               "Summary": "httpd is ok",
+               "Message": "all checks ok"
+             }
+           ]
+         },
+         {
+           "Name": "httpd_memory",
+           "Service": "httpd",
+           "Details": [
+             {
+               "Timestamp": "2015-06-20T06:00:00Z",
+               "Value": "OK",
+               "Summary": "memcheck ok",
+               "Message": "memory under 20%"
+             },
+             {
+               "Timestamp": "2015-06-20T09:00:00Z",
+               "Value": "OK",
+               "Summary": "memcheck ok",
+               "Message": "memory under 20%"
+             },
+             {
+               "Timestamp": "2015-06-20T18:00:00Z",
+               "Value": "OK",
+               "Summary": "memcheck ok",
+               "Message": "memory under 20%"
+             },
+           ]
+         }
+       ]
+     }
+   ]
+ }
+```


### PR DESCRIPTION
# Goal
Add optional filter parameter when request list of metric data for host

# Implementation 
- Add optional `filter` parameter in request handler
- Use optional filter parameter in method that prepares query for list of metric data
- Update swagger
- Update docs