### PR TITLE
ARGO-2002 Add history functionality for ops profiles

### DIFF
--- a/app/operationsProfiles/controller.go
+++ b/app/operationsProfiles/controller.go
@@ -37,10 +37,52 @@ import (
 	"gopkg.in/mgo.v2/bson"
 
 	"github.com/ARGOeu/argo-web-api/respond"
+	"github.com/ARGOeu/argo-web-api/utils"
 	"github.com/ARGOeu/argo-web-api/utils/config"
 	"github.com/ARGOeu/argo-web-api/utils/mongo"
 	"github.com/gorilla/mux"
 )
+
+// datastore collection name that contains operations profile records
+const opsColName = "operations_profiles"
+
+func prepMultiQuery(dt int, name string) interface{} {
+
+	matchQuery := bson.M{"date_integer": bson.M{"$lte": dt}}
+
+	if name != "" {
+		matchQuery["name"] = name
+	}
+
+	return []bson.M{
+		{
+			"$match": matchQuery,
+		},
+		{
+			"$group": bson.M{
+				"_id": bson.M{
+					"id": "$id",
+				},
+				// operations_profiles collection is meant to have an index with date_integer:-1 and id:1 so
+				// when searching by date the documents are sorted with the recent timestamp first
+				// so we need the recent item available to our query timepoint which is specific date
+				"id":               bson.M{"$first": "$id"},
+				"date":             bson.M{"$first": "$date"},
+				"name":             bson.M{"$first": "$name"},
+				"available_states": bson.M{"$first": "$available_states"},
+				"defaults":         bson.M{"$first": "$defaults"},
+				"operations":       bson.M{"$first": "$operations"},
+			},
+		},
+	}
+
+}
+
+func prepQuery(dt int, id string) interface{} {
+
+	return bson.M{"date_integer": bson.M{"$lte": dt}, "id": id}
+
+}
 
 // ListOne handles the listing of one specific profile based on its given id
 func ListOne(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
@@ -58,6 +100,13 @@ func ListOne(r *http.Request, cfg config.Config) (int, http.Header, []byte, erro
 	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
 
 	vars := mux.Vars(r)
+	urlValues := r.URL.Query()
+	dateStr := urlValues.Get("date")
+
+	if err != nil {
+		code = http.StatusBadRequest
+		return code, h, output, err
+	}
 
 	// Grab Tenant DB configuration from context
 	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
@@ -71,26 +120,30 @@ func ListOne(r *http.Request, cfg config.Config) (int, http.Header, []byte, erro
 		return code, h, output, err
 	}
 
-	filter := bson.M{"id": vars["ID"]}
-
 	// Retrieve Results from database
-	results := []OpsProfile{}
-	err = mongo.Find(session, tenantDbConfig.Db, "operations_profiles", filter, "name", &results)
+	result := OpsProfile{}
 
+	dt, dateStr, err := utils.ParseZuluDate(dateStr)
 	if err != nil {
+		code = http.StatusBadRequest
+		return code, h, output, err
+	}
+	opsQuery := prepQuery(dt, vars["ID"])
+
+	opsCol := session.DB(tenantDbConfig.Db).C(opsColName)
+	err = opsCol.Find(opsQuery).One(&result)
+	if err != nil {
+		if err.Error() == "not found" {
+			output, _ = respond.MarshalContent(respond.ErrNotFound, contentType, "", " ")
+			code = 404
+			return code, h, output, err
+		}
 		code = http.StatusInternalServerError
 		return code, h, output, err
 	}
 
-	// Check if nothing found
-	if len(results) < 1 {
-		output, _ = respond.MarshalContent(respond.ErrNotFound, contentType, "", " ")
-		code = 404
-		return code, h, output, err
-	}
-
 	// Create view of the results
-	output, err = createListView(results, "Success", code) //Render the results into JSON
+	output, err = createListView([]OpsProfile{result}, "Success", code) //Render the results into JSON
 
 	if err != nil {
 		code = http.StatusInternalServerError
@@ -120,6 +173,8 @@ func List(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) 
 	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
 
 	urlValues := r.URL.Query()
+	dateStr := urlValues.Get("date")
+	name := urlValues.Get("name")
 
 	// Grab Tenant DB configuration from context
 	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
@@ -133,20 +188,30 @@ func List(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) 
 		return code, h, output, err
 	}
 
-	// Retrieve Results from database
-
-	var filter interface{}
-	if len(urlValues["name"]) > 0 {
-		filter = bson.M{"name": urlValues["name"][0]}
-	} else {
-		filter = nil
+	dt, dateStr, err := utils.ParseZuluDate(dateStr)
+	if err != nil {
+		code = http.StatusBadRequest
+		return code, h, output, err
 	}
+	opsQuery := prepMultiQuery(dt, name)
 
-	results := []OpsProfile{}
-	err = mongo.Find(session, tenantDbConfig.Db, "operations_profiles", filter, "name", &results)
+	opsCol := session.DB(tenantDbConfig.Db).C(opsColName)
 
 	if err != nil {
 		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	results := []OpsProfile{}
+	err = opsCol.Pipe(opsQuery).All(&results)
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	if len(results) < 1 {
+		output, _ = respond.MarshalContent(respond.ErrNotFound, contentType, "", " ")
+		code = 404
 		return code, h, output, err
 	}
 
@@ -178,6 +243,13 @@ func Create(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 
 	// Grab Tenant DB configuration from context
 	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
+	urlValues := r.URL.Query()
+	dateStr := urlValues.Get("date")
+	dt, dateStr, err := utils.ParseZuluDate(dateStr)
+	if err != nil {
+		code = http.StatusBadRequest
+		return code, h, output, err
+	}
 
 	session, err := mongo.OpenSession(tenantDbConfig)
 	defer mongo.CloseSession(session)
@@ -187,6 +259,8 @@ func Create(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 	}
 
 	incoming := OpsProfile{}
+	incoming.DateInt = dt
+	incoming.Date = dateStr
 
 	// Try ingest request body
 	body, err := ioutil.ReadAll(io.LimitReader(r.Body, cfg.Server.ReqSizeLimit))
@@ -220,7 +294,7 @@ func Create(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 	results := []OpsProfile{}
 	query := bson.M{"name": incoming.Name}
 
-	err = mongo.Find(session, tenantDbConfig.Db, "operations_profiles", query, "", &results)
+	err = mongo.Find(session, tenantDbConfig.Db, opsColName, query, "", &results)
 
 	if err != nil {
 		code = http.StatusInternalServerError
@@ -238,7 +312,7 @@ func Create(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 
 	// Generate new id
 	incoming.ID = mongo.NewUUID()
-	err = mongo.Insert(session, tenantDbConfig.Db, "operations_profiles", incoming)
+	err = mongo.Insert(session, tenantDbConfig.Db, opsColName, incoming)
 
 	if err != nil {
 		panic(err)
@@ -261,6 +335,13 @@ func Update(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 	//STANDARD DECLARATIONS END
 
 	vars := mux.Vars(r)
+	urlValues := r.URL.Query()
+	dateStr := urlValues.Get("date")
+	dt, dateStr, err := utils.ParseZuluDate(dateStr)
+	if err != nil {
+		code = http.StatusBadRequest
+		return code, h, output, err
+	}
 
 	// Set Content-Type response Header value
 	contentType := r.Header.Get("Accept")
@@ -270,6 +351,8 @@ func Update(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
 
 	incoming := OpsProfile{}
+	incoming.DateInt = dt
+	incoming.Date = dateStr
 
 	// ingest body data
 	body, err := ioutil.ReadAll(io.LimitReader(r.Body, cfg.Server.ReqSizeLimit))
@@ -294,13 +377,13 @@ func Update(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 	}
 
 	// create filter to retrieve specific profile with id
-	filter := bson.M{"id": vars["ID"]}
+	filter := bson.M{"id": vars["ID"], "date_integer": bson.M{"$lte": dt}}
 
 	incoming.ID = vars["ID"]
 
 	// Retrieve Results from database
 	results := []OpsProfile{}
-	err = mongo.Find(session, tenantDbConfig.Db, "operations_profiles", filter, "name", &results)
+	err = mongo.Find(session, tenantDbConfig.Db, opsColName, filter, "name", &results)
 
 	if err != nil {
 		panic(err)
@@ -329,9 +412,9 @@ func Update(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 	if incoming.Name != results[0].Name {
 
 		results = []OpsProfile{}
-		query := bson.M{"name": incoming.Name}
+		query := bson.M{"name": incoming.Name, "id": bson.M{"$ne": vars["ID"]}}
 
-		err = mongo.Find(session, tenantDbConfig.Db, "operations_profiles", query, "", &results)
+		err = mongo.Find(session, tenantDbConfig.Db, opsColName, query, "", &results)
 
 		if err != nil {
 			code = http.StatusInternalServerError
@@ -339,7 +422,7 @@ func Update(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 		}
 
 		// If results are returned for the specific name
-		// then we already have an existing report and we must
+		// then we already have an existing operations profile and we must
 		// abort creation notifying the user
 		if len(results) > 0 {
 			output, _ = respond.MarshalContent(respond.ErrConflict("Operations profile with the same name already exists"), contentType, "", " ")
@@ -349,15 +432,22 @@ func Update(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 	}
 
 	// run the update query
-	err = mongo.Update(session, tenantDbConfig.Db, "operations_profiles", filter, incoming)
 
+	opsCol := session.DB(tenantDbConfig.Db).C(opsColName)
+	info, err := opsCol.Upsert(bson.M{"id": vars["ID"], "date_integer": dt}, incoming)
 	if err != nil {
 		code = http.StatusInternalServerError
 		return code, h, output, err
 	}
 
+	updMsg := "Operations Profile successfully updated"
+
+	if info.Updated <= 0 {
+		updMsg = "Operations Profile successfully updated (new history snapshot)"
+	}
+
 	// Create view for response message
-	output, err = createMsgView("Operations Profile successfully updated", 200) //Render the results into JSON
+	output, err = createMsgView(updMsg, 200) //Render the results into JSON
 	code = 200
 	return code, h, output, err
 }
@@ -397,7 +487,7 @@ func Delete(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 
 	// Retrieve Results from database
 	results := []OpsProfile{}
-	err = mongo.Find(session, tenantDbConfig.Db, "operations_profiles", filter, "name", &results)
+	err = mongo.Find(session, tenantDbConfig.Db, opsColName, filter, "name", &results)
 
 	if err != nil {
 		code = http.StatusInternalServerError
@@ -411,7 +501,8 @@ func Delete(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 		return code, h, output, err
 	}
 
-	mongo.Remove(session, tenantDbConfig.Db, "operations_profiles", filter)
+	// Remove also removes multiple documents with specific id, thus erasing all history
+	mongo.Remove(session, tenantDbConfig.Db, opsColName, filter)
 
 	if err != nil {
 		code = http.StatusInternalServerError

--- a/app/operationsProfiles/model.go
+++ b/app/operationsProfiles/model.go
@@ -31,6 +31,8 @@ import "sort"
 // OpsProfile to retrieve and insert operationsProfiles in mongo
 type OpsProfile struct {
 	ID          string        `bson:"id" json:"id"`
+	DateInt     int           `bson:"date_integer" json:"-"`
+	Date        string        `bson:"date" json:"date"`
 	Name        string        `bson:"name" json:"name"`
 	AvailStates []string      `bson:"available_states" json:"available_states"`
 	Defaults    DefaultStates `bson:"defaults" json:"defaults"`

--- a/app/operationsProfiles/operationsProfiles_test.go
+++ b/app/operationsProfiles/operationsProfiles_test.go
@@ -208,10 +208,13 @@ func (suite *OperationsProfilesTestSuite) SetupTest() {
 
 	// Seed database with operations profiles
 	c = session.DB(suite.tenantDbConf.Db).C("operations_profiles")
+	c.EnsureIndexKey("-date_integer", "id")
 	c.Insert(
 		bson.M{
 			"id":               "6ac7d684-1f8e-4a02-a502-720e8f11e50b",
 			"name":             "ops1",
+			"date_integer":     20191004,
+			"date":             "2019-10-04",
 			"available_states": []string{"A,B,C"},
 			"defaults": bson.M{
 				"missing": "A",
@@ -255,6 +258,57 @@ func (suite *OperationsProfilesTestSuite) SetupTest() {
 							"x": "B",
 						}}},
 			}})
+	// Seed database with operations profiles
+	c = session.DB(suite.tenantDbConf.Db).C("operations_profiles")
+	c.Insert(
+		bson.M{
+			"id":               "6ac7d684-1f8e-4a02-a502-720e8f11e50b",
+			"name":             "ops1",
+			"date_integer":     20191104,
+			"date":             "2019-11-04",
+			"available_states": []string{"A,B,C"},
+			"defaults": bson.M{
+				"missing": "A",
+				"down":    "B",
+				"unknown": "C"},
+			"operations": []bson.M{
+				bson.M{
+					"name": "AND3",
+					"truth_table": []bson.M{
+						bson.M{
+							"a": "A",
+							"b": "B",
+							"x": "B",
+						},
+						bson.M{
+							"a": "A",
+							"b": "C",
+							"x": "C",
+						},
+						bson.M{
+							"a": "B",
+							"b": "C",
+							"x": "C",
+						}}},
+				bson.M{
+					"name": "OR3",
+					"truth_table": []bson.M{
+						bson.M{
+							"a": "A",
+							"b": "B",
+							"x": "A",
+						},
+						bson.M{
+							"a": "A",
+							"b": "C",
+							"x": "A",
+						},
+						bson.M{
+							"a": "B",
+							"b": "C",
+							"x": "B",
+						}}},
+			}})
 
 	// Seed database with operations profiles
 	c = session.DB(suite.tenantDbConf.Db).C("operations_profiles")
@@ -262,6 +316,8 @@ func (suite *OperationsProfilesTestSuite) SetupTest() {
 		bson.M{
 			"id":               "6ac7d684-1f8e-4a02-a502-720e8f11e50c",
 			"name":             "ops2",
+			"date_integer":     20190504,
+			"date":             "2019-05-04",
 			"available_states": []string{"X,Y,Z"},
 			"defaults": bson.M{
 				"missing": "X",
@@ -305,6 +361,55 @@ func (suite *OperationsProfilesTestSuite) SetupTest() {
 							"x": "Y",
 						}}},
 			}})
+	c.Insert(
+		bson.M{
+			"id":               "6ac7d684-1f8e-4a02-a502-720e8f11e50c",
+			"name":             "ops2",
+			"date_integer":     20190804,
+			"date":             "2019-08-04",
+			"available_states": []string{"X,Y,Z"},
+			"defaults": bson.M{
+				"missing": "X",
+				"down":    "Y",
+				"unknown": "Z"},
+			"operations": []bson.M{
+				bson.M{
+					"name": "AND2",
+					"truth_table": []bson.M{
+						bson.M{
+							"a": "X",
+							"b": "Y",
+							"x": "Y",
+						},
+						bson.M{
+							"a": "X",
+							"b": "Z",
+							"x": "Z",
+						},
+						bson.M{
+							"a": "Y",
+							"b": "Z",
+							"x": "Z",
+						}}},
+				bson.M{
+					"name": "OR2",
+					"truth_table": []bson.M{
+						bson.M{
+							"a": "X",
+							"b": "Y",
+							"x": "X",
+						},
+						bson.M{
+							"a": "X",
+							"b": "Z",
+							"x": "X",
+						},
+						bson.M{
+							"a": "Y",
+							"b": "Z",
+							"x": "Y",
+						}}},
+			}})
 }
 
 func (suite *OperationsProfilesTestSuite) TestList() {
@@ -326,61 +431,8 @@ func (suite *OperationsProfilesTestSuite) TestList() {
  },
  "data": [
   {
-   "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50b",
-   "name": "ops1",
-   "available_states": [
-    "A,B,C"
-   ],
-   "defaults": {
-    "down": "B",
-    "missing": "A",
-    "unknown": "C"
-   },
-   "operations": [
-    {
-     "name": "AND",
-     "truth_table": [
-      {
-       "a": "A",
-       "b": "B",
-       "x": "B"
-      },
-      {
-       "a": "A",
-       "b": "C",
-       "x": "C"
-      },
-      {
-       "a": "B",
-       "b": "C",
-       "x": "C"
-      }
-     ]
-    },
-    {
-     "name": "OR",
-     "truth_table": [
-      {
-       "a": "A",
-       "b": "B",
-       "x": "A"
-      },
-      {
-       "a": "A",
-       "b": "C",
-       "x": "A"
-      },
-      {
-       "a": "B",
-       "b": "C",
-       "x": "B"
-      }
-     ]
-    }
-   ]
-  },
-  {
    "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50c",
+   "date": "2019-08-04",
    "name": "ops2",
    "available_states": [
     "X,Y,Z"
@@ -392,7 +444,7 @@ func (suite *OperationsProfilesTestSuite) TestList() {
    },
    "operations": [
     {
-     "name": "AND",
+     "name": "AND2",
      "truth_table": [
       {
        "a": "X",
@@ -412,7 +464,7 @@ func (suite *OperationsProfilesTestSuite) TestList() {
      ]
     },
     {
-     "name": "OR",
+     "name": "OR2",
      "truth_table": [
       {
        "a": "X",
@@ -428,6 +480,61 @@ func (suite *OperationsProfilesTestSuite) TestList() {
        "a": "Y",
        "b": "Z",
        "x": "Y"
+      }
+     ]
+    }
+   ]
+  },
+  {
+   "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50b",
+   "date": "2019-11-04",
+   "name": "ops1",
+   "available_states": [
+    "A,B,C"
+   ],
+   "defaults": {
+    "down": "B",
+    "missing": "A",
+    "unknown": "C"
+   },
+   "operations": [
+    {
+     "name": "AND3",
+     "truth_table": [
+      {
+       "a": "A",
+       "b": "B",
+       "x": "B"
+      },
+      {
+       "a": "A",
+       "b": "C",
+       "x": "C"
+      },
+      {
+       "a": "B",
+       "b": "C",
+       "x": "C"
+      }
+     ]
+    },
+    {
+     "name": "OR3",
+     "truth_table": [
+      {
+       "a": "A",
+       "b": "B",
+       "x": "A"
+      },
+      {
+       "a": "A",
+       "b": "C",
+       "x": "A"
+      },
+      {
+       "a": "B",
+       "b": "C",
+       "x": "B"
       }
      ]
     }
@@ -462,6 +569,7 @@ func (suite *OperationsProfilesTestSuite) TestListQueryName() {
  "data": [
   {
    "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50b",
+   "date": "2019-11-04",
    "name": "ops1",
    "available_states": [
     "A,B,C"
@@ -473,7 +581,7 @@ func (suite *OperationsProfilesTestSuite) TestListQueryName() {
    },
    "operations": [
     {
-     "name": "AND",
+     "name": "AND3",
      "truth_table": [
       {
        "a": "A",
@@ -493,7 +601,7 @@ func (suite *OperationsProfilesTestSuite) TestListQueryName() {
      ]
     },
     {
-     "name": "OR",
+     "name": "OR3",
      "truth_table": [
       {
        "a": "A",
@@ -520,7 +628,6 @@ func (suite *OperationsProfilesTestSuite) TestListQueryName() {
 	suite.Equal(200, code, "Internal Server Error")
 	// Compare the expected and actual json response
 	suite.Equal(profileJSON, output, "Response body mismatch")
-
 }
 
 func (suite *OperationsProfilesTestSuite) TestListOneNotFound() {
@@ -578,6 +685,7 @@ func (suite *OperationsProfilesTestSuite) TestListOne() {
  "data": [
   {
    "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50b",
+   "date": "2019-11-04",
    "name": "ops1",
    "available_states": [
     "A,B,C"
@@ -589,7 +697,7 @@ func (suite *OperationsProfilesTestSuite) TestListOne() {
    },
    "operations": [
     {
-     "name": "AND",
+     "name": "AND3",
      "truth_table": [
       {
        "a": "A",
@@ -609,7 +717,7 @@ func (suite *OperationsProfilesTestSuite) TestListOne() {
      ]
     },
     {
-     "name": "OR",
+     "name": "OR3",
      "truth_table": [
       {
        "a": "A",
@@ -926,6 +1034,7 @@ func (suite *OperationsProfilesTestSuite) TestCreate() {
  "data": [
   {
    "id": "{{ID}}",
+   "date": "2019-12-12",
    "name": "tops1",
    "available_states": [
     "A",
@@ -983,7 +1092,7 @@ func (suite *OperationsProfilesTestSuite) TestCreate() {
  ]
 }`
 
-	request, _ := http.NewRequest("POST", "/api/v2/operations_profiles", strings.NewReader(jsonInput))
+	request, _ := http.NewRequest("POST", "/api/v2/operations_profiles?date=2019-12-12", strings.NewReader(jsonInput))
 	request.Header.Set("x-api-key", suite.clientkey)
 	request.Header.Set("Accept", "application/json")
 	response := httptest.NewRecorder()
@@ -1007,7 +1116,7 @@ func (suite *OperationsProfilesTestSuite) TestCreate() {
 	var result map[string]interface{}
 	c := session.DB(suite.tenantDbConf.Db).C("operations_profiles")
 
-	c.Find(bson.M{"name": "tops1"}).One(&result)
+	c.Find(bson.M{"name": "tops1", "date": "2019-12-12"}).One(&result)
 	id := result["id"].(string)
 
 	// Apply id to output template and check
@@ -1015,7 +1124,7 @@ func (suite *OperationsProfilesTestSuite) TestCreate() {
 
 	// Check that actually the item has been created
 	// Call List one with the specific ID
-	request2, _ := http.NewRequest("GET", "/api/v2/operations_profiles/"+id, strings.NewReader(jsonInput))
+	request2, _ := http.NewRequest("GET", "/api/v2/operations_profiles/"+id+"?date=2019-12-12", strings.NewReader(""))
 	request2.Header.Set("x-api-key", suite.clientkey)
 	request2.Header.Set("Accept", "application/json")
 	response2 := httptest.NewRecorder()
@@ -1028,6 +1137,7 @@ func (suite *OperationsProfilesTestSuite) TestCreate() {
 	suite.Equal(200, code2, "Internal Server Error")
 	// Compare the expected and actual json response
 	suite.Equal(strings.Replace(jsonCreated, "{{ID}}", id, 1), output2, "Response body mismatch")
+
 }
 
 func (suite *OperationsProfilesTestSuite) TestCreateNameAlreadyExists() {
@@ -1379,60 +1489,121 @@ func (suite *OperationsProfilesTestSuite) TestInvalidUpdate() {
 func (suite *OperationsProfilesTestSuite) TestUpdate() {
 
 	jsonInput := `{
-	 "name": "tops1",
-	 "available_states": [
-		"A","B","C"
-	 ],
-	 "defaults": {
-		"down": "B",
-		"missing": "A",
-		"unknown": "C"
-	 },
-	 "operations": [
+	"name": "tops1",
+	"available_states": [
+	"A","B","C"
+	],
+	"defaults": {
+	"down": "B",
+	"missing": "A",
+	"unknown": "C"
+	},
+	"operations": [
+	{
+		"name": "AND66",
+		"truth_table": [
 		{
-		 "name": "AND",
-		 "truth_table": [
-			{
-			 "a": "A",
-			 "b": "B",
-			 "x": "B"
-			},
-			{
-			 "a": "A",
-			 "b": "C",
-			 "x": "C"
-			},
-			{
-			 "a": "B",
-			 "b": "C",
-			 "x": "C"
-			}
-		 ]
+			"a": "A",
+			"b": "B",
+			"x": "B"
 		},
 		{
-		 "name": "OR",
-		 "truth_table": [
-			{
-			 "a": "A",
-			 "b": "B",
-			 "x": "A"
-			},
-			{
-			 "a": "A",
-			 "b": "C",
-			 "x": "A"
-			},
-			{
-			 "a": "B",
-			 "b": "C",
-			 "x": "B"
-			}
-		 ]
+			"a": "A",
+			"b": "C",
+			"x": "C"
+		},
+		{
+			"a": "B",
+			"b": "C",
+			"x": "C"
 		}
-	 ]
-	}`
+		]
+	},
+	{
+		"name": "OR66",
+		"truth_table": [
+		{
+			"a": "A",
+			"b": "B",
+			"x": "A"
+		},
+		{
+			"a": "A",
+			"b": "C",
+			"x": "A"
+		},
+		{
+			"a": "B",
+			"b": "C",
+			"x": "B"
+		}
+		]
+	}
+	]
+}`
+
+	jsonInput2 := `{
+	"name": "tops1",
+	"available_states": [
+	"A","B","C"
+	],
+	"defaults": {
+	"down": "B",
+	"missing": "A",
+	"unknown": "C"
+	},
+	"operations": [
+	{
+		"name": "AND12",
+		"truth_table": [
+		{
+			"a": "A",
+			"b": "B",
+			"x": "B"
+		},
+		{
+			"a": "A",
+			"b": "C",
+			"x": "C"
+		},
+		{
+			"a": "B",
+			"b": "C",
+			"x": "C"
+		}
+		]
+	},
+	{
+		"name": "OR12",
+		"truth_table": [
+		{
+			"a": "A",
+			"b": "B",
+			"x": "A"
+		},
+		{
+			"a": "A",
+			"b": "C",
+			"x": "A"
+		},
+		{
+			"a": "B",
+			"b": "C",
+			"x": "B"
+		}
+		]
+	}
+	]
+}`
 
 	jsonOutput := `{
+ "status": {
+  "message": "Operations Profile successfully updated (new history snapshot)",
+  "code": "200"
+ }
+}`
+
+	jsonOutput2 := `{
  "status": {
   "message": "Operations Profile successfully updated",
   "code": "200"
@@ -1447,6 +1618,7 @@ func (suite *OperationsProfilesTestSuite) TestUpdate() {
  "data": [
   {
    "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50c",
+   "date": "2019-12-12",
    "name": "tops1",
    "available_states": [
     "A",
@@ -1460,7 +1632,7 @@ func (suite *OperationsProfilesTestSuite) TestUpdate() {
    },
    "operations": [
     {
-     "name": "AND",
+     "name": "AND66",
      "truth_table": [
       {
        "a": "A",
@@ -1480,7 +1652,7 @@ func (suite *OperationsProfilesTestSuite) TestUpdate() {
      ]
     },
     {
-     "name": "OR",
+     "name": "OR66",
      "truth_table": [
       {
        "a": "A",
@@ -1504,7 +1676,73 @@ func (suite *OperationsProfilesTestSuite) TestUpdate() {
  ]
 }`
 
-	request, _ := http.NewRequest("PUT", "/api/v2/operations_profiles/6ac7d684-1f8e-4a02-a502-720e8f11e50c", strings.NewReader(jsonInput))
+	jsonUpdated2 := `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50c",
+   "date": "2019-12-12",
+   "name": "tops1",
+   "available_states": [
+    "A",
+    "B",
+    "C"
+   ],
+   "defaults": {
+    "down": "B",
+    "missing": "A",
+    "unknown": "C"
+   },
+   "operations": [
+    {
+     "name": "AND12",
+     "truth_table": [
+      {
+       "a": "A",
+       "b": "B",
+       "x": "B"
+      },
+      {
+       "a": "A",
+       "b": "C",
+       "x": "C"
+      },
+      {
+       "a": "B",
+       "b": "C",
+       "x": "C"
+      }
+     ]
+    },
+    {
+     "name": "OR12",
+     "truth_table": [
+      {
+       "a": "A",
+       "b": "B",
+       "x": "A"
+      },
+      {
+       "a": "A",
+       "b": "C",
+       "x": "A"
+      },
+      {
+       "a": "B",
+       "b": "C",
+       "x": "B"
+      }
+     ]
+    }
+   ]
+  }
+ ]
+}`
+
+	request, _ := http.NewRequest("PUT", "/api/v2/operations_profiles/6ac7d684-1f8e-4a02-a502-720e8f11e50c?date=2019-12-12", strings.NewReader(jsonInput))
 	request.Header.Set("x-api-key", suite.clientkey)
 	request.Header.Set("Accept", "application/json")
 	response := httptest.NewRecorder()
@@ -1523,7 +1761,7 @@ func (suite *OperationsProfilesTestSuite) TestUpdate() {
 
 	// Check that the item has actually updated
 	// run a list specific
-	request2, _ := http.NewRequest("GET", "/api/v2/operations_profiles/6ac7d684-1f8e-4a02-a502-720e8f11e50c", strings.NewReader(jsonInput))
+	request2, _ := http.NewRequest("GET", "/api/v2/operations_profiles/6ac7d684-1f8e-4a02-a502-720e8f11e50c?date=2019-12-12", strings.NewReader(""))
 	request2.Header.Set("x-api-key", suite.clientkey)
 	request2.Header.Set("Accept", "application/json")
 	response2 := httptest.NewRecorder()
@@ -1536,6 +1774,40 @@ func (suite *OperationsProfilesTestSuite) TestUpdate() {
 	suite.Equal(200, code2, "Internal Server Error")
 	// Compare the expected and actual json response
 	suite.Equal(jsonUpdated, output2, "Response body mismatch")
+
+	request3, _ := http.NewRequest("PUT", "/api/v2/operations_profiles/6ac7d684-1f8e-4a02-a502-720e8f11e50c?date=2019-12-12", strings.NewReader(jsonInput2))
+	request3.Header.Set("x-api-key", suite.clientkey)
+	request3.Header.Set("Accept", "application/json")
+	response3 := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response3, request3)
+
+	code3 := response3.Code
+	output3 := response3.Body.String()
+
+	// Check that we must have a 200 ok code
+	suite.Equal(200, code3, "Internal Server Error")
+	// Compare the expected and actual json response
+
+	// Apply id to output template and check
+	suite.Equal(jsonOutput2, output3, "Response body mismatch")
+
+	// Check that the item has actually updated
+	// run a list specific
+	request4, _ := http.NewRequest("GET", "/api/v2/operations_profiles/6ac7d684-1f8e-4a02-a502-720e8f11e50c?date=2019-12-12", strings.NewReader(""))
+	request4.Header.Set("x-api-key", suite.clientkey)
+	request4.Header.Set("Accept", "application/json")
+	response4 := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response4, request4)
+
+	code4 := response4.Code
+	output4 := response4.Body.String()
+	// Check that we must have a 200 ok code
+	suite.Equal(200, code4, "Internal Server Error")
+	// Compare the expected and actual json response
+	suite.Equal(jsonUpdated2, output4, "Response body mismatch")
+
 }
 
 func (suite *OperationsProfilesTestSuite) TestDeleteNotFound() {

--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -577,6 +577,7 @@ paths:
           required: true
           type: string
         - $ref: "#/parameters/apiKey"
+        - $ref: "#/parameters/profDate"
       responses:
         '200':
           description: A list with one operations profile
@@ -610,6 +611,7 @@ paths:
         - "application/json"
       parameters:
         - $ref: "#/parameters/apiKey"
+        - $ref: "#/parameters/profDate"
         - name: "PROFILE_ID"
           in: "path"
           description: "id of the operations profile"
@@ -697,6 +699,7 @@ paths:
         - "application/json"
       parameters:
         - $ref: "#/parameters/apiKey"
+        - $ref: "#/parameters/profDate"
       responses:
         '200':
           description: A list of Operations profiles
@@ -725,6 +728,7 @@ paths:
       produces:
         - "application/json"
       parameters:
+        - $ref: "#/parameters/profDate"
         - name: "x-api-key"
           in: "header"
           description: "the x-api-key"
@@ -2552,6 +2556,12 @@ paths:
 
 
 parameters:
+  profDate:
+    name: "date"
+    in: "query"
+    type: string
+    description: "target date to retrieve a historic version of the profile"
+    default: todays_date in YYYY-MM-DD format
   topoDate:
     name: "date"
     in: "query"
@@ -3424,6 +3434,8 @@ definitions:
     type: object
     properties:
       id:
+        type: string
+      date:
         type: string
       name:
         type: string

--- a/doc/v2/docs/operations_profiles.md
+++ b/doc/v2/docs/operations_profiles.md
@@ -19,7 +19,7 @@ DELETE: Delete an  Operations profile |This method can be used to delete an exis
 
 ## [GET]: List Operations Profiles
 
-This method can be used to retrieve a list of current  Operations profiles
+This method can be used to retrieve a list of current  Operations profiles. 
 
 ### Input
 
@@ -32,6 +32,7 @@ GET /operations_profiles
 Type            | Description                                                                                     | Required
 --------------- | ----------------------------------------------------------------------------------------------- | --------
 `name`          | Operations profile name to be used as query                                                     | NO      
+`date`          | Date to retrieve a historic version of the operation profile. If no date parameter is provided the most current profile will be returned | NO
 
 #### Request headers
 
@@ -55,6 +56,7 @@ Json Response
  "data": [
   {
    "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50b",
+   "date": "2019-11-04",
    "name": "ops1",
    "available_states": [
     "A,B,C"
@@ -109,6 +111,7 @@ Json Response
   },
   {
    "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50c",
+   "date": "2019-11-02",
    "name": "ops2",
    "available_states": [
     "X,Y,Z"
@@ -176,6 +179,13 @@ This method can be used to retrieve specific Operations profile based on its id
 GET /operations_profiles/{ID}
 ```
 
+#### Optional Query Parameters
+
+Type            | Description                                                                                     | Required
+--------------- | ----------------------------------------------------------------------------------------------- | --------
+`date`          | Date to retrieve a historic version of the operation profile. If no date parameter is provided the most current profile will be returned | NO
+
+
 #### Request headers
 
 ```
@@ -198,6 +208,7 @@ Json Response
  "data": [
   {
    "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50b",
+   "date": "2019-11-04",
    "name": "ops1",
    "available_states": [
     "A,B,C"
@@ -271,6 +282,13 @@ POST /operations_profiles
 x-api-key: shared_key_value
 Accept: application/json
 ```
+
+#### Optional Query Parameters
+
+Type            | Description                                                                                     | Required
+--------------- | ----------------------------------------------------------------------------------------------- | --------
+`date`          | Date to create a  new historic version of the operation profile. If no date parameter is provided current date will be supplied automatically | NO
+
 
 #### POST BODY
 
@@ -362,6 +380,13 @@ This method can be used to update information on an existing operations profile
 PUT /operations_profiles/{ID}
 ```
 
+#### Optional Query Parameters
+
+Type            | Description                                                                                     | Required
+--------------- | ----------------------------------------------------------------------------------------------- | --------
+`date`          | Date to update a historic version of the operation profile. If no date parameter is provided the current date will be supplied automatically | NO
+
+
 #### Request headers
 
 ```
@@ -436,7 +461,7 @@ Json Response
 ```json
 {
  "status": {
-  "message": "Operations Profile successfully updated",
+  "message": "Operations Profile successfully updated (new snapshot created)",
   "code": "200"
  }
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,0 +1,23 @@
+package utils
+
+import (
+	"strconv"
+	"time"
+)
+
+const zuluDateOnly = "2006-01-02"
+const ymdForm = "20060102"
+
+// ParseZuluDate is used to parse a zulu formatted date to integer. If no date is entered
+// ParseZuluDate returns a Zulu representation of current time
+func ParseZuluDate(dateStr string) (int, string, error) {
+	parsedTime := time.Now().UTC()
+	if dateStr != "" {
+		parsedTime, _ = time.Parse(zuluDateOnly, dateStr)
+	} else {
+		dateStr = parsedTime.Format(zuluDateOnly)
+	}
+	dateInt, err := strconv.Atoi(parsedTime.Format(ymdForm))
+	return dateInt, dateStr, err
+
+}


### PR DESCRIPTION
## Goal 
Give the ability to maintain historic version of the operations profiles when they change

## Implementation
Add an extra url parameter `date` in operations_profiles request signatures (GET, POST, PUT)
When using date with GET the closest historic version of the profile is retrieved. If date is ommited the most recent profile is retrieved
When using date with POST a specific historic profile entry is created (new snapshot)
When using date with PUT an update is performed on a specific historic version of the profile


:red_circle:  note that a specific indexing scheme should be prepared in operations_profile mongodb collection in order the queries to work correctly

- [x] Modify ops profile model to incorporate historicversioning
- [x] Modify ops profile controllers to use historic versioning
- [x] Update unit tests
- [x] Update docs