### PR TITLE
ARGO-2190 Support tags filtering when listing group topology

### DIFF
--- a/app/topology/controller.go
+++ b/app/topology/controller.go
@@ -552,6 +552,11 @@ func prepGroupQuery(date int, filter fltrGroup) bson.M {
 		}
 	}
 
+	// check if tags exist to append them to query
+	if filter.Tags != "" {
+		appendTags(query, filter.Tags)
+	}
+
 	return query
 }
 
@@ -594,6 +599,7 @@ func ListGroups(r *http.Request, cfg config.Config) (int, http.Header, []byte, e
 	fltr.Group = urlValues.Get("group")
 	fltr.GroupType = urlValues.Get("type")
 	fltr.Subgroup = urlValues.Get("subgroup")
+	fltr.Tags = urlValues.Get("tags")
 
 	expDate := getCloseDate(colGroup, dt)
 

--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -1843,6 +1843,10 @@ paths:
           name: subgroup
           type: string
           description: filter results by subgroup
+        - in: query
+          name: tags
+          type: string
+          description: filter results by tags using the pattern tags=key:value,key:value etc...
         - $ref: "#/parameters/apiKey"
         - $ref: "#/parameters/profDate"
       responses:

--- a/doc/v2/docs/topology_endpoints.md
+++ b/doc/v2/docs/topology_endpoints.md
@@ -123,7 +123,7 @@ GET /topology/endpoints?date=YYYY-MM-DD
 | `tags`     | filter by tag key:value pairs | NO       |               |
 
 _note_ : user can use wildcard \* in filters
-_note_ : when using tags filter the query string must follow the pattern: `?tags=key1:value1,key2:value2`
+_note_ : when using tag filters the query string must follow the pattern: `?tags=key1:value1,key2:value2`
 
 #### Headers
 

--- a/doc/v2/docs/topology_groups.md
+++ b/doc/v2/docs/topology_groups.md
@@ -120,12 +120,16 @@ GET /topology/groups?date=YYYY-MM-DD
 
 #### Url Parameters
 
-| Type       | Description            | Required | Default value |
-| ---------- | ---------------------- | -------- | ------------- |
-| `date`     | target a specific date | NO       | today's date  |
-| `group`    | filter by group name   | NO       |               |
-| `type`     | filter by group type   | NO       |               |
-| `subgroup` | filter by subgroup     | NO       |               |
+| Type       | Description                   | Required | Default value |
+| ---------- | ----------------------------- | -------- | ------------- |
+| `date`     | target a specific date        | NO       | today's date  |
+| `group`    | filter by group name          | NO       |               |
+| `type`     | filter by group type          | NO       |               |
+| `subgroup` | filter by subgroup            | NO       |               |
+| `tags`     | filter by tag key:value pairs | NO       |               |
+
+_note_ : user can use wildcard \* in filters
+_note_ : when using tag filters the query string must follow the pattern: `?tags=key1:value1,key2:value2`
 
 _note_ : user can use wildcard \* in filters
 


### PR DESCRIPTION
# Goal
Allow users to filter group topology using tags key value pairs

# Implementation
Allow a new query paramterer named tags to be used to define tag key:value pair filters in the following pattern:
`GET /v2/api/topology/groups?tags=key1:value1,key2:value2`

- [x] Modify prepGroupQuery to receive `tags` url query string and construct corresponding datastore filters on tags nested dictionaries
- [x] Update unit tests
- [x] Update swagger
- [x] Update docs