### PR TITLE
ARGO-2137 Add historic versioning to downtimes resources

### DIFF
--- a/app/downtimes/model.go
+++ b/app/downtimes/model.go
@@ -3,6 +3,8 @@ package downtimes
 //Downtimes holds a list of downtimes for endpoints for a specific day
 type Downtimes struct {
 	ID        string     `bson:"id" json:"id"`
+	DateInt   int        `bson:"date_integer" json:"-"`
+	Date      string     `bson:"date" json:"date"`
 	Name      string     `bson:"name" json:"name"`
 	Endpoints []Downtime `bson:"endpoints" json:"endpoints"`
 }

--- a/app/weights/weights_test.go
+++ b/app/weights/weights_test.go
@@ -911,7 +911,7 @@ func (suite *WeightsTestSuite) TestUpdate() {
  "data": [
   {
    "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50c",
-   "date": "2019-12-05",
+   "date": "2019-12-04",
    "name": "NonCritical",
    "weight_type": "hepsepc5",
    "group_type": "SITES",
@@ -929,7 +929,7 @@ func (suite *WeightsTestSuite) TestUpdate() {
  ]
 }`
 
-	request, _ := http.NewRequest("PUT", "/api/v2/weights/6ac7d684-1f8e-4a02-a502-720e8f11e50c", strings.NewReader(jsonInput))
+	request, _ := http.NewRequest("PUT", "/api/v2/weights/6ac7d684-1f8e-4a02-a502-720e8f11e50c?date=2019-12-04", strings.NewReader(jsonInput))
 	request.Header.Set("x-api-key", suite.clientkey)
 	request.Header.Set("Accept", "application/json")
 	response := httptest.NewRecorder()

--- a/doc/v2/docs/downtimes.md
+++ b/doc/v2/docs/downtimes.md
@@ -29,9 +29,10 @@ GET /downtimes
 
 #### Optional Query Parameters
 
-| Type   | Description                                | Required |
-| ------ | ------------------------------------------ | -------- |
-| `name` | downtime resource name to be used as query | NO       |
+| Type   | Description                                                                                                                               | Required |
+| ------ | ----------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| `name` | downtime resource name to be used as query                                                                                                | NO       |
+| `date` | Date to retrieve a historic version of the downtime resource. If no date parameter is provided the most current resource will be returned | NO       |
 
 ### Request headers
 
@@ -57,6 +58,7 @@ Json Response
     "data": [
         {
             "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50b",
+            "date": "2019-11-04",
             "name": "Critical",
             "endpoints": [
                 {
@@ -81,6 +83,7 @@ Json Response
         },
         {
             "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50c",
+            "date": "2019-11-02",
             "name": "NonCritical",
             "endpoints": [
                 {
@@ -113,6 +116,12 @@ This method can be used to retrieve specific downtime resource based on its id
 GET /downtimes/{ID}
 ```
 
+#### Optional Query Parameters
+
+| Type   | Description                                                                                                                                        | Required |
+| ------ | -------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| `date` | Date to retrieve a historic version of the downtime resource. If no date parameter is provided the most current downtime resource will be returned | NO       |
+
 #### Request headers
 
 ```
@@ -137,6 +146,7 @@ Json Response
     "data": [
         {
             "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50b",
+            "date": "2019-11-04",
             "name": "Critical",
             "endpoints": [
                 {
@@ -174,6 +184,12 @@ This method can be used to insert a new downtime resource
 ```
 POST /downtimes
 ```
+
+#### Optional Query Parameters
+
+| Type   | Description                                                                                                                                  | Required |
+| ------ | -------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| `date` | Date to create a new historic version of the downtime resource. If no date parameter is provided current date will be supplied automatically | NO       |
 
 #### Request headers
 
@@ -234,6 +250,12 @@ This method can be used to update information on an existing downtime resource
 ```
 PUT /downtimes/{ID}
 ```
+
+#### Optional Query Parameters
+
+| Type   | Description                                                                                                                                  | Required |
+| ------ | -------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| `date` | Date to update a historic version of the downtime resource. If no date parameter is provided the current date will be supplied automatically | NO       |
 
 #### Request headers
 


### PR DESCRIPTION
## Goal 
Give the ability to maintain historic version of the downtimes resources when they change

## Implementation
Add an extra url parameter `date` in downtimes request signatures (GET, POST, PUT)
When using date with GET the closest historic version of the profile is retrieved. If date is ommited the most recent downtimes resource is retrieved
When using date with POST a specific historic entry is created (new snapshot)
When using date with PUT an update is performed on a specific historic version of the downtimes resource


:red_circle:  note that a specific indexing scheme should be prepared in downtimes mongodb collection in order the queries to work correctly

- [x] Modify downtimes model to incorporate historicversioning
- [x] Modify downtimes controllers to use historic versioning
- [x] Update unit tests
- [x] Update docs