### PR TITLE
ARGO-2185 Support basic filtering when listing endpoint topology

### DIFF
--- a/app/topology/model.go
+++ b/app/topology/model.go
@@ -50,6 +50,13 @@ type messageOUT struct {
 	Code    string   `xml:"code,omitempty" json:"code,omitempty"`
 }
 
+type fltrEndpoint struct {
+	Group     string
+	GroupType string
+	Service   string
+	Hostname  string
+}
+
 // Endpoint includes information on endpoint group topology
 type Endpoint struct {
 	Date      string            `bson:"date" json:"date"`

--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -1933,6 +1933,22 @@ paths:
       produces:
         - "application/json"
       parameters:
+        - in: query
+          name: name
+          type: string
+          description: filter results by group name
+        - in: query
+          name: type
+          type: string
+          description: filter results by group type
+        - in: query
+          name: service
+          type: string
+          description: filter results by service
+        - in: query
+          name: hostname
+          type: string
+          description: filter results by hostname
         - $ref: "#/parameters/apiKey"
         - $ref: "#/parameters/profDate"
       responses:

--- a/doc/v2/docs/topology_endpoints.md
+++ b/doc/v2/docs/topology_endpoints.md
@@ -113,9 +113,15 @@ GET /topology/endpoints?date=YYYY-MM-DD
 
 #### Url Parameters
 
-| Type   | Description            | Required | Default value |
-| ------ | ---------------------- | -------- | ------------- |
-| `date` | target a specific date | NO       | today's date  |
+| Type       | Description            | Required | Default value |
+| ---------- | ---------------------- | -------- | ------------- |
+| `date`     | target a specific date | NO       | today's date  |
+| `group`    | filter by group name   | NO       |               |
+| `type`     | filter by group type   | NO       |               |
+| `service`  | filter by service      | NO       |               |
+| `hostname` | filter by hostname     | NO       |               |
+
+_note_ : user can use wildcard \* in filters
 
 #### Headers
 


### PR DESCRIPTION
# Goal 
When listing endpoint topology allow filtering results by using the basic fields
`GET /api/v2/topology/endpoints?date=YYYY-MM-DD&group=val1&type=val2&hostname=val3&service=val4`
User can also use wildcards* in filter values

# Implementation
- [x] Add a FilterEndpoint structure in models to hold filter url query data
- [x] Add a prepareEndpointQuery method that checks filter url query data and prepares accordingly the datastore query 
- [x] update unit tests
- [x] update swagger
- [x] update docs