### PR TITLE
ARGO-2181 Use report topology option to filter group topology

### DIFF
--- a/app/topology/routing.go
+++ b/app/topology/routing.go
@@ -44,6 +44,7 @@ func HandleSubrouter(s *mux.Router, confhandler *respond.ConfHandler) {
 }
 
 var appRoutesV2 = []respond.AppRoutes{
+	{"topology_groups_report.list", "GET", "/groups/by_report/{report}", ListGroupsByReport},
 	{"topology_groups.delete", "DELETE", "/groups", DeleteGroups},
 	{"topology_groups.list", "GET", "/groups", ListGroups},
 	{"topology_groups.insert", "POST", "/groups", CreateGroups},

--- a/app/topology/topology_test.go
+++ b/app/topology/topology_test.go
@@ -164,6 +164,11 @@ func (suite *topologyTestSuite) SetupTest() {
 	c = session.DB(suite.cfg.MongoDB.Db).C("roles")
 	c.Insert(
 		bson.M{
+			"resource": "topology_groups_report.list",
+			"roles":    []string{"editor", "viewer"},
+		})
+	c.Insert(
+		bson.M{
 			"resource": "topology_groups.delete",
 			"roles":    []string{"editor", "viewer"},
 		})
@@ -471,6 +476,90 @@ func (suite *topologyTestSuite) SetupTest() {
 				"name":  "name2",
 				"value": "value2"},
 		}})
+
+	c.Insert(bson.M{
+		"id": "eba61a9e-22e9-4521-9e47-ecaa4a49435",
+		"info": bson.M{
+			"name":        "Critical2",
+			"description": "lalalallala",
+		},
+		"topology_schema": bson.M{
+			"group": bson.M{
+				"type": "NGIS",
+				"group": bson.M{
+					"type": "SITE",
+				},
+			},
+		},
+		"profiles": []bson.M{
+			bson.M{
+				"type": "metric",
+				"name": "ch.cern.SAM.ROC_CRITICAL"},
+		},
+		"filter_tags": []bson.M{
+			bson.M{
+				"name":  "name1",
+				"value": "value1"},
+			bson.M{
+				"name":  "name2",
+				"value": "value2"},
+		}})
+
+	c.Insert(bson.M{
+		"id": "eba61a9e-22e9-4521-9e47-ecaa4a49438",
+		"info": bson.M{
+			"name":        "Critical3",
+			"description": "lalalallala",
+		},
+		"topology_schema": bson.M{
+			"group": bson.M{
+				"type": "ORG",
+				"group": bson.M{
+					"type": "SITE",
+				},
+			},
+		},
+		"profiles": []bson.M{
+			bson.M{
+				"type": "metric",
+				"name": "ch.cern.SAM.ROC_CRITICAL"},
+		},
+		"filter_tags": []bson.M{
+			bson.M{
+				"name":  "name1",
+				"value": "value1"},
+			bson.M{
+				"name":  "name2",
+				"value": "value2"},
+		}})
+
+	c.Insert(bson.M{
+		"id": "eba61a9e-22e9-4521-9e47-ecaa4a49438",
+		"info": bson.M{
+			"name":        "Critical4",
+			"description": "lalalallala",
+		},
+		"topology_schema": bson.M{
+			"group": bson.M{
+				"type": "PROJECT",
+				"group": bson.M{
+					"type": "SITE",
+				},
+			},
+		},
+		"profiles": []bson.M{
+			bson.M{
+				"type": "metric",
+				"name": "ch.cern.SAM.ROC_CRITICAL"},
+		},
+		"filter_tags": []bson.M{
+			bson.M{
+				"name":  "name1",
+				"value": "value1"},
+			bson.M{
+				"name":  "name2",
+				"value": "value2"},
+		}})
 	// Seed database with endpoint topology
 	c = session.DB(suite.tenantDbConf.Db).C(endpointColName)
 	c.EnsureIndexKey("-date_integer", "group")
