### PR TITLE
ARGO-2059 Fix latest strict result order by time instead of group name

### DIFF
--- a/app/latest/controller.go
+++ b/app/latest/controller.go
@@ -191,6 +191,12 @@ func prepQuery(dateStr string, report string, group string, filter string, stric
 					"status":         bson.M{"$first": "$status"},
 					"message":        bson.M{"$first": "$message"},
 					"summary":        bson.M{"$first": "$summary"},
+					"time_integer":   bson.M{"$first": "$time_integer"},
+				},
+			},
+			{
+				"$sort": bson.M{
+					"time_integer": -1,
 				},
 			},
 		}

--- a/app/latest/latest_test.go
+++ b/app/latest/latest_test.go
@@ -268,7 +268,7 @@ func (suite *LatestTestSuite) SetupTest() {
 		"endpoint_group":     "EL-01-AUTH",
 		"metric":             "someService-FileTransfer",
 		"status":             "OK",
-		"time_integer":       0,
+		"time_integer":       232000,
 		"previous_state":     "OK",
 		"previous_timestamp": "2015-05-01T22:20:00Z",
 		"summary":            "someService status is ok",
@@ -703,6 +703,16 @@ func (suite *LatestTestSuite) TestListLatest() {
  },
  "data": {
   "metric_data": [
+   {
+    "endpoint_group": "EL-01-AUTH",
+    "service": "someService-A",
+    "endpoint": "someservice.example.gr",
+    "metric": "someService-FileTransfer",
+    "timestamp": "2015-05-01T23:20:00Z",
+    "status": "OK",
+    "summary": "someService status is ok",
+    "message": "someService data upload test return value of ok"
+   },
    {
     "endpoint_group": "HG-03-AUTH",
     "service": "CREAM-CE",

--- a/app/latest/model.go
+++ b/app/latest/model.go
@@ -31,11 +31,12 @@ import "encoding/xml"
 // 	Services []Serv `bson:"services" json:"services"`
 // }
 
-// Service struct to represent services with their metrics
+// MetricList represents a list of metric data
 type MetricList struct {
 	MetricData []MetricData `bson:"metric_data" json:"metric_data"`
 }
 
+// MetricData is a struct representing a metric data record
 type MetricData struct {
 	Group     string `bson:"endpoint_group" json:"endpoint_group"`
 	Service   string `bson:"service" json:"service"`

--- a/version/version.go
+++ b/version/version.go
@@ -6,7 +6,7 @@ import (
 
 var (
 	// Release version of the service. Bump it up during new version release
-	Release = "1.8.0"
+	Release = "1.8.1"
 	// Commit hash provided during build
 	Commit = "Unknown"
 	// BuildTime provided during build


### PR DESCRIPTION
Version bump to 1.8.1

Issue: 
`/v2/api/latest` when `strict=true` returns the correct list of results but they are order by group name and not by time

Fix:
- After computing the correct results add a last pipeline stage to sort by time 
- Fix a data prep issue in unit test