### PR TITLE
ARGO-2184 Fix db reference name in package latest unittest

### DIFF
--- a/app/latest/latest_test.go
+++ b/app/latest/latest_test.go
@@ -71,7 +71,7 @@ func (suite *LatestTestSuite) SetupTest() {
     [mongodb]
     host = "127.0.0.1"
     port = 27017
-    db = "argotest_metrics"
+    db = "argotest_latest"
 `
 
 	_ = gcfg.ReadStringInto(&suite.cfg, testConfig)


### PR DESCRIPTION
Change db name used in unit tests to be consistent with context 