### PR TITLE
ARGO-2112 List group topology per day

### DIFF
--- a/app/topology/routing.go
+++ b/app/topology/routing.go
@@ -44,6 +44,7 @@ func HandleSubrouter(s *mux.Router, confhandler *respond.ConfHandler) {
 }
 
 var appRoutesV2 = []respond.AppRoutes{
+	{"topology_groups.list", "GET", "/groups", ListGroups},
 	{"topology_groups.insert", "POST", "/groups", CreateGroups},
 	{"topology_endpoints.insert", "POST", "/endpoints", CreateEndpoints},
 	{"topology_endpoints.list", "GET", "/endpoints", ListEndpoints},

--- a/app/topology/view.go
+++ b/app/topology/view.go
@@ -44,8 +44,22 @@ func createTopoView(results Topology, msg string, code int) ([]byte, error) {
 
 }
 
-// createListView constructs the list response template and exports it as json
 func createListEndpoint(results []Endpoint, msg string, code int) ([]byte, error) {
+
+	docRoot := &respond.ResponseMessage{
+		Status: respond.StatusResponse{
+			Message: msg,
+			Code:    strconv.Itoa(code),
+		},
+	}
+	docRoot.Data = results
+
+	output, err := json.MarshalIndent(docRoot, "", " ")
+	return output, err
+
+}
+
+func createListGroup(results []Group, msg string, code int) ([]byte, error) {
 
 	docRoot := &respond.ResponseMessage{
 		Status: respond.StatusResponse{

--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -1820,6 +1820,36 @@ paths:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Status_error'
+    get:
+      summary: List group topology per date
+      operationId: topology_groups.list
+      description: List group topology per date
+      tags:
+        - Topology
+      consumes:
+        - "application/json"
+      produces:
+        - "application/json"
+      parameters:
+        - $ref: "#/parameters/apiKey"
+        - $ref: "#/parameters/profDate"
+      responses:
+        '200':
+          description: Topology resources listed
+          schema:
+            $ref: '#/definitions/Self_reference'
+        '401':
+          description: Unauthorized user
+          schema:
+            $ref: '#/definitions/Status_error'
+        '406':
+          description: Content Not acceptable
+          schema:
+            $ref: '#/definitions/Status_error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Status_error'
           
   /topology/endpoints:
     post:
@@ -1846,20 +1876,12 @@ paths:
           description: Topology resource Created
           schema:
             $ref: '#/definitions/Self_reference'
-        '400':
-          description: Bad request due to malformed JSON in post body
-          schema:
-            $ref: '#/definitions/Status_error'
         '401':
           description: Unauthorized user
           schema:
             $ref: '#/definitions/Status_error'
         '406':
           description: Content Not acceptable
-          schema:
-            $ref: '#/definitions/Status_error'
-        '409':
-          description: Content already created for specific date
           schema:
             $ref: '#/definitions/Status_error'
         default:
@@ -1882,23 +1904,15 @@ paths:
         - $ref: "#/parameters/profDate"
       responses:
         '200':
-          description: Topology resource Created
+          description: Topology resource listed
           schema:
             $ref: '#/definitions/Self_reference'
-        '400':
-          description: Bad request due to malformed JSON in post body
-          schema:
-            $ref: '#/definitions/Status_error'
         '401':
           description: Unauthorized user
           schema:
             $ref: '#/definitions/Status_error'
         '406':
           description: Content Not acceptable
-          schema:
-            $ref: '#/definitions/Status_error'
-        '409':
-          description: Content already created for specific date
           schema:
             $ref: '#/definitions/Status_error'
         default:
@@ -1938,7 +1952,6 @@ paths:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Status_error'
-            
 
   /latest/{report_name}/{lgroup_type}:
     get:

--- a/doc/v2/docs/topology_endpoints.md
+++ b/doc/v2/docs/topology_endpoints.md
@@ -1,4 +1,4 @@
-#Topology Endpoints
+# Topology Endpoints
 
 API calls for handling topology endpoint resources
 

--- a/doc/v2/docs/topology_groups.md
+++ b/doc/v2/docs/topology_groups.md
@@ -2,9 +2,10 @@
 
 API calls for handling topology group resources
 
-| Name                                             | Description                                                         | Shortcut                     |
-| ------------------------------------------------ | ------------------------------------------------------------------- | ---------------------------- |
-| POST: Create endpoint topology for specific date | Creates a daily group topology mapping endpoints to endpoint groups | <a href="#1">Description</a> |
+| Name                                          | Description                                                         | Shortcut                     |
+| --------------------------------------------- | ------------------------------------------------------------------- | ---------------------------- |
+| POST: Create group topology for specific date | Creates a daily group topology mapping endpoints to endpoint groups | <a href="#1">Description</a> |
+| GET: List group topology for specific date    | Lists group topology for a specific date                            | <a href="#2">Description</a> |
 
 <a id="1"></a>
 
@@ -103,3 +104,83 @@ Status: 409 Conflict
 ```
 
 User can proceed with either updating the existing topology OR deleting before trying to create it anew
+
+<a id="2"></a>
+
+## POST: List group topology for specific date
+
+Lists group topology items for specific date
+
+### Input
+
+```
+GET /topology/groups?date=YYYY-MM-DD
+```
+
+#### Url Parameters
+
+| Type   | Description            | Required | Default value |
+| ------ | ---------------------- | -------- | ------------- |
+| `date` | target a specific date | NO       | today's date  |
+
+#### Headers
+
+```
+x-api-key: secret_key_value
+Accept: application/json
+```
+
+#### Example Request
+
+```
+GET /topology/groups?date=2015-07-22
+```
+
+#### Response Code
+
+```
+Status: 200 OK
+```
+
+### Response body
+
+```json
+{
+    "status": {
+        "message": "Success",
+        "code": "200"
+    },
+    "data": [
+        {
+            "date": "2015-07-22",
+            "group": "NGIA",
+            "type": "NGIS",
+            "subgroup": "SITEA",
+            "tags": {
+                "certification": "Certified",
+                "infrastructure": "Production"
+            }
+        },
+        {
+            "date": "2015-07-22",
+            "group": "NGIA",
+            "type": "NGIS",
+            "subgroup": "SITEB",
+            "tags": {
+                "certification": "Certified",
+                "infrastructure": "Production"
+            }
+        },
+        {
+            "date": "2015-07-22",
+            "group": "NGIX",
+            "type": "NGIS",
+            "subgroup": "SITEX",
+            "tags": {
+                "certification": "Certified",
+                "infrastructure": "Production"
+            }
+        }
+    ]
+}
+```

--- a/scripts/mongodb/populate_default_roles.js
+++ b/scripts/mongodb/populate_default_roles.js
@@ -168,6 +168,10 @@ function populate_default_roles() {
         {
             resource: "topology_groups.insert",
             roles: ["admin", "editor"]
+        },
+        {
+            resource: "topology_groups.list",
+            roles: ["admin", "editor"]
         }
     ]);
     print("INFO\tPolulated default roles in 'roles' collection");


### PR DESCRIPTION
:warning: to be reviewed after /pull/330
### Goal
Allow to list group topology information per date

### Implementation
In existing `topology` package implement a new api call in the following route:
`GET /api/v2/topology/groups`

The model that describes each item in group topology per day is the following:
```json
{ 
  "date" : "date representation in daily format YYYY-DD-MM",
  "group" :"group name",
  "type": "group type like PROJECTS, NGIS or other",
 "subgroup": "subgroup name that is contained in this group",
  "tags": { "key": "value", "key2": "value2"}
}
```
Each daily topology consists of a list of the above items like in the following example:
```json
[
    {
        "group": "NGIA",
        "type": "NGIS",
        "service": "SITEA",
        "tags": {
            "scope": "FEDERATION",
            "infrastructure": "Production",
            "certification": "Certified"
        }
    },
    {
        "group": "NGIA",
        "type": "NGIS",
        "service": "SITEB",
        "tags": {
            "scope": "FEDERATION",
            "infrastructure": "Production",
            "certification": "Certified"
        }
    },
    {
        "group": "NGIZ",
        "type": "NGIS",
        "service": "SITEZ",
        "tags": {
            "scope": "FEDERATION",
            "infrastructure": "Production",
            "certification": "Certified"
        }
    }
]
```


- [x] Add a new handler for listing group topologies per day 
- [x] Add unit tests
- [x] update docs
- [x] update swagger


