### PR TITLE
ARGO-2106 Insert Endpoint Group Topology per day

### DIFF
--- a/app/topology/model.go
+++ b/app/topology/model.go
@@ -49,3 +49,14 @@ type messageOUT struct {
 	Message string   `xml:"message" json:"message"`
 	Code    string   `xml:"code,omitempty" json:"code,omitempty"`
 }
+
+// Endpoint includes information on endpoint group topology
+type Endpoint struct {
+	Date      string            `bson:"date" json:"-"`
+	DateInt   int               `bson:"date_integer" json:"-"`
+	Group     string            `bson:"group" json:"group"`
+	GroupType string            `bson:"type" bson:"type"`
+	Service   string            `bson:"service" json:"service"`
+	Hostname  string            `bson:"hostname" json:"hostname"`
+	Tags      map[string]string `bson:"tags" json:"tags"`
+}

--- a/app/topology/routing.go
+++ b/app/topology/routing.go
@@ -44,6 +44,8 @@ func HandleSubrouter(s *mux.Router, confhandler *respond.ConfHandler) {
 }
 
 var appRoutesV2 = []respond.AppRoutes{
+	{"topology_endpoints.insert", "POST", "/endpoints", CreateEndpoints},
+	{"topology_endpoints.options", "OPTIONS", "/endpoints", Options},
 	{"topology.list", "GET", "/stats/{report_name}", routeCheckGroup},
 	{"topology.options", "OPTIONS", "/stats/{report_name}", Options},
 }

--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -1774,6 +1774,53 @@ paths:
           $ref: "#/responses/422"
         500:
           $ref: "#/responses/ServerError"
+          
+  /topology/endpoints:
+    post:
+      summary: Create a new endpoints topology resource
+      operationId: topology_endpoints.create
+      description: Create a new endpoints topology resource which maps endpoints to endpoint groups
+      tags:
+        - Topology
+      consumes:
+        - "application/json"
+      produces:
+        - "application/json"
+      parameters:
+        - name: "endpoint_resource"
+          in: "body"
+          description: "Json description of endpoint topology items to be created"
+          required: true
+          schema:
+            $ref: '#/definitions/TopologyEndpoints'
+        - $ref: "#/parameters/apiKey"
+        - $ref: "#/parameters/profDate"
+      responses:
+        '200':
+          description: Topology resource Created
+          schema:
+            $ref: '#/definitions/Self_reference'
+        '400':
+          description: Bad request due to malformed JSON in post body
+          schema:
+            $ref: '#/definitions/Status_error'
+        '401':
+          description: Unauthorized user
+          schema:
+            $ref: '#/definitions/Status_error'
+        '406':
+          description: Content Not acceptable
+          schema:
+            $ref: '#/definitions/Status_error'
+        '409':
+          description: Content already created for specific date
+          schema:
+            $ref: '#/definitions/Status_error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Status_error'
+
 
   /latest/{report_name}/{lgroup_type}:
     get:
@@ -3117,6 +3164,31 @@ responses:
       $ref: '#/definitions/Status_error'
 
 definitions:
+
+  TopologyEndpoint:
+    type: object
+    properties:
+      group:
+        type: string
+        description: "name of the endpoint group"
+      type:
+        type: string
+        description: "type of the endpoint group, for example: SITES or SERVICEGROUPS etc... "
+      service:
+        type: string
+        description: "service type of the endpoint belonging to the endpoint group"
+      hostname:
+        type: string
+        description: "hostname of the endpoint belonging to the endpoint group"
+      tags:
+        type: object
+        description: "key value tags"
+
+  TopologyEndpoints:
+    type: array
+    items:
+      $ref: '#/definitions/TopologyEndpoint'
+      
 
   FactorsResponse:
     type: object

