### PR TITLE
ARGO-2186 Support tags filtering in endpoint topology

### DIFF
--- a/app/topology/model.go
+++ b/app/topology/model.go
@@ -55,12 +55,14 @@ type fltrEndpoint struct {
 	GroupType string
 	Service   string
 	Hostname  string
+	Tags      string
 }
 
 type fltrGroup struct {
 	Group     string
 	GroupType string
 	Subgroup  string
+	Tags      string
 }
 
 // Endpoint includes information on endpoint group topology

--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -1961,6 +1961,10 @@ paths:
           name: hostname
           type: string
           description: filter results by hostname
+        - in: query
+          name: tags
+          type: string
+          description: filter results by tags using the pattern tags=key:value,key:value etc...
         - $ref: "#/parameters/apiKey"
         - $ref: "#/parameters/profDate"
       responses:

--- a/doc/v2/docs/topology_endpoints.md
+++ b/doc/v2/docs/topology_endpoints.md
@@ -113,15 +113,17 @@ GET /topology/endpoints?date=YYYY-MM-DD
 
 #### Url Parameters
 
-| Type       | Description            | Required | Default value |
-| ---------- | ---------------------- | -------- | ------------- |
-| `date`     | target a specific date | NO       | today's date  |
-| `group`    | filter by group name   | NO       |               |
-| `type`     | filter by group type   | NO       |               |
-| `service`  | filter by service      | NO       |               |
-| `hostname` | filter by hostname     | NO       |               |
+| Type       | Description                   | Required | Default value |
+| ---------- | ----------------------------- | -------- | ------------- |
+| `date`     | target a specific date        | NO       | today's date  |
+| `group`    | filter by group name          | NO       |               |
+| `type`     | filter by group type          | NO       |               |
+| `service`  | filter by service             | NO       |               |
+| `hostname` | filter by hostname            | NO       |               |
+| `tags`     | filter by tag key:value pairs | NO       |               |
 
 _note_ : user can use wildcard \* in filters
+_note_ : when using tags filter the query string must follow the pattern: `?tags=key1:value1,key2:value2`
 
 #### Headers
 


### PR DESCRIPTION
# Goal
Allow users to filter endpoint topology using tags key value pairs

# Implementation
Allow a new query paramterer named tags to be used to define tag key:value pair filters in the following pattern:
`GET /v2/api/topology/endpoints?tags=key1:value1,key2:value2`

- [x] Modify prepEndpointQuery to receive `tags` url query string and construct corresponding datastore filters on tags nested dictionaries
- [x] Update unit tests
- [x] Update swagger
- [x] Update docs