### PR TITLE
ARGO-2088 Add historic functionality for thresholds profiles

### DIFF
--- a/app/aggregationProfiles/controller.go
+++ b/app/aggregationProfiles/controller.go
@@ -152,7 +152,7 @@ func ListOne(r *http.Request, cfg config.Config) (int, http.Header, []byte, erro
 	return code, h, output, err
 }
 
-// List the existing metric profiles for the tenant making the request
+// List the existing aggregation profiles for the tenant making the request
 // Also there is an optional url param "name" to filter results by
 func List(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
 
@@ -314,7 +314,7 @@ func Create(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 	return code, h, output, err
 }
 
-//Update function to update contents of an existing metric profile
+//Update function to update contents of an existing aggregation profile
 func Update(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
 	//STANDARD DECLARATIONS START
 	code := http.StatusOK

--- a/app/operationsProfiles/controller.go
+++ b/app/operationsProfiles/controller.go
@@ -333,7 +333,6 @@ func Update(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 	urlValues := r.URL.Query()
 	dateStr := urlValues.Get("date")
 	dt, dateStr, err := utils.ParseZuluDate(dateStr)
-
 	if err != nil {
 		code = http.StatusBadRequest
 		return code, h, output, err

--- a/app/thresholdsProfiles/controller.go
+++ b/app/thresholdsProfiles/controller.go
@@ -33,10 +33,50 @@ import (
 	"gopkg.in/mgo.v2/bson"
 
 	"github.com/ARGOeu/argo-web-api/respond"
+	"github.com/ARGOeu/argo-web-api/utils"
 	"github.com/ARGOeu/argo-web-api/utils/config"
 	"github.com/ARGOeu/argo-web-api/utils/mongo"
 	"github.com/gorilla/mux"
 )
+
+// datastore collection name that contains threshold profile records
+const thColName = "thresholds_profiles"
+
+func prepMultiQuery(dt int, name string) interface{} {
+
+	matchQuery := bson.M{"date_integer": bson.M{"$lte": dt}}
+
+	if name != "" {
+		matchQuery["name"] = name
+	}
+
+	return []bson.M{
+		{
+			"$match": matchQuery,
+		},
+		{
+			"$group": bson.M{
+				"_id": bson.M{
+					"id": "$id",
+				},
+				// threshold_profile collection is meant to have an index with date_integer:-1 and id:1 so
+				// when searching by date the documents are sorted with the recent timestamp first
+				// so we need the recent item available to our query timepoint which is specific date
+				"id":    bson.M{"$first": "$id"},
+				"date":  bson.M{"$first": "$date"},
+				"name":  bson.M{"$first": "$name"},
+				"rules": bson.M{"$first": "$rules"},
+			},
+		},
+	}
+
+}
+
+func prepQuery(dt int, id string) interface{} {
+
+	return bson.M{"date_integer": bson.M{"$lte": dt}, "id": id}
+
+}
 
 // ListOne handles the listing of one specific profile based on its given id
 func ListOne(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
@@ -54,6 +94,8 @@ func ListOne(r *http.Request, cfg config.Config) (int, http.Header, []byte, erro
 	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
 
 	vars := mux.Vars(r)
+	urlValues := r.URL.Query()
+	dateStr := urlValues.Get("date")
 
 	// Grab Tenant DB configuration from context
 	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
@@ -67,26 +109,29 @@ func ListOne(r *http.Request, cfg config.Config) (int, http.Header, []byte, erro
 		return code, h, output, err
 	}
 
-	filter := bson.M{"id": vars["ID"]}
-
 	// Retrieve Results from database
-	results := []ThresholdsProfile{}
-	err = mongo.Find(session, tenantDbConfig.Db, "thresholds_profiles", filter, "name", &results)
-
+	result := ThresholdsProfile{}
+	dt, dateStr, err := utils.ParseZuluDate(dateStr)
 	if err != nil {
+		code = http.StatusBadRequest
+		return code, h, output, err
+	}
+	thQuery := prepQuery(dt, vars["ID"])
+
+	thCol := session.DB(tenantDbConfig.Db).C(thColName)
+	err = thCol.Find(thQuery).One(&result)
+	if err != nil {
+		if err.Error() == "not found" {
+			output, _ = respond.MarshalContent(respond.ErrNotFound, contentType, "", " ")
+			code = 404
+			return code, h, output, err
+		}
 		code = http.StatusInternalServerError
 		return code, h, output, err
 	}
 
-	// Check if nothing found
-	if len(results) < 1 {
-		output, _ = respond.MarshalContent(respond.ErrNotFound, contentType, "", " ")
-		code = 404
-		return code, h, output, err
-	}
-
 	// Create view of the results
-	output, err = createListView(results, "Success", code) //Render the results into JSON
+	output, err = createListView([]ThresholdsProfile{result}, "Success", code) //Render the results into JSON
 
 	if err != nil {
 		code = http.StatusInternalServerError
@@ -97,7 +142,7 @@ func ListOne(r *http.Request, cfg config.Config) (int, http.Header, []byte, erro
 	return code, h, output, err
 }
 
-// List the existing metric profiles for the tenant making the request
+// List the existing thresholds profiles for the tenant making the request
 // Also there is an optional url param "name" to filter results by
 func List(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
 
@@ -116,6 +161,8 @@ func List(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) 
 	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
 
 	urlValues := r.URL.Query()
+	dateStr := urlValues.Get("date")
+	name := urlValues.Get("name")
 
 	// Grab Tenant DB configuration from context
 	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
@@ -131,18 +178,30 @@ func List(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) 
 
 	// Retrieve Results from database
 
-	var filter interface{}
-	if len(urlValues["name"]) > 0 {
-		filter = bson.M{"name": urlValues["name"][0]}
-	} else {
-		filter = nil
+	dt, dateStr, err := utils.ParseZuluDate(dateStr)
+	if err != nil {
+		code = http.StatusBadRequest
+		return code, h, output, err
 	}
+	thQuery := prepMultiQuery(dt, name)
 
-	results := []ThresholdsProfile{}
-	err = mongo.Find(session, tenantDbConfig.Db, "thresholds_profiles", filter, "name", &results)
+	thCol := session.DB(tenantDbConfig.Db).C(thColName)
 
 	if err != nil {
 		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	results := []ThresholdsProfile{}
+	err = thCol.Pipe(thQuery).All(&results)
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	if len(results) < 1 {
+		output, _ = respond.MarshalContent(respond.ErrNotFound, contentType, "", " ")
+		code = 404
 		return code, h, output, err
 	}
 
@@ -174,6 +233,13 @@ func Create(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 
 	// Grab Tenant DB configuration from context
 	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
+	urlValues := r.URL.Query()
+	dateStr := urlValues.Get("date")
+	dt, dateStr, err := utils.ParseZuluDate(dateStr)
+	if err != nil {
+		code = http.StatusBadRequest
+		return code, h, output, err
+	}
 
 	session, err := mongo.OpenSession(tenantDbConfig)
 	defer mongo.CloseSession(session)
@@ -183,6 +249,8 @@ func Create(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 	}
 
 	incoming := ThresholdsProfile{}
+	incoming.DateInt = dt
+	incoming.Date = dateStr
 
 	// Try ingest request body
 	body, err := ioutil.ReadAll(io.LimitReader(r.Body, cfg.Server.ReqSizeLimit))
@@ -200,6 +268,26 @@ func Create(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 		return code, h, output, err
 	}
 
+	// check if the threshold profile's name is unique
+	results := []ThresholdsProfile{}
+	query := bson.M{"name": incoming.Name}
+
+	err = mongo.Find(session, tenantDbConfig.Db, thColName, query, "", &results)
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	// If results are returned for the specific name
+	// then we already have an existing report and we must
+	// abort creation notifying the user
+	if len(results) > 0 {
+		output, _ = respond.MarshalContent(respond.ErrConflict("Thresholds profile with the same name already exists"), contentType, "", " ")
+		code = http.StatusConflict
+		return code, h, output, err
+	}
+
 	// Validate States
 	var errList []string
 	errList = append(errList, incoming.Validate()...)
@@ -212,7 +300,7 @@ func Create(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 
 	// Generate new id
 	incoming.ID = mongo.NewUUID()
-	err = mongo.Insert(session, tenantDbConfig.Db, "thresholds_profiles", incoming)
+	err = mongo.Insert(session, tenantDbConfig.Db, thColName, incoming)
 
 	if err != nil {
 		panic(err)
@@ -224,7 +312,7 @@ func Create(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 	return code, h, output, err
 }
 
-//Update function to update contents of an existing metric profile
+//Update function to update contents of an existing thresholds profile
 func Update(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
 	//STANDARD DECLARATIONS START
 	code := http.StatusOK
@@ -235,6 +323,13 @@ func Update(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 	//STANDARD DECLARATIONS END
 
 	vars := mux.Vars(r)
+	urlValues := r.URL.Query()
+	dateStr := urlValues.Get("date")
+	dt, dateStr, err := utils.ParseZuluDate(dateStr)
+	if err != nil {
+		code = http.StatusBadRequest
+		return code, h, output, err
+	}
 
 	// Set Content-Type response Header value
 	contentType := r.Header.Get("Accept")
@@ -244,6 +339,8 @@ func Update(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
 
 	incoming := ThresholdsProfile{}
+	incoming.Date = dateStr
+	incoming.DateInt = dt
 
 	// ingest body data
 	body, err := ioutil.ReadAll(io.LimitReader(r.Body, cfg.Server.ReqSizeLimit))
@@ -274,7 +371,7 @@ func Update(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 
 	// Retrieve Results from database
 	results := []ThresholdsProfile{}
-	err = mongo.Find(session, tenantDbConfig.Db, "thresholds_profiles", filter, "name", &results)
+	err = mongo.Find(session, tenantDbConfig.Db, thColName, filter, "name", &results)
 
 	if err != nil {
 		panic(err)
@@ -298,7 +395,7 @@ func Update(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 	}
 
 	// run the update query
-	err = mongo.Update(session, tenantDbConfig.Db, "thresholds_profiles", filter, incoming)
+	err = mongo.Update(session, tenantDbConfig.Db, thColName, filter, incoming)
 
 	if err != nil {
 		code = http.StatusInternalServerError
@@ -346,7 +443,7 @@ func Delete(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 
 	// Retrieve Results from database
 	results := []ThresholdsProfile{}
-	err = mongo.Find(session, tenantDbConfig.Db, "thresholds_profiles", filter, "name", &results)
+	err = mongo.Find(session, tenantDbConfig.Db, thColName, filter, "name", &results)
 
 	if err != nil {
 		code = http.StatusInternalServerError
@@ -360,7 +457,7 @@ func Delete(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 		return code, h, output, err
 	}
 
-	mongo.Remove(session, tenantDbConfig.Db, "thresholds_profiles", filter)
+	mongo.Remove(session, tenantDbConfig.Db, thColName, filter)
 
 	if err != nil {
 		code = http.StatusInternalServerError

--- a/app/thresholdsProfiles/model.go
+++ b/app/thresholdsProfiles/model.go
@@ -27,11 +27,16 @@ import (
 	"regexp"
 )
 
+// datastore collection name that contains threshold profile records
+const aggColName = "threshold_profiles"
+
 // ThresholdsProfile struct that holds information about threshold rules
 type ThresholdsProfile struct {
-	ID    string `bson:"id" json:"id"`
-	Name  string `bson:"name" json:"name"`
-	Rules []Rule `bson:"rules" json:"rules"`
+	ID      string `bson:"id" json:"id"`
+	DateInt int    `bson:"date_integer" json:"-"`
+	Date    string `bson:"date" json:"date"`
+	Name    string `bson:"name" json:"name"`
+	Rules   []Rule `bson:"rules" json:"rules"`
 }
 
 // Rule represents a thresholds rule that must be applied to a metric and then optionally to a host and/or endpoint group

--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -1177,6 +1177,7 @@ paths:
         - "application/json"
       parameters:
         - $ref: "#/parameters/apiKey"
+        - $ref: "#/parameters/profDate"
         - name: "PROFILE_ID"
           in: "path"
           description: "id of the thresholds profile"
@@ -1215,6 +1216,7 @@ paths:
         - "application/json"
       parameters:
         - $ref: "#/parameters/apiKey"
+        - $ref: "#/parameters/profDate"
         - name: "PROFILE_ID"
           in: "path"
           description: "id of the thresholds profile"
@@ -1299,6 +1301,7 @@ paths:
         - "application/json"
       parameters:
         - $ref: "#/parameters/apiKey"
+        - $ref: "#/parameters/profDate"
       responses:
         '200':
           description: A list of thresholds profiles
@@ -1334,6 +1337,7 @@ paths:
           schema:
             $ref: '#/definitions/Thresholds_profile'
         - $ref: "#/parameters/apiKey"
+        - $ref: "#/parameters/profDate"
       responses:
         '200':
           description: Thresholds profile Created

--- a/doc/v2/docs/threshold_profiles.md
+++ b/doc/v2/docs/threshold_profiles.md
@@ -1,42 +1,47 @@
 ---
-title: 'API documentation | ARGO'
+title: "API documentation | ARGO"
 page_title: API - Operations Profile Requests
 font_title: fa fa-cogs
 description: API Calls for listing existing and creating new threshold profiles
 ---
 
 # Description
+
 A Threshold profile contains a list of threshold rules. Threshold rules refer to low level monitoring numeric values
 that accompany metric data and threshold limits on those values that can deem the status 'WARNING' or 'CRITICAL'
 
 # Threshold format
+
 Each threhsold rule is expressed as string in the following format
 `{label}={value}[uom];{warning};{critical};{min};{max}`
 
-- `label` : can contain alphanumeric characters but must always begin with a letter
-- `value` : is a float or integer
-- `uom`   : is a string unit of measurement (accepted values: `s`,`us`,`ms`,`B`,`KB`,`MB`,`TB`,`%`,`c`)
-- `warning`: is a range defining the warning threshold limits
-- `critical`: is a range defining the critical threshold limits
-- `min`: is a float or integer defining the minimum value
-- `max`: is a float or integer defining the maximum value
+-   `label` : can contain alphanumeric characters but must always begin with a letter
+-   `value` : is a float or integer
+-   `uom` : is a string unit of measurement (accepted values: `s`,`us`,`ms`,`B`,`KB`,`MB`,`TB`,`%`,`c`)
+-   `warning`: is a range defining the warning threshold limits
+-   `critical`: is a range defining the critical threshold limits
+-   `min`: is a float or integer defining the minimum value
+-   `max`: is a float or integer defining the maximum value
 
 Note: min,max can be omitted.
 
 Ranges (`{warning}` or `{critical}`) are defined in the following format:
-`@{floor}:{ceiling}`
--`@`: optional - negates the range (value should belong outside ranges limits)
-- `floor`: integer/float or `~` that defines negative infinity
-- `ceiling`: integer/float or empty (defining positive infinity)
+`@{floor}:{ceiling}` -`@`: optional - negates the range (value should belong outside ranges limits)
+
+-   `floor`: integer/float or `~` that defines negative infinity
+-   `ceiling`: integer/float or empty (defining positive infinity)
 
 # Thresholds rule
+
 Each thresholds rule can contain multiple threshold definitions separated by space
 for e.g.
 `label01=1s;0:10;11:12 label02=1B;0:200;199:500;0;500`
 
 # Thresholds profile
+
 Each threhsolds profile has a name and contains a list of thresholds rules in the following json format
 Each rule must always refer to a metric. It can optionally refer to a host and an endpoint group.
+
 ```
 {
   "id": "68dbd3d8-c95d-41ea-b13e-7ea3644285e5",
@@ -60,16 +65,15 @@ Each rule must always refer to a metric. It can optionally refer to a host and a
 }
 ```
 
-
 # API Calls
 
-Name                                     | Description                                                                            | Shortcut
----------------------------------------- | -------------------------------------------------------------------------------------- | ------------------
-GET: List Thresholds Profile Requests         | This method can be used to retrieve a list of current Thresholds profiles.          | [ Description](#1)
-GET: List a specific  Threshold profile         | This method can be used to retrieve a specific  Threshold profile based on its id.          | [ Description](#2)
-POST: Create a new  Threshold profile  | This method can be used to create a new  Threshold profile | [ Description](#3)
-PUT: Update an Threshold profile |This method can be used to update information on an existing  Threshold profile | [ Description](#4)
-DELETE: Delete an  Threshold profile |This method can be used to delete an existing Threshold profile | [ Description](#5)
+| Name                                   | Description                                                                       | Shortcut           |
+| -------------------------------------- | --------------------------------------------------------------------------------- | ------------------ |
+| GET: List Thresholds Profile Requests  | This method can be used to retrieve a list of current Thresholds profiles.        | [ Description](#1) |
+| GET: List a specific Threshold profile | This method can be used to retrieve a specific Threshold profile based on its id. | [ Description](#2) |
+| POST: Create a new Threshold profile   | This method can be used to create a new Threshold profile                         | [ Description](#3) |
+| PUT: Update an Threshold profile       | This method can be used to update information on an existing Threshold profile    | [ Description](#4) |
+| DELETE: Delete an Threshold profile    | This method can be used to delete an existing Threshold profile                   | [ Description](#5) |
 
 <a id='1'></a>
 
@@ -85,9 +89,10 @@ GET /thresholds_profiles
 
 #### Optional Query Parameters
 
-Type            | Description                                                                                     | Required
---------------- | ----------------------------------------------------------------------------------------------- | --------
-`name`          | thresholds profile name to be used as query                                                     | NO      
+| Type   | Description                                                                                                                                | Required |
+| ------ | ------------------------------------------------------------------------------------------------------------------------------------------ | -------- |
+| `name` | thresholds profile name to be used as query                                                                                                | NO       |
+| `date` | Date to retrieve a historic version of the thresholds profiles. If no date parameter is provided the most current profile will be returned | NO       |
 
 #### Request headers
 
@@ -97,58 +102,61 @@ Accept: application/json
 ```
 
 ### Response
+
 Headers: `Status: 200 OK`
 
 #### Response body
+
 Json Response
 
 ```json
 {
-"status": {
-"message": "Success",
-"code": "200"
-},
-"data": [
-{
- "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50b",
- "name": "thr01",
- "rules": [
-  {
-   "host": "hostFoo",
-   "metric": "metricA",
-   "thresholds": "freshnesss=1s;10;9:;0;25 entries=1;3;2:0;10"
-  }
- ]
-},
-{
- "id": "6ac7d222-1f8e-4a02-a502-720e8f11e50b",
- "name": "thr02",
- "rules": [
-  {
-   "host": "hostFoo",
-   "metric": "metricA",
-   "thresholds": "freshness=1s;10;9:;0;25 entries=1;3;2:0;10"
-  }
- ]
-},
-{
- "id": "6ac7d555-1f8e-4a02-a502-720e8f11e50b",
- "name": "thr03",
- "rules": [
-  {
-   "host": "hostFoo",
-   "metric": "metricA",
-   "thresholds": "freshness=1s;10;9:;0;25 entries=1;3;2:0;10"
-  }
- ]
-}
-]
+    "status": {
+        "message": "Success",
+        "code": "200"
+    },
+    "data": [
+        {
+            "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50b",
+            "name": "thr01",
+            "rules": [
+                {
+                    "host": "hostFoo",
+                    "metric": "metricA",
+                    "thresholds": "freshnesss=1s;10;9:;0;25 entries=1;3;2:0;10"
+                }
+            ]
+        },
+        {
+            "id": "6ac7d222-1f8e-4a02-a502-720e8f11e50b",
+            "name": "thr02",
+            "rules": [
+                {
+                    "host": "hostFoo",
+                    "metric": "metricA",
+                    "thresholds": "freshness=1s;10;9:;0;25 entries=1;3;2:0;10"
+                }
+            ]
+        },
+        {
+            "id": "6ac7d555-1f8e-4a02-a502-720e8f11e50b",
+            "name": "thr03",
+            "rules": [
+                {
+                    "host": "hostFoo",
+                    "metric": "metricA",
+                    "thresholds": "freshness=1s;10;9:;0;25 entries=1;3;2:0;10"
+                }
+            ]
+        }
+    ]
 }
 ```
 
 <a id='2'></a>
 
 ## [GET]: List A Specific Thresholds profile
+
 This method can be used to retrieve specific Thresholds profile based on its id
 
 ### Input
@@ -164,37 +172,46 @@ x-api-key: shared_key_value
 Accept: application/json
 ```
 
+#### Optional Query Parameters
+
+| Type   | Description                                                                                                                               | Required |
+| ------ | ----------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| `date` | Date to retrieve a historic version of the thresholds profile. If no date parameter is provided the most current profile will be returned | NO       |
+
 ### Response
+
 Headers: `Status: 200 OK`
 
 #### Response body
+
 Json Response
 
 ```json
 {
-"status": {
-"message": "Success",
-"code": "200"
-},
-"data": [
-{
- "id": "6ac7d222-1f8e-4a02-a502-720e8f11e50b",
- "name": "thr02",
- "rules": [
-  {
-   "host": "hostFoo",
-   "metric": "metricA",
-   "thresholds": "freshness=1s;10;9:;0;25 entries=1;3;2:0;10"
-  }
- ]
-}
-]
+    "status": {
+        "message": "Success",
+        "code": "200"
+    },
+    "data": [
+        {
+            "id": "6ac7d222-1f8e-4a02-a502-720e8f11e50b",
+            "name": "thr02",
+            "rules": [
+                {
+                    "host": "hostFoo",
+                    "metric": "metricA",
+                    "thresholds": "freshness=1s;10;9:;0;25 entries=1;3;2:0;10"
+                }
+            ]
+        }
+    ]
 }
 ```
 
 <a id='3'></a>
 
 ## [POST]: Create a new Thresholds Profile
+
 This method can be used to insert a new thresholds profile
 
 ### Input
@@ -210,44 +227,51 @@ x-api-key: shared_key_value
 Accept: application/json
 ```
 
+| Type   | Description                                                                                                                             | Required |
+| ------ | --------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| `date` | Date to create a historic version of the thresholds profile. If no date parameter is provided the most current profile will be returned | NO       |
+
 #### POST BODY
 
 ```json
 {
-"name" : "thr04",
-"rules": [
-  {
-    "metric": "metricB",
-    "thresholds": "time=1s;10;9:30;0;30"
-  }
-]
+    "name": "thr04",
+    "rules": [
+        {
+            "metric": "metricB",
+            "thresholds": "time=1s;10;9:30;0;30"
+        }
+    ]
 }
 ```
 
 ### Response
+
 Headers: `Status: 201 Created`
 
 #### Response body
+
 Json Response
 
 ```json
 {
-"status": {
-"message": "Thresholds Profile successfully created",
-"code": "201"
-},
-"data": {
-"id": "{{ID}}",
-"links": {
- "self": "https:///api/v2/thresholds_profiles/{{ID}}"
-}
-}
+    "status": {
+        "message": "Thresholds Profile successfully created",
+        "code": "201"
+    },
+    "data": {
+        "id": "{{ID}}",
+        "links": {
+            "self": "https:///api/v2/thresholds_profiles/{{ID}}"
+        }
+    }
 }
 ```
 
 <a id='4'></a>
 
 ## [PUT]: Update information on an existing operations profile
+
 This method can be used to update information on an existing operations profile
 
 ### Input
@@ -263,38 +287,45 @@ x-api-key: shared_key_value
 Accept: application/json
 ```
 
+| Type   | Description                                                                                                                             | Required |
+| ------ | --------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| `date` | Date to update a historic version of the thresholds profile. If no date parameter is provided the most current profile will be returned | NO       |
+
 #### PUT BODY
 
 ```json
 {
-"name" : "thr04",
-"rules": [
-  {
-    "metric": "metricB",
-    "thresholds": "time=1s;10;9:30;0;30"
-  }
-]
+    "name": "thr04",
+    "rules": [
+        {
+            "metric": "metricB",
+            "thresholds": "time=1s;10;9:30;0;30"
+        }
+    ]
 }
 ```
 
 ### Response
+
 Headers: `Status: 200 OK`
 
 #### Response body
+
 Json Response
 
 ```json
 {
- "status": {
-  "message": "Thresholds Profile successfully updated",
-  "code": "200"
- }
+    "status": {
+        "message": "Thresholds Profile successfully updated",
+        "code": "200"
+    }
 }
 ```
 
 <a id='5'></a>
 
 ## [DELETE]: Delete an existing aggregation profile
+
 This method can be used to delete an existing aggregation profile
 
 ### Input
@@ -310,25 +341,28 @@ x-api-key: shared_key_value
 Accept: application/json
 ```
 
-
 ### Response
+
 Headers: `Status: 200 OK`
 
 #### Response body
+
 Json Response
 
 ```json
 {
- "status": {
-  "message": "Operations Profile Successfully Deleted",
-  "code": "200"
- }
+    "status": {
+        "message": "Operations Profile Successfully Deleted",
+        "code": "200"
+    }
 }
 ```
 
 ## Validation Checks
+
 When submitting or updating a new threshold profile, validation checks are performed on json POST/PUT body for the following cases:
-  - Check if each thresholds rule is valid according to threshold specification discussed in the first paragraph
+
+-   Check if each thresholds rule is valid according to threshold specification discussed in the first paragraph
 
 When an invalid operations profile is submitted the api responds with a validation error list:
 
@@ -336,46 +370,47 @@ When an invalid operations profile is submitted the api responds with a validati
 
 ```json
 {
-    "name":"test-invalid-01",
-    "rules":[
-      {"thresholds":"bad01=33;33s"},
-      {"thresholds":"good01=33s;33 good02=1s;~:10;9:;-20;30"},
-      {"thresholds":"bad02=33sbad03=1s;~~:10;9:;-20;30"},
-      {"thresholds":"33;33 bad04=33s;33 -20;30"},
-      {"thresholds":"good01=2KB;0:3;2:10;0;20 good02=1c;~:10;9:30;-30;30"}
+    "name": "test-invalid-01",
+    "rules": [
+        { "thresholds": "bad01=33;33s" },
+        { "thresholds": "good01=33s;33 good02=1s;~:10;9:;-20;30" },
+        { "thresholds": "bad02=33sbad03=1s;~~:10;9:;-20;30" },
+        { "thresholds": "33;33 bad04=33s;33 -20;30" },
+        { "thresholds": "good01=2KB;0:3;2:10;0;20 good02=1c;~:10;9:30;-30;30" }
     ]
 }
-  ```
+```
 
-  Api response is the following:
+Api response is the following:
 
 ### Response
+
 Headers: `Status: 422 Unprocessable Entity`
 
 #### Response body
 
- ```json
- {
-  "status": {
-   "message": "Validation Error",
-   "code": "422"
-  },
-  "errors": [
-   {
-    "message": "Validation Failed",
-    "code": "422",
-    "details": "Invalid threshold: bad01=33;33s"
-   },
-   {
-    "message": "Validation Failed",
-    "code": "422",
-    "details": "Invalid threshold: bad02=33sbad03=1s;~~:10;9:;-20;30"
-   },
-   {
-    "message": "Validation Failed",
-    "code": "422",
-    "details": "Invalid threshold: 33;33 bad04=33s;33 -20;30"
-   }
-  ]
- }
- ```
+```json
+{
+    "status": {
+        "message": "Validation Error",
+        "code": "422"
+    },
+    "errors": [
+        {
+            "message": "Validation Failed",
+            "code": "422",
+            "details": "Invalid threshold: bad01=33;33s"
+        },
+        {
+            "message": "Validation Failed",
+            "code": "422",
+            "details": "Invalid threshold: bad02=33sbad03=1s;~~:10;9:;-20;30"
+        },
+        {
+            "message": "Validation Failed",
+            "code": "422",
+            "details": "Invalid threshold: 33;33 bad04=33s;33 -20;30"
+        }
+    ]
+}
+```


### PR DESCRIPTION
:warning: to be merged after https://github.com/ARGOeu/argo-web-api/pull/308

## Goal 
Give the ability to maintain historic version of the thresholds profiles when they change

## Implementation
Add an extra url parameter `date` in thresholds_profiles request signatures (GET, POST, PUT)
When using date with GET the closest historic version of the profile is retrieved. If date is ommited the most recent profile is retrieved
When using date with POST a specific historic profile entry is created (new snapshot)
When using date with PUT an update is performed on a specific historic version of the profile


:red_circle:  note that a specific indexing scheme should be prepared in thresholds_profiles mongodb collection in order the queries to work correctly

- [x] Modify thresholds profile model to incorporate historicversioning
- [x] Modify thresholds profile controllers to use historic versioning
- [x] Update unit tests
- [x] Update docs