--- a/doc/v2/docs/topology_endpoints.md
+++ b/doc/v2/docs/topology_endpoints.md
@@ -1,0 +1,96 @@
+#Topology Endpoints
+
+API calls for handling topology endpoint resources
+
+| Name                                             | Description                                                            | Shortcut                     |
+| ------------------------------------------------ | ---------------------------------------------------------------------- | ---------------------------- |
+| POST: Create endpoint topology for specific date | Creates a daily endpoint topology mapping endpoints to endpoint groups | <a href="#1">Description</a> |
+
+<a id="1"></a>
+
+## POST: Create endpoint topology for specific date
+
+Creates a daily endpoint topology mapping endpoints to endpoint groups
+
+### Input
+
+```
+POST /topology/endpoints?date=YYYY-MM-DD
+```
+
+#### Url Parameters
+
+| Type   | Description            | Required | Default value |
+| ------ | ---------------------- | -------- | ------------- |
+| `date` | target a specific data | NO       | today's date  |
+
+#### Headers
+
+```
+x-api-key: secret_key_value
+Accept: application/json
+```
+
+### POST BODY
+
+```json
+[
+    {
+        "group": "SITE_A",
+        "hostname": "host1.site-a.foo",
+        "type": "SITES",
+        "service": "a.service.foo",
+        "tags": { "scope": "TENANT", "production": "1", "monitored": "1" }
+    },
+    {
+        "group": "SITE_A",
+        "hostname": "host2.site-b.foo",
+        "type": "SITES",
+        "service": "b.service.foo",
+        "tags": { "scope": "TENANT", "production": "1", "monitored": "1" }
+    },
+    {
+        "group": "SITE_B",
+        "hostname": "host1.site-a.foo",
+        "type": "SITES",
+        "service": "c.service.foo",
+        "tags": { "scope": "TENANT", "production": "1", "monitored": "1" }
+    }
+]
+```
+
+#### Response Code
+
+```
+Status: 201 OK Created
+```
+
+### Response body
+
+```json
+{
+    "message": "Topology of 3 endpoints created for date: YYYY-MM-DD",
+    "code": "201"
+}
+```
+
+## 409 Conflict when trying to insert a topology that already exists
+
+When trying to insert a topology for a specific date that already exists the api will answer with the following reponse:
+
+### Response Code
+
+```
+Status: 409 Conflict
+```
+
+### Response body
+
+```json
+{
+    "message": "topology already exists for date: YYYY-MM-DD, please either update it or delete it first!",
+    "code": "409"
+}
+```
+
+User can proceed with either updating the existing endpoint topology OR deleting before trying to create it anew

--- a/doc/v2/docs/topology_stats.md
+++ b/doc/v2/docs/topology_stats.md
@@ -14,7 +14,7 @@ This method may be used to retrieve topology statistics for a specific report. T
 
 ### Input
 
-##### List All latest metric data
+##### List All topology statistics
 
 ```
 /topology/stats/{report}/?[date]

--- a/doc/v2/mkdocs.yml
+++ b/doc/v2/mkdocs.yml
@@ -19,7 +19,8 @@ pages:
     - Validation Checks: validations.md
     - Metrics: metrics.md
     - Latest results: latest.md
-    - Topology statistics: topology.md
+    - Topology statistics: topology_stats.md
+    - Topology Endpoints: topology_endpoints.md
     - Weights resource: weights.md
 
 theme: readthedocs

--- a/scripts/mongodb/populate_default_roles.js
+++ b/scripts/mongodb/populate_default_roles.js
@@ -152,6 +152,10 @@ function populate_default_roles() {
         {
             resource: "recomputations.update",
             roles: ["admin", "editor", "admin_ui"]
+        },
+        {
+            resource: "topology_endpoints.insert",
+            roles: ["admin", "editor"]
         }
     ]);
     print("INFO\tPolulated default roles in 'roles' collection");


### PR DESCRIPTION
### Goal
Allow to insert endpoint topology information to argo-web-api

### Implementation
In existing `topology` package implement a new api call in the following route:
`POST /api/v2/topology/endpoints`

The model that describes each item in endpoint topology per day is the following:
```json
{ 
  "date" : "date representation in daily format YYYY-DD-MM",
  "hostname": "endpoint's hostname",
  "service": "endpoint's service type",
  "group" :"endpoint group that the endpoint belongs to",
  "type": "endpoint group type like SITES or SERVICEGROUPS or other",
  "tags": { "key": "value", "key2": "value2}
}
```
Each daily topology consists of a list of the above items like in the following example:
```json
[
{"group": "SITE_A", "hostname": "host1.site-a.foo", "type": "SITES", "service": "a.service.foo", "tags": {"scope": "TENANT", "production": "1", "monitored": "1"}},
{"group": "SITE_A", "hostname": "host2.site-b.foo", "type": "SITES", "service": "b.service.foo", "tags": {"scope": "TENANT", "production": "1", "monitored": "1"}},
{"group": "SITE_B", "hostname": "host1.site-a.foo", "type": "SITES", "service": "c.service.foo", "tags": {"scope": "TENANT", "production": "1", "monitored": "1"}}
]
```
If the creation is succesfull the user will be greeted with the following message:
```json
{
    "message": "Topology of 3 endpoint groups created for date: 2019-03-03",
    "code": "201"
}
```
If user tries to create an endpoint topology for a specific date that an endpoint topology exists he will be greeted with the following message:
```json
{
    "message": "Topology already exists for date: 2019-03-03, please either update it or delete it first!",
    "code": "409"
}
```


- [x] Add a new model for representing endpoint topology
- [x] Add a new handler for creating endpoint topologies per day allowing to insert many endpoint items per request in the datastore
- [x] Add unit tests
- [x] update docs
- [x] update swagger

