### PR TITLE
ARGO-2142 Fix double routing prefixes for weights and downtimes.

### DIFF
--- a/app/downtimes/controller.go
+++ b/app/downtimes/controller.go
@@ -261,12 +261,6 @@ func List(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) 
 		return code, h, output, err
 	}
 
-	if len(results) < 1 {
-		output, _ = respond.MarshalContent(respond.ErrNotFound, contentType, "", " ")
-		code = 404
-		return code, h, output, err
-	}
-
 	// Create view of the results
 	output, err = createListView(results, "Success", code) //Render the results into JSON
 

--- a/app/weights/controller.go
+++ b/app/weights/controller.go
@@ -262,12 +262,6 @@ func List(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) 
 		return code, h, output, err
 	}
 
-	if len(results) < 1 {
-		output, _ = respond.MarshalContent(respond.ErrNotFound, contentType, "", " ")
-		code = 404
-		return code, h, output, err
-	}
-
 	// Create view of the results
 	output, err = createListView(results, "Success", code) //Render the results into JSON
 

--- a/routing/routes.go
+++ b/routing/routes.go
@@ -45,8 +45,7 @@ import (
 )
 
 var routesV2 = []RouteV2{
-	{"Downtimes", "/downtimes", downtimes.HandleSubrouter},
-	{"Weights", "/weights", weights.HandleSubrouter},
+
 	{"Topology", "/topology", topology.HandleSubrouter},
 	{"Latest", "/latest", latest.HandleSubrouter},
 	{"Results", "/results", results.HandleSubrouter},
@@ -64,4 +63,6 @@ var routesV2 = []RouteV2{
 	{"Tenants", "/admin", tenants.HandleSubrouter},
 	{"Factors", "", factors.HandleSubrouter},
 	{"Version", "", version.HandleSubrouter},
+	{"Downtimes", "", downtimes.HandleSubrouter},
+	{"Weights", "", weights.HandleSubrouter},
 }


### PR DESCRIPTION
Fix 404 response when lists empty

- Remove `weights` and `downtimes` prefix from outer router (already declared in subrouter)
- Remove 404 check when `weights` and `downtimes` lists are empty