@@ -651,6 +740,30 @@ func (suite *topologyTestSuite) SetupTest() {
 			"type":         "NGIS",
 			"subgroup":     "SITEX",
 			"tags":         bson.M{"infrastructure": "Production", "certification": "Certified"},
+		},
+		bson.M{
+			"date":         "2020-01-11",
+			"date_integer": 20200111,
+			"group":        "NGIX",
+			"type":         "NGIS",
+			"subgroup":     "SITEX",
+			"tags":         bson.M{"infrastructure": "Production", "certification": "Certified"},
+		},
+		bson.M{
+			"date":         "2020-01-11",
+			"date_integer": 20200111,
+			"group":        "ORGB",
+			"type":         "ORG",
+			"subgroup":     "SITEORG",
+			"tags":         bson.M{"infrastructure": "Production", "certification": "Uncertified"},
+		},
+		bson.M{
+			"date":         "2012-01-11",
+			"date_integer": 20200111,
+			"group":        "PR01",
+			"type":         "PROJECT",
+			"subgroup":     "SITEPROJECT",
+			"tags":         bson.M{"infrastructure": "Devel", "certification": "Certified"},
 		})
 
 }
@@ -889,7 +1002,7 @@ func (suite *topologyTestSuite) TestListFilterGroupTags() {
 	}
 }
 
