### PR TITLE
ARGO-1997 Change recomputation status through web-api

### DIFF
--- a/app/recomputations2/Controller.go
+++ b/app/recomputations2/Controller.go
@@ -178,8 +178,8 @@ func SubmitRecomputation(r *http.Request, cfg config.Config) (int, http.Header, 
 	now := time.Now()
 	recomputation := MongoInterface{
 		ID:             mongo.NewUUID(),
-		RequesterName:  tenantDbConfig.User,
-		RequesterEmail: tenantDbConfig.Email,
+		RequesterName:  recompSubmission.RequesterName,
+		RequesterEmail: recompSubmission.RequesterEmail,
 		StartTime:      recompSubmission.StartTime,
 		EndTime:        recompSubmission.EndTime,
 		Reason:         recompSubmission.Reason,
@@ -263,8 +263,8 @@ func Update(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 
 	recomputation := MongoInterface{
 		ID:             vars["ID"],
-		RequesterName:  tenantDbConfig.User,
-		RequesterEmail: tenantDbConfig.Email,
+		RequesterName:  recompSubmission.RequesterName,
+		RequesterEmail: recompSubmission.RequesterEmail,
 		StartTime:      recompSubmission.StartTime,
 		EndTime:        recompSubmission.EndTime,
 		Reason:         recompSubmission.Reason,

--- a/app/recomputations2/Model.go
+++ b/app/recomputations2/Model.go
@@ -48,18 +48,28 @@ type Links struct {
 	Self string `xml:"self" json:"self"`
 }
 
+type IncomingStatus struct {
+	Status string `xml:"status" json:"status"`
+}
+
 type MongoInterface struct {
-	XMLName        xml.Name `bson:"-" xml:"recomputation" json:"-"`
-	ID             string   `bson:"id" xml:"id" json:"id"`
-	RequesterName  string   `bson:"requester_name" xml:"requester_name" json:"requester_name"`
-	RequesterEmail string   `bson:"requester_email" xml:"requester_email" json:"requester_email"`
-	Reason         string   `bson:"reason" xml:"reason" json:"reason"`
-	StartTime      string   `bson:"start_time" xml:"start_time" json:"start_time"`
-	EndTime        string   `bson:"end_time" xml:"end_time" json:"end_time"`
-	Report         string   `bson:"report" xml:"report" json:"report"`
-	Exclude        []string `bson:"exclude" xml:"exclude>group" json:"exclude"`
-	Status         string   `bson:"status" xml:"status" json:"status"`
-	Timestamp      string   `bson:"timestamp" xml:"timestamp" json:"timestamp"`
+	XMLName        xml.Name      `bson:"-" xml:"recomputation" json:"-"`
+	ID             string        `bson:"id" xml:"id" json:"id"`
+	RequesterName  string        `bson:"requester_name" xml:"requester_name" json:"requester_name"`
+	RequesterEmail string        `bson:"requester_email" xml:"requester_email" json:"requester_email"`
+	Reason         string        `bson:"reason" xml:"reason" json:"reason"`
+	StartTime      string        `bson:"start_time" xml:"start_time" json:"start_time"`
+	EndTime        string        `bson:"end_time" xml:"end_time" json:"end_time"`
+	Report         string        `bson:"report" xml:"report" json:"report"`
+	Exclude        []string      `bson:"exclude" xml:"exclude>group" json:"exclude"`
+	Status         string        `bson:"status" xml:"status" json:"status"`
+	Timestamp      string        `bson:"timestamp" xml:"timestamp" json:"timestamp"`
+	History        []HistoryItem `bson:"history" xml:"history" json:"history"`
+}
+
+type HistoryItem struct {
+	Status    string `bson:"status" xml:"status" json:"status"`
+	Timestamp string `bson:"timestamp" xml:"timestamp" json:"timestamp"`
 }
 
 type Exclude struct {

--- a/app/recomputations2/Model.go
+++ b/app/recomputations2/Model.go
@@ -29,12 +29,14 @@ type IncomingRequest struct {
 }
 
 type IncomingRecomputation struct {
-	ID        string   `xml:"id" json:"id" bson:"id,omitempty"`
-	StartTime string   `xml:"start_time,attr" json:"start_time" bson:"start_time,omitempty"`
-	EndTime   string   `xml:"end_time,attr" json:"end_time" bson:"end_time,omitempty"`
-	Reason    string   `xml:"reason,attr" json:"reason" bson:"reason,omitempty"`
-	Report    string   `xml:"report,attr" json:"report" bson:"report,omitempty"`
-	Exclude   []string `xml:"exclude" json:"exclude" bson:"exclude,omitempty"`
+	ID             string   `xml:"id" json:"id" bson:"id,omitempty"`
+	StartTime      string   `xml:"start_time,attr" json:"start_time" bson:"start_time,omitempty"`
+	RequesterName  string   `xml:"requester_name" json:"requester_name" bson:"requester_name,omitempty" `
+	RequesterEmail string   `xml:"requester_email" json:"requester_email" bson:"requester_email,omitempty" `
+	EndTime        string   `xml:"end_time,attr" json:"end_time" bson:"end_time,omitempty"`
+	Reason         string   `xml:"reason,attr" json:"reason" bson:"reason,omitempty"`
+	Report         string   `xml:"report,attr" json:"report" bson:"report,omitempty"`
+	Exclude        []string `xml:"exclude" json:"exclude" bson:"exclude,omitempty"`
 }
 
 type SelfReference struct {

--- a/app/recomputations2/recomputation_test.go
+++ b/app/recomputations2/recomputation_test.go
@@ -393,11 +393,13 @@ func (suite *RecomputationsProfileTestSuite) TestListRecomputations() {
 
 func (suite *RecomputationsProfileTestSuite) TestSubmitRecomputations() {
 	submission := IncomingRecomputation{
-		StartTime: "2015-01-10T12:00:00Z",
-		EndTime:   "2015-01-30T23:00:00Z",
-		Reason:    "Ups failure",
-		Report:    "EGI_Critical",
-		Exclude:   []string{"SITE5", "SITE8"},
+		StartTime:      "2015-01-10T12:00:00Z",
+		EndTime:        "2015-01-30T23:00:00Z",
+		RequesterName:  "Joe Complexz",
+		RequesterEmail: "C.Joecz@egi.eu",
+		Reason:         "Ups failure",
+		Report:         "EGI_Critical",
+		Exclude:        []string{"SITE5", "SITE8"},
 	}
 	jsonsubmission, _ := json.Marshal(submission)
 
@@ -461,8 +463,8 @@ func (suite *RecomputationsProfileTestSuite) TestSubmitRecomputations() {
  \},
  \{
   "id": ".+-.+-.+-.+-.+",
-  "requester_name": "Joe Complex",
-  "requester_email": "C.Joe@egi.eu",
+  "requester_name": "Joe Complexz",
+  "requester_email": "C.Joecz@egi.eu",
   "reason": "Ups failure",
   "start_time": "2015-01-10T12:00:00Z",
   "end_time": "2015-01-30T23:00:00Z",

--- a/app/recomputations2/routing.go
+++ b/app/recomputations2/routing.go
@@ -36,6 +36,8 @@ func HandleSubrouter(s *mux.Router, confhandler *respond.ConfHandler) {
 }
 
 var appRoutesV2 = []respond.AppRoutes{
+	{"recomputations.changeStatus", "POST", "/recomputations/{ID}/status", ChangeStatus},
+	{"recomputations.resetStatus", "DELETE", "/recomputations/{ID}/status", ResetStatus},
 	{"recomputations.list", "GET", "/recomputations", List},
 	{"recomputations.get", "GET", "/recomputations/{ID}", ListOne},
 	{"recomputations.delete", "DELETE", "/recomputations/{ID}", Delete},

--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -3008,6 +3008,12 @@ definitions:
   recomputation_request:
     type: object
     properties:
+      requester_name:
+        type: string
+        description: "Name of the person submitting the recompuatation request"
+      requester_email:
+        type: string
+        description: "Email of the person submitting the recomputation request"
       reason:
         type: string
         description: "A reason why this request is being submitted"

--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -2342,6 +2342,71 @@ paths:
           $ref: "#/responses/422"
         500:
           $ref: "#/responses/ServerError"
+          
+  /recomputations/{ID}/status:
+    post:
+      summary: "change recomputation status"
+      description: "change status of a recomputation with a given ID"
+      tags:
+        - Recomputations
+      produces:
+        - "application/json"
+        - "application/xml"
+      parameters:
+        - name: "ID"
+          in: "path"
+          description: "the recomputation id"
+          required: true
+          type: string
+        - $ref: "#/parameters/apiKey"
+        - name: "status"
+          in: "body"
+          description: "incoming status recomputation"
+          schema:
+            $ref: "#/definitions/recomputation_status"
+      responses:
+        200:
+          description: "Successful change of status in recomputation"
+          schema:
+            $ref: "#/definitions/Status"
+        400:
+          $ref: "#/responses/404"
+        401:
+          $ref: "#/responses/Unauthorized"
+        406:
+          $ref: "#/responses/406"
+        422:
+          $ref: "#/responses/422"
+        500:
+          $ref: "#/responses/ServerError"
+    delete:
+      summary: "reset a recomputation status"
+      description: "reset status for a given recomputation"
+      tags:
+        - Recomputations
+      produces:
+        - "application/json"
+        - "application/xml"
+      parameters:
+        - name: "ID"
+          in: "path"
+          description: "the recomputation id"
+          required: true
+          type: string
+        - $ref: "#/parameters/apiKey"
+      responses:
+        200:
+          description: "Successful reset status of recomputation"
+          schema:
+            $ref: '#/definitions/Status'
+        401:
+          $ref: "#/responses/Unauthorized"
+        406:
+          $ref: "#/responses/406"
+        404:
+          $ref: "#/responses/404"
+        500:
+          $ref: "#/responses/ServerError"
 
   /recomputations/{ID}:
     get:
@@ -2984,6 +3049,8 @@ definitions:
         type: string
       requester_email:
         type: string
+      report:
+        type: string
       reason:
         type: string
         description: "The reason why this request has been submitted"
@@ -3000,10 +3067,32 @@ definitions:
           type: string
       status:
         type: string
-        description: "Can be one of pending, running or done"
+        description: "Can be one of approved, rejected, pending, running or done"
       timestamp:
         type: string
-        description: "Timestamp of last status change"
+        description: "Creation timestamp"
+      history:
+        type: array
+        description: "List of status changes"
+        items:
+          $ref: '#/definitions/recomputation_status_item'
+
+  recomputation_status_item:
+    type: object
+    properties:
+      status:
+        type: string
+        description: "Can be one of approved, rejected, pending, running or done"
+      timestamp:
+        type: string
+        description: "zulu format timestamp when the status was changed"
+        
+  recomputation_status:
+    type: object
+    properties:
+      status:
+        type: string
+        description: "Can be one of approved, rejected, pending, running or done"
 
   recomputation_request:
     type: object

--- a/doc/v2/docs/recomputations.md
+++ b/doc/v2/docs/recomputations.md
@@ -6,6 +6,9 @@ Name                                     | Description                          
 GET: List Recomputation Requests         | This method can be used to retrieve a list of current Recomputation requests.          | [ Description](#1)
 POST: Create a new recomputation request | This method can be used to insert a new recomputation request onto the Compute Engine. | [ Description](#2)
 DELETE: Delete a specific recomputation  | This method can be used to delete a specific recomputation. | [ Description](#3)
+POST: change status  | This method can be used to change status of a specific recomputation. | [ Description](#4)
+DELETE: Reset status of recomputation  | This method can be used to reset status of a specific recomputation. | [ Description](#5)
+
 
 <a id='1'></a>
 
@@ -46,28 +49,27 @@ Json Response
            "Gluster"
           ],
           "status": "running",
-          "timestamp": "2015-02-01 14:58:40"
+          "timestamp": "2015-02-01T14:58:40",
+          "history": [
+              { 
+                  "status": "pending", 
+                  "timestamp" : "2015-02-01T14:58:40"
+              },
+              { 
+                  "status": "approved", 
+                  "timestamp" : "2015-02-02T08:58:40"
+              },
+              { 
+                  "status": "running", 
+                  "timestamp" : "2015-02-02T09:10:40"
+              },
+
+          ]
      }
  ]
 }
 ```
 
-Xml Response
-```xml
-<root>
-    <Result>
-        <requester_name>Arya Stark</requester_name>
-        <requester_email>astark@shadowguild.com</requester_email>
-        <reason>power cuts</reason>
-        <start_time>2015-01-10T12:00:00Z</start_time>
-        <end_time>2015-01-30T23:00:00Z</end_time>
-        <report>EGI_Critical</report>
-        <exclude>Gluster</exclude>
-        <status>running</status>
-        <timestamp>2015-02-01 14:58:40</timestamp>
-    </Result>
-</root>
-```
 
 <a id='2'></a>
 
@@ -119,3 +121,81 @@ Accept: application/json
 
 ### Response
 `Status 200 OK`
+
+<a id='4'></a>
+
+## [POST]: Change status of recomputation
+
+```
+POST /recomputations/{ID}/status
+```
+
+#### Request headers
+
+```
+x-api-key: shared_key_value
+Accept: application/json
+```
+
+### POST body
+```json
+{
+  "status" : "approved"
+}
+```
+
+Eligible recomputation status values:
+
+- pending
+- approved
+- rejected
+- running
+- done
+
+If recomputation status input not in eligible values the api will respond with status code `404`:`conflict`
+
+### Response
+`Status 200 OK`
+
+#### Response body
+Json Response
+
+```json
+{
+ "status": {
+  "message": "Recomputation status updated successfully to: approved",
+  "code": "200"
+ }
+}
+```
+
+
+<a id='5'></a>
+
+## [DELETE]: Reset status of a specific recomputation
+
+```
+DELETE /recomputations/{ID}/status
+```
+
+#### Request headers
+
+```
+x-api-key: shared_key_value
+Accept: application/json
+```
+
+### Response
+`Status 200 OK`
+
+#### Response body
+Json Response
+
+```json
+{
+ "status": {
+  "message": "Recomputation status reset to: pending",
+  "code": "200"
+ }
+}
+```

--- a/doc/v2/docs/recomputations.md
+++ b/doc/v2/docs/recomputations.md
@@ -94,6 +94,8 @@ Type         | Description                                                      
 `start_time` | UTC time in W3C format                                                                                                                                 | YES      |
 `end_time`   | UTC time in W3C format                                                                                                                                 | YES      |
 `reason`     | Explain the need for a recomputation                                                                                                                   | YES      |
+`requester_name`     | The name of the person submitting the recomputation                                                                                            | YES      |
+`requester_email`    | The email of the person submitting the recomputation                                                                                           | YES      |
 `report`     | Report for which the recomputation is requested                                                                                                        | YES      |
 `exclude`    | Groups to be excluded from recomputation. If more than one group are to be excluded use the parameter as many times as needed within the same API call | NO       |
 


### PR DESCRIPTION
# Issue 
Give the ability to change recomputation status through web api 
Allow to hold a history of status changes for each recomputation 

# Implementation 
- In recomputation model add new field: `History`   that holds a list of (status,timestamp) items 
- add a new api request exclusively for changing recomputation statuses 
  request signature: `POST /api/v2/recomputations/{id}/status`
  accepts a POST BODY e.g.: `{"status": "approved"}` Status history is updated on the recomputation item
- add a new api request exclusively for reseting a recomputation status history
  request signature: `DELETE /api/v2/recomputations/{id}/status
   