### PR TITLE
ARGO-2000 Add history functionality for metric profiles

### DIFF
--- a/app/metricProfiles/controller.go
+++ b/app/metricProfiles/controller.go
@@ -37,10 +37,50 @@ import (
 	"gopkg.in/mgo.v2/bson"
 
 	"github.com/ARGOeu/argo-web-api/respond"
+	"github.com/ARGOeu/argo-web-api/utils"
 	"github.com/ARGOeu/argo-web-api/utils/config"
 	"github.com/ARGOeu/argo-web-api/utils/mongo"
 	"github.com/gorilla/mux"
 )
+
+// Name of datastore collection containing metric profiles
+const mpColName = "metric_profiles"
+
+func prepMultiQuery(dt int, name string) interface{} {
+
+	matchQuery := bson.M{"date_integer": bson.M{"$lte": dt}}
+
+	if name != "" {
+		matchQuery["name"] = name
+	}
+
+	return []bson.M{
+		{
+			"$match": matchQuery,
+		},
+		{
+			"$group": bson.M{
+				"_id": bson.M{
+					"id": "$id",
+				},
+				// metric_profiles collection is meant to have an index with date_integer:-1 and id:1 so
+				// when searching by date the documents are sorted with the recent timestamp first
+				// so we need the recent item available to our query timepoint which is specific date
+				"id":       bson.M{"$first": "$id"},
+				"date":     bson.M{"$first": "$date"},
+				"name":     bson.M{"$first": "$name"},
+				"services": bson.M{"$first": "$services"},
+			},
+		},
+	}
+
+}
+
+func prepQuery(dt int, id string) interface{} {
+
+	return bson.M{"date_integer": bson.M{"$lte": dt}, "id": id}
+
+}
 
 // ListOne handles the listing of one specific profile based on its given id
 func ListOne(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
@@ -60,6 +100,13 @@ func ListOne(r *http.Request, cfg config.Config) (int, http.Header, []byte, erro
 	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
 
 	vars := mux.Vars(r)
+	urlValues := r.URL.Query()
+	dateStr := urlValues.Get("date")
+
+	if err != nil {
+		code = http.StatusBadRequest
+		return code, h, output, err
+	}
 
 	// Grab Tenant DB configuration from context
 	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
@@ -73,26 +120,29 @@ func ListOne(r *http.Request, cfg config.Config) (int, http.Header, []byte, erro
 		return code, h, output, err
 	}
 
-	filter := bson.M{"id": vars["ID"]}
-
 	// Retrieve Results from database
-	results := []MongoInterface{}
-	err = mongo.Find(session, tenantDbConfig.Db, "metric_profiles", filter, "name", &results)
-
+	result := MetricProfile{}
+	dt, dateStr, err := utils.ParseZuluDate(dateStr)
 	if err != nil {
+		code = http.StatusBadRequest
+		return code, h, output, err
+	}
+	mpQuery := prepQuery(dt, vars["ID"])
+
+	mpCol := session.DB(tenantDbConfig.Db).C(mpColName)
+	err = mpCol.Find(mpQuery).One(&result)
+	if err != nil {
+		if err.Error() == "not found" {
+			output, _ = respond.MarshalContent(respond.ErrNotFound, contentType, "", " ")
+			code = 404
+			return code, h, output, err
+		}
 		code = http.StatusInternalServerError
 		return code, h, output, err
 	}
 
-	// Check if nothing found
-	if len(results) < 1 {
-		output, _ = respond.MarshalContent(respond.ErrNotFound, contentType, "", " ")
-		code = 404
-		return code, h, output, err
-	}
-
 	// Create view of the results
-	output, err = createListView(results, "Success", code) //Render the results into JSON
+	output, err = createListView([]MetricProfile{result}, "Success", code) //Render the results into JSON
 
 	if err != nil {
 		code = http.StatusInternalServerError
@@ -122,6 +172,8 @@ func List(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) 
 	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
 
 	urlValues := r.URL.Query()
+	dateStr := urlValues.Get("date")
+	name := urlValues.Get("name")
 
 	// Grab Tenant DB configuration from context
 	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
@@ -137,18 +189,30 @@ func List(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) 
 
 	// Retrieve Results from database
 
-	var filter interface{}
-	if len(urlValues["name"]) > 0 {
-		filter = bson.M{"name": urlValues["name"][0]}
-	} else {
-		filter = nil
+	dt, dateStr, err := utils.ParseZuluDate(dateStr)
+	if err != nil {
+		code = http.StatusBadRequest
+		return code, h, output, err
 	}
+	mpQuery := prepMultiQuery(dt, name)
 
-	results := []MongoInterface{}
-	err = mongo.Find(session, tenantDbConfig.Db, "metric_profiles", filter, "name", &results)
+	opsCol := session.DB(tenantDbConfig.Db).C(mpColName)
 
 	if err != nil {
 		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	results := []MetricProfile{}
+	err = opsCol.Pipe(mpQuery).All(&results)
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	if len(results) < 1 {
+		output, _ = respond.MarshalContent(respond.ErrNotFound, contentType, "", " ")
+		code = 404
 		return code, h, output, err
 	}
 
@@ -180,6 +244,13 @@ func Create(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 
 	// Grab Tenant DB configuration from context
 	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
+	urlValues := r.URL.Query()
+	dateStr := urlValues.Get("date")
+	dt, dateStr, err := utils.ParseZuluDate(dateStr)
+	if err != nil {
+		code = http.StatusBadRequest
+		return code, h, output, err
+	}
 
 	session, err := mongo.OpenSession(tenantDbConfig)
 	defer mongo.CloseSession(session)
@@ -188,7 +259,9 @@ func Create(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 		return code, h, output, err
 	}
 
-	incoming := MongoInterface{}
+	incoming := MetricProfile{}
+	incoming.DateInt = dt
+	incoming.Date = dateStr
 
 	// Try ingest request body
 	body, err := ioutil.ReadAll(io.LimitReader(r.Body, cfg.Server.ReqSizeLimit))
@@ -208,10 +281,10 @@ func Create(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 
 	// check if the metric profile's name is unique
 
-	results := []MongoInterface{}
+	results := []MetricProfile{}
 	query := bson.M{"name": incoming.Name}
 
-	err = mongo.Find(session, tenantDbConfig.Db, "metric_profiles", query, "", &results)
+	err = mongo.Find(session, tenantDbConfig.Db, mpColName, query, "", &results)
 
 	if err != nil {
 		code = http.StatusInternalServerError
@@ -230,7 +303,7 @@ func Create(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 	// Generate new id
 	incoming.ID = mongo.NewUUID()
 
-	err = mongo.Insert(session, tenantDbConfig.Db, "metric_profiles", incoming)
+	err = mongo.Insert(session, tenantDbConfig.Db, mpColName, incoming)
 
 	if err != nil {
 		panic(err)
@@ -253,6 +326,13 @@ func Update(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 	//STANDARD DECLARATIONS END
 
 	vars := mux.Vars(r)
+	urlValues := r.URL.Query()
+	dateStr := urlValues.Get("date")
+	dt, dateStr, err := utils.ParseZuluDate(dateStr)
+	if err != nil {
+		code = http.StatusBadRequest
+		return code, h, output, err
+	}
 
 	// Set Content-Type response Header value
 	contentType := r.Header.Get("Accept")
@@ -261,7 +341,7 @@ func Update(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 	// Grab Tenant DB configuration from context
 	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
 
-	incoming := MongoInterface{}
+	incoming := MetricProfile{}
 
 	// ingest body data
 	body, err := ioutil.ReadAll(io.LimitReader(r.Body, cfg.Server.ReqSizeLimit))
@@ -288,10 +368,12 @@ func Update(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 	filter := bson.M{"id": vars["ID"]}
 
 	incoming.ID = vars["ID"]
+	incoming.DateInt = dt
+	incoming.Date = dateStr
 
 	// Retrieve Results from database
-	results := []MongoInterface{}
-	err = mongo.Find(session, tenantDbConfig.Db, "metric_profiles", filter, "name", &results)
+	results := []MetricProfile{}
+	err = mongo.Find(session, tenantDbConfig.Db, mpColName, filter, "name", &results)
 
 	if err != nil {
 		panic(err)
@@ -307,10 +389,10 @@ func Update(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 	// check if the metric profile's name is unique
 	if incoming.Name != results[0].Name {
 
-		results = []MongoInterface{}
-		query := bson.M{"name": incoming.Name}
+		results = []MetricProfile{}
+		query := bson.M{"name": incoming.Name, "id": bson.M{"$ne": vars["ID"]}}
 
-		err = mongo.Find(session, tenantDbConfig.Db, "metric_profiles", query, "", &results)
+		err = mongo.Find(session, tenantDbConfig.Db, mpColName, query, "", &results)
 
 		if err != nil {
 			code = http.StatusInternalServerError
@@ -327,15 +409,21 @@ func Update(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 		}
 	}
 	// run the update query
-	err = mongo.Update(session, tenantDbConfig.Db, "metric_profiles", filter, incoming)
-
+	mpCol := session.DB(tenantDbConfig.Db).C(mpColName)
+	info, err := mpCol.Upsert(bson.M{"id": vars["ID"], "date_integer": dt}, incoming)
 	if err != nil {
 		code = http.StatusInternalServerError
 		return code, h, output, err
 	}
 
+	updMsg := "Metric Profile successfully updated"
+
+	if info.Updated <= 0 {
+		updMsg = "Metric Profile successfully updated (new history snapshot)"
+	}
+
 	// Create view for response message
-	output, err = createMsgView("Metric Profile successfully updated", 200) //Render the results into JSON
+	output, err = createMsgView(updMsg, 200) //Render the results into JSON
 	code = 200
 	return code, h, output, err
 }
@@ -380,8 +468,8 @@ func Delete(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 	filter := bson.M{"id": vars["ID"]}
 
 	// Retrieve Results from database
-	results := []MongoInterface{}
-	err = mongo.Find(session, tenantDbConfig.Db, "metric_profiles", filter, "name", &results)
+	results := []MetricProfile{}
+	err = mongo.Find(session, tenantDbConfig.Db, mpColName, filter, "name", &results)
 
 	if err != nil {
 		code = http.StatusInternalServerError
@@ -395,7 +483,7 @@ func Delete(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 		return code, h, output, err
 	}
 
-	mongo.Remove(session, tenantDbConfig.Db, "metric_profiles", filter)
+	mongo.Remove(session, tenantDbConfig.Db, mpColName, filter)
 
 	if err != nil {
 		code = http.StatusInternalServerError

--- a/app/metricProfiles/metricProfiles_test.go
+++ b/app/metricProfiles/metricProfiles_test.go
@@ -207,10 +207,13 @@ func (suite *MetricProfilesTestSuite) SetupTest() {
 
 	// Seed database with metric profiles
 	c = session.DB(suite.tenantDbConf.Db).C("metric_profiles")
+	c.EnsureIndexKey("-date_integer", "id")
 	c.Insert(
 		bson.M{
-			"id":   "6ac7d684-1f8e-4a02-a502-720e8f11e50b",
-			"name": "ch.cern.SAM.ROC_CRITICAL",
+			"id":           "6ac7d684-1f8e-4a02-a502-720e8f11e50b",
+			"name":         "ch.cern.SAM.ROC_CRITICAL",
+			"date_integer": 20191004,
+			"date":         "2019-10-04",
 			"services": []bson.M{
 				bson.M{"service": "CREAM-CE",
 					"metrics": []string{
@@ -233,8 +236,36 @@ func (suite *MetricProfilesTestSuite) SetupTest() {
 		})
 	c.Insert(
 		bson.M{
-			"id":   "6ac7d684-1f8e-4a02-a502-720e8f11e50c",
-			"name": "ch.cern.SAM.ROC",
+			"id":           "6ac7d684-1f8e-4a02-a502-720e8f11e50b",
+			"name":         "ch.cern.SAM.ROC_CRITICAL",
+			"date_integer": 20191104,
+			"date":         "2019-11-04",
+			"services": []bson.M{
+				bson.M{"service": "CREAM-CE2",
+					"metrics": []string{
+						"emi.cream.CREAMCE-JobSubmit",
+						"emi.wn.WN-Bi",
+						"emi.wn.WN-Csh",
+						"emi.wn.WN-SoftVer"},
+				},
+				bson.M{"service": "SRMv3",
+					"metrics": []string{"hr.srce.SRM2-CertLifetime",
+						"org.sam.SRM-Del",
+						"org.sam.SRM-Get",
+						"org.sam.SRM-GetSURLs",
+						"org.sam.SRM-GetTURLs",
+						"org.sam.SRM-Ls",
+						"org.sam.SRM-LsDir",
+						"org.sam.SRM-Put"},
+				},
+			},
+		})
+	c.Insert(
+		bson.M{
+			"id":           "6ac7d684-1f8e-4a02-a502-720e8f11e50c",
+			"name":         "ch.cern.SAM.ROC",
+			"date_integer": 20190504,
+			"date":         "2019-05-04",
 			"services": []bson.M{
 				bson.M{"service": "CREAM-CE",
 					"metrics": []string{
@@ -246,6 +277,34 @@ func (suite *MetricProfilesTestSuite) SetupTest() {
 						"emi.wn.WN-SoftVer"},
 				},
 				bson.M{"service": "SRMv2",
+					"metrics": []string{"hr.srce.SRM2-CertLifetime",
+						"org.sam.SRM-Del",
+						"org.sam.SRM-Get",
+						"org.sam.SRM-GetSURLs",
+						"org.sam.SRM-GetTURLs",
+						"org.sam.SRM-Ls",
+						"org.sam.SRM-LsDir",
+						"org.sam.SRM-Put"},
+				},
+			},
+		})
+	c.Insert(
+		bson.M{
+			"id":           "6ac7d684-1f8e-4a02-a502-720e8f11e50c",
+			"name":         "ch.cern.SAM.ROC",
+			"date_integer": 20190604,
+			"date":         "2019-06-04",
+			"services": []bson.M{
+				bson.M{"service": "CREAM-CE2",
+					"metrics": []string{
+						"emi.cream.CREAMCE-JobSubmit",
+						"emi.wn.WN-Bi",
+						"emi.wn.WN-Csh",
+						"hr.srce.CADist-Check",
+						"hr.srce.CREAMCE-CertLifetime",
+						"emi.wn.WN-SoftVer"},
+				},
+				bson.M{"service": "SRMv3",
 					"metrics": []string{"hr.srce.SRM2-CertLifetime",
 						"org.sam.SRM-Del",
 						"org.sam.SRM-Get",
@@ -280,10 +339,11 @@ func (suite *MetricProfilesTestSuite) TestList() {
  "data": [
   {
    "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50c",
+   "date": "2019-06-04",
    "name": "ch.cern.SAM.ROC",
    "services": [
     {
-     "service": "CREAM-CE",
+     "service": "CREAM-CE2",
      "metrics": [
       "emi.cream.CREAMCE-JobSubmit",
       "emi.wn.WN-Bi",
@@ -294,7 +354,7 @@ func (suite *MetricProfilesTestSuite) TestList() {
      ]
     },
     {
-     "service": "SRMv2",
+     "service": "SRMv3",
      "metrics": [
       "hr.srce.SRM2-CertLifetime",
       "org.sam.SRM-Del",
@@ -310,10 +370,11 @@ func (suite *MetricProfilesTestSuite) TestList() {
   },
   {
    "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50b",
+   "date": "2019-11-04",
    "name": "ch.cern.SAM.ROC_CRITICAL",
    "services": [
     {
-     "service": "CREAM-CE",
+     "service": "CREAM-CE2",
      "metrics": [
       "emi.cream.CREAMCE-JobSubmit",
       "emi.wn.WN-Bi",
@@ -322,7 +383,7 @@ func (suite *MetricProfilesTestSuite) TestList() {
      ]
     },
     {
-     "service": "SRMv2",
+     "service": "SRMv3",
      "metrics": [
       "hr.srce.SRM2-CertLifetime",
       "org.sam.SRM-Del",
@@ -365,10 +426,11 @@ func (suite *MetricProfilesTestSuite) TestListQueryName() {
  "data": [
   {
    "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50c",
+   "date": "2019-06-04",
    "name": "ch.cern.SAM.ROC",
    "services": [
     {
-     "service": "CREAM-CE",
+     "service": "CREAM-CE2",
      "metrics": [
       "emi.cream.CREAMCE-JobSubmit",
       "emi.wn.WN-Bi",
@@ -379,7 +441,7 @@ func (suite *MetricProfilesTestSuite) TestListQueryName() {
      ]
     },
     {
-     "service": "SRMv2",
+     "service": "SRMv3",
      "metrics": [
       "hr.srce.SRM2-CertLifetime",
       "org.sam.SRM-Del",
@@ -457,10 +519,11 @@ func (suite *MetricProfilesTestSuite) TestListOne() {
  "data": [
   {
    "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50b",
+   "date": "2019-11-04",
    "name": "ch.cern.SAM.ROC_CRITICAL",
    "services": [
     {
-     "service": "CREAM-CE",
+     "service": "CREAM-CE2",
      "metrics": [
       "emi.cream.CREAMCE-JobSubmit",
       "emi.wn.WN-Bi",
@@ -469,7 +532,7 @@ func (suite *MetricProfilesTestSuite) TestListOne() {
      ]
     },
     {
-     "service": "SRMv2",
+     "service": "SRMv3",
      "metrics": [
       "hr.srce.SRM2-CertLifetime",
       "org.sam.SRM-Del",
@@ -589,6 +652,7 @@ func (suite *MetricProfilesTestSuite) TestCreate() {
  "data": [
   {
    "id": "{{id}}",
+   "date": "2019-11-08",
    "name": "test_profile",
    "services": [
     {
@@ -612,7 +676,7 @@ func (suite *MetricProfilesTestSuite) TestCreate() {
  ]
 }`
 
-	request, _ := http.NewRequest("POST", "/api/v2/metric_profiles", strings.NewReader(jsonInput))
+	request, _ := http.NewRequest("POST", "/api/v2/metric_profiles?date=2019-11-08", strings.NewReader(jsonInput))
 	request.Header.Set("x-api-key", suite.clientkey)
 	request.Header.Set("Accept", "application/json")
 	response := httptest.NewRecorder()
@@ -857,7 +921,7 @@ func (suite *MetricProfilesTestSuite) TestUpdate() {
   "name": "test_profile",
   "services": [
     {
-      "service": "Service-A",
+      "service": "Service-AX",
       "metrics": [
         "metric.A.1",
         "metric.A.2",
@@ -866,7 +930,7 @@ func (suite *MetricProfilesTestSuite) TestUpdate() {
       ]
     },
     {
-      "service": "Service-B",
+      "service": "Service-BX",
       "metrics": [
         "metric.B.1",
         "metric.B.2"
@@ -877,7 +941,7 @@ func (suite *MetricProfilesTestSuite) TestUpdate() {
 
 	jsonOutput := `{
  "status": {
-  "message": "Metric Profile successfully updated",
+  "message": "Metric Profile successfully updated (new history snapshot)",
   "code": "200"
  }
 }`
@@ -890,10 +954,11 @@ func (suite *MetricProfilesTestSuite) TestUpdate() {
  "data": [
   {
    "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50c",
+   "date": "2019-07-08",
    "name": "test_profile",
    "services": [
     {
-     "service": "Service-A",
+     "service": "Service-AX",
      "metrics": [
       "metric.A.1",
       "metric.A.2",
@@ -902,7 +967,7 @@ func (suite *MetricProfilesTestSuite) TestUpdate() {
      ]
     },
     {
-     "service": "Service-B",
+     "service": "Service-BX",
      "metrics": [
       "metric.B.1",
       "metric.B.2"
@@ -913,7 +978,7 @@ func (suite *MetricProfilesTestSuite) TestUpdate() {
  ]
 }`
 
-	request, _ := http.NewRequest("PUT", "/api/v2/metric_profiles/6ac7d684-1f8e-4a02-a502-720e8f11e50c", strings.NewReader(jsonInput))
+	request, _ := http.NewRequest("PUT", "/api/v2/metric_profiles/6ac7d684-1f8e-4a02-a502-720e8f11e50c?date=2019-07-08", strings.NewReader(jsonInput))
 	request.Header.Set("x-api-key", suite.clientkey)
 	request.Header.Set("Accept", "application/json")
 	response := httptest.NewRecorder()

--- a/app/metricProfiles/model.go
+++ b/app/metricProfiles/model.go
@@ -26,9 +26,11 @@
 
 package metricProfiles
 
-// MongoInterface to retrieve and insert metricProfiles in mongo
-type MongoInterface struct {
+//MetricProfile struct used to retrieve and insert metricProfiles in mongo
+type MetricProfile struct {
 	ID       string    `bson:"id" json:"id"`
+	DateInt  int       `bson:"date_integer" json:"-"`
+	Date     string    `bson:"date" json:"date"`
 	Name     string    `bson:"name" json:"name"`
 	Services []Service `bson:"services" json:"services"`
 }

--- a/app/metricProfiles/view.go
+++ b/app/metricProfiles/view.go
@@ -35,7 +35,7 @@ import (
 )
 
 // createListView constructs the list response template and exports it as json
-func createListView(results []MongoInterface, msg string, code int) ([]byte, error) {
+func createListView(results []MetricProfile, msg string, code int) ([]byte, error) {
 
 	docRoot := &respond.ResponseMessage{
 		Status: respond.StatusResponse{
@@ -51,7 +51,7 @@ func createListView(results []MongoInterface, msg string, code int) ([]byte, err
 }
 
 // createListView constructs self-reference response and exports it as json
-func createRefView(inserted MongoInterface, msg string, code int, r *http.Request) ([]byte, error) {
+func createRefView(inserted MetricProfile, msg string, code int, r *http.Request) ([]byte, error) {
 	docRoot := &respond.ResponseMessage{
 		Status: respond.StatusResponse{
 			Message: msg,

--- a/app/operationsProfiles/controller.go
+++ b/app/operationsProfiles/controller.go
@@ -333,7 +333,10 @@ func Update(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 	urlValues := r.URL.Query()
 	dateStr := urlValues.Get("date")
 	dt, dateStr, err := utils.ParseZuluDate(dateStr)
+<<<<<<< HEAD
 
+=======
+>>>>>>> ARGO-2002 Add History for operations profiles
 	if err != nil {
 		code = http.StatusBadRequest
 		return code, h, output, err

--- a/app/weights/controller.go
+++ b/app/weights/controller.go
@@ -1,0 +1,409 @@
+package weights
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/ARGOeu/argo-web-api/respond"
+	"github.com/ARGOeu/argo-web-api/utils/config"
+	"github.com/ARGOeu/argo-web-api/utils/mongo"
+	"github.com/gorilla/context"
+	"github.com/gorilla/mux"
+	"gopkg.in/mgo.v2/bson"
+)
+
+//Create a new weights resource
+const weightCol = "weights"
+
+// Create request handler creates a new weight resource
+func Create(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
+	//STANDARD DECLARATIONS START
+	code := http.StatusOK
+	h := http.Header{}
+	output := []byte("")
+	err := error(nil)
+	charset := "utf-8"
+	//STANDARD DECLARATIONS END
+
+	// Set Content-Type response Header value
+	contentType := r.Header.Get("Accept")
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+
+	// Grab Tenant DB configuration from context
+	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
+
+	session, err := mongo.OpenSession(tenantDbConfig)
+	defer mongo.CloseSession(session)
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	incoming := Weights{}
+
+	// Try ingest request body
+	body, err := ioutil.ReadAll(io.LimitReader(r.Body, cfg.Server.ReqSizeLimit))
+	if err != nil {
+		panic(err)
+	}
+	if err := r.Body.Close(); err != nil {
+		panic(err)
+	}
+
+	// Parse body json
+	if err := json.Unmarshal(body, &incoming); err != nil {
+		output, _ = respond.MarshalContent(respond.BadRequestInvalidJSON, contentType, "", " ")
+		code = 400
+		return code, h, output, err
+	}
+
+	// check if the weights resource name is unique
+	results := []Weights{}
+	query := bson.M{"name": incoming.Name}
+
+	err = mongo.Find(session, tenantDbConfig.Db, weightCol, query, "", &results)
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	// If results are returned for the specific name
+	// then we already have an existing report and we must
+	// abort creation notifying the user
+	if len(results) > 0 {
+		output, _ = respond.MarshalContent(respond.ErrConflict("Weights resource with the same name already exists"), contentType, "", " ")
+		code = http.StatusConflict
+		return code, h, output, err
+	}
+
+	// Generate new weights id
+	incoming.ID = mongo.NewUUID()
+
+	err = mongo.Insert(session, tenantDbConfig.Db, weightCol, incoming)
+
+	if err != nil {
+		panic(err)
+	}
+
+	// Create view of the results
+	output, err = createRefView(incoming, "Weights resource succesfully created", 201, r) //Render the results into JSON
+	code = 201
+	return code, h, output, err
+}
+
+// ListOne handles the listing of one weight resource based on its given id
+func ListOne(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
+
+	//STANDARD DECLARATIONS START
+
+	code := http.StatusOK
+	h := http.Header{}
+	output := []byte("")
+	err := error(nil)
+	charset := "utf-8"
+
+	//STANDARD DECLARATIONS END
+
+	// Set Content-Type response Header value
+	contentType := r.Header.Get("Accept")
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+
+	vars := mux.Vars(r)
+
+	// Grab Tenant DB configuration from context
+	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
+
+	// Open session to tenant database
+	session, err := mongo.OpenSession(tenantDbConfig)
+	defer mongo.CloseSession(session)
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	filter := bson.M{"id": vars["ID"]}
+
+	// Retrieve Results from database
+	results := []Weights{}
+	err = mongo.Find(session, tenantDbConfig.Db, weightCol, filter, "name", &results)
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	// Check if nothing found
+	if len(results) < 1 {
+		output, _ = respond.MarshalContent(respond.ErrNotFound, contentType, "", " ")
+		code = 404
+		return code, h, output, err
+	}
+
+	// Create view of the results
+	output, err = createListView(results, "Success", code) //Render the results into JSON
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+	return code, h, output, err
+}
+
+// List the existing weight resources for the tenant making the request
+func List(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
+
+	//STANDARD DECLARATIONS START
+
+	code := http.StatusOK
+	h := http.Header{}
+	output := []byte("")
+	err := error(nil)
+	charset := "utf-8"
+
+	//STANDARD DECLARATIONS END
+
+	// Set Content-Type response Header value
+	contentType := r.Header.Get("Accept")
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+
+	urlValues := r.URL.Query()
+
+	// Grab Tenant DB configuration from context
+	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
+
+	// Open session to tenant database
+	session, err := mongo.OpenSession(tenantDbConfig)
+	defer mongo.CloseSession(session)
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	results := []Weights{}
+
+	// Retrieve Results from database
+
+	var filter interface{}
+	if len(urlValues["name"]) > 0 {
+		filter = bson.M{"name": urlValues["name"][0]}
+	} else {
+		filter = nil
+	}
+	err = mongo.Find(session, tenantDbConfig.Db, weightCol, filter, "name", &results)
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	// Create view of the results
+	output, err = createListView(results, "Success", code) //Render the results into JSON
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+	return code, h, output, err
+}
+
+//Update function to update contents of an existing weights resource
+func Update(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
+	//STANDARD DECLARATIONS START
+	code := http.StatusOK
+	h := http.Header{}
+	output := []byte("")
+	err := error(nil)
+	charset := "utf-8"
+	//STANDARD DECLARATIONS END
+
+	vars := mux.Vars(r)
+
+	// Set Content-Type response Header value
+	contentType := r.Header.Get("Accept")
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+
+	// Grab Tenant DB configuration from context
+	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
+
+	incoming := Weights{}
+
+	// ingest body data
+	body, err := ioutil.ReadAll(io.LimitReader(r.Body, cfg.Server.ReqSizeLimit))
+	if err != nil {
+		panic(err)
+	}
+	if err := r.Body.Close(); err != nil {
+		panic(err)
+	}
+	// parse body json
+	if err := json.Unmarshal(body, &incoming); err != nil {
+		output, _ = respond.MarshalContent(respond.BadRequestInvalidJSON, contentType, "", " ")
+		code = 400
+		return code, h, output, err
+	}
+
+	session, err := mongo.OpenSession(tenantDbConfig)
+	defer mongo.CloseSession(session)
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+	// create filter to retrieve specific weight resource with id
+	filter := bson.M{"id": vars["ID"]}
+
+	incoming.ID = vars["ID"]
+
+	// Retrieve Results from database
+	results := []Weights{}
+	err = mongo.Find(session, tenantDbConfig.Db, weightCol, filter, "name", &results)
+
+	if err != nil {
+		panic(err)
+	}
+
+	// Check if nothing found
+	if len(results) < 1 {
+		output, _ = respond.MarshalContent(respond.ErrNotFound, contentType, "", " ")
+		code = 404
+		return code, h, output, err
+	}
+
+	// check if the weights resource name is unique
+	if incoming.Name != results[0].Name {
+
+		results = []Weights{}
+		query := bson.M{"name": incoming.Name}
+
+		err = mongo.Find(session, tenantDbConfig.Db, weightCol, query, "", &results)
+
+		if err != nil {
+			code = http.StatusInternalServerError
+			return code, h, output, err
+		}
+
+		// If results are returned for the specific name
+		// then we already have an existing weight resource
+		// abort creation notifying the user
+		if len(results) > 0 {
+			output, _ = respond.MarshalContent(respond.ErrConflict("Weights resource with the same name already exists"), contentType, "", " ")
+			code = http.StatusConflict
+			return code, h, output, err
+		}
+	}
+	// run the update query
+	err = mongo.Update(session, tenantDbConfig.Db, weightCol, filter, incoming)
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	// Create view for response message
+	output, err = createMsgView("Weights resource successfully updated", 200) //Render the results into JSON
+	code = 200
+	return code, h, output, err
+}
+
+//Delete weights resource based on ID
+func Delete(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
+
+	//STANDARD DECLARATIONS START
+
+	code := http.StatusOK
+	h := http.Header{}
+	output := []byte("")
+	err := error(nil)
+	charset := "utf-8"
+
+	//STANDARD DECLARATIONS END
+
+	// Set Content-Type response Header value
+	contentType := r.Header.Get("Accept")
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+
+	vars := mux.Vars(r)
+
+	// Grab Tenant DB configuration from context
+	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
+
+	if err != nil {
+		output, _ = respond.MarshalContent(respond.UnauthorizedMessage, contentType, "", " ")
+		code = http.StatusUnauthorized //If wrong api key is passed we return UNAUTHORIZED http status
+		return code, h, output, err
+	}
+
+	// Open session to tenant database
+	session, err := mongo.OpenSession(tenantDbConfig)
+	defer mongo.CloseSession(session)
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	filter := bson.M{"id": vars["ID"]}
+
+	// Retrieve Results from database
+	results := []Weights{}
+	err = mongo.Find(session, tenantDbConfig.Db, weightCol, filter, "name", &results)
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	// Check if nothing found
+	if len(results) < 1 {
+		output, _ = respond.MarshalContent(respond.ErrNotFound, contentType, "", " ")
+		code = 404
+		return code, h, output, err
+	}
+
+	mongo.Remove(session, tenantDbConfig.Db, weightCol, filter)
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	// Create view of the results
+	output, err = createMsgView("Weights resource successfully deleted", 200) //Render the results into JSON
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+	return code, h, output, err
+}
+
+// Options request handler
+func Options(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
+
+	//STANDARD DECLARATIONS START
+
+	code := http.StatusOK
+	h := http.Header{}
+	output := []byte("")
+	err := error(nil)
+	contentType := "text/plain"
+	charset := "utf-8"
+
+	//STANDARD DECLARATIONS END
+
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+	h.Set("Allow", fmt.Sprintf("GET, POST, DELETE, PUT, OPTIONS"))
+	return code, h, output, err
+
+}

--- a/app/weights/model.go
+++ b/app/weights/model.go
@@ -1,0 +1,27 @@
+package weights
+
+//Weights holds a list of group weights of specific type and of specific group type
+type Weights struct {
+	ID         string   `bson:"id" json:"id"`
+	Name       string   `bson:"name" json:"name"`
+	WeightType string   `bson:"weight_type" json:"weight_type"`
+	GroupType  string   `bson:"group_type" json:"group_type"`
+	Groups     []Weight `bson:"groups" json:"groups"`
+}
+
+//Weight hols a mapping between group name and weight value
+type Weight struct {
+	Name  string  `bson:"name" json:"name"`
+	Value float64 `bson:"value" json:"value"`
+}
+
+// SelfReference to hold links and id
+type SelfReference struct {
+	ID    string `json:"id" bson:"id,omitempty"`
+	Links Links  `json:"links"`
+}
+
+// Links struct to hold links
+type Links struct {
+	Self string `json:"self"`
+}

--- a/app/weights/routing.go
+++ b/app/weights/routing.go
@@ -1,0 +1,24 @@
+package weights
+
+import (
+	"github.com/ARGOeu/argo-web-api/respond"
+	"github.com/gorilla/mux"
+)
+
+// HandleSubrouter uses the subrouter for a specific calls and creates a tree of sorts
+// handling each route with a different subrouter
+func HandleSubrouter(s *mux.Router, confhandler *respond.ConfHandler) {
+
+	s = respond.PrepAppRoutes(s, confhandler, appRoutesV2)
+
+}
+
+var appRoutesV2 = []respond.AppRoutes{
+	{Name: "weights.create", Verb: "POST", Path: "/weights", SubrouterHandler: Create},
+	{Name: "weights.update", Verb: "PUT", Path: "/weights/{ID}", SubrouterHandler: Update},
+	{Name: "weights.list", Verb: "GET", Path: "/weights", SubrouterHandler: List},
+	{Name: "weights.get", Verb: "GET", Path: "/weights/{ID}", SubrouterHandler: ListOne},
+	{Name: "weights.delete", Verb: "DELETE", Path: "/weights/{ID}", SubrouterHandler: Delete},
+	{Name: "weights.options", Verb: "OPTIONS", Path: "/weights", SubrouterHandler: Options},
+	{Name: "weights.options", Verb: "OPTIONS", Path: "/weights/{ID}", SubrouterHandler: Options},
+}

--- a/app/weights/view.go
+++ b/app/weights/view.go
@@ -1,0 +1,54 @@
+package weights
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+
+	"github.com/ARGOeu/argo-web-api/respond"
+)
+
+func createRefView(inserted Weights, msg string, code int, r *http.Request) ([]byte, error) {
+	docRoot := &respond.ResponseMessage{
+		Status: respond.StatusResponse{
+			Message: msg,
+			Code:    strconv.Itoa(code),
+		},
+		Data: SelfReference{
+			ID:    inserted.ID,
+			Links: Links{Self: "https://" + r.Host + r.URL.Path + "/" + inserted.ID},
+		},
+	}
+
+	output, err := json.MarshalIndent(docRoot, "", " ")
+	return output, err
+}
+
+// createListView constructs the list response template and exports it as json
+func createListView(results []Weights, msg string, code int) ([]byte, error) {
+
+	docRoot := &respond.ResponseMessage{
+		Status: respond.StatusResponse{
+			Message: msg,
+			Code:    strconv.Itoa(code),
+		},
+	}
+	docRoot.Data = results
+
+	output, err := json.MarshalIndent(docRoot, "", " ")
+	return output, err
+
+}
+
+// createMsgView constructs a simple message response without data
+func createMsgView(msg string, code int) ([]byte, error) {
+	docRoot := &respond.ResponseMessage{
+		Status: respond.StatusResponse{
+			Message: msg,
+			Code:    strconv.Itoa(code),
+		},
+	}
+
+	output, err := json.MarshalIndent(docRoot, "", " ")
+	return output, err
+}

--- a/app/weights/weights_test.go
+++ b/app/weights/weights_test.go
@@ -1,0 +1,972 @@
+package weights
+
+import (
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/ARGOeu/argo-web-api/respond"
+	"github.com/ARGOeu/argo-web-api/utils/config"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/suite"
+	"gopkg.in/gcfg.v1"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+)
+
+// This is a util. suite struct used in tests (see pkg "testify")
+type WeightsTestSuite struct {
+	suite.Suite
+	cfg                       config.Config
+	router                    *mux.Router
+	confHandler               respond.ConfHandler
+	tenantDbConf              config.MongoConfig
+	clientkey                 string
+	respRecomputationsCreated string
+	respUnauthorized          string
+}
+
+// Setup the Test Environment
+func (suite *WeightsTestSuite) SetupSuite() {
+	const testConfig = `
+	 [server]
+	 bindip = ""
+	 port = 8080
+	 maxprocs = 4
+	 cache = false
+	 lrucache = 700000000
+	 gzip = true
+	 reqsizelimit = 1073741824
+ 
+	 [mongodb]
+	 host = "127.0.0.1"
+	 port = 27017
+	 db = "AR_test_mprof"
+	 `
+
+	_ = gcfg.ReadStringInto(&suite.cfg, testConfig)
+
+	suite.respUnauthorized = "Unauthorized"
+	suite.tenantDbConf = config.MongoConfig{
+		Host:     "localhost",
+		Port:     27017,
+		Db:       "AR_test_weights_tenant",
+		Password: "pass",
+		Username: "dbuser",
+		Store:    "ar",
+	}
+	suite.clientkey = "123456"
+
+	suite.confHandler = respond.ConfHandler{Config: suite.cfg}
+	suite.router = mux.NewRouter().StrictSlash(false).PathPrefix("/api/v2").Subrouter()
+	HandleSubrouter(suite.router, &suite.confHandler)
+}
+
+// This function runs before any test and setups the environment
+func (suite *WeightsTestSuite) SetupTest() {
+
+	log.SetOutput(ioutil.Discard)
+
+	// seed mongo
+	session, err := mgo.Dial(suite.cfg.MongoDB.Host)
+	if err != nil {
+		panic(err)
+	}
+	defer session.Close()
+
+	// Seed database with tenants
+	c := session.DB(suite.cfg.MongoDB.Db).C("tenants")
+	c.Insert(
+		bson.M{"id": "6ac7d684-1f8e-4a02-a502-720e8f11e50c",
+			"info": bson.M{
+				"name":    "GUARDIANS",
+				"email":   "email@something2",
+				"website": "www.gotg.com",
+				"created": "2015-10-20 02:08:04",
+				"updated": "2015-10-20 02:08:04"},
+			"db_conf": []bson.M{
+
+				bson.M{
+					"server":   "localhost",
+					"port":     27017,
+					"database": "argo_FOO",
+				},
+				bson.M{
+					"server":   "localhost",
+					"port":     27017,
+					"database": "argo_FOO",
+				},
+			},
+			"users": []bson.M{
+
+				bson.M{
+					"name":    "user1",
+					"email":   "user1@email.com",
+					"api_key": "USER1KEY",
+					"roles":   []string{"editor"},
+				},
+				bson.M{
+					"name":    "user2",
+					"email":   "user2@email.com",
+					"api_key": "USER2KEY",
+					"roles":   []string{"editor"},
+				},
+			}})
+	c.Insert(
+		bson.M{"id": "6ac7d684-1f8e-4a02-a502-720e8f11e50d",
+			"info": bson.M{
+				"name":    "AVENGERS",
+				"email":   "email@something2",
+				"website": "www.gotg.com",
+				"created": "2015-10-20 02:08:04",
+				"updated": "2015-10-20 02:08:04"},
+			"db_conf": []bson.M{
+
+				bson.M{
+					// "store":    "ar",
+					"server":   suite.tenantDbConf.Host,
+					"port":     suite.tenantDbConf.Port,
+					"database": suite.tenantDbConf.Db,
+					"username": suite.tenantDbConf.Username,
+					"password": suite.tenantDbConf.Password,
+				},
+				bson.M{
+					"server":   suite.tenantDbConf.Host,
+					"port":     suite.tenantDbConf.Port,
+					"database": suite.tenantDbConf.Db,
+				},
+			},
+			"users": []bson.M{
+
+				bson.M{
+					"name":    "user3",
+					"email":   "user3@email.com",
+					"api_key": suite.clientkey,
+					"roles":   []string{"editor"},
+				},
+				bson.M{
+					"name":    "user4",
+					"email":   "user4@email.com",
+					"api_key": "VIEWERKEY",
+					"roles":   []string{"viewer"},
+				},
+			}})
+
+	c = session.DB(suite.cfg.MongoDB.Db).C("roles")
+	c.Insert(
+		bson.M{
+			"resource": "weights.list",
+			"roles":    []string{"editor", "viewer"},
+		})
+	c.Insert(
+		bson.M{
+			"resource": "weights.get",
+			"roles":    []string{"editor", "viewer"},
+		})
+	c.Insert(
+		bson.M{
+			"resource": "weights.create",
+			"roles":    []string{"editor"},
+		})
+	c.Insert(
+		bson.M{
+			"resource": "weights.delete",
+			"roles":    []string{"editor"},
+		})
+	c.Insert(
+		bson.M{
+			"resource": "weights.update",
+			"roles":    []string{"editor"},
+		})
+
+	// Seed database with weights
+	c = session.DB(suite.tenantDbConf.Db).C("weights")
+	c.Insert(
+		bson.M{
+			"id":          "6ac7d684-1f8e-4a02-a502-720e8f11e50b",
+			"name":        "Critical",
+			"weight_type": "hepsepc",
+			"group_type":  "SITES",
+			"groups": []bson.M{
+				bson.M{"name": "SITE-A", "value": 1673},
+				bson.M{"name": "SITE-B", "value": 1234},
+				bson.M{"name": "SITE-C", "value": 523},
+				bson.M{"name": "SITE-D", "value": 2},
+			},
+		})
+	c.Insert(
+		bson.M{
+			"id":          "6ac7d684-1f8e-4a02-a502-720e8f11e50c",
+			"name":        "NonCritical",
+			"weight_type": "hepsepc",
+			"group_type":  "SERVICEGROUPS",
+			"groups": []bson.M{
+				bson.M{"name": "SVGROUP-A", "value": 334},
+				bson.M{"name": "SVGROUP-B", "value": 588},
+			},
+		})
+
+}
+
+func (suite *WeightsTestSuite) TestCreateBadJson() {
+
+	jsonInput := `{
+   "weight_type":"hepsec",
+   "group_type": "SITES",
+   "groups": [
+	 {
+	   "name": "SITE-A",
+		"value": 33.33
+	 `
+
+	jsonOutput := `{
+ "status": {
+  "message": "Bad Request",
+  "code": "400"
+ },
+ "errors": [
+  {
+   "message": "Bad Request",
+   "code": "400",
+   "details": "Request Body contains malformed JSON, thus rendering the Request Bad"
+  }
+ ]
+}`
+
+	request, _ := http.NewRequest("POST", "/api/v2/weights", strings.NewReader(jsonInput))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code := response.Code
+	output := response.Body.String()
+	// Check that we must have a 200 ok code
+	suite.Equal(400, code, "Internal Server Error")
+	// Compare the expected and actual json response
+
+	suite.Equal(jsonOutput, output, "Response body mismatch")
+
+}
+
+func (suite *WeightsTestSuite) TestCreate() {
+
+	jsonInput := `{
+   "name": "weight_set3",
+   "weight_type": "hepspec2",
+   "group_type": "SITES",
+   "groups": [
+	 { "name": "site-a" , "value": 336 },
+	 { "name": "site-b" , "value": 343 },
+	 { "name": "site-c" , "value": 553 },
+	 { "name": "site-d" , "value": 435 },
+	 { "name": "site-e" , "value": 3.33 },
+	 { "name": "site-f" , "value": 323.3 }
+   ]
+ }`
+
+	jsonOutput := `{
+ "status": {
+  "message": "Weights resource succesfully created",
+  "code": "201"
+ },
+ "data": {
+  "id": "{{id}}",
+  "links": {
+   "self": "https:///api/v2/weights/{{id}}"
+  }
+ }
+}`
+
+	jsonCreated := `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "id": "{{id}}",
+   "name": "weight_set3",
+   "weight_type": "hepspec2",
+   "group_type": "SITES",
+   "groups": [
+    {
+     "name": "site-a",
+     "value": 336
+    },
+    {
+     "name": "site-b",
+     "value": 343
+    },
+    {
+     "name": "site-c",
+     "value": 553
+    },
+    {
+     "name": "site-d",
+     "value": 435
+    },
+    {
+     "name": "site-e",
+     "value": 3.33
+    },
+    {
+     "name": "site-f",
+     "value": 323.3
+    }
+   ]
+  }
+ ]
+}`
+
+	request, _ := http.NewRequest("POST", "/api/v2/weights", strings.NewReader(jsonInput))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code := response.Code
+	output := response.Body.String()
+	// Check that we must have a 200 ok code
+	suite.Equal(201, code, "Internal Server Error")
+	// Compare the expected and actual json response
+
+	// Grab id from mongodb
+	session, err := mgo.Dial(suite.cfg.MongoDB.Host)
+	defer session.Close()
+	if err != nil {
+		panic(err)
+	}
+	// Retrieve id from database
+	var result map[string]interface{}
+	c := session.DB(suite.tenantDbConf.Db).C("weights")
+	c.Find(bson.M{"name": "weight_set3"}).One(&result)
+	id := result["id"].(string)
+
+	// Apply id to output template and check
+	suite.Equal(strings.Replace(jsonOutput, "{{id}}", id, 2), output, "Response body mismatch")
+
+	// Apply id to output template and check
+	suite.Equal(strings.Replace(jsonOutput, "{{id}}", id, 2), output, "Response body mismatch")
+
+	// Check that actually the item has been created
+	// Call List one with the specific id
+	request2, _ := http.NewRequest("GET", "/api/v2/weights/"+id, strings.NewReader(jsonInput))
+	request2.Header.Set("x-api-key", suite.clientkey)
+	request2.Header.Set("Accept", "application/json")
+	response2 := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response2, request2)
+
+	code2 := response2.Code
+	output2 := response2.Body.String()
+	// Check that we must have a 200 ok code
+	suite.Equal(200, code2, "Internal Server Error")
+	// Compare the expected and actual json response
+	suite.Equal(strings.Replace(jsonCreated, "{{id}}", id, 2), output2, "Response body mismatch")
+
+}
+
+func (suite *WeightsTestSuite) TestList() {
+
+	request, _ := http.NewRequest("GET", "/api/v2/weights", strings.NewReader(""))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code := response.Code
+	output := response.Body.String()
+
+	weightsJSON := `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50b",
+   "name": "Critical",
+   "weight_type": "hepsepc",
+   "group_type": "SITES",
+   "groups": [
+    {
+     "name": "SITE-A",
+     "value": 1673
+    },
+    {
+     "name": "SITE-B",
+     "value": 1234
+    },
+    {
+     "name": "SITE-C",
+     "value": 523
+    },
+    {
+     "name": "SITE-D",
+     "value": 2
+    }
+   ]
+  },
+  {
+   "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50c",
+   "name": "NonCritical",
+   "weight_type": "hepsepc",
+   "group_type": "SERVICEGROUPS",
+   "groups": [
+    {
+     "name": "SVGROUP-A",
+     "value": 334
+    },
+    {
+     "name": "SVGROUP-B",
+     "value": 588
+    }
+   ]
+  }
+ ]
+}`
+	// Check that we must have a 200 ok code
+	suite.Equal(200, code, "Internal Server Error")
+	// Compare the expected and actual json response
+	suite.Equal(weightsJSON, output, "Response body mismatch")
+
+}
+
+func (suite *WeightsTestSuite) TestOptionsWeights() {
+	request, _ := http.NewRequest("OPTIONS", "/api/v2/weights", strings.NewReader(""))
+
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code := response.Code
+	output := response.Body.String()
+	headers := response.HeaderMap
+
+	suite.Equal(200, code, "Error in response code")
+	suite.Equal("", output, "Expected empty response body")
+	suite.Equal("GET, POST, DELETE, PUT, OPTIONS", headers.Get("Allow"), "Error in Allow header response (supported resource verbs of resource)")
+	suite.Equal("text/plain; charset=utf-8", headers.Get("Content-Type"), "Error in Content-Type header response")
+
+	response = httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code = response.Code
+	output = response.Body.String()
+	headers = response.HeaderMap
+
+	suite.Equal(200, code, "Error in response code")
+	suite.Equal("", output, "Expected empty response body")
+	suite.Equal("GET, POST, DELETE, PUT, OPTIONS", headers.Get("Allow"), "Error in Allow header response (supported resource verbs of resource)")
+	suite.Equal("text/plain; charset=utf-8", headers.Get("Content-Type"), "Error in Content-Type header response")
+
+}
+
+//TearDownTest to tear down every test
+func (suite *WeightsTestSuite) TearDownTest() {
+
+	session, err := mgo.Dial(suite.cfg.MongoDB.Host)
+	if err != nil {
+		panic(err)
+	}
+
+	tenantDB := session.DB(suite.tenantDbConf.Db)
+	mainDB := session.DB(suite.cfg.MongoDB.Db)
+
+	cols, err := tenantDB.CollectionNames()
+	for _, col := range cols {
+		tenantDB.C(col).RemoveAll(nil)
+	}
+
+	cols, err = mainDB.CollectionNames()
+	for _, col := range cols {
+		mainDB.C(col).RemoveAll(nil)
+	}
+
+}
+
+func (suite *WeightsTestSuite) TestListOneNotFound() {
+
+	jsonInput := `{}`
+
+	jsonOutput := `{
+ "status": {
+  "message": "Not Found",
+  "code": "404"
+ },
+ "errors": [
+  {
+   "message": "Not Found",
+   "code": "404",
+   "details": "item with the specific ID was not found on the server"
+  }
+ ]
+}`
+
+	request, _ := http.NewRequest("GET", "/api/v2/weights/wrong-id", strings.NewReader(jsonInput))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code := response.Code
+	output := response.Body.String()
+	// Check that we must have a 200 ok code
+	suite.Equal(404, code, "Internal Server Error")
+	// Compare the expected and actual json response
+
+	suite.Equal(jsonOutput, output, "Response body mismatch")
+
+}
+
+func (suite *WeightsTestSuite) TestListOne() {
+
+	request, _ := http.NewRequest("GET", "/api/v2/weights/6ac7d684-1f8e-4a02-a502-720e8f11e50b", strings.NewReader(""))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code := response.Code
+	output := response.Body.String()
+
+	weightsJSON := `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50b",
+   "name": "Critical",
+   "weight_type": "hepsepc",
+   "group_type": "SITES",
+   "groups": [
+    {
+     "name": "SITE-A",
+     "value": 1673
+    },
+    {
+     "name": "SITE-B",
+     "value": 1234
+    },
+    {
+     "name": "SITE-C",
+     "value": 523
+    },
+    {
+     "name": "SITE-D",
+     "value": 2
+    }
+   ]
+  }
+ ]
+}`
+	// Check that we must have a 200 ok code
+	suite.Equal(200, code, "Internal Server Error")
+	// Compare the expected and actual json response
+	suite.Equal(weightsJSON, output, "Response body mismatch")
+
+}
+
+func (suite *WeightsTestSuite) TestUpdateNameAlreadyExists() {
+
+	jsonInput := `{
+   "name": "Critical",
+   "weight_type": "hepsepc5",
+   "group_type": "SITES",
+   "groups": [
+    {
+     "name": "SITE-A",
+     "value": 16733
+    },
+    {
+     "name": "SITE-B",
+     "value": 12345
+    },
+    {
+     "name": "SITE-C",
+     "value": 5233
+    },
+    {
+     "name": "SITE-D",
+     "value": 23
+    }
+   ]
+}`
+
+	jsonOutput := `{
+ "status": {
+  "message": "Conflict",
+  "code": "409"
+ },
+ "errors": [
+  {
+   "message": "Conflict",
+   "code": "409",
+   "details": "Weights resource with the same name already exists"
+  }
+ ]
+}`
+
+	request, _ := http.NewRequest("PUT", "/api/v2/weights/6ac7d684-1f8e-4a02-a502-720e8f11e50c", strings.NewReader(jsonInput))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code := response.Code
+	output := response.Body.String()
+
+	suite.Equal(409, code)
+	suite.Equal(jsonOutput, output)
+
+}
+
+func (suite *WeightsTestSuite) TestUpdateBadJson() {
+
+	jsonInput := `{
+   "name": "Critical",
+   "weight_type": "hepsepc5",
+   "group_type": "SITES",
+   "groups": [
+    {
+     "name": "SITE-A",
+     "value": 16733
+    },
+    {
+`
+
+	jsonOutput := `{
+ "status": {
+  "message": "Bad Request",
+  "code": "400"
+ },
+ "errors": [
+  {
+   "message": "Bad Request",
+   "code": "400",
+   "details": "Request Body contains malformed JSON, thus rendering the Request Bad"
+  }
+ ]
+}`
+
+	request, _ := http.NewRequest("PUT", "/api/v2/weights/6ac7d684-1f8e-4a02-a502-720e8f11e50c", strings.NewReader(jsonInput))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code := response.Code
+	output := response.Body.String()
+	// Check that we must have a 200 ok code
+	suite.Equal(400, code, "Internal Server Error")
+	// Compare the expected and actual json response
+
+	suite.Equal(jsonOutput, output, "Response body mismatch")
+
+}
+
+func (suite *WeightsTestSuite) TestUpdateNotFound() {
+
+	jsonInput := `{}`
+
+	jsonOutput := `{
+ "status": {
+  "message": "Not Found",
+  "code": "404"
+ },
+ "errors": [
+  {
+   "message": "Not Found",
+   "code": "404",
+   "details": "item with the specific ID was not found on the server"
+  }
+ ]
+}`
+
+	request, _ := http.NewRequest("PUT", "/api/v2/weights/wrong-id", strings.NewReader(jsonInput))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code := response.Code
+	output := response.Body.String()
+	// Check that we must have a 200 ok code
+	suite.Equal(404, code, "Internal Server Error")
+	// Compare the expected and actual json response
+
+	suite.Equal(jsonOutput, output, "Response body mismatch")
+
+}
+
+func (suite *WeightsTestSuite) TestUpdate() {
+
+	jsonInput := `{
+   "name": "NonCritical",
+   "weight_type": "hepsepc5",
+   "group_type": "SITES",
+   "groups": [
+    {
+     "name": "SITE-A",
+     "value": 16733
+    },
+    {
+     "name": "SITE-B",
+     "value": 12345
+    }
+   ]
+}`
+
+	jsonOutput := `{
+ "status": {
+  "message": "Weights resource successfully updated",
+  "code": "200"
+ }
+}`
+
+	jsonUpdated := `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50c",
+   "name": "NonCritical",
+   "weight_type": "hepsepc5",
+   "group_type": "SITES",
+   "groups": [
+    {
+     "name": "SITE-A",
+     "value": 16733
+    },
+    {
+     "name": "SITE-B",
+     "value": 12345
+    }
+   ]
+  }
+ ]
+}`
+
+	request, _ := http.NewRequest("PUT", "/api/v2/weights/6ac7d684-1f8e-4a02-a502-720e8f11e50c", strings.NewReader(jsonInput))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code := response.Code
+	output := response.Body.String()
+
+	// Check that we must have a 200 ok code
+	suite.Equal(200, code, "Internal Server Error")
+	// Compare the expected and actual json response
+
+	// Apply id to output template and check
+	suite.Equal(jsonOutput, output, "Response body mismatch")
+
+	// Check that the item has actually updated
+	// run a list specific
+	request2, _ := http.NewRequest("GET", "/api/v2/weights/6ac7d684-1f8e-4a02-a502-720e8f11e50c", strings.NewReader(jsonInput))
+	request2.Header.Set("x-api-key", suite.clientkey)
+	request2.Header.Set("Accept", "application/json")
+	response2 := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response2, request2)
+
+	code2 := response2.Code
+	output2 := response2.Body.String()
+	// Check that we must have a 200 ok code
+	suite.Equal(200, code2, "Internal Server Error")
+	// Compare the expected and actual json response
+
+	suite.Equal(jsonUpdated, output2, "Response body mismatch")
+
+}
+
+func (suite *WeightsTestSuite) TestDeleteNotFound() {
+
+	jsonInput := `{}`
+
+	jsonOutput := `{
+ "status": {
+  "message": "Not Found",
+  "code": "404"
+ },
+ "errors": [
+  {
+   "message": "Not Found",
+   "code": "404",
+   "details": "item with the specific ID was not found on the server"
+  }
+ ]
+}`
+
+	request, _ := http.NewRequest("DELETE", "/api/v2/weights/wrong-id", strings.NewReader(jsonInput))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code := response.Code
+	output := response.Body.String()
+	// Check that we must have a 200 ok code
+	suite.Equal(404, code, "Internal Server Error")
+	// Compare the expected and actual json response
+
+	suite.Equal(jsonOutput, output, "Response body mismatch")
+
+}
+
+func (suite *WeightsTestSuite) TestDelete() {
+
+	request, _ := http.NewRequest("DELETE", "/api/v2/weights/6ac7d684-1f8e-4a02-a502-720e8f11e50b", strings.NewReader(""))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code := response.Code
+	output := response.Body.String()
+
+	metricProfileJSON := `{
+ "status": {
+  "message": "Weights resource successfully deleted",
+  "code": "200"
+ }
+}`
+	// Check that we must have a 200 ok code
+	suite.Equal(200, code, "Internal Server Error")
+	// Compare the expected and actual json response
+	suite.Equal(metricProfileJSON, output, "Response body mismatch")
+
+	// check that the element has actually been Deleted
+	// connect to mongodb
+	session, err := mgo.Dial(suite.cfg.MongoDB.Host)
+	defer session.Close()
+	if err != nil {
+		panic(err)
+	}
+	// try to retrieve item
+	var result map[string]interface{}
+	c := session.DB(suite.tenantDbConf.Db).C("weights")
+	err = c.Find(bson.M{"id": "6ac7d684-1f8e-4a02-a502-720e8f11e50b"}).One(&result)
+
+	suite.NotEqual(err, nil, "No not found error")
+	suite.Equal(err.Error(), "not found", "No not found error")
+}
+
+func (suite *WeightsTestSuite) TestCreateForbidViewer() {
+
+	jsonInput := `{
+   "name": "test_profile",
+   "namespace [
+	 `
+
+	jsonOutput := `{
+ "status": {
+  "message": "Access to the resource is Forbidden",
+  "code": "403"
+ }
+}`
+
+	request, _ := http.NewRequest("POST", "/api/v2/weights", strings.NewReader(jsonInput))
+	request.Header.Set("x-api-key", "VIEWERKEY")
+	request.Header.Set("Accept", "application/json")
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code := response.Code
+	output := response.Body.String()
+	// Check that we must have a 200 ok code
+	suite.Equal(403, code, "Internal Server Error")
+	// Compare the expected and actual json response
+
+	suite.Equal(jsonOutput, output, "Response body mismatch")
+}
+
+func (suite *WeightsTestSuite) TestUpdateForbidViewer() {
+
+	jsonInput := `{}`
+
+	jsonOutput := `{
+ "status": {
+  "message": "Access to the resource is Forbidden",
+  "code": "403"
+ }
+}`
+
+	request, _ := http.NewRequest("PUT", "/api/v2/weights/6ac7d684-1f8e-4a02-a502-720e8f11e007", strings.NewReader(jsonInput))
+	request.Header.Set("x-api-key", "VIEWERKEY")
+	request.Header.Set("Accept", "application/json")
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code := response.Code
+	output := response.Body.String()
+	// Check that we must have a 200 ok code
+	suite.Equal(403, code, "Internal Server Error")
+	// Compare the expected and actual json response
+
+	suite.Equal(jsonOutput, output, "Response body mismatch")
+
+}
+
+func (suite *WeightsTestSuite) TestDeleteForbidViewer() {
+
+	request, _ := http.NewRequest("DELETE", "/api/v2/weights/6ac7d684-1f8e-4a02-a502-720e8f11e50b", strings.NewReader(""))
+	request.Header.Set("x-api-key", "VIEWERKEY")
+	request.Header.Set("Accept", "application/json")
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code := response.Code
+	output := response.Body.String()
+
+	metricProfileJSON := `{
+ "status": {
+  "message": "Access to the resource is Forbidden",
+  "code": "403"
+ }
+}`
+	// Check that we must have a 200 ok code
+	suite.Equal(403, code, "Internal Server Error")
+	// Compare the expected and actual json response
+	suite.Equal(metricProfileJSON, output, "Response body mismatch")
+}
+
+//TearDownTest to tear down every test
+func (suite *WeightsTestSuite) TearDownSuite() {
+
+	session, err := mgo.Dial(suite.cfg.MongoDB.Host)
+	if err != nil {
+		panic(err)
+	}
+	session.DB(suite.tenantDbConf.Db).DropDatabase()
+	session.DB(suite.cfg.MongoDB.Db).DropDatabase()
+}
+
+func TestWeightsTestSuite(t *testing.T) {
+	suite.Run(t, new(WeightsTestSuite))
+}

--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -1347,6 +1347,197 @@ paths:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Status_error'
+            
+  
+  /weights/{PROFILE_ID}:
+    get:
+      summary: List a specific weights resource
+      operationId: weights.ListOne
+      description: List one specific weights resource targeted by it's unique id
+      tags:
+        - Weights
+      produces:
+        - "application/json"
+      parameters:
+        - $ref: "#/parameters/apiKey"
+        - name: "PROFILE_ID"
+          in: "path"
+          description: "id of the weights resource"
+          required: true
+          type: string
+      responses:
+        '200':
+          description: A list with a weights resource
+          schema:
+            $ref: '#/definitions/Weights_list'
+        '401':
+          description: Unauthorized user
+          schema:
+            $ref: '#/definitions/Status_error'
+        '404':
+          description: Item not found
+          schema:
+            $ref: '#/definitions/Status_error'
+        '406':
+          description: Content Not acceptable
+          schema:
+            $ref: '#/definitions/Status_error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Status_error'
+    put:
+      summary: update an existing weights resource
+      operationId: weights.Update
+      description: update information on a specific weights resource which is targeted by it's unique id
+      tags:
+        - Weights
+      consumes:
+        - "application/json"
+      produces:
+        - "application/json"
+      parameters:
+        - $ref: "#/parameters/apiKey"
+        - name: "PROFILE_ID"
+          in: "path"
+          description: "id of the weights resource"
+          required: true
+          type: string
+        - name: "weights_resource"
+          in: "body"
+          description: "Json description of the weight_resource to be updated"
+          required: true
+          schema:
+            $ref: '#/definitions/Weights'
+      responses:
+        '201':
+          description: Weights resource Updated
+          schema:
+            $ref: '#/definitions/Status'
+        '400':
+          description: Bad request due to malformed JSON in put body
+          schema:
+            $ref: '#/definitions/Status_error'
+        '401':
+          description: Unauthorized user
+          schema:
+            $ref: '#/definitions/Status_error'
+        '404':
+          description: Item not found
+          schema:
+            $ref: '#/definitions/Status_error'
+        '406':
+          description: Content Not acceptable
+          schema:
+            $ref: '#/definitions/Status_error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Status_error'
+    delete:
+      summary: Delete a weights resource
+      operationId: weights.Delete
+      description: Delete a specific weights resource which is targeted by it's unique id
+      tags:
+        - Weights
+      produces:
+        - "application/json"
+      parameters:
+        - $ref: "#/parameters/apiKey"
+        - name: "PROFILE_ID"
+          in: "path"
+          description: "id of the weights resource"
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Weights resource deleted
+          schema:
+            $ref: '#/definitions/Status'
+        '401':
+          description: Unauthorized user
+          schema:
+            $ref: '#/definitions/Status_error'
+        '404':
+          description: Item not found
+          schema:
+            $ref: '#/definitions/Status_error'
+        '406':
+          description: Content Not acceptable
+          schema:
+            $ref: '#/definitions/Status_error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Status_error'
+
+  /weights:
+    get:
+      summary: List all weight resource
+      operationId: weights.List
+      description: List available weight resources
+      tags:
+        - Weights
+      produces:
+        - "application/json"
+      parameters:
+        - $ref: "#/parameters/apiKey"
+      responses:
+        '200':
+          description: A list of weights resources
+          schema:
+            $ref: '#/definitions/Weights_list'
+        '401':
+          description: Unauthorized user
+          schema:
+            $ref: '#/definitions/Status_error'
+        '406':
+          description: Content Not acceptable
+          schema:
+            $ref: '#/definitions/Status_error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Status_error'
+    post:
+      summary: Create a new weights resource
+      operationId: weights.Create
+      description: Create a new weights resource that includes mapping of groups and weights to be used through a computation
+      tags:
+        - Weights
+      consumes:
+        - "application/json"
+      produces:
+        - "application/json"
+      parameters:
+        - name: "weights_resource"
+          in: "body"
+          description: "Json description of the weights resource to be created"
+          required: true
+          schema:
+            $ref: '#/definitions/Weights'
+        - $ref: "#/parameters/apiKey"
+      responses:
+        '200':
+          description: Weights resource Created
+          schema:
+            $ref: '#/definitions/Self_reference'
+        '400':
+          description: Bad request due to malformed JSON in post body
+          schema:
+            $ref: '#/definitions/Status_error'
+        '401':
+          description: Unauthorized user
+          schema:
+            $ref: '#/definitions/Status_error'
+        '406':
+          description: Content Not acceptable
+          schema:
+            $ref: '#/definitions/Status_error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Status_error'
 
   /topology/{report_name}:
     get:
@@ -3234,6 +3425,17 @@ definitions:
               type: string
             details:
               type: string
+              
+              
+  Weights_list:
+    type: object
+    properties:
+      status:
+       $ref: '#/definitions/Status'
+      data:
+        type: array
+        items:
+          $ref: '#/definitions/Weights'
 
   Thresholds_profile_list:
     type: object
@@ -3429,6 +3631,31 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/Operation'
+          
+  Weights:
+    type: object
+    properties:
+      id:
+        type: string
+      name:
+        type: string
+      weight_type:
+        type: string
+      group_type:
+        type: string
+      groups:
+        type: array
+        items:
+          $ref: '#/definitions/GroupWeight'
+
+  GroupWeight:
+    type: object
+    properties:
+      name: 
+        type: string
+      value:
+        type: number
+    
 
   Operations_profile:
     type: object

--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -979,6 +979,7 @@ paths:
       produces:
         - "application/json"
       parameters:
+        - $ref: "#/parameters/profDate"
         - $ref: "#/parameters/apiKey"
         - name: "PROFILE_ID"
           in: "path"
@@ -1018,6 +1019,7 @@ paths:
         - "application/json"
       parameters:
         - $ref: "#/parameters/apiKey"
+        - $ref: "#/parameters/profDate"
         - name: "PROFILE_ID"
           in: "path"
           description: "id of the metric profile"
@@ -1100,6 +1102,7 @@ paths:
       produces:
         - "application/json"
       parameters:
+        - $ref: "#/parameters/profDate"
         - $ref: "#/parameters/apiKey"
       responses:
         '200':
@@ -1136,6 +1139,7 @@ paths:
           schema:
             $ref: '#/definitions/Metric_profile'
         - $ref: "#/parameters/apiKey"
+        - $ref: "#/parameters/profDate"
       responses:
         '200':
           description: Metric profile Created

--- a/doc/v2/docs/metric_profiles.md
+++ b/doc/v2/docs/metric_profiles.md
@@ -31,6 +31,7 @@ GET /metric_profiles
 Type            | Description                                                                                     | Required
 --------------- | ----------------------------------------------------------------------------------------------- | --------
 `name`          | metric profile name to be used as query                                                         | NO      
+`date`          | Date to retrieve a historic version of the metric profile. If no date parameter is provided the most current profile will be returned | NO
 
 ### Request headers
 
@@ -54,6 +55,7 @@ Json Response
  "data": [
   {
    "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50c",
+   "date": "2019-10-10",
    "name": "ch.cern.SAM.ROC",
    "services": [
     {
@@ -84,6 +86,7 @@ Json Response
   },
   {
    "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50b",
+   "date" : "2019-11-01",
    "name": "ch.cern.SAM.ROC_CRITICAL",
    "services": [
     {
@@ -125,6 +128,13 @@ This method can be used to retrieve specific metric profile based on its id
 GET /metric_profiles/{ID}
 ```
 
+#### Optional Query Parameters
+
+Type            | Description                                                                                     | Required
+--------------- | ----------------------------------------------------------------------------------------------- | --------
+`date`          | Date to retrieve a historic version of the metric profile. If no date parameter is provided the most current profile will be returned | NO
+
+
 #### Request headers
 
 ```
@@ -147,6 +157,7 @@ Json Response
  "data": [
   {
    "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50b",
+   "date" : "2019-11-01",
    "name": "ch.cern.SAM.ROC_CRITICAL",
    "services": [
     {
@@ -194,6 +205,13 @@ POST /metric_profiles
 x-api-key: shared_key_value
 Accept: application/json
 ```
+
+
+#### Optional Query Parameters
+
+Type            | Description                                                                                     | Required
+--------------- | ----------------------------------------------------------------------------------------------- | --------
+`date`          | Date to create a  new historic version of the metric profile. If no date parameter is provided current date will be supplied automatically | NO
 
 #### POST BODY
 
@@ -259,6 +277,13 @@ PUT /metric_profiles/{ID}
 x-api-key: shared_key_value
 Accept: application/json
 ```
+
+
+#### Optional Query Parameters
+
+Type            | Description                                                                                     | Required
+--------------- | ----------------------------------------------------------------------------------------------- | --------
+`date`          | Date to update a  new historic version of the operation profile. If no date parameter is provided current date will be supplied automatically | NO
 
 #### PUT BODY
 

--- a/doc/v2/docs/weights.md
+++ b/doc/v2/docs/weights.md
@@ -1,0 +1,306 @@
+---
+title: "API documentation | ARGO"
+page_title: API - Weights resource requests
+font_title: fa fa-cogs
+description: API Calls for listing existing and creating new weights resources
+---
+
+# API Calls
+
+| Name                                  | Description                                                                     | Shortcut           |
+| ------------------------------------- | ------------------------------------------------------------------------------- | ------------------ |
+| GET: List Weights resources Request   | This method can be used to retrieve a list of current weight resources.         | [ Description](#1) |
+| GET: List a specific Weights resource | This method can be used to retrieve a specific weight resource based on its id. | [ Description](#2) |
+| POST: Create a new weight resource    | This method can be used to create a new weight resource                         | [ Description](#3) |
+| PUT: Update a weight resource         | This method can be used to update information on an existing weight resource    | [ Description](#4) |
+| DELETE: Delete a weight resource      | This method can be used to delete an existing weight resource                   | [ Description](#5) |
+
+<a id='1'></a>
+
+## [GET]: List weight resources
+
+This method can be used to retrieve a list of current weight resources
+
+### Input
+
+```
+GET /weights
+```
+
+#### Optional Query Parameters
+
+| Type   | Description                              | Required |
+| ------ | ---------------------------------------- | -------- |
+| `name` | weight resource name to be used as query | NO       |
+
+### Request headers
+
+```
+x-api-key: shared_key_value
+Accept: application/json
+```
+
+### Response
+
+Headers: `Status: 200 OK`
+
+#### Response body
+
+Json Response
+
+```json
+{
+    "status": {
+        "message": "Success",
+        "code": "200"
+    },
+    "data": [
+        {
+            "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50b",
+            "name": "Critical",
+            "weight_type": "hepsepc",
+            "group_type": "SITES",
+            "groups": [
+                {
+                    "name": "SITE-A",
+                    "value": 1673
+                },
+                {
+                    "name": "SITE-B",
+                    "value": 1234
+                },
+                {
+                    "name": "SITE-C",
+                    "value": 523
+                },
+                {
+                    "name": "SITE-D",
+                    "value": 2
+                }
+            ]
+        },
+        {
+            "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50c",
+            "name": "NonCritical",
+            "weight_type": "hepsepc",
+            "group_type": "SERVICEGROUPS",
+            "groups": [
+                {
+                    "name": "SVGROUP-A",
+                    "value": 334
+                },
+                {
+                    "name": "SVGROUP-B",
+                    "value": 588
+                }
+            ]
+        }
+    ]
+}
+```
+
+<a id='2'></a>
+
+## [GET]: List A Specific weight resource
+
+This method can be used to retrieve specific weight resource based on its id
+
+### Input
+
+```
+GET /weights/{ID}
+```
+
+#### Request headers
+
+```
+x-api-key: shared_key_value
+Accept: application/json
+```
+
+### Response
+
+Headers: `Status: 200 OK`
+
+#### Response body
+
+Json Response
+
+```json
+{
+    "status": {
+        "message": "Success",
+        "code": "200"
+    },
+    "data": [
+        {
+            "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50c",
+            "name": "NonCritical",
+            "weight_type": "hepsepc",
+            "group_type": "SERVICEGROUPS",
+            "groups": [
+                {
+                    "name": "SVGROUP-A",
+                    "value": 334
+                },
+                {
+                    "name": "SVGROUP-B",
+                    "value": 588
+                }
+            ]
+        }
+    ]
+}
+```
+
+<a id='3'></a>
+
+## [POST]: Create a new weight resource
+
+This method can be used to insert a new weight resource
+
+### Input
+
+```
+POST /weights
+```
+
+#### Request headers
+
+```
+x-api-key: shared_key_value
+Accept: application/json
+```
+
+#### POST BODY
+
+```json
+{
+    "name": "weight_set3",
+    "weight_type": "hepspec2",
+    "group_type": "SITES",
+    "groups": [
+        { "name": "site-a", "value": 336 },
+        { "name": "site-b", "value": 343 },
+        { "name": "site-c", "value": 553 },
+        { "name": "site-d", "value": 435 },
+        { "name": "site-e", "value": 3.33 },
+        { "name": "site-f", "value": 323.3 }
+    ]
+}
+```
+
+### Response
+
+Headers: `Status: 201 Created`
+
+#### Response body
+
+Json Response
+
+```json
+{
+    "status": {
+        "message": "Weight resource successfully created",
+        "code": "201"
+    },
+    "data": {
+        "id": "{{ID}}",
+        "links": {
+            "self": "https:///api/v2/weights/{{ID}}"
+        }
+    }
+}
+```
+
+<a id='4'></a>
+
+## [PUT]: Update information on an existing weight resource
+
+This method can be used to update information on an existing weight resource
+
+### Input
+
+```
+PUT /weights/{ID}
+```
+
+#### Request headers
+
+```
+x-api-key: shared_key_value
+Accept: application/json
+```
+
+#### PUT BODY
+
+```json
+{
+    "name": "weight_set3",
+    "weight_type": "hepspec2",
+    "group_type": "SITES",
+    "groups": [
+        { "name": "site-a", "value": 1336 },
+        { "name": "site-b", "value": 1343 }
+    ]
+}
+```
+
+### Response
+
+Headers: `Status: 200 OK`
+
+#### Response body
+
+Json Response
+
+```json
+{
+    "status": {
+        "message": "Weight resource successfully updated",
+        "code": "200"
+    },
+    "data": {
+        "id": "{{ID}}",
+        "links": {
+            "self": "https:///api/v2/weights/{{ID}}"
+        }
+    }
+}
+```
+
+<a id='5'></a>
+
+## [DELETE]: Delete an existing weight resource
+
+This method can be used to delete an existing weight resource
+
+### Input
+
+```
+DELETE /weights/{ID}
+```
+
+#### Request headers
+
+```
+x-api-key: shared_key_value
+Accept: application/json
+```
+
+### Response
+
+Headers: `Status: 200 OK`
+
+#### Response body
+
+Json Response
+
+```json
+{
+    "status": {
+        "message": "Weight resource Successfully Deleted",
+        "code": "200"
+    }
+}
+```

--- a/doc/v2/mkdocs.yml
+++ b/doc/v2/mkdocs.yml
@@ -6,19 +6,20 @@ remote_branch: master
 copyright: Copyright © 2014 - 2015 GRNET S.A.
 
 pages:
-  - Home: index.md
-  - Recomputations Requests: recomputations.md
-  - Results : results.md
-  - Status Results : status.md
-  - Metric Profiles : metric_profiles.md
-  - Aggregation Profiles : aggregation_profiles.md
-  - Operations Profiles : operations_profiles.md
-  - Reports : reports.md
-  - Tenants : tenants.md
-  - Error Codes: errors.md
-  - Validation Checks: validations.md
-  - Metrics: metrics.md
-  - Latest results: latest.md
-  - Topology statistics: topology.md
+    - Home: index.md
+    - Recomputations Requests: recomputations.md
+    - Results: results.md
+    - Status Results: status.md
+    - Metric Profiles: metric_profiles.md
+    - Aggregation Profiles: aggregation_profiles.md
+    - Operations Profiles: operations_profiles.md
+    - Reports: reports.md
+    - Tenants: tenants.md
+    - Error Codes: errors.md
+    - Validation Checks: validations.md
+    - Metrics: metrics.md
+    - Latest results: latest.md
+    - Topology statistics: topology.md
+    - Weights resource: weights.md
 
 theme: readthedocs

--- a/routing/routes.go
+++ b/routing/routes.go
@@ -39,10 +39,12 @@ import (
 	"github.com/ARGOeu/argo-web-api/app/tenants"
 	"github.com/ARGOeu/argo-web-api/app/thresholdsProfiles"
 	"github.com/ARGOeu/argo-web-api/app/topology"
+	"github.com/ARGOeu/argo-web-api/app/weights"
 	"github.com/ARGOeu/argo-web-api/version"
 )
 
 var routesV2 = []RouteV2{
+	{"Weights", "/weights", weights.HandleSubrouter},
 	{"Topology", "/topology", topology.HandleSubrouter},
 	{"Latest", "/latest", latest.HandleSubrouter},
 	{"Results", "/results", results.HandleSubrouter},

--- a/scripts/mongodb/populate_default_roles.js
+++ b/scripts/mongodb/populate_default_roles.js
@@ -14,57 +14,145 @@
 //   INFO	Opened argo_core db
 //   INFO	Polulated default roles in 'roles' collection
 
-
-function populate_default_roles()
-{
-  db = db.getSiblingDB('argo_core')
-  print("INFO\tOpened argo_core db")
-  db.roles.insert([
-  {"resource" : "topology.list", "roles": ["admin", "editor", "viewer", "admin_ui"]},
-  {"resource" : "latest.get", "roles": ["admin", "editor", "viewer", "admin_ui"]},
-  {"resource" : "reports.get", "roles" : [ "admin", "editor","viewer", "admin_ui"] },
-  {"resource" : "reports.list", "roles" : [ "admin", "editor","viewer", "admin_ui"]},
-  {"resource" : "reports.create", "roles" : [ "admin", "editor" ] },
-  {"resource" : "reports.delete", "roles" : [ "admin", "editor" ] },
-  {"resource" : "reports.update", "roles" : [ "admin", "editor" ] },
-  {"resource" : "metricProfiles.get", "roles" : [ "admin", "editor","viewer", "admin_ui"] },
-  {"resource" : "metricProfiles.list", "roles" : [ "admin", "editor","viewer", "admin_ui" ]},
-  {"resource" : "metricProfiles.create", "roles" : [ "admin", "editor" ] },
-  {"resource" : "metricProfiles.delete", "roles" : [ "admin", "editor" ] },
-  {"resource" : "metricProfiles.update", "roles" : [ "admin", "editor" ] },
-  {"resource" : "operationsProfiles.get", "roles" : [ "admin", "editor","viewer", "admin_ui"] },
-  {"resource" : "operationsProfiles.list", "roles" : [ "admin", "editor","viewer", "admin_ui" ]},
-  {"resource" : "operationsProfiles.create", "roles" : [ "admin", "editor" ] },
-  {"resource" : "operationsProfiles.delete", "roles" : [ "admin", "editor" ] },
-  {"resource" : "operationsProfiles.update", "roles" : [ "admin", "editor" ] },
-  {"resource" : "aggregationProfiles.get", "roles" : [ "admin", "editor","viewer" ,"admin_ui"] },
-  {"resource" : "aggregationProfiles.list", "roles" : [ "admin", "editor","viewer", "admin_ui" ]},
-  {"resource" : "aggregationProfiles.create", "roles" : [ "admin", "editor" ] },
-  {"resource" : "aggregationProfiles.delete", "roles" : [ "admin", "editor" ] },
-  {"resource" : "aggregationProfiles.update", "roles" : [ "admin", "editor" ] },
-  {"resource" : "thresholdsProfiles.get", "roles" : [ "admin", "editor", "viewer", "admin_ui" ] },
-  {"resource" : "thresholdsProfiles.list", "roles" : [ "admin", "editor", "viewer", "admin_ui" ] },
-  {"resource" : "thresholdsProfiles.update", "roles" : [ "admin", "editor" ] },
-  {"resource" : "thresholdsProfiles.create", "roles" : [ "admin", "editor" ] },
-  {"resource" : "thresholdsProfiles.delete", "roles" : [ "admin", "editor" ] },
-  {"resource" : "results.get", "roles" : [ "admin", "editor","viewer", "admin_ui"] },
-  {"resource" : "results.list", "roles" : [ "admin", "editor","viewer", "admin_ui" ]},
-  {"resource" : "status.get", "roles" : [ "admin", "editor","viewer", "admin_ui"] },
-  {"resource" : "status.list", "roles" : [ "admin", "editor","viewer", "admin_ui" ]},
-  {"resource" : "factors.list", "roles" : [ "admin", "editor","viewer", "admin_ui"] },
-  {"resource" : "tenants.get", "roles" : [ "super_admin"] },
-  {"resource" : "tenants.list", "roles" : [ "super_admin", "super_admin_restricted", "super_admin_ui" ]},
-  {"resource" : "tenants.create", "roles" : [ "super_admin" ] },
-  {"resource" : "tenants.delete", "roles" : [ "super_admin" ] },
-  {"resource" : "tenants.update", "roles" : [ "super_admin" ] },
-  {"resource" : "tenants.user_by_id", "roles" : [ "super_admin", "super_admin_restricted", "super_admin_ui" ] },
-  {"resource" : "tenants.get_status", "roles": ["super_admin", "super_admin_restricted", "super_admin_ui"]},
-  {"resource" : "tenants.update_status", "roles": ["super_admin"]},
-  {"resource" : "metricResult.get", "roles" : [ "admin", "editor","viewer", "admin_ui" ]},
-  {"resource" : "recomputations.list", "roles" : [ "admin","editor", "admin_ui"]},
-  {"resource" : "recomputations.get", "roles" : [ "admin","editor", "admin_ui"]},
-  {"resource" : "recomputations.submit", "roles" : [ "admin","editor", "admin_ui"]},
-  {"resource" : "recomputations.delete", "roles" : [ "admin","editor", "admin_ui"]},
-  {"resource" : "recomputations.update", "roles" : [ "admin","editor", "admin_ui"]},]);
-  print("INFO\tPolulated default roles in \'roles\' collection")
+function populate_default_roles() {
+    db = db.getSiblingDB("argo_core");
+    print("INFO\tOpened argo_core db");
+    db.roles.insert([
+        {
+            resource: "topology.list",
+            roles: ["admin", "editor", "viewer", "admin_ui"]
+        },
+        {
+            resource: "latest.get",
+            roles: ["admin", "editor", "viewer", "admin_ui"]
+        },
+        {
+            resource: "reports.get",
+            roles: ["admin", "editor", "viewer", "admin_ui"]
+        },
+        {
+            resource: "reports.list",
+            roles: ["admin", "editor", "viewer", "admin_ui"]
+        },
+        { resource: "reports.create", roles: ["admin", "editor"] },
+        { resource: "reports.delete", roles: ["admin", "editor"] },
+        { resource: "reports.update", roles: ["admin", "editor"] },
+        {
+            resource: "metricProfiles.get",
+            roles: ["admin", "editor", "viewer", "admin_ui"]
+        },
+        {
+            resource: "metricProfiles.list",
+            roles: ["admin", "editor", "viewer", "admin_ui"]
+        },
+        { resource: "metricProfiles.create", roles: ["admin", "editor"] },
+        { resource: "metricProfiles.delete", roles: ["admin", "editor"] },
+        { resource: "metricProfiles.update", roles: ["admin", "editor"] },
+        {
+            resource: "operationsProfiles.get",
+            roles: ["admin", "editor", "viewer", "admin_ui"]
+        },
+        {
+            resource: "operationsProfiles.list",
+            roles: ["admin", "editor", "viewer", "admin_ui"]
+        },
+        { resource: "operationsProfiles.create", roles: ["admin", "editor"] },
+        { resource: "operationsProfiles.delete", roles: ["admin", "editor"] },
+        { resource: "operationsProfiles.update", roles: ["admin", "editor"] },
+        {
+            resource: "aggregationProfiles.get",
+            roles: ["admin", "editor", "viewer", "admin_ui"]
+        },
+        {
+            resource: "aggregationProfiles.list",
+            roles: ["admin", "editor", "viewer", "admin_ui"]
+        },
+        { resource: "aggregationProfiles.create", roles: ["admin", "editor"] },
+        { resource: "aggregationProfiles.delete", roles: ["admin", "editor"] },
+        { resource: "aggregationProfiles.update", roles: ["admin", "editor"] },
+        {
+            resource: "thresholdsProfiles.get",
+            roles: ["admin", "editor", "viewer", "admin_ui"]
+        },
+        {
+            resource: "thresholdsProfiles.list",
+            roles: ["admin", "editor", "viewer", "admin_ui"]
+        },
+        { resource: "thresholdsProfiles.update", roles: ["admin", "editor"] },
+        { resource: "thresholdsProfiles.create", roles: ["admin", "editor"] },
+        { resource: "thresholdsProfiles.delete", roles: ["admin", "editor"] },
+        {
+            resource: "weights.get",
+            roles: ["admin", "editor", "viewer", "admin_ui"]
+        },
+        {
+            resource: "weights.list",
+            roles: ["admin", "editor", "viewer", "admin_ui"]
+        },
+        { resource: "weights.create", roles: ["admin", "editor"] },
+        { resource: "weights.delete", roles: ["admin", "editor"] },
+        { resource: "weights.update", roles: ["admin", "editor"] },
+        {
+            resource: "results.get",
+            roles: ["admin", "editor", "viewer", "admin_ui"]
+        },
+        {
+            resource: "results.list",
+            roles: ["admin", "editor", "viewer", "admin_ui"]
+        },
+        {
+            resource: "status.get",
+            roles: ["admin", "editor", "viewer", "admin_ui"]
+        },
+        {
+            resource: "status.list",
+            roles: ["admin", "editor", "viewer", "admin_ui"]
+        },
+        {
+            resource: "factors.list",
+            roles: ["admin", "editor", "viewer", "admin_ui"]
+        },
+        { resource: "tenants.get", roles: ["super_admin"] },
+        {
+            resource: "tenants.list",
+            roles: ["super_admin", "super_admin_restricted", "super_admin_ui"]
+        },
+        { resource: "tenants.create", roles: ["super_admin"] },
+        { resource: "tenants.delete", roles: ["super_admin"] },
+        { resource: "tenants.update", roles: ["super_admin"] },
+        {
+            resource: "tenants.user_by_id",
+            roles: ["super_admin", "super_admin_restricted", "super_admin_ui"]
+        },
+        {
+            resource: "tenants.get_status",
+            roles: ["super_admin", "super_admin_restricted", "super_admin_ui"]
+        },
+        { resource: "tenants.update_status", roles: ["super_admin"] },
+        {
+            resource: "metricResult.get",
+            roles: ["admin", "editor", "viewer", "admin_ui"]
+        },
+        {
+            resource: "recomputations.list",
+            roles: ["admin", "editor", "admin_ui"]
+        },
+        {
+            resource: "recomputations.get",
+            roles: ["admin", "editor", "admin_ui"]
+        },
+        {
+            resource: "recomputations.submit",
+            roles: ["admin", "editor", "admin_ui"]
+        },
+        {
+            resource: "recomputations.delete",
+            roles: ["admin", "editor", "admin_ui"]
+        },
+        {
+            resource: "recomputations.update",
+            roles: ["admin", "editor", "admin_ui"]
+        }
+    ]);
+    print("INFO\tPolulated default roles in 'roles' collection");
 }


### PR DESCRIPTION
:warning: to be merged after https://github.com/ARGOeu/argo-web-api/pull/301

## Goal 
Give the ability to maintain historic version of the metric profiles when they change

## Implementation
Add an extra url parameter `date` in metric_profiles request signatures (GET, POST, PUT)
When using date with GET the closest historic version of the profile is retrieved. If date is ommited the most recent profile is retrieved
When using date with POST a specific historic profile entry is created (new snapshot)
When using date with PUT an update is performed on a specific historic version of the profile


:red_circle:  note that a specific indexing scheme should be prepared in metric_profiles mongodb collection in order the queries to work correctly

- [x] Modify metric profile model to incorporate historicversioning
- [x] Modify metric profile controllers to use historic versioning
- [x] Update unit tests
- [x] Update docs