### PR TITLE
ARGO-2099 Add historic versioning to weights resources

### DIFF
--- a/app/weights/model.go
+++ b/app/weights/model.go
@@ -3,6 +3,8 @@ package weights
 //Weights holds a list of group weights of specific type and of specific group type
 type Weights struct {
 	ID         string   `bson:"id" json:"id"`
+	DateInt    int      `bson:"date_integer" json:"-"`
+	Date       string   `bson:"date" json:"date"`
 	Name       string   `bson:"name" json:"name"`
 	WeightType string   `bson:"weight_type" json:"weight_type"`
 	GroupType  string   `bson:"group_type" json:"group_type"`

--- a/app/weights/weights_test.go
+++ b/app/weights/weights_test.go
@@ -44,7 +44,7 @@ func (suite *WeightsTestSuite) SetupSuite() {
 	 [mongodb]
 	 host = "127.0.0.1"
 	 port = 27017
-	 db = "AR_test_mprof"
+	 db = "AR_test_weights"
 	 `
 
 	_ = gcfg.ReadStringInto(&suite.cfg, testConfig)

--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -1368,6 +1368,7 @@ paths:
         - "application/json"
       parameters:
         - $ref: "#/parameters/apiKey"
+        - $ref: "#/parameters/profDate"
         - name: "PROFILE_ID"
           in: "path"
           description: "id of the weights resource"
@@ -1406,6 +1407,7 @@ paths:
         - "application/json"
       parameters:
         - $ref: "#/parameters/apiKey"
+        - $ref: "#/parameters/profDate"
         - name: "PROFILE_ID"
           in: "path"
           description: "id of the weights resource"
@@ -1490,6 +1492,7 @@ paths:
         - "application/json"
       parameters:
         - $ref: "#/parameters/apiKey"
+        - $ref: "#/parameters/profDate"
       responses:
         '200':
           description: A list of weights resources
@@ -1525,6 +1528,7 @@ paths:
           schema:
             $ref: '#/definitions/Weights'
         - $ref: "#/parameters/apiKey"
+        - $ref: "#/parameters/profDate"
       responses:
         '200':
           description: Weights resource Created
@@ -3644,6 +3648,8 @@ definitions:
     type: object
     properties:
       id:
+        type: string
+      date:
         type: string
       name:
         type: string

--- a/doc/v2/docs/weights.md
+++ b/doc/v2/docs/weights.md
@@ -29,9 +29,10 @@ GET /weights
 
 #### Optional Query Parameters
 
-| Type   | Description                              | Required |
-| ------ | ---------------------------------------- | -------- |
-| `name` | weight resource name to be used as query | NO       |
+| Type   | Description                                                                                                                             | Required |
+| ------ | --------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| `name` | weight resource name to be used as query                                                                                                | NO       |
+| `date` | Date to retrieve a historic version of the weights resource. If no date parameter is provided the most current profile will be returned | NO       |
 
 ### Request headers
 
@@ -57,6 +58,7 @@ Json Response
     "data": [
         {
             "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50b",
+            "date": "2019-11-04",
             "name": "Critical",
             "weight_type": "hepsepc",
             "group_type": "SITES",
@@ -81,6 +83,7 @@ Json Response
         },
         {
             "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50c",
+            "date": "2019-11-02",
             "name": "NonCritical",
             "weight_type": "hepsepc",
             "group_type": "SERVICEGROUPS",
@@ -111,6 +114,12 @@ This method can be used to retrieve specific weight resource based on its id
 GET /weights/{ID}
 ```
 
+#### Optional Query Parameters
+
+| Type   | Description                                                                                                                             | Required |
+| ------ | --------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| `date` | Date to retrieve a historic version of the weights resource. If no date parameter is provided the most current profile will be returned | NO       |
+
 #### Request headers
 
 ```
@@ -135,6 +144,7 @@ Json Response
     "data": [
         {
             "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50c",
+            "date": "2019-11-02",
             "name": "NonCritical",
             "weight_type": "hepsepc",
             "group_type": "SERVICEGROUPS",
@@ -164,6 +174,12 @@ This method can be used to insert a new weight resource
 ```
 POST /weights
 ```
+
+#### Optional Query Parameters
+
+| Type   | Description                                                                                                                                 | Required |
+| ------ | ------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| `date` | Date to create a historic version of the weights resource. If no date parameter is provided the current date will be supplied automatically | NO       |
 
 #### Request headers
 
@@ -224,6 +240,12 @@ This method can be used to update information on an existing weight resource
 ```
 PUT /weights/{ID}
 ```
+
+#### Optional Query Parameters
+
+| Type   | Description                                                                                                                                                                  | Required |
+| ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| `date` | Date to update a historic version of the weights resource. If no date parameter is provided If no date parameter is provided the current date will be supplied automatically | NO       |
 
 #### Request headers
 


### PR DESCRIPTION
## Goal 
Give the ability to maintain historic version of the weight resources when they change

## Implementation
Add an extra url parameter `date` in weights request signatures (GET, POST, PUT)
When using date with GET the closest historic version of the profile is retrieved. If date is ommited the most recent weights resource is retrieved
When using date with POST a specific historic entry is created (new snapshot)
When using date with PUT an update is performed on a specific historic version of the weights resource


:red_circle:  note that a specific indexing scheme should be prepared in weights mongodb collection in order the queries to work correctly

- [x] Modify weights model to incorporate historicversioning
- [x] Modify weights controllers to use historic versioning
- [x] Update unit tests
- [x] Update docs