### PR TITLE
ARGO-2058 Set strict=false by default in latest results call

### DIFF
--- a/app/latest/controller.go
+++ b/app/latest/controller.go
@@ -59,14 +59,14 @@ func ListLatestResults(r *http.Request, cfg config.Config) (int, http.Header, []
 	vars := mux.Vars(r)
 
 	endpointGroup := vars["group_name"]
-	report_name := vars["report_name"]
+	reportName := vars["report_name"]
 	limit := urlValues.Get("limit")
 	dateStr := urlValues.Get("date")
 	filter := urlValues.Get("filter")
 
-	strict := true
-	if urlValues.Get("strict") == "false" {
-		strict = false
+	strict := false
+	if urlValues.Get("strict") == "true" {
+		strict = true
 	}
 
 	lim, err := strconv.Atoi(limit)
@@ -83,7 +83,7 @@ func ListLatestResults(r *http.Request, cfg config.Config) (int, http.Header, []
 	}
 
 	// find the report id first
-	reportID, err := mongo.GetReportID(session, tenantDbConfig.Db, report_name)
+	reportID, err := mongo.GetReportID(session, tenantDbConfig.Db, reportName)
 	if err != nil {
 		code = http.StatusInternalServerError
 		return code, h, output, err

--- a/app/latest/latest_test.go
+++ b/app/latest/latest_test.go
@@ -714,19 +714,19 @@ func (suite *LatestTestSuite) TestListLatest() {
 		"?date=2015-05-01T00:00:00Z&limit=1&strict=false"
 
 	fullurl4 := "/api/v2/latest/Report_B/EUDAT_SITES/EL-01-AUTH" +
-		"?date=2015-05-01T00:00:00Z&filter=non-ok&strict=false"
+		"?date=2015-05-01T00:00:00Z&filter=non-ok"
 
 	fullurl5 := "/api/v2/latest/Report_B/EUDAT_SITES/EL-01-AUTH" +
-		"?date=2015-05-01T00:00:00Z&filter=critical&strict=false"
+		"?date=2015-05-01T00:00:00Z&filter=critical"
 
 	fullurl6 := "/api/v2/latest/Report_B/EUDAT_SITES/EL-01-AUTH" +
-		"?date=2015-05-01T00:00:00Z&filter=ok&strict=false"
+		"?date=2015-05-01T00:00:00Z&filter=ok"
 
 	fullurl7 := "/api/v2/latest/Report_A/SITES/HG-03-AUTH" +
-		"?date=2015-05-01T00:00:00Z"
+		"?date=2015-05-01T00:00:00Z&strict=true"
 
 	fullurl8 := "/api/v2/latest/Report_A/SITES" +
-		"?date=2015-05-01T00:00:00Z"
+		"?date=2015-05-01T00:00:00Z&strict=true"
 
 	// 3. EGI JSON REQUEST
 	// init the response placeholder

--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -2678,7 +2678,7 @@ parameters:
     in: query
     type: string
     description: "the servce will return only the latest entry grouped by endpoint_group/host/service/metric"
-    default: "true"
+    default: "false"
 
 responses:
   Unauthorized:

--- a/doc/v2/docs/latest.md
+++ b/doc/v2/docs/latest.md
@@ -35,7 +35,7 @@ of results returned
 |`date`|  target a specific data | NO | today's date |
 |`filter`| filter by status values (`all`,`non-ok`,`ok`,`critical`,`warning`,`unknown`,`missing`)| NO | all |
 |`limit`| limit number of results returned | NO | 500  |
-|`strict`| strict mode on/off | NO | "true" |
+|`strict`| strict mode on/off | NO | "false" |
 
 
 ___Notes___:
@@ -179,7 +179,7 @@ of results returned
 |`date`|  target a specific data | NO | today's date |
 |`filter`| filter by status values (`all`,`non-ok`,`ok`,`critical`,`warning`,`unknown`,`missing`)| NO | all |
 |`limit`| limit number of results returned | NO | 500  |
-|`strict`| strict mode on/off | NO | "true" |
+|`strict`| strict mode on/off | NO | "false" |
 
 
 ___Notes___:


### PR DESCRIPTION
Make `/api/v2/latest` to use parameter `strict=false` by default.
If user wants to use strict mode, it must be supplied as a url parameter `strict=true`

