### PR TITLE
ARGO-2108 List Endpoint topology per day

### DIFF
--- a/app/topology/model.go
+++ b/app/topology/model.go
@@ -52,10 +52,10 @@ type messageOUT struct {
 
 // Endpoint includes information on endpoint group topology
 type Endpoint struct {
-	Date      string            `bson:"date" json:"-"`
+	Date      string            `bson:"date" json:"date"`
 	DateInt   int               `bson:"date_integer" json:"-"`
 	Group     string            `bson:"group" json:"group"`
-	GroupType string            `bson:"type" bson:"type"`
+	GroupType string            `bson:"type" json:"type"`
 	Service   string            `bson:"service" json:"service"`
 	Hostname  string            `bson:"hostname" json:"hostname"`
 	Tags      map[string]string `bson:"tags" json:"tags"`

--- a/app/topology/model.go
+++ b/app/topology/model.go
@@ -49,3 +49,14 @@ type messageOUT struct {
 	Message string   `xml:"message" json:"message"`
 	Code    string   `xml:"code,omitempty" json:"code,omitempty"`
 }
+
+// Endpoint includes information on endpoint group topology
+type Endpoint struct {
+	Date      string            `bson:"date" json:"-"`
+	DateInt   int               `bson:"date_integer" json:"-"`
+	Group     string            `bson:"group" json:"group"`
+	GroupType string            `bson:"type" bson:"type"`
+	Service   string            `bson:"service" json:"service"`
+	Hostname  string            `bson:"hostname" json:"hostname"`
+	Tags      map[string]string `bson:"tags" json:"tags"`
+}

--- a/app/topology/routing.go
+++ b/app/topology/routing.go
@@ -45,8 +45,9 @@ func HandleSubrouter(s *mux.Router, confhandler *respond.ConfHandler) {
 
 var appRoutesV2 = []respond.AppRoutes{
 	{"topology_endpoints.insert", "POST", "/endpoints", CreateEndpoints},
+	{"topology_endpoints.list", "GET", "/endpoints", ListEndpoints},
 	{"topology_endpoints.options", "OPTIONS", "/endpoints", Options},
-	{"topology.list", "GET", "/stats/{report_name}", routeCheckGroup},
+	{"topology_stats.list", "GET", "/stats/{report_name}", routeCheckGroup},
 	{"topology.options", "OPTIONS", "/stats/{report_name}", Options},
 }
 

--- a/app/topology/routing.go
+++ b/app/topology/routing.go
@@ -44,6 +44,8 @@ func HandleSubrouter(s *mux.Router, confhandler *respond.ConfHandler) {
 }
 
 var appRoutesV2 = []respond.AppRoutes{
+	{"topology_endpoints.insert", "POST", "/endpoints", CreateEndpoints},
+	{"topology_endpoints.options", "OPTIONS", "/endpoints", Options},
 	{"topology.list", "GET", "/stats/{report_name}", routeCheckGroup},
 	{"topology.options", "OPTIONS", "/stats/{report_name}", Options},
 }

--- a/app/topology/view.go
+++ b/app/topology/view.go
@@ -44,6 +44,22 @@ func createTopoView(results Topology, msg string, code int) ([]byte, error) {
 
 }
 
+// createListView constructs the list response template and exports it as json
+func createListEndpoint(results []Endpoint, msg string, code int) ([]byte, error) {
+
+	docRoot := &respond.ResponseMessage{
+		Status: respond.StatusResponse{
+			Message: msg,
+			Code:    strconv.Itoa(code),
+		},
+	}
+	docRoot.Data = results
+
+	output, err := json.MarshalIndent(docRoot, "", " ")
+	return output, err
+
+}
+
 func createMessageOUT(message string, code int, format string) ([]byte, error) {
 
 	output := []byte("message placeholder")

--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -1774,6 +1774,53 @@ paths:
           $ref: "#/responses/422"
         500:
           $ref: "#/responses/ServerError"
+          
+  /topology/endpoints:
+    post:
+      summary: Create a new endpoints topology resource
+      operationId: topology_endpoints.create
+      description: Create a new endpoints topology resource which maps endpoints to endpoint groups
+      tags:
+        - Topology
+      consumes:
+        - "application/json"
+      produces:
+        - "application/json"
+      parameters:
+        - name: "endpoint_resource"
+          in: "body"
+          description: "Json description of endpoint topology items to be created"
+          required: true
+          schema:
+            $ref: '#/definitions/TopologyEndpoints'
+        - $ref: "#/parameters/apiKey"
+        - $ref: "#/parameters/profDate"
+      responses:
+        '200':
+          description: Topology resource Created
+          schema:
+            $ref: '#/definitions/Self_reference'
+        '400':
+          description: Bad request due to malformed JSON in post body
+          schema:
+            $ref: '#/definitions/Status_error'
+        '401':
+          description: Unauthorized user
+          schema:
+            $ref: '#/definitions/Status_error'
+        '406':
+          description: Content Not acceptable
+          schema:
+            $ref: '#/definitions/Status_error'
+        '409':
+          description: Content already created for specific date
+          schema:
+            $ref: '#/definitions/Status_error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Status_error'
+
 
   /latest/{report_name}/{lgroup_type}:
     get:
@@ -3117,6 +3164,31 @@ responses:
       $ref: '#/definitions/Status_error'
 
 definitions:
+
+  TopologyEndpoint:
+    type: object
+    properties:
+      group:
+        type: string
+        description: "name of the endpoint group"
+      type:
+        type: string
+        description: "type of the endpoint group, for example: SITES or SERVICEGROUPS etc... "
+      service:
+        type: string
+        description: "service type of the endpoint belonging to the endpoint group"
+      hostname:
+        type: string
+        description: "hostname of the endpoint belonging to the endpoint group"
+      tags:
+        type: object
+        description: "key value tags"
+
+  TopologyEndpoints:
+    type: array
+    items:
+      $ref: '#/definitions/TopologyEndpoint'
+      
 
   FactorsResponse:
     type: object

--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -1820,6 +1820,47 @@ paths:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Status_error'
+            
+    get:
+      summary: List topology endpoints per date
+      operationId: topology_endpoints.list
+      description: List topology endpoints per date
+      tags:
+        - Topology
+      consumes:
+        - "application/json"
+      produces:
+        - "application/json"
+      parameters:
+        - $ref: "#/parameters/apiKey"
+        - $ref: "#/parameters/profDate"
+      responses:
+        '200':
+          description: Topology resource Created
+          schema:
+            $ref: '#/definitions/Self_reference'
+        '400':
+          description: Bad request due to malformed JSON in post body
+          schema:
+            $ref: '#/definitions/Status_error'
+        '401':
+          description: Unauthorized user
+          schema:
+            $ref: '#/definitions/Status_error'
+        '406':
+          description: Content Not acceptable
+          schema:
+            $ref: '#/definitions/Status_error'
+        '409':
+          description: Content already created for specific date
+          schema:
+            $ref: '#/definitions/Status_error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Status_error'
+            
+  
 
 
   /latest/{report_name}/{lgroup_type}:

--- a/doc/v2/docs/topology_endpoints.md
+++ b/doc/v2/docs/topology_endpoints.md
@@ -1,0 +1,96 @@
+#Topology Endpoints
+
+API calls for handling topology endpoint resources
+
+| Name                                             | Description                                                            | Shortcut                     |
+| ------------------------------------------------ | ---------------------------------------------------------------------- | ---------------------------- |
+| POST: Create endpoint topology for specific date | Creates a daily endpoint topology mapping endpoints to endpoint groups | <a href="#1">Description</a> |
+
+<a id="1"></a>
+
+## POST: Create endpoint topology for specific date
+
+Creates a daily endpoint topology mapping endpoints to endpoint groups
+
+### Input
+
+```
+POST /topology/endpoints?date=YYYY-MM-DD
+```
+
+#### Url Parameters
+
+| Type   | Description            | Required | Default value |
+| ------ | ---------------------- | -------- | ------------- |
+| `date` | target a specific data | NO       | today's date  |
+
+#### Headers
+
+```
+x-api-key: secret_key_value
+Accept: application/json
+```
+
+### POST BODY
+
+```json
+[
+    {
+        "group": "SITE_A",
+        "hostname": "host1.site-a.foo",
+        "type": "SITES",
+        "service": "a.service.foo",
+        "tags": { "scope": "TENANT", "production": "1", "monitored": "1" }
+    },
+    {
+        "group": "SITE_A",
+        "hostname": "host2.site-b.foo",
+        "type": "SITES",
+        "service": "b.service.foo",
+        "tags": { "scope": "TENANT", "production": "1", "monitored": "1" }
+    },
+    {
+        "group": "SITE_B",
+        "hostname": "host1.site-a.foo",
+        "type": "SITES",
+        "service": "c.service.foo",
+        "tags": { "scope": "TENANT", "production": "1", "monitored": "1" }
+    }
+]
+```
+
+#### Response Code
+
+```
+Status: 201 OK Created
+```
+
+### Response body
+
+```json
+{
+    "message": "Topology of 3 endpoints created for date: YYYY-MM-DD",
+    "code": "201"
+}
+```
+
+## 409 Conflict when trying to insert a topology that already exists
+
+When trying to insert a topology for a specific date that already exists the api will answer with the following reponse:
+
+### Response Code
+
+```
+Status: 409 Conflict
+```
+
+### Response body
+
+```json
+{
+    "message": "topology already exists for date: YYYY-MM-DD, please either update it or delete it first!",
+    "code": "409"
+}
+```
+
+User can proceed with either updating the existing endpoint topology OR deleting before trying to create it anew

--- a/doc/v2/docs/topology_endpoints.md
+++ b/doc/v2/docs/topology_endpoints.md
@@ -5,6 +5,7 @@ API calls for handling topology endpoint resources
 | Name                                             | Description                                                            | Shortcut                     |
 | ------------------------------------------------ | ---------------------------------------------------------------------- | ---------------------------- |
 | POST: Create endpoint topology for specific date | Creates a daily endpoint topology mapping endpoints to endpoint groups | <a href="#1">Description</a> |
+| GET: List endpoint topology for specific date    | Lists endpoint topology for a specific date                            | <a href="#2">Description</a> |
 
 <a id="1"></a>
 
@@ -22,7 +23,7 @@ POST /topology/endpoints?date=YYYY-MM-DD
 
 | Type   | Description            | Required | Default value |
 | ------ | ---------------------- | -------- | ------------- |
-| `date` | target a specific data | NO       | today's date  |
+| `date` | target a specific date | NO       | today's date  |
 
 #### Headers
 
@@ -94,3 +95,67 @@ Status: 409 Conflict
 ```
 
 User can proceed with either updating the existing endpoint topology OR deleting before trying to create it anew
+
+<a id="2"></a>
+
+## GET: List endpoint topology per date
+
+List endpoint topology for a specific date or the closest availabe topology to that date. If date is not provided list the latest available endpoint topology.
+
+### Input
+
+##### List All topology statistics
+
+```
+GET /topology/endpoints?date=YYYY-MM-DD
+```
+
+#### Url Parameters
+
+| Type   | Description            | Required | Default value |
+| ------ | ---------------------- | -------- | ------------- |
+| `date` | target a specific date | NO       | today's date  |
+
+#### Headers
+
+```
+x-api-key: secret_key_value
+Accept: application/json
+```
+
+#### Response Code
+
+```
+Status: 200 OK
+```
+
+### Response body
+
+```json
+[
+    {
+        "date": "2019-12-12",
+        "group": "SITE_A",
+        "hostname": "host1.site-a.foo",
+        "type": "SITES",
+        "service": "a.service.foo",
+        "tags": { "scope": "TENANT", "production": "1", "monitored": "1" }
+    },
+    {
+        "date": "2019-12-12",
+        "group": "SITE_A",
+        "hostname": "host2.site-b.foo",
+        "type": "SITES",
+        "service": "b.service.foo",
+        "tags": { "scope": "TENANT", "production": "1", "monitored": "1" }
+    },
+    {
+        "date": "2019-12-12",
+        "group": "SITE_B",
+        "hostname": "host1.site-a.foo",
+        "type": "SITES",
+        "service": "c.service.foo",
+        "tags": { "scope": "TENANT", "production": "1", "monitored": "1" }
+    }
+]
+```

--- a/doc/v2/docs/topology_stats.md
+++ b/doc/v2/docs/topology_stats.md
@@ -14,7 +14,7 @@ This method may be used to retrieve topology statistics for a specific report. T
 
 ### Input
 
-##### List All latest metric data
+##### List All topology statistics
 
 ```
 /topology/stats/{report}/?[date]

--- a/doc/v2/mkdocs.yml
+++ b/doc/v2/mkdocs.yml
@@ -19,7 +19,8 @@ pages:
     - Validation Checks: validations.md
     - Metrics: metrics.md
     - Latest results: latest.md
-    - Topology statistics: topology.md
+    - Topology statistics: topology_stats.md
+    - Topology Endpoints: topology_endpoints.md
     - Weights resource: weights.md
 
 theme: readthedocs

--- a/respond/respond.go
+++ b/respond/respond.go
@@ -353,6 +353,16 @@ var NotFound = ResponseMessage{
 	},
 }
 
+var ErrNotFoundQuery = ResponseMessage{
+	Status: StatusResponse{
+		Message: "Not Found",
+		Code:    "404",
+	},
+	Errors: []StatusResponse{
+		{Message: "Not Found", Code: "404", Details: "Specific query returned no items"},
+	},
+}
+
 // NotFound is used to inform the user about not found item
 var ErrNotFound = ResponseMessage{
 	Status: StatusResponse{

--- a/scripts/mongodb/populate_default_roles.js
+++ b/scripts/mongodb/populate_default_roles.js
@@ -152,6 +152,10 @@ function populate_default_roles() {
         {
             resource: "recomputations.update",
             roles: ["admin", "editor", "admin_ui"]
+        },
+        {
+            resource: "topology_endpoints.insert",
+            roles: ["admin", "editor"]
         }
     ]);
     print("INFO\tPolulated default roles in 'roles' collection");

--- a/scripts/mongodb/populate_default_roles.js
+++ b/scripts/mongodb/populate_default_roles.js
@@ -19,7 +19,7 @@ function populate_default_roles() {
     print("INFO\tOpened argo_core db");
     db.roles.insert([
         {
-            resource: "topology.list",
+            resource: "topology_stats.list",
             roles: ["admin", "editor", "viewer", "admin_ui"]
         },
         {
@@ -155,6 +155,10 @@ function populate_default_roles() {
         },
         {
             resource: "topology_endpoints.insert",
+            roles: ["admin", "editor"]
+        },
+        {
+            resource: "topology_endpoints.list",
             roles: ["admin", "editor"]
         }
     ]);


### PR DESCRIPTION
:warning: to be reviewed after https://github.com/ARGOeu/argo-web-api/pull/326

## Goal
Diplay endpoint topology per day 

## Implementation
In existing topology package implement a new api call in the following route:
`GET /api/v2/topology/endpoints?date=2019-12-12`

The model that describes each item in endpoint topology per day is the following:
```
{ 
  "date" : "date representation in daily format YYYY-DD-MM",
  "hostname": "endpoint's hostname",
  "service": "endpoint's service type",
  "group" :"endpoint group that the endpoint belongs to",
  "type": "endpoint group type like SITES or SERVICEGROUPS or other",
  "tags": { "key": "value", "key2": "value2}
}
```
Each daily topology consists of a list of the above items like in the following example:
```
[
{"date"="2019-12-12", "group": "SITE_A", "hostname": "host1.site-a.foo", "type": "SITES", "service": "a.service.foo", "tags": {"scope": "TENANT", "production": "1", "monitored": "1"}},
{"date"="2019-12-12", "group": "SITE_A", "hostname": "host2.site-b.foo", "type": "SITES", "service": "b.service.foo", "tags": {"scope": "TENANT", "production": "1", "monitored": "1"}},
{"date"="2019-12-12", "group": "SITE_B", "hostname": "host1.site-a.foo", "type": "SITES", "service": "c.service.foo", "tags": {"scope": "TENANT", "production": "1", "monitored": "1"}}
]
```

If user tries to query for a topology and topology doesn't exists, he will receive the following message
```
{
    "message": "Topology already exists for date: 2019-03-03, please either update it or delete it first!",
    "code": "409"
}
```
 
 - [x] Add a new handler for listing  endpoint topologies per day allowing to insert many endpoint items per request in the datastore
 - [x] Add unit tests
 - [x] update docs
 - [x] update swagger