### PR TITLE
ARGO-2001 Add history functionality for aggregation profiles

### DIFF
--- a/app/aggregationProfiles/aggregationProfiles_test.go
+++ b/app/aggregationProfiles/aggregationProfiles_test.go
@@ -209,9 +209,12 @@ func (suite *AggregationProfilesTestSuite) SetupTest() {
 			}})
 	// Seed database with metric profiles
 	c = session.DB(suite.tenantDbConf.Db).C("aggregation_profiles")
+	c.EnsureIndexKey("-date_integer", "id")
 	c.Insert(
 		bson.M{
 			"id":                "6ac7d684-1f8e-4a02-a502-720e8f11e50b",
+			"date_integer":      20191004,
+			"date":              "2019-10-04",
 			"name":              "critical",
 			"namespace":         "test",
 			"endpoint_group":    "sites",
@@ -249,7 +252,49 @@ func (suite *AggregationProfilesTestSuite) SetupTest() {
 			}})
 	c.Insert(
 		bson.M{
+			"id":                "6ac7d684-1f8e-4a02-a502-720e8f11e50b",
+			"date_integer":      20191104,
+			"date":              "2019-11-04",
+			"name":              "critical",
+			"namespace":         "test",
+			"endpoint_group":    "sites",
+			"metric_operation":  "AND",
+			"profile_operation": "AND",
+			"metric_profile": bson.M{
+				"name": "roc.critical",
+				"id":   "5637d684-1f8e-4a02-a502-720e8f11e432",
+			},
+			"groups": []bson.M{
+				bson.M{"name": "compute2",
+					"operation": "OR",
+					"services": []bson.M{
+						bson.M{
+							"name":      "CREAM-CE",
+							"operation": "AND",
+						},
+						bson.M{
+							"name":      "ARC-CE",
+							"operation": "AND",
+						},
+					}},
+				bson.M{"name": "storage2",
+					"operation": "OR",
+					"services": []bson.M{
+						bson.M{
+							"name":      "SRMv2",
+							"operation": "AND",
+						},
+						bson.M{
+							"name":      "SRM",
+							"operation": "AND",
+						},
+					}},
+			}})
+	c.Insert(
+		bson.M{
 			"id":                "6ac7d684-1f8e-4a02-a502-720e8f11e50c",
+			"date_integer":      20190404,
+			"date":              "2019-04-04",
 			"name":              "cloud",
 			"namespace":         "test",
 			"endpoint_group":    "sites",
@@ -273,6 +318,46 @@ func (suite *AggregationProfilesTestSuite) SetupTest() {
 						},
 					}},
 				bson.M{"name": "images",
+					"operation": "OR",
+					"services": []bson.M{
+						bson.M{
+							"name":      "SERVICEC",
+							"operation": "AND",
+						},
+						bson.M{
+							"name":      "SERVICED",
+							"operation": "AND",
+						},
+					}},
+			}})
+	c.Insert(
+		bson.M{
+			"id":                "6ac7d684-1f8e-4a02-a502-720e8f11e50c",
+			"date_integer":      20190504,
+			"date":              "2019-05-04",
+			"name":              "cloud",
+			"namespace":         "test",
+			"endpoint_group":    "sites",
+			"metric_operation":  "AND",
+			"profile_operation": "AND",
+			"metric_profile": bson.M{
+				"name": "roc.critical",
+				"id":   "5637d684-1f8e-4a02-a502-720e8f11e432",
+			},
+			"groups": []bson.M{
+				bson.M{"name": "compute2",
+					"operation": "OR",
+					"services": []bson.M{
+						bson.M{
+							"name":      "SERVICEA",
+							"operation": "AND",
+						},
+						bson.M{
+							"name":      "SERVICEB",
+							"operation": "AND",
+						},
+					}},
+				bson.M{"name": "images2",
 					"operation": "OR",
 					"services": []bson.M{
 						bson.M{
@@ -335,6 +420,7 @@ func (suite *AggregationProfilesTestSuite) TestList() {
  "data": [
   {
    "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50c",
+   "date": "2019-05-04",
    "name": "cloud",
    "namespace": "test",
    "endpoint_group": "sites",
@@ -346,7 +432,7 @@ func (suite *AggregationProfilesTestSuite) TestList() {
    },
    "groups": [
     {
-     "name": "compute",
+     "name": "compute2",
      "operation": "OR",
      "services": [
       {
@@ -360,7 +446,7 @@ func (suite *AggregationProfilesTestSuite) TestList() {
      ]
     },
     {
-     "name": "images",
+     "name": "images2",
      "operation": "OR",
      "services": [
       {
@@ -377,6 +463,7 @@ func (suite *AggregationProfilesTestSuite) TestList() {
   },
   {
    "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50b",
+   "date": "2019-11-04",
    "name": "critical",
    "namespace": "test",
    "endpoint_group": "sites",
@@ -388,7 +475,7 @@ func (suite *AggregationProfilesTestSuite) TestList() {
    },
    "groups": [
     {
-     "name": "compute",
+     "name": "compute2",
      "operation": "OR",
      "services": [
       {
@@ -402,7 +489,7 @@ func (suite *AggregationProfilesTestSuite) TestList() {
      ]
     },
     {
-     "name": "storage",
+     "name": "storage2",
      "operation": "OR",
      "services": [
       {
@@ -446,6 +533,7 @@ func (suite *AggregationProfilesTestSuite) TestListQueryName() {
  "data": [
   {
    "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50c",
+   "date": "2019-05-04",
    "name": "cloud",
    "namespace": "test",
    "endpoint_group": "sites",
@@ -457,7 +545,7 @@ func (suite *AggregationProfilesTestSuite) TestListQueryName() {
    },
    "groups": [
     {
-     "name": "compute",
+     "name": "compute2",
      "operation": "OR",
      "services": [
       {
@@ -471,7 +559,7 @@ func (suite *AggregationProfilesTestSuite) TestListQueryName() {
      ]
     },
     {
-     "name": "images",
+     "name": "images2",
      "operation": "OR",
      "services": [
       {
@@ -550,6 +638,7 @@ func (suite *AggregationProfilesTestSuite) TestListOne() {
  "data": [
   {
    "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50b",
+   "date": "2019-11-04",
    "name": "critical",
    "namespace": "test",
    "endpoint_group": "sites",
@@ -561,7 +650,7 @@ func (suite *AggregationProfilesTestSuite) TestListOne() {
    },
    "groups": [
     {
-     "name": "compute",
+     "name": "compute2",
      "operation": "OR",
      "services": [
       {
@@ -575,7 +664,7 @@ func (suite *AggregationProfilesTestSuite) TestListOne() {
      ]
     },
     {
-     "name": "storage",
+     "name": "storage2",
      "operation": "OR",
      "services": [
       {
@@ -857,6 +946,7 @@ func (suite *AggregationProfilesTestSuite) TestCreate() {
  "data": [
   {
    "id": "{{id}}",
+   "date": "2019-03-03",
    "name": "yolo",
    "namespace": "testing-namespace",
    "endpoint_group": "test",
@@ -900,7 +990,7 @@ func (suite *AggregationProfilesTestSuite) TestCreate() {
  ]
 }`
 
-	request, _ := http.NewRequest("POST", "/api/v2/aggregation_profiles", strings.NewReader(jsonInput))
+	request, _ := http.NewRequest("POST", "/api/v2/aggregation_profiles?date=2019-03-03", strings.NewReader(jsonInput))
 	request.Header.Set("x-api-key", suite.clientkey)
 	request.Header.Set("Accept", "application/json")
 	response := httptest.NewRecorder()
@@ -1359,7 +1449,7 @@ func (suite *AggregationProfilesTestSuite) TestUpdate() {
 
 	jsonOutput := `{
  "status": {
-  "message": "Aggregation Profile successfully updated",
+  "message": "Aggregations Profile successfully updated (new history snapshot)",
   "code": "200"
  }
 }`
@@ -1372,6 +1462,7 @@ func (suite *AggregationProfilesTestSuite) TestUpdate() {
  "data": [
   {
    "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50c",
+   "date": "2019-12-12",
    "name": "yolo",
    "namespace": "testing-namespace",
    "endpoint_group": "test",
@@ -1415,7 +1506,7 @@ func (suite *AggregationProfilesTestSuite) TestUpdate() {
  ]
 }`
 
-	request, _ := http.NewRequest("PUT", "/api/v2/aggregation_profiles/6ac7d684-1f8e-4a02-a502-720e8f11e50c", strings.NewReader(jsonInput))
+	request, _ := http.NewRequest("PUT", "/api/v2/aggregation_profiles/6ac7d684-1f8e-4a02-a502-720e8f11e50c?date=2019-12-12", strings.NewReader(jsonInput))
 	request.Header.Set("x-api-key", suite.clientkey)
 	request.Header.Set("Accept", "application/json")
 	response := httptest.NewRecorder()
@@ -1434,7 +1525,7 @@ func (suite *AggregationProfilesTestSuite) TestUpdate() {
 
 	// Check that the item has actually updated
 	// run a list specific
-	request2, _ := http.NewRequest("GET", "/api/v2/aggregation_profiles/6ac7d684-1f8e-4a02-a502-720e8f11e50c", strings.NewReader(jsonInput))
+	request2, _ := http.NewRequest("GET", "/api/v2/aggregation_profiles/6ac7d684-1f8e-4a02-a502-720e8f11e50c?date=2019-12-12", strings.NewReader(jsonInput))
 	request2.Header.Set("x-api-key", suite.clientkey)
 	request2.Header.Set("Accept", "application/json")
 	response2 := httptest.NewRecorder()

--- a/app/aggregationProfiles/controller.go
+++ b/app/aggregationProfiles/controller.go
@@ -37,10 +37,55 @@ import (
 	"gopkg.in/mgo.v2/bson"
 
 	"github.com/ARGOeu/argo-web-api/respond"
+	"github.com/ARGOeu/argo-web-api/utils"
 	"github.com/ARGOeu/argo-web-api/utils/config"
 	"github.com/ARGOeu/argo-web-api/utils/mongo"
 	"github.com/gorilla/mux"
 )
+
+// datastore collection name that contains aggregations profile records
+const aggColName = "aggregation_profiles"
+
+func prepMultiQuery(dt int, name string) interface{} {
+
+	matchQuery := bson.M{"date_integer": bson.M{"$lte": dt}}
+
+	if name != "" {
+		matchQuery["name"] = name
+	}
+
+	return []bson.M{
+		{
+			"$match": matchQuery,
+		},
+		{
+			"$group": bson.M{
+				"_id": bson.M{
+					"id": "$id",
+				},
+				// aggregation_profiles collection is meant to have an index with date_integer:-1 and id:1 so
+				// when searching by date the documents are sorted with the recent timestamp first
+				// so we need the recent item available to our query timepoint which is specific date
+				"id":                bson.M{"$first": "$id"},
+				"date":              bson.M{"$first": "$date"},
+				"name":              bson.M{"$first": "$name"},
+				"namespace":         bson.M{"$first": "$namespace"},
+				"endpoint_group":    bson.M{"$first": "$endpoint_group"},
+				"metric_operation":  bson.M{"$first": "$metric_operation"},
+				"profile_operation": bson.M{"$first": "$profile_operation"},
+				"metric_profile":    bson.M{"$first": "$metric_profile"},
+				"groups":            bson.M{"$first": "$groups"},
+			},
+		},
+	}
+
+}
+
+func prepQuery(dt int, id string) interface{} {
+
+	return bson.M{"date_integer": bson.M{"$lte": dt}, "id": id}
+
+}
 
 // ListOne handles the listing of one specific profile based on its given id
 func ListOne(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
@@ -60,6 +105,8 @@ func ListOne(r *http.Request, cfg config.Config) (int, http.Header, []byte, erro
 	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
 
 	vars := mux.Vars(r)
+	urlValues := r.URL.Query()
+	dateStr := urlValues.Get("date")
 
 	// Grab Tenant DB configuration from context
 	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
@@ -73,26 +120,28 @@ func ListOne(r *http.Request, cfg config.Config) (int, http.Header, []byte, erro
 		return code, h, output, err
 	}
 
-	filter := bson.M{"id": vars["ID"]}
-
 	// Retrieve Results from database
-	results := []MongoInterface{}
-	err = mongo.Find(session, tenantDbConfig.Db, "aggregation_profiles", filter, "name", &results)
-
+	result := AggProfile{}
+	dt, dateStr, err := utils.ParseZuluDate(dateStr)
 	if err != nil {
+		code = http.StatusBadRequest
+		return code, h, output, err
+	}
+	aggQuery := prepQuery(dt, vars["ID"])
+
+	aggCol := session.DB(tenantDbConfig.Db).C(aggColName)
+	err = aggCol.Find(aggQuery).One(&result)
+	if err != nil {
+		if err.Error() == "not found" {
+			output, _ = respond.MarshalContent(respond.ErrNotFound, contentType, "", " ")
+			code = 404
+			return code, h, output, err
+		}
 		code = http.StatusInternalServerError
 		return code, h, output, err
 	}
-
-	// Check if nothing found
-	if len(results) < 1 {
-		output, _ = respond.MarshalContent(respond.ErrNotFound, contentType, "", " ")
-		code = 404
-		return code, h, output, err
-	}
-
 	// Create view of the results
-	output, err = createListView(results, "Success", code) //Render the results into JSON
+	output, err = createListView([]AggProfile{result}, "Success", code) //Render the results into JSON
 
 	if err != nil {
 		code = http.StatusInternalServerError
@@ -122,6 +171,8 @@ func List(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) 
 	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
 
 	urlValues := r.URL.Query()
+	dateStr := urlValues.Get("date")
+	name := urlValues.Get("name")
 
 	// Grab Tenant DB configuration from context
 	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
@@ -130,25 +181,30 @@ func List(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) 
 	session, err := mongo.OpenSession(tenantDbConfig)
 	defer mongo.CloseSession(session)
 
+	dt, dateStr, err := utils.ParseZuluDate(dateStr)
+	if err != nil {
+		code = http.StatusBadRequest
+		return code, h, output, err
+	}
+	aggQuery := prepMultiQuery(dt, name)
+
+	aggCol := session.DB(tenantDbConfig.Db).C(aggColName)
+
 	if err != nil {
 		code = http.StatusInternalServerError
 		return code, h, output, err
 	}
 
-	// Retrieve Results from database
-
-	var filter interface{}
-	if len(urlValues["name"]) > 0 {
-		filter = bson.M{"name": urlValues["name"][0]}
-	} else {
-		filter = nil
-	}
-
-	results := []MongoInterface{}
-	err = mongo.Find(session, tenantDbConfig.Db, "aggregation_profiles", filter, "name", &results)
-
+	results := []AggProfile{}
+	err = aggCol.Pipe(aggQuery).All(&results)
 	if err != nil {
 		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	if len(results) < 1 {
+		output, _ = respond.MarshalContent(respond.ErrNotFound, contentType, "", " ")
+		code = 404
 		return code, h, output, err
 	}
 
@@ -180,6 +236,13 @@ func Create(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 
 	// Grab Tenant DB configuration from context
 	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
+	urlValues := r.URL.Query()
+	dateStr := urlValues.Get("date")
+	dt, dateStr, err := utils.ParseZuluDate(dateStr)
+	if err != nil {
+		code = http.StatusBadRequest
+		return code, h, output, err
+	}
 
 	session, err := mongo.OpenSession(tenantDbConfig)
 	defer mongo.CloseSession(session)
@@ -188,7 +251,9 @@ func Create(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 		return code, h, output, err
 	}
 
-	incoming := MongoInterface{}
+	incoming := AggProfile{}
+	incoming.DateInt = dt
+	incoming.Date = dateStr
 
 	// Try ingest request body
 	body, err := ioutil.ReadAll(io.LimitReader(r.Body, cfg.Server.ReqSizeLimit))
@@ -216,10 +281,10 @@ func Create(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 	}
 
 	// check if the aggregation profile's name is unique
-	results := []MongoInterface{}
+	results := []AggProfile{}
 	query := bson.M{"name": incoming.Name}
 
-	err = mongo.Find(session, tenantDbConfig.Db, "aggregation_profiles", query, "", &results)
+	err = mongo.Find(session, tenantDbConfig.Db, aggColName, query, "", &results)
 
 	if err != nil {
 		code = http.StatusInternalServerError
@@ -237,7 +302,7 @@ func Create(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 
 	// Generate new id
 	incoming.ID = mongo.NewUUID()
-	err = mongo.Insert(session, tenantDbConfig.Db, "aggregation_profiles", incoming)
+	err = mongo.Insert(session, tenantDbConfig.Db, aggColName, incoming)
 
 	if err != nil {
 		panic(err)
@@ -260,6 +325,13 @@ func Update(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 	//STANDARD DECLARATIONS END
 
 	vars := mux.Vars(r)
+	urlValues := r.URL.Query()
+	dateStr := urlValues.Get("date")
+	dt, dateStr, err := utils.ParseZuluDate(dateStr)
+	if err != nil {
+		code = http.StatusBadRequest
+		return code, h, output, err
+	}
 
 	// Set Content-Type response Header value
 	contentType := r.Header.Get("Accept")
@@ -268,7 +340,9 @@ func Update(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 	// Grab Tenant DB configuration from context
 	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
 
-	incoming := MongoInterface{}
+	incoming := AggProfile{}
+	incoming.DateInt = dt
+	incoming.Date = dateStr
 
 	// ingest body data
 	body, err := ioutil.ReadAll(io.LimitReader(r.Body, cfg.Server.ReqSizeLimit))
@@ -298,8 +372,8 @@ func Update(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 	incoming.ID = vars["ID"]
 
 	// Retrieve Results from database
-	results := []MongoInterface{}
-	err = mongo.Find(session, tenantDbConfig.Db, "aggregation_profiles", filter, "name", &results)
+	results := []AggProfile{}
+	err = mongo.Find(session, tenantDbConfig.Db, aggColName, filter, "name", &results)
 
 	if err != nil {
 		panic(err)
@@ -315,10 +389,10 @@ func Update(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 	// check if the aggregation profile's name is unique
 	if incoming.Name != results[0].Name {
 
-		results = []MongoInterface{}
-		query := bson.M{"name": incoming.Name}
+		results = []AggProfile{}
+		query := bson.M{"name": incoming.Name, "id": bson.M{"$ne": vars["ID"]}}
 
-		err = mongo.Find(session, tenantDbConfig.Db, "aggregation_profiles", query, "", &results)
+		err = mongo.Find(session, tenantDbConfig.Db, aggColName, query, "", &results)
 
 		if err != nil {
 			code = http.StatusInternalServerError
@@ -345,15 +419,21 @@ func Update(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 	}
 
 	// run the update query
-	err = mongo.Update(session, tenantDbConfig.Db, "aggregation_profiles", filter, incoming)
-
+	aggCol := session.DB(tenantDbConfig.Db).C(aggColName)
+	info, err := aggCol.Upsert(bson.M{"id": vars["ID"], "date_integer": dt}, incoming)
 	if err != nil {
 		code = http.StatusInternalServerError
 		return code, h, output, err
 	}
 
+	updMsg := "Aggregations Profile successfully updated"
+
+	if info.Updated <= 0 {
+		updMsg = "Aggregations Profile successfully updated (new history snapshot)"
+	}
+
 	// Create view for response message
-	output, err = createMsgView("Aggregation Profile successfully updated", 200) //Render the results into JSON
+	output, err = createMsgView(updMsg, 200) //Render the results into JSON
 	code = 200
 	return code, h, output, err
 }
@@ -392,8 +472,8 @@ func Delete(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 	filter := bson.M{"id": vars["ID"]}
 
 	// Retrieve Results from database
-	results := []MongoInterface{}
-	err = mongo.Find(session, tenantDbConfig.Db, "aggregation_profiles", filter, "name", &results)
+	results := []AggProfile{}
+	err = mongo.Find(session, tenantDbConfig.Db, aggColName, filter, "name", &results)
 
 	if err != nil {
 		code = http.StatusInternalServerError
@@ -407,7 +487,7 @@ func Delete(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 		return code, h, output, err
 	}
 
-	mongo.Remove(session, tenantDbConfig.Db, "aggregation_profiles", filter)
+	mongo.Remove(session, tenantDbConfig.Db, aggColName, filter)
 
 	if err != nil {
 		code = http.StatusInternalServerError

--- a/app/aggregationProfiles/model.go
+++ b/app/aggregationProfiles/model.go
@@ -34,9 +34,11 @@ import (
 	"gopkg.in/mgo.v2/bson"
 )
 
-// MongoInterface to retrieve and insert metricProfiles in mongo
-type MongoInterface struct {
+// AggProfile struct to retrieve and insert aggregation profiles in mongo
+type AggProfile struct {
 	ID            string        `bson:"id" json:"id"`
+	DateInt       int           `bson:"date_integer" json:"-"`
+	Date          string        `bson:"date" json:"date"`
 	Name          string        `bson:"name" json:"name"`
 	Namespace     string        `bson:"namespace" json:"namespace"`
 	EndpointGroup string        `bson:"endpoint_group" json:"endpoint_group"`

--- a/app/aggregationProfiles/view.go
+++ b/app/aggregationProfiles/view.go
@@ -35,7 +35,7 @@ import (
 )
 
 // createListView constructs the list response template and exports it as json
-func createListView(results []MongoInterface, msg string, code int) ([]byte, error) {
+func createListView(results []AggProfile, msg string, code int) ([]byte, error) {
 
 	docRoot := &respond.ResponseMessage{
 		Status: respond.StatusResponse{
@@ -51,7 +51,7 @@ func createListView(results []MongoInterface, msg string, code int) ([]byte, err
 }
 
 // createListView constructs self-reference response and exports it as json
-func createRefView(inserted MongoInterface, msg string, code int, r *http.Request) ([]byte, error) {
+func createRefView(inserted AggProfile, msg string, code int, r *http.Request) ([]byte, error) {
 	docRoot := &respond.ResponseMessage{
 		Status: respond.StatusResponse{
 			Message: msg,

--- a/app/operationsProfiles/controller.go
+++ b/app/operationsProfiles/controller.go
@@ -102,6 +102,14 @@ func ListOne(r *http.Request, cfg config.Config) (int, http.Header, []byte, erro
 	vars := mux.Vars(r)
 	urlValues := r.URL.Query()
 	dateStr := urlValues.Get("date")
+<<<<<<< HEAD
+=======
+
+	if err != nil {
+		code = http.StatusBadRequest
+		return code, h, output, err
+	}
+>>>>>>> ARGO-2002 Add History for operations profiles
 
 	// Grab Tenant DB configuration from context
 	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
@@ -189,9 +197,15 @@ func List(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) 
 		return code, h, output, err
 	}
 	opsQuery := prepMultiQuery(dt, name)
+<<<<<<< HEAD
 
 	opsCol := session.DB(tenantDbConfig.Db).C(opsColName)
 
+=======
+
+	opsCol := session.DB(tenantDbConfig.Db).C(opsColName)
+
+>>>>>>> ARGO-2002 Add History for operations profiles
 	if err != nil {
 		code = http.StatusInternalServerError
 		return code, h, output, err
@@ -334,7 +348,10 @@ func Update(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 	dateStr := urlValues.Get("date")
 	dt, dateStr, err := utils.ParseZuluDate(dateStr)
 <<<<<<< HEAD
+<<<<<<< HEAD
 
+=======
+>>>>>>> ARGO-2002 Add History for operations profiles
 =======
 >>>>>>> ARGO-2002 Add History for operations profiles
 	if err != nil {

--- a/app/operationsProfiles/controller.go
+++ b/app/operationsProfiles/controller.go
@@ -102,14 +102,6 @@ func ListOne(r *http.Request, cfg config.Config) (int, http.Header, []byte, erro
 	vars := mux.Vars(r)
 	urlValues := r.URL.Query()
 	dateStr := urlValues.Get("date")
-<<<<<<< HEAD
-=======
-
-	if err != nil {
-		code = http.StatusBadRequest
-		return code, h, output, err
-	}
->>>>>>> ARGO-2002 Add History for operations profiles
 
 	// Grab Tenant DB configuration from context
 	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
@@ -197,15 +189,9 @@ func List(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) 
 		return code, h, output, err
 	}
 	opsQuery := prepMultiQuery(dt, name)
-<<<<<<< HEAD
 
 	opsCol := session.DB(tenantDbConfig.Db).C(opsColName)
 
-=======
-
-	opsCol := session.DB(tenantDbConfig.Db).C(opsColName)
-
->>>>>>> ARGO-2002 Add History for operations profiles
 	if err != nil {
 		code = http.StatusInternalServerError
 		return code, h, output, err
@@ -347,13 +333,7 @@ func Update(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 	urlValues := r.URL.Query()
 	dateStr := urlValues.Get("date")
 	dt, dateStr, err := utils.ParseZuluDate(dateStr)
-<<<<<<< HEAD
-<<<<<<< HEAD
 
-=======
->>>>>>> ARGO-2002 Add History for operations profiles
-=======
->>>>>>> ARGO-2002 Add History for operations profiles
 	if err != nil {
 		code = http.StatusBadRequest
 		return code, h, output, err

--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -783,6 +783,7 @@ paths:
           required: true
           type: string
         - $ref: "#/parameters/apiKey"
+        - $ref: "#/parameters/profDate"
       responses:
         '200':
           description: A list with one aggregation profile
@@ -827,6 +828,7 @@ paths:
           schema:
             $ref: '#/definitions/Aggregation_profile'
         - $ref: "#/parameters/apiKey"
+        - $ref: "#/parameters/profDate"
       responses:
         '201':
           description: Aggregation profile Updated
@@ -907,6 +909,7 @@ paths:
         - "application/json"
       parameters:
         - $ref: "#/parameters/apiKey"
+        - $ref: "#/parameters/profDate"
       responses:
         '200':
           description: A list of aggregation profiles
@@ -942,6 +945,7 @@ paths:
           schema:
             $ref: '#/definitions/Aggregation_profile'
         - $ref: "#/parameters/apiKey"
+        - $ref: "#/parameters/profDate"
       responses:
         '200':
           description: Aggregation profile Created

--- a/doc/v2/docs/aggregation_profiles.md
+++ b/doc/v2/docs/aggregation_profiles.md
@@ -30,6 +30,7 @@ GET /aggregation_profiles
 Type            | Description                                                                                     | Required
 --------------- | ----------------------------------------------------------------------------------------------- | --------
 `name`          | aggregation profile name to be used as query                                                    | NO      
+`date`          | Date to retrieve a historic version of the aggregations profiles. If no date parameter is provided the most current profile will be returned | NO
 
 #### Request headers
 
@@ -53,6 +54,7 @@ Json Response
  "data": [
   {
    "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50c",
+   "date": "2019-10-10",
    "name": "cloud",
    "namespace": "test",
    "endpoint_group": "sites",
@@ -95,6 +97,7 @@ Json Response
   },
   {
    "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50b",
+   "date": "2019-11-11",
    "name": "critical",
    "namespace": "test",
    "endpoint_group": "sites",
@@ -157,6 +160,13 @@ x-api-key: shared_key_value
 Accept: application/json
 ```
 
+
+#### Optional Query Parameters
+
+Type            | Description                                                                                     | Required
+--------------- | ----------------------------------------------------------------------------------------------- | --------
+`date`          | Date to list a historic version of the aggregation profile. If no date parameter is provided current date will be supplied automatically | NO
+
 ### Response
 Headers: `Status: 200 OK`
 
@@ -172,6 +182,7 @@ Json Response
  "data": [
   {
    "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50c",
+   "date": "2019-10-10",
    "name": "cloud",
    "namespace": "test",
    "endpoint_group": "sites",
@@ -234,11 +245,19 @@ x-api-key: shared_key_value
 Accept: application/json
 ```
 
+
+#### Optional Query Parameters
+
+Type            | Description                                                                                     | Required
+--------------- | ----------------------------------------------------------------------------------------------- | --------
+`date`          | Date to create a  new historic version of the aggregation profile. If no date parameter is provided current date will be supplied automatically | NO
+
 #### POST BODY
 
 ```json
 {
    "name": "new_aggregation_profile",
+   "date": "2019-12-12",
    "namespace": "test",
    "endpoint_group": "sites",
    "metric_operation": "AND",
@@ -318,6 +337,13 @@ PUT /aggregation_profiles/{ID}
 x-api-key: shared_key_value
 Accept: application/json
 ```
+
+
+#### Optional Query Parameters
+
+Type            | Description                                                                                     | Required
+--------------- | ----------------------------------------------------------------------------------------------- | --------
+`date`          | Date to update a  new historic version of the aggregation profile. If no date parameter is provided current date will be supplied automatically | NO
 
 #### PUT BODY
 


### PR DESCRIPTION
:warning: to be merged after https://github.com/ARGOeu/argo-web-api/pull/306

## Goal 
Give the ability to maintain historic version of the aggregations profiles when they change

## Implementation
Add an extra url parameter `date` in aggregations_profiles request signatures (GET, POST, PUT)
When using date with GET the closest historic version of the profile is retrieved. If date is ommited the most recent profile is retrieved
When using date with POST a specific historic profile entry is created (new snapshot)
When using date with PUT an update is performed on a specific historic version of the profile


:red_circle:  note that a specific indexing scheme should be prepared in aggregations_profiles mongodb collection in order the queries to work correctly

- [x] Modify aggregations profile model to incorporate historicversioning
- [x] Modify aggregations profile controllers to use historic versioning
- [x] Update unit tests
- [x] Update docs