### PR TITLE
ARGO-2126 Create jenkins file for argo-web-api

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,21 +1,115 @@
 pipeline {
-    agent any
-
+    agent { 
+        docker { 
+            image 'epel7mgo' 
+            label 'slave01'
+            args '-u jenkins:jenkins'
+        }
+    }
+    options { checkoutToSubdirectory('argo-web-api') }
     stages {
+         
         stage('Build') {
+            
             steps {
-                echo 'Building..'
+                echo 'Build...'
+                sh '''export GIT_COMMIT=$(git rev-list -1 HEAD)
+                export BUILD_TIME=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+                mkdir -p ${WORKSPACE}/go/src/github.com/ARGOeu
+                export GOPATH=${WORKSPACE}/go
+                ln -sf ${WORKSPACE}/argo-web-api ${WORKSPACE}/go/src/github.com/ARGOeu/argo-web-api
+                rm -rf ${WORKSPACE}/go/src/github.com/ARGOeu/argo-web-api/argo-web-api
+                cd ${WORKSPACE}/go/src/github.com/ARGOeu/argo-web-api && go build
+                '''
             }
         }
         stage('Test') {
             steps {
-                echo 'Testing..'
+                echo 'Test & Coverage...'
+                sh '''mkdir -p ${WORKSPACE}/go/src/github.com/ARGOeu
+                export GOPATH=${WORKSPACE}/go
+                ln -sf ${WORKSPACE}/argo-web-api ${WORKSPACE}/go/src/github.com/ARGOeu/argo-web-api
+                sudo /etc/init.d/mongod restart
+                cd ${WORKSPACE}/go/src/github.com/ARGOeu/argo-web-api && gocov test -p 1 $(go list ./... | grep -v /vendor/) | gocov-xml > ${WORKSPACE}/coverage.xml
+                cd ${WORKSPACE}/go/src/github.com/ARGOeu/argo-web-api && go test -p 1 $(go list ./... | grep -v /vendor/) -v=1 | go-junit-report > ${WORKSPACE}/junit.xml
+                '''
+                junit '**/junit.xml'
+                cobertura coberturaReportFile: '**/coverage.xml'
+
             }
         }
-        stage('Deploy') {
+        stage('Package') {
             steps {
-                echo 'Deploying....'
+                echo 'Building Rpm...'
+                sh '''cd ${WORKSPACE}/argo-web-api && make sources
+                cp ${WORKSPACE}/argo-web-api/argo-web-api*.tar.gz /home/jenkins/rpmbuild/SOURCES/
+                cd ${WORKSPACE}/argo-web-api && export GIT_COMMIT=${GIT_COMMIT:-`git log -1 --format="%H"`}
+                cd ${WORKSPACE}/argo-web-api && export GIT_COMMIT_HASH=`echo ${GIT_COMMIT} | cut -c1-7`
+                cd ${WORKSPACE}/argo-web-api && export _GIT_COMMIT_DATE=`git show -s --format=%ci ${GIT_COMMIT_HASH}`
+                cd ${WORKSPACE}/argo-web-api && export GIT_COMMIT_DATE=`date -d "${_GIT_COMMIT_DATE}" "+%Y%m%d%H%M%S"`
+                sed -i 's/^Release.*/Release: %(echo $GIT_COMMIT_DATE).%(echo $GIT_COMMIT_HASH)%{?dist}/' ${WORKSPACE}/argo-web-api/argo-web-api.spec
+                cd /home/jenkins/rpmbuild/SOURCES && tar -xzvf argo-web-api*.tar.gz
+                cp ${WORKSPACE}/argo-web-api/argo-web-api.spec /home/jenkins/rpmbuild/SPECS/
+                rpmbuild -bb /home/jenkins/rpmbuild/SPECS/*.spec
+                rm -f ${WORKSPACE}/*.rpm
+                cp /home/jenkins/rpmbuild/RPMS/**/*.rpm ${WORKSPACE}/
+                '''
+                archiveArtifacts artifacts: '**/*.rpm', fingerprint: true
             }
         }
+       
+        stage('Package for Devel') {
+            when {
+                branch 'devel'
+            }
+            steps {
+                echo 'Building Rpm for Devel...'
+                sh '''cd ${WORKSPACE}/argo-web-api && make sources
+                cp ${WORKSPACE}/argo-web-api/argo-web-api*.tar.gz /home/jenkins/rpmbuild/SOURCES/
+                cd ${WORKSPACE}/argo-web-api && export GIT_COMMIT=${GIT_COMMIT:-`git log -1 --format="%H"`}
+                cd ${WORKSPACE}/argo-web-api && export GIT_COMMIT_HASH=`echo ${GIT_COMMIT} | cut -c1-7`
+                cd ${WORKSPACE}/argo-web-api && export _GIT_COMMIT_DATE=`git show -s --format=%ci ${GIT_COMMIT_HASH}`
+                cd ${WORKSPACE}/argo-web-api && export GIT_COMMIT_DATE=`date -d "${_GIT_COMMIT_DATE}" "+%Y%m%d%H%M%S"`
+                sed -i 's/^Release.*/Release: %(echo $GIT_COMMIT_DATE).%(echo $GIT_COMMIT_HASH)%{?dist}/' ${WORKSPACE}/argo-web-api/argo-web-api.spec
+                cd /home/jenkins/rpmbuild/SOURCES && tar -xzvf argo-web-api*.tar.gz
+                cp ${WORKSPACE}/argo-web-api/argo-web-api.spec /home/jenkins/rpmbuild/SPECS/
+                rpmbuild -bb /home/jenkins/rpmbuild/SPECS/*.spec
+                rm -f ${WORKSPACE}/*.rpm
+                cp /home/jenkins/rpmbuild/RPMS/**/*.rpm ${WORKSPACE}/
+                '''
+                archiveArtifacts artifacts: '**/*.rpm', fingerprint: true
+                echo 'Uploading rpm for devel...'
+                withCredentials(bindings: [sshUserPrivateKey(credentialsId: 'jenkins-repo', usernameVariable: 'REPOUSER', \
+                                                             keyFileVariable: 'REPOKEY')]) {
+                  sh '''
+                  scp -i ${REPOKEY} -o StrictHostKeyChecking=no ${WORKSPACE}/*.rpm ${REPOUSER}@rpm-repo.argo.grnet.gr:/repos/ARGO/devel/centos7/
+                  '''
+                }
+            }
+        }
+        stage('Package for Production') {
+            when {
+                branch 'master'
+            }
+            steps {
+                echo 'Building Rpm for Production...'
+                sh '''cd ${WORKSPACE}/argo-web-api && make sources
+                cd /home/jenkins/rpmbuild/SOURCES && tar -xzvf argo-web-api*.tar.gz
+                cp ${WORKSPACE}/argo-web-api/argo-web-api.spec /home/jenkins/rpmbuild/SPECS/
+                rpmbuild -bb /home/jenkins/rpmbuild/SPECS/*.spec
+                rm -f ${WORKSPACE}/*.rpm
+                cp /home/jenkins/rpmbuild/RPMS/**/*.rpm ${WORKSPACE}/
+                '''
+                archiveArtifacts artifacts: '**/*.rpm', fingerprint: true
+                echo 'Uploading rpm for devel...'
+                withCredentials(bindings: [sshUserPrivateKey(credentialsId: 'jenkins-repo', usernameVariable: 'REPOUSER', \
+                                                             keyFileVariable: 'REPOKEY')]) {
+                  sh '''
+                  scp -i ${REPOKEY} -o StrictHostKeyChecking=no ${WORKSPACE}/*.rpm ${REPOUSER}@rpm-repo.argo.grnet.gr:/repos/ARGO/prod/centos7/
+                  '''
+                }
+            }
+        }
+        
     }
 }

--- a/app/latest/latest_test.go
+++ b/app/latest/latest_test.go
@@ -71,7 +71,7 @@ func (suite *LatestTestSuite) SetupTest() {
     [mongodb]
     host = "127.0.0.1"
     port = 27017
-    db = "argotest_metrics"
+    db = "argotest_latest"
 `
 
 	_ = gcfg.ReadStringInto(&suite.cfg, testConfig)


### PR DESCRIPTION
Constructed JenkinsFile Pipeline with the following stages
- Added a `build` stage: test actual build if succeeds or not
- Added a `test` stage: Run unit tests and produce coverage reports. Capture results in jenkins
- Added a `package` stage: Try to create a current temp package (update version in spec file by adding latest commit hash and commit date) and capture the artifact only in jenkins. Usefull if having changes in spec files etc
- Added a `package for devel` stage: Change spec version with latest commit hash and commit date and create a package for devel repo. Capture artifact in jenkins. Upload devel rpm to repo
- Added a `package for prod` stage: Build production rpm with explicit spec version. Capture artifact in jenkins. Upload devel rpm to repo