### PR TITLE
ARGO-2125 Fix regression of returning 404 when profile list were empty

### DIFF
--- a/app/aggregationProfiles/aggregationProfiles_test.go
+++ b/app/aggregationProfiles/aggregationProfiles_test.go
@@ -513,6 +513,41 @@ func (suite *AggregationProfilesTestSuite) TestList() {
 
 }
 
+func (suite *AggregationProfilesTestSuite) TestListEmpty() {
+
+	session, err := mgo.Dial(suite.cfg.MongoDB.Host)
+	defer session.Close()
+	if err != nil {
+		panic(err)
+	}
+
+	c := session.DB(suite.tenantDbConf.Db).C("aggregation_profiles")
+	c.DropCollection()
+
+	request, _ := http.NewRequest("GET", "/api/v2/aggregation_profiles", strings.NewReader(""))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code := response.Code
+	output := response.Body.String()
+
+	emptyList := `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": []
+}`
+	// Check that we must have a 200 ok code
+	suite.Equal(200, code, "Internal Server Error")
+	// Compare the expected and actual json response
+	suite.Equal(emptyList, output, "Response body mismatch")
+
+}
+
 func (suite *AggregationProfilesTestSuite) TestListQueryName() {
 
 	request, _ := http.NewRequest("GET", "/api/v2/aggregation_profiles?name=cloud", strings.NewReader(""))

--- a/app/aggregationProfiles/controller.go
+++ b/app/aggregationProfiles/controller.go
@@ -202,12 +202,6 @@ func List(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) 
 		return code, h, output, err
 	}
 
-	if len(results) < 1 {
-		output, _ = respond.MarshalContent(respond.ErrNotFound, contentType, "", " ")
-		code = 404
-		return code, h, output, err
-	}
-
 	// Create view of the results
 	output, err = createListView(results, "Success", code) //Render the results into JSON
 

--- a/app/metricProfiles/controller.go
+++ b/app/metricProfiles/controller.go
@@ -210,12 +210,6 @@ func List(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) 
 		return code, h, output, err
 	}
 
-	if len(results) < 1 {
-		output, _ = respond.MarshalContent(respond.ErrNotFound, contentType, "", " ")
-		code = 404
-		return code, h, output, err
-	}
-
 	// Create view of the results
 	output, err = createListView(results, "Success", code) //Render the results into JSON
 

--- a/app/metricProfiles/metricProfiles_test.go
+++ b/app/metricProfiles/metricProfiles_test.go
@@ -1014,6 +1014,41 @@ func (suite *MetricProfilesTestSuite) TestUpdate() {
 
 }
 
+func (suite *MetricProfilesTestSuite) TestListEmpty() {
+
+	session, err := mgo.Dial(suite.cfg.MongoDB.Host)
+	defer session.Close()
+	if err != nil {
+		panic(err)
+	}
+
+	c := session.DB(suite.tenantDbConf.Db).C("metric_profiles")
+	c.DropCollection()
+
+	request, _ := http.NewRequest("GET", "/api/v2/metric_profiles", strings.NewReader(""))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code := response.Code
+	output := response.Body.String()
+
+	emptyList := `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": []
+}`
+	// Check that we must have a 200 ok code
+	suite.Equal(200, code, "Internal Server Error")
+	// Compare the expected and actual json response
+	suite.Equal(emptyList, output, "Response body mismatch")
+
+}
+
 func (suite *MetricProfilesTestSuite) TestDeleteNotFound() {
 
 	jsonInput := `{}`

--- a/app/operationsProfiles/controller.go
+++ b/app/operationsProfiles/controller.go
@@ -204,12 +204,6 @@ func List(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) 
 		return code, h, output, err
 	}
 
-	if len(results) < 1 {
-		output, _ = respond.MarshalContent(respond.ErrNotFound, contentType, "", " ")
-		code = 404
-		return code, h, output, err
-	}
-
 	// Create view of the results
 	output, err = createListView(results, "Success", code) //Render the results into JSON
 

--- a/app/operationsProfiles/operationsProfiles_test.go
+++ b/app/operationsProfiles/operationsProfiles_test.go
@@ -1845,6 +1845,41 @@ func (suite *OperationsProfilesTestSuite) TestDeleteNotFound() {
 
 }
 
+func (suite *OperationsProfilesTestSuite) TestListEmpty() {
+
+	session, err := mgo.Dial(suite.cfg.MongoDB.Host)
+	defer session.Close()
+	if err != nil {
+		panic(err)
+	}
+
+	c := session.DB(suite.tenantDbConf.Db).C("operations_profiles")
+	c.DropCollection()
+
+	request, _ := http.NewRequest("GET", "/api/v2/operations_profiles", strings.NewReader(""))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code := response.Code
+	output := response.Body.String()
+
+	emptyList := `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": []
+}`
+	// Check that we must have a 200 ok code
+	suite.Equal(200, code, "Internal Server Error")
+	// Compare the expected and actual json response
+	suite.Equal(emptyList, output, "Response body mismatch")
+
+}
+
 func (suite *OperationsProfilesTestSuite) TestDelete() {
 
 	request, _ := http.NewRequest("DELETE", "/api/v2/operations_profiles/6ac7d684-1f8e-4a02-a502-720e8f11e50b", strings.NewReader(""))

--- a/app/thresholdsProfiles/controller.go
+++ b/app/thresholdsProfiles/controller.go
@@ -199,12 +199,6 @@ func List(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) 
 		return code, h, output, err
 	}
 
-	if len(results) < 1 {
-		output, _ = respond.MarshalContent(respond.ErrNotFound, contentType, "", " ")
-		code = 404
-		return code, h, output, err
-	}
-
 	// Create view of the results
 	output, err = createListView(results, "Success", code) //Render the results into JSON
 

--- a/app/thresholdsProfiles/thresholdsProfiles_test.go
+++ b/app/thresholdsProfiles/thresholdsProfiles_test.go
@@ -793,6 +793,41 @@ func (suite *ThresholdsProfilesTestSuite) TestDelete() {
 	suite.Equal(err.Error(), "not found", "No not found error")
 }
 
+func (suite *ThresholdsProfilesTestSuite) TestListEmpty() {
+
+	session, err := mgo.Dial(suite.cfg.MongoDB.Host)
+	defer session.Close()
+	if err != nil {
+		panic(err)
+	}
+
+	c := session.DB(suite.tenantDbConf.Db).C("thresholds_profiles")
+	c.DropCollection()
+
+	request, _ := http.NewRequest("GET", "/api/v2/thresholds_profiles", strings.NewReader(""))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code := response.Code
+	output := response.Body.String()
+
+	emptyList := `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": []
+}`
+	// Check that we must have a 200 ok code
+	suite.Equal(200, code, "Internal Server Error")
+	// Compare the expected and actual json response
+	suite.Equal(emptyList, output, "Response body mismatch")
+
+}
+
 func (suite *ThresholdsProfilesTestSuite) TestOptionsOperationsProfiles() {
 	request, _ := http.NewRequest("OPTIONS", "/api/v2/thresholds_profiles", strings.NewReader(""))
 


### PR DESCRIPTION
Issue: When profiles are emtpy HTTP GET /*_profiles list returns 404 instead of an empty list

Fix: Change List controllers in operations, metrics, aggregation and thresholds profiles to return 200 OK and empty list instead of a 404 not foun