### PR TITLE
ARGO-2106 Delete group topology

### DIFF
--- a/app/topology/routing.go
+++ b/app/topology/routing.go
@@ -44,6 +44,7 @@ func HandleSubrouter(s *mux.Router, confhandler *respond.ConfHandler) {
 }
 
 var appRoutesV2 = []respond.AppRoutes{
+	{"topology_groups.delete", "DELETE", "/groups", DeleteGroups},
 	{"topology_groups.list", "GET", "/groups", ListGroups},
 	{"topology_groups.insert", "POST", "/groups", CreateGroups},
 	{"topology_endpoints.insert", "POST", "/endpoints", CreateEndpoints},

--- a/app/topology/topology_test.go
+++ b/app/topology/topology_test.go
@@ -164,6 +164,11 @@ func (suite *topologyTestSuite) SetupTest() {
 	c = session.DB(suite.cfg.MongoDB.Db).C("roles")
 	c.Insert(
 		bson.M{
+			"resource": "topology_groups.delete",
+			"roles":    []string{"editor", "viewer"},
+		})
+	c.Insert(
+		bson.M{
 			"resource": "topology_groups.list",
 			"roles":    []string{"editor", "viewer"},
 		})
@@ -1167,6 +1172,58 @@ func (suite *topologyTestSuite) TestListGroups5() {
 	suite.Equal(404, code, "Internal Server Error")
 	// Compare the expected and actual json response
 	suite.Equal(profileJSON, output, "Response body mismatch")
+}
+
+func (suite *topologyTestSuite) TestDeleteGroups() {
+
+	request, _ := http.NewRequest("DELETE", "/api/v2/topology/groups?date=2015-07-22", strings.NewReader(""))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code := response.Code
+	output := response.Body.String()
+
+	output1JSON := `{
+ "message": "Topology of 3 groups deleted for date: 2015-07-22",
+ "code": "200"
+}`
+
+	output2JSON := `{
+ "status": {
+  "message": "Not Found",
+  "code": "404"
+ },
+ "errors": [
+  {
+   "message": "Not Found",
+   "code": "404",
+   "details": "Specific query returned no items"
+  }
+ ]
+}`
+	// Check that we must have a 200 ok code
+	suite.Equal(200, code, "Internal Server Error")
+	// Compare the expected and actual json response
+	suite.Equal(output1JSON, output, "Response body mismatch")
+
+	request, _ = http.NewRequest("DELETE", "/api/v2/topology/groups?date=2015-08-10", strings.NewReader(""))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+	response = httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code = response.Code
+	output = response.Body.String()
+
+	// Check that we must have a 404 not found
+	suite.Equal(404, code, "Internal Server Error")
+	// Compare the expected and actual json response
+	suite.Equal(output2JSON, output, "Response body mismatch")
+
 }
 
 // TestListTopologyStats

--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -1850,6 +1850,39 @@ paths:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Status_error'
+    
+    delete:
+      summary: Delete topology of groups for a specific date
+      operationId: topology_groups.delete
+      description: Delete a list of groups (topology) for a specific date
+      tags:
+        - Topology
+      produces:
+        - "application/json"
+      parameters:
+        - $ref: "#/parameters/apiKey"
+        - $ref: "#/parameters/profDate"
+      responses:
+        '200':
+          description: groups topology definition Deleted
+          schema:
+            $ref: '#/definitions/Status'
+        '401':
+          description: Unauthorized user
+          schema:
+            $ref: '#/definitions/Status_error'
+        '404':
+          description: Item not found
+          schema:
+            $ref: '#/definitions/Status_error'
+        '406':
+          description: Content Not acceptable
+          schema:
+            $ref: '#/definitions/Status_error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Status_error'
           
   /topology/endpoints:
     post:

--- a/doc/v2/docs/topology_groups.md
+++ b/doc/v2/docs/topology_groups.md
@@ -1,11 +1,12 @@
-#Topology Groups
+# Topology Groups
 
 API calls for handling topology group resources
 
-| Name                                          | Description                                                         | Shortcut                     |
-| --------------------------------------------- | ------------------------------------------------------------------- | ---------------------------- |
-| POST: Create group topology for specific date | Creates a daily group topology mapping endpoints to endpoint groups | <a href="#1">Description</a> |
-| GET: List group topology for specific date    | Lists group topology for a specific date                            | <a href="#2">Description</a> |
+| Name                                            | Description                                                         | Shortcut                     |
+| ----------------------------------------------- | ------------------------------------------------------------------- | ---------------------------- |
+| POST: Create group topology for specific date   | Creates a daily group topology mapping endpoints to endpoint groups | <a href="#1">Description</a> |
+| GET: List group topology for specific date      | Lists group topology for a specific date                            | <a href="#2">Description</a> |
+| DELETE: Delete group topology for specific date | Delete group topology items for specific date                       | <a href="#3">Description</a> |
 
 <a id="1"></a>
 
@@ -182,5 +183,40 @@ Status: 200 OK
             }
         }
     ]
+}
+```
+
+<a id='3'></a>
+
+## [DELETE]: Delete group topology for a specific date
+
+This method can be used to delete all group items contributing to the group topology of a specific date
+
+### Input
+
+```
+DELETE /topology/groups?date=YYYY-MM-DD
+```
+
+#### Request headers
+
+```
+x-api-key: shared_key_value
+Content-Type: application/json
+Accept: application/json
+```
+
+### Response
+
+Headers: `Status: 200 OK`
+
+#### Response body
+
+Json Response
+
+```json
+{
+    "message": "Topology of 3 groups deleted for date: 2019-12-12",
+    "code": "200"
 }
 ```

--- a/scripts/mongodb/populate_default_roles.js
+++ b/scripts/mongodb/populate_default_roles.js
@@ -172,6 +172,10 @@ function populate_default_roles() {
         {
             resource: "topology_groups.list",
             roles: ["admin", "editor"]
+        },
+        {
+            resource: "topology_groups.delete",
+            roles: ["admin", "editor"]
         }
     ]);
     print("INFO\tPolulated default roles in 'roles' collection");


### PR DESCRIPTION
:warning: to be reviewed after: https://github.com/ARGOeu/argo-web-api/pull/331

## Goal 
Allow to delete group endpoints for a specific date 

example
```
DELETE /v2/api/group/endpoints?date=YYYY-MM-DD
```

## Implementation 
- [x] Add an Group Delete handler in topology package
- [x] Update routing and roles
- [x] Add unit tests
- [x] Update docs
- [x] Update swagger