-func (suite *topologyTestSuite) TestListFilterEndpointTags() {
+func (suite *topologyTestSuite) TestListFilterGroupsByReport() {
 
 	type TestReq struct {
 		Path string
@@ -899,7 +1012,7 @@ func (suite *topologyTestSuite) TestListFilterEndpointTags() {
 
 	expected := []TestReq{
 		TestReq{
-			Path: "/api/v2/topology/endpoints?&date=2015-06-12&tags=production:1",
+			Path: "/api/v2/topology/groups/by_report/Critical2",
 			Code: 200,
 			JSON: `{
  "status": {
@@ -908,20 +1021,19 @@ func (suite *topologyTestSuite) TestListFilterEndpointTags() {
  },
  "data": [
   {
-   "date": "2015-06-11",
-   "group": "SITEA",
-   "type": "SITES",
-   "service": "service_1",
-   "hostname": "host1.site_a.foo",
+   "date": "2020-01-11",
+   "group": "NGIX",
+   "type": "NGIS",
+   "subgroup": "SITEX",
    "tags": {
-    "monitored": "Yes",
-    "production": "1"
+    "certification": "Certified",
+    "infrastructure": "Production"
    }
   }
  ]
 }`},
 		TestReq{
-			Path: "/api/v2/topology/endpoints?&date=2015-06-12&tags=production:1*",
+			Path: "/api/v2/topology/groups/by_report/Critical3",
 			Code: 200,
 			JSON: `{
  "status": {
@@ -930,32 +1042,20 @@ func (suite *topologyTestSuite) TestListFilterEndpointTags() {
  },
  "data": [
   {
-   "date": "2015-06-11",
-   "group": "SITEA",
-   "type": "SITES",
-   "service": "service_1",
-   "hostname": "host1.site_a.foo",
+   "date": "2020-01-11",
+   "group": "ORGB",
+   "type": "ORG",
+   "subgroup": "SITEORG",
    "tags": {
-    "monitored": "Yes",
-    "production": "1"
-   }
-  },
-  {
-   "date": "2015-06-11",
-   "group": "SITEB",
-   "type": "SITES",
-   "service": "service_1",
-   "hostname": "host1.site_b.foo",
-   "tags": {
-    "monitored": "YesNo",
-    "production": "1Prod"
+    "certification": "Uncertified",
+    "infrastructure": "Production"
    }
   }
  ]
 }`},
 
 		TestReq{
-			Path: "/api/v2/topology/endpoints?&date=2015-06-12&tags=production:1*,monitored:Yes",
+			Path: "/api/v2/topology/groups/by_report/Critical4",
 			Code: 200,
 			JSON: `{
  "status": {
@@ -964,48 +1064,13 @@ func (suite *topologyTestSuite) TestListFilterEndpointTags() {
  },
  "data": [
   {
-   "date": "2015-06-11",
-   "group": "SITEA",
-   "type": "SITES",
-   "service": "service_1",
-   "hostname": "host1.site_a.foo",
+   "date": "2012-01-11",
+   "group": "PR01",
+   "type": "PROJECT",
+   "subgroup": "SITEPROJECT",
    "tags": {
-    "monitored": "Yes",
-    "production": "1"
-   }
-  }
- ]
-}`},
-
-		TestReq{
-			Path: "/api/v2/topology/endpoints?&date=2015-06-12&tags=production:1*,monitored:Yes*",
-			Code: 200,
-			JSON: `{
- "status": {
-  "message": "Success",
-  "code": "200"
- },
- "data": [
-  {
-   "date": "2015-06-11",
-   "group": "SITEA",
-   "type": "SITES",
-   "service": "service_1",
-   "hostname": "host1.site_a.foo",
-   "tags": {
-    "monitored": "Yes",
-    "production": "1"
-   }
-  },
-  {
-   "date": "2015-06-11",
-   "group": "SITEB",
-   "type": "SITES",
-   "service": "service_1",
-   "hostname": "host1.site_b.foo",
-   "tags": {
-    "monitored": "YesNo",
-    "production": "1Prod"
+    "certification": "Certified",
+    "infrastructure": "Devel"
    }
   }
  ]
@@ -1667,13 +1732,33 @@ func (suite *topologyTestSuite) TestListGroups() {
  },
  "data": [
   {
-   "date": "2015-08-11",
+   "date": "2020-01-11",
    "group": "NGIX",
    "type": "NGIS",
    "subgroup": "SITEX",
    "tags": {
     "certification": "Certified",
     "infrastructure": "Production"
+   }
+  },
+  {
+   "date": "2020-01-11",
+   "group": "ORGB",
+   "type": "ORG",
+   "subgroup": "SITEORG",
+   "tags": {
+    "certification": "Uncertified",
+    "infrastructure": "Production"
+   }
+  },
+  {
+   "date": "2012-01-11",
+   "group": "PR01",
+   "type": "PROJECT",
+   "subgroup": "SITEPROJECT",
+   "tags": {
+    "certification": "Certified",
+    "infrastructure": "Devel"
    }
   }
  ]

--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -1899,6 +1899,44 @@ paths:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Status_error'
+            
+  /topology/groups/by_report/{report_name}:
+    get:
+      summary: List group topology per date and filter by report
+      operationId: topology_groups_report.list
+      description: List group topology per date and filter by report
+      tags:
+        - Topology
+      consumes:
+        - "application/json"
+      produces:
+        - "application/json"
+      parameters:
+        - in: path
+          name: report_name
+          type: string
+          description: filter results based on selected report
+          required: true
+        - $ref: "#/parameters/apiKey"
+        - $ref: "#/parameters/profDate"
+      responses:
+        '200':
+          description: filtered topology resources listed based on report
+          schema:
+            $ref: '#/definitions/Self_reference'
+        '401':
+          description: Unauthorized user
+          schema:
+            $ref: '#/definitions/Status_error'
+        '406':
+          description: Content Not acceptable
+          schema:
+            $ref: '#/definitions/Status_error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Status_error'
+      
           
   /topology/endpoints:
     post:

--- a/doc/v2/docs/topology_groups.md
+++ b/doc/v2/docs/topology_groups.md
@@ -7,6 +7,7 @@ API calls for handling topology group resources
 | POST: Create group topology for specific date   | Creates a daily group topology mapping endpoints to endpoint groups | <a href="#1">Description</a> |
 | GET: List group topology for specific date      | Lists group topology for a specific date                            | <a href="#2">Description</a> |
 | DELETE: Delete group topology for specific date | Delete group topology items for specific date                       | <a href="#3">Description</a> |
+| GET: List group topology for specific report    | Lists group topology for a specific report                          | <a href="#4">Description</a> |
 
 <a id="1"></a>
 
@@ -58,8 +59,8 @@ Accept: application/json
         }
     },
     {
-        "group": "NGIZ",
-        "type": "NGIS",
+        "group": "PROJECTZ",
+        "type": "PROJECT",
         "service": "SITEZ",
         "tags": {
             "scope": "FEDERATION",
@@ -108,7 +109,7 @@ User can proceed with either updating the existing topology OR deleting before t
 
 <a id="2"></a>
 
-## POST: List group topology for specific date
+## GET: List group topology for specific date
 
 Lists group topology items for specific date
 
@@ -180,16 +181,6 @@ Status: 200 OK
                 "certification": "Certified",
                 "infrastructure": "Production"
             }
-        },
-        {
-            "date": "2015-07-22",
-            "group": "NGIX",
-            "type": "NGIS",
-            "subgroup": "SITEX",
-            "tags": {
-                "certification": "Certified",
-                "infrastructure": "Production"
-            }
         }
     ]
 }
@@ -227,5 +218,86 @@ Json Response
 {
     "message": "Topology of 3 groups deleted for date: 2019-12-12",
     "code": "200"
+}
+```
+
+<a id="4"></a>
+
+## GET: List group topology for specific report
+
+Lists group topology items for specific report
+
+### Input
+
+```
+GET /topology/groups/by_report/{report-name}?date=YYYY-MM-DD
+```
+
+#### Url Parameters
+
+| Type          | Description              | Required | Default value |
+| ------------- | ------------------------ | -------- | ------------- |
+| `report-name` | target a specific report | YES      | none          |
+| `date`        | target a specific date   | NO       | today's date  |
+
+#### Headers
+
+```
+x-api-key: secret_key_value
+Accept: application/json
+```
+
+#### Example Request
+
+```
+GET /topology/groups/by_report/Critical?date=2015-07-22
+```
+
+#### Response Code
+
+```
+Status: 200 OK
+```
+
+### Response body
+
+```json
+{
+    "status": {
+        "message": "Success",
+        "code": "200"
+    },
+    "data": [
+        {
+            "date": "2015-07-22",
+            "group": "NGIA",
+            "type": "NGIS",
+            "subgroup": "SITEA",
+            "tags": {
+                "certification": "Certified",
+                "infrastructure": "Production"
+            }
+        },
+        {
+            "date": "2015-07-22",
+            "group": "NGIA",
+            "type": "NGIS",
+            "subgroup": "SITEB",
+            "tags": {
+                "certification": "Certified",
+                "infrastructure": "Production"
+            }
+        },
+        {
+            "date": "2015-07-22",
+            "group": "NGIX",
+            "type": "NGIS",
+            "subgroup": "SITEX",
+            "tags": {
+                "certification": "Certified",
+                "infrastructure": "Production"
+            }
+        }
+    ]
 }
 ```

--- a/scripts/mongodb/populate_default_roles.js
+++ b/scripts/mongodb/populate_default_roles.js
@@ -176,6 +176,10 @@ function populate_default_roles() {
         {
             resource: "topology_groups.delete",
             roles: ["admin", "editor"]
+        },
+        {
+            resource: "topology_groups_report.list",
+            roles: ["admin", "editor"]
         }
     ]);
     print("INFO\tPolulated default roles in 'roles' collection");


### PR DESCRIPTION
### Goal
Give the ability to fitler group topology based on report configuration. Each report has a topology schema reference fields which states the type of top-level and bottom-level groups. Api should read the top-level group type stated at the report and filter the group topology accordingly. The new feature is to be implemented at the following path 
`GET /api/v2/topology/groups/by_report/{report_name}`

### Implementation
- [x] Add a new routing option and implement handler to list groups per report
- [x] Update unit tests
- [x] Update swagger
- [x] Update docs 