### PR TITLE
ARGO-2189 Support basic filtering when listing group topology

### DIFF
--- a/app/topology/model.go
+++ b/app/topology/model.go
@@ -57,6 +57,12 @@ type fltrEndpoint struct {
 	Hostname  string
 }
 
+type fltrGroup struct {
+	Group     string
+	GroupType string
+	Subgroup  string
+}
+
 // Endpoint includes information on endpoint group topology
 type Endpoint struct {
 	Date      string            `bson:"date" json:"date"`

--- a/app/topology/topology_test.go
+++ b/app/topology/topology_test.go
@@ -702,6 +702,119 @@ func (suite *topologyTestSuite) TestCreateGroupTopology() {
 
 }
 
+func (suite *topologyTestSuite) TestListFilterGroups() {
+
+	type TestReq struct {
+		Path string
+		Code int
+		JSON string
+	}
+
+	expected := []TestReq{
+		TestReq{
+			Path: "/api/v2/topology/groups?date=2015-06-30&group=NGIA",
+			Code: 200,
+			JSON: `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "date": "2015-06-22",
+   "group": "NGIA",
+   "type": "NGIS",
+   "subgroup": "SITEA",
+   "tags": {
+    "certification": "Certified",
+    "infrastructure": "Production"
+   }
+  },
+  {
+   "date": "2015-06-22",
+   "group": "NGIA",
+   "type": "NGIS",
+   "subgroup": "SITEB",
+   "tags": {
+    "certification": "Certified",
+    "infrastructure": "Production"
+   }
+  }
+ ]
+}`},
+		TestReq{
+			Path: "/api/v2/topology/groups?date=2015-06-30&group=NGIA&subgroup=SITEB",
+			Code: 200,
+			JSON: `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "date": "2015-06-22",
+   "group": "NGIA",
+   "type": "NGIS",
+   "subgroup": "SITEB",
+   "tags": {
+    "certification": "Certified",
+    "infrastructure": "Production"
+   }
+  }
+ ]
+}`},
+		TestReq{
+			Path: "/api/v2/topology/groups?date=2015-06-30&subgroup=*A",
+			Code: 200,
+			JSON: `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "date": "2015-06-22",
+   "group": "NGIA",
+   "type": "NGIS",
+   "subgroup": "SITEA",
+   "tags": {
+    "certification": "Certified",
+    "infrastructure": "Production"
+   }
+  }
+ ]
+}`},
+		TestReq{
+			Path: "/api/v2/topology/groups?date=2015-06-30&subgroup=A*",
+			Code: 200,
+			JSON: `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": []
+}`},
+	}
+
+	for _, exp := range expected {
+		request, _ := http.NewRequest("GET", exp.Path, strings.NewReader(""))
+		request.Header.Set("x-api-key", suite.clientkey)
+		request.Header.Set("Accept", "application/json")
+		response := httptest.NewRecorder()
+
+		suite.router.ServeHTTP(response, request)
+
+		code := response.Code
+		output := response.Body.String()
+
+		// Check that we must have a 200 ok code
+		suite.Equal(exp.Code, code, "Response Code Mismatch on call:"+exp.Path)
+		// Compare the expected and actual json response
+		suite.Equal(exp.JSON, output, "Response body mismatch on call:"+exp.Path)
+
+	}
+}
+
 func (suite *topologyTestSuite) TestListFilterEndpoints() {
 
 	type TestReq struct {
@@ -741,19 +854,7 @@ func (suite *topologyTestSuite) TestListFilterEndpoints() {
   "message": "Success",
   "code": "200"
  },
- "data": [
-  {
-   "date": "2015-08-10",
-   "group": "SITEB",
-   "type": "SITES",
-   "service": "service_x",
-   "hostname": "host0.site_b.foo",
-   "tags": {
-    "monitored": "0",
-    "production": "0"
-   }
-  }
- ]
+ "data": []
 }`},
 		TestReq{
 			Path: "/api/v2/topology/endpoints?service=serv*",

--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -1831,6 +1831,18 @@ paths:
       produces:
         - "application/json"
       parameters:
+        - in: query
+          name: name
+          type: string
+          description: filter results by group name
+        - in: query
+          name: type
+          type: string
+          description: filter results by group type
+        - in: query
+          name: subgroup
+          type: string
+          description: filter results by subgroup
         - $ref: "#/parameters/apiKey"
         - $ref: "#/parameters/profDate"
       responses:

--- a/doc/v2/docs/topology_groups.md
+++ b/doc/v2/docs/topology_groups.md
@@ -120,9 +120,14 @@ GET /topology/groups?date=YYYY-MM-DD
 
 #### Url Parameters
 
-| Type   | Description            | Required | Default value |
-| ------ | ---------------------- | -------- | ------------- |
-| `date` | target a specific date | NO       | today's date  |
+| Type       | Description            | Required | Default value |
+| ---------- | ---------------------- | -------- | ------------- |
+| `date`     | target a specific date | NO       | today's date  |
+| `group`    | filter by group name   | NO       |               |
+| `type`     | filter by group type   | NO       |               |
+| `subgroup` | filter by subgroup     | NO       |               |
+
+_note_ : user can use wildcard \* in filters
 
 #### Headers
 


### PR DESCRIPTION
# Goal 
When listing group topology allow filtering results by using the basic fields
`GET /api/v2/topology/groups?date=YYYY-MM-DD&group=val1&type=val2&subgroup=val3`
User can also use wildcards* in filter values

# Implementation
- [x] Add a FilterGroup structure in models to hold filter url query data
- [x] Add a prepareGroupQuery method that checks filter url query data and prepares accordingly the datastore query 
- [x] update unit tests
- [x] update swagger
- [x] update docs