### PR TITLE
ARGO-2192 Use report's filter tags field to automatically filter group topology

### DIFF
--- a/app/topology/controller.go
+++ b/app/topology/controller.go
@@ -573,6 +573,23 @@ func getReportEndpointGroupType(r reports.MongoInterface) string {
 	return ""
 }
 
+func getReportTags(r reports.MongoInterface) string {
+	tagStr := ""
+	first := false
+	for _, tag := range r.Tags {
+		if tag.Context == "argo.group.filter.tags" {
+			if !first {
+				tagStr = tagStr + ","
+			} else {
+				first = false
+			}
+
+			tagStr = tagStr + tag.Name + ":" + tag.Value
+		}
+	}
+	return tagStr
+}
+
 func getReportGroupType(r reports.MongoInterface) string {
 
 	if r.Topology.Group != nil {
@@ -629,6 +646,7 @@ func ListGroupsByReport(r *http.Request, cfg config.Config) (int, http.Header, [
 	}
 
 	groupType := getReportGroupType(report)
+	groupTags := getReportTags(report)
 
 	dt, dateStr, err := utils.ParseZuluDate(dateStr)
 	if err != nil {
@@ -639,6 +657,9 @@ func ListGroupsByReport(r *http.Request, cfg config.Config) (int, http.Header, [
 	fltr := fltrGroup{}
 	if groupType != "" {
 		fltr.GroupType = groupType
+	}
+	if groupTags != "" {
+		fltr.Tags = groupTags
 	}
 
 	expDate := getCloseDate(colGroup, dt)

--- a/app/topology/routing.go
+++ b/app/topology/routing.go
@@ -44,6 +44,7 @@ func HandleSubrouter(s *mux.Router, confhandler *respond.ConfHandler) {
 }
 
 var appRoutesV2 = []respond.AppRoutes{
+	{"topology_groups_report.list", "GET", "/groups/by_report/{report}", ListGroupsByReport},
 	{"topology_groups.delete", "DELETE", "/groups", DeleteGroups},
 	{"topology_groups.list", "GET", "/groups", ListGroups},
 	{"topology_groups.insert", "POST", "/groups", CreateGroups},

--- a/app/topology/topology_test.go
+++ b/app/topology/topology_test.go
@@ -164,6 +164,11 @@ func (suite *topologyTestSuite) SetupTest() {
 	c = session.DB(suite.cfg.MongoDB.Db).C("roles")
 	c.Insert(
 		bson.M{
+			"resource": "topology_groups_report.list",
+			"roles":    []string{"editor", "viewer"},
+		})
+	c.Insert(
+		bson.M{
 			"resource": "topology_groups.delete",
 			"roles":    []string{"editor", "viewer"},
 		})
@@ -471,6 +476,90 @@ func (suite *topologyTestSuite) SetupTest() {
 				"name":  "name2",
 				"value": "value2"},
 		}})
+
+	c.Insert(bson.M{
+		"id": "eba61a9e-22e9-4521-9e47-ecaa4a49435",
+		"info": bson.M{
+			"name":        "Critical2",
+			"description": "lalalallala",
+		},
+		"topology_schema": bson.M{
+			"group": bson.M{
+				"type": "NGIS",
+				"group": bson.M{
+					"type": "SITE",
+				},
+			},
+		},
+		"profiles": []bson.M{
+			bson.M{
+				"type": "metric",
+				"name": "ch.cern.SAM.ROC_CRITICAL"},
+		},
+		"filter_tags": []bson.M{
+			bson.M{
+				"name":  "name1",
+				"value": "value1"},
+			bson.M{
+				"name":  "name2",
+				"value": "value2"},
+		}})
+
+	c.Insert(bson.M{
+		"id": "eba61a9e-22e9-4521-9e47-ecaa4a49438",
+		"info": bson.M{
+			"name":        "Critical3",
+			"description": "lalalallala",
+		},
+		"topology_schema": bson.M{
+			"group": bson.M{
+				"type": "ORG",
+				"group": bson.M{
+					"type": "SITE",
+				},
+			},
+		},
+		"profiles": []bson.M{
+			bson.M{
+				"type": "metric",
+				"name": "ch.cern.SAM.ROC_CRITICAL"},
+		},
+		"filter_tags": []bson.M{
+			bson.M{
+				"name":  "name1",
+				"value": "value1"},
+			bson.M{
+				"name":  "name2",
+				"value": "value2"},
+		}})
+
+	c.Insert(bson.M{
+		"id": "eba61a9e-22e9-4521-9e47-ecaa4a49438",
+		"info": bson.M{
+			"name":        "Critical4",
+			"description": "lalalallala",
+		},
+		"topology_schema": bson.M{
+			"group": bson.M{
+				"type": "PROJECT",
+				"group": bson.M{
+					"type": "SITE",
+				},
+			},
+		},
+		"profiles": []bson.M{
+			bson.M{
+				"type": "metric",
+				"name": "ch.cern.SAM.ROC_CRITICAL"},
+		},
+		"filter_tags": []bson.M{
+			bson.M{
+				"name":  "name1",
+				"value": "value1"},
+			bson.M{
+				"name":  "name2",
+				"value": "value2"},
+		}})
 	// Seed database with endpoint topology
 	c = session.DB(suite.tenantDbConf.Db).C(endpointColName)
 	c.EnsureIndexKey("-date_integer", "group")
@@ -651,6 +740,30 @@ func (suite *topologyTestSuite) SetupTest() {
 			"type":         "NGIS",
 			"subgroup":     "SITEX",
 			"tags":         bson.M{"infrastructure": "Production", "certification": "Certified"},
+		},
+		bson.M{
+			"date":         "2020-01-11",
+			"date_integer": 20200111,
+			"group":        "NGIX",
+			"type":         "NGIS",
+			"subgroup":     "SITEX",
+			"tags":         bson.M{"infrastructure": "Production", "certification": "Certified"},
+		},
+		bson.M{
+			"date":         "2020-01-11",
+			"date_integer": 20200111,
+			"group":        "ORGB",
+			"type":         "ORG",
+			"subgroup":     "SITEORG",
+			"tags":         bson.M{"infrastructure": "Production", "certification": "Uncertified"},
+		},
+		bson.M{
+			"date":         "2012-01-11",
+			"date_integer": 20200111,
+			"group":        "PR01",
+			"type":         "PROJECT",
+			"subgroup":     "SITEPROJECT",
+			"tags":         bson.M{"infrastructure": "Devel", "certification": "Certified"},
 		})
 
 }
@@ -889,7 +1002,7 @@ func (suite *topologyTestSuite) TestListFilterGroupTags() {
 	}
 }
 
-func (suite *topologyTestSuite) TestListFilterEndpointTags() {
+func (suite *topologyTestSuite) TestListFilterGroupsByReport() {
 
 	type TestReq struct {
 		Path string
@@ -899,7 +1012,7 @@ func (suite *topologyTestSuite) TestListFilterEndpointTags() {
 
 	expected := []TestReq{
 		TestReq{
-			Path: "/api/v2/topology/endpoints?&date=2015-06-12&tags=production:1",
+			Path: "/api/v2/topology/groups/by_report/Critical2",
 			Code: 200,
 			JSON: `{
  "status": {
@@ -908,20 +1021,19 @@ func (suite *topologyTestSuite) TestListFilterEndpointTags() {
  },
  "data": [
   {
-   "date": "2015-06-11",
-   "group": "SITEA",
-   "type": "SITES",
-   "service": "service_1",
-   "hostname": "host1.site_a.foo",
+   "date": "2020-01-11",
+   "group": "NGIX",
+   "type": "NGIS",
+   "subgroup": "SITEX",
    "tags": {
-    "monitored": "Yes",
-    "production": "1"
+    "certification": "Certified",
+    "infrastructure": "Production"
    }
   }
  ]
 }`},
 		TestReq{
-			Path: "/api/v2/topology/endpoints?&date=2015-06-12&tags=production:1*",
+			Path: "/api/v2/topology/groups/by_report/Critical3",
 			Code: 200,
 			JSON: `{
  "status": {
@@ -930,32 +1042,20 @@ func (suite *topologyTestSuite) TestListFilterEndpointTags() {
  },
  "data": [
   {
-   "date": "2015-06-11",
-   "group": "SITEA",
-   "type": "SITES",
-   "service": "service_1",
-   "hostname": "host1.site_a.foo",
+   "date": "2020-01-11",
+   "group": "ORGB",
+   "type": "ORG",
+   "subgroup": "SITEORG",
    "tags": {
-    "monitored": "Yes",
-    "production": "1"
-   }
-  },
-  {
-   "date": "2015-06-11",
-   "group": "SITEB",
-   "type": "SITES",
-   "service": "service_1",
-   "hostname": "host1.site_b.foo",
-   "tags": {
-    "monitored": "YesNo",
-    "production": "1Prod"
+    "certification": "Uncertified",
+    "infrastructure": "Production"
    }
   }
  ]
 }`},
 
 		TestReq{
-			Path: "/api/v2/topology/endpoints?&date=2015-06-12&tags=production:1*,monitored:Yes",
+			Path: "/api/v2/topology/groups/by_report/Critical4",
 			Code: 200,
 			JSON: `{
  "status": {
@@ -964,48 +1064,13 @@ func (suite *topologyTestSuite) TestListFilterEndpointTags() {
  },
  "data": [
   {
-   "date": "2015-06-11",
-   "group": "SITEA",
-   "type": "SITES",
-   "service": "service_1",
-   "hostname": "host1.site_a.foo",
+   "date": "2012-01-11",
+   "group": "PR01",
+   "type": "PROJECT",
+   "subgroup": "SITEPROJECT",
    "tags": {
-    "monitored": "Yes",
-    "production": "1"
-   }
-  }
- ]
-}`},
-
-		TestReq{
-			Path: "/api/v2/topology/endpoints?&date=2015-06-12&tags=production:1*,monitored:Yes*",
-			Code: 200,
-			JSON: `{
- "status": {
-  "message": "Success",
-  "code": "200"
- },
- "data": [
-  {
-   "date": "2015-06-11",
-   "group": "SITEA",
-   "type": "SITES",
-   "service": "service_1",
-   "hostname": "host1.site_a.foo",
-   "tags": {
-    "monitored": "Yes",
-    "production": "1"
-   }
-  },
-  {
-   "date": "2015-06-11",
-   "group": "SITEB",
-   "type": "SITES",
-   "service": "service_1",
-   "hostname": "host1.site_b.foo",
-   "tags": {
-    "monitored": "YesNo",
-    "production": "1Prod"
+    "certification": "Certified",
+    "infrastructure": "Devel"
    }
   }
  ]
@@ -1667,13 +1732,33 @@ func (suite *topologyTestSuite) TestListGroups() {
  },
  "data": [
   {
-   "date": "2015-08-11",
+   "date": "2020-01-11",
    "group": "NGIX",
    "type": "NGIS",
    "subgroup": "SITEX",
    "tags": {
     "certification": "Certified",
     "infrastructure": "Production"
+   }
+  },
+  {
+   "date": "2020-01-11",
+   "group": "ORGB",
+   "type": "ORG",
+   "subgroup": "SITEORG",
+   "tags": {
+    "certification": "Uncertified",
+    "infrastructure": "Production"
+   }
+  },
+  {
+   "date": "2012-01-11",
+   "group": "PR01",
+   "type": "PROJECT",
+   "subgroup": "SITEPROJECT",
+   "tags": {
+    "certification": "Certified",
+    "infrastructure": "Devel"
    }
   }
  ]

--- a/app/topology/topology_test.go
+++ b/app/topology/topology_test.go
@@ -506,7 +506,7 @@ func (suite *topologyTestSuite) SetupTest() {
 		}})
 
 	c.Insert(bson.M{
-		"id": "eba61a9e-22e9-4521-9e47-ecaa4a49438",
+		"id": "eba61a9e-22e9-4521-9e47-ecaa4a4943x",
 		"info": bson.M{
 			"name":        "Critical3",
 			"description": "lalalallala",
@@ -534,7 +534,7 @@ func (suite *topologyTestSuite) SetupTest() {
 		}})
 
 	c.Insert(bson.M{
-		"id": "eba61a9e-22e9-4521-9e47-ecaa4a49438",
+		"id": "eba61a9e-22e9-4521-9e47-ecaa4a4943p",
 		"info": bson.M{
 			"name":        "Critical4",
 			"description": "lalalallala",
@@ -559,6 +559,57 @@ func (suite *topologyTestSuite) SetupTest() {
 			bson.M{
 				"name":  "name2",
 				"value": "value2"},
+		}})
+	c.Insert(bson.M{
+		"id": "eba61a9e-22e9-4521-9e47-ecaa4a4943d",
+		"info": bson.M{
+			"name":        "Critical5",
+			"description": "lalalallala",
+		},
+		"topology_schema": bson.M{
+			"group": bson.M{
+				"type": "PROJECT",
+				"group": bson.M{
+					"type": "SITE",
+				},
+			},
+		},
+		"profiles": []bson.M{
+			bson.M{
+				"type": "metric",
+				"name": "ch.cern.SAM.ROC_CRITICAL"},
+		},
+		"filter_tags": []bson.M{
+			bson.M{
+				"context": "argo.group.filter.tags",
+				"name":    "infrastructure",
+				"value":   "Devel"},
+		}})
+
+	c.Insert(bson.M{
+		"id": "eba61a9e-22e9-4521-9e47-ecaa4a4943z",
+		"info": bson.M{
+			"name":        "Critical6",
+			"description": "lalalallala",
+		},
+		"topology_schema": bson.M{
+			"group": bson.M{
+				"type": "PROJECT",
+				"group": bson.M{
+					"type": "SITE",
+				},
+			},
+		},
+		"profiles": []bson.M{
+			bson.M{
+				"type": "metric",
+				"name": "ch.cern.SAM.ROC_CRITICAL"},
+		},
+		"filter_tags": []bson.M{
+			bson.M{
+				"context": "argo.group.filter.tags",
+				"name":    "certification",
+				"value":   "Certified"},
 		}})
 	// Seed database with endpoint topology
 	c = session.DB(suite.tenantDbConf.Db).C(endpointColName)
@@ -746,8 +797,24 @@ func (suite *topologyTestSuite) SetupTest() {
 			"date_integer": 20200111,
 			"group":        "NGIX",
 			"type":         "NGIS",
-			"subgroup":     "SITEX",
+			"subgroup":     "SITEXYZ",
+			"tags":         bson.M{"infrastructure": "Devel", "certification": "Uncertified"},
+		},
+		bson.M{
+			"date":         "2020-01-11",
+			"date_integer": 20200111,
+			"group":        "NGIX",
+			"type":         "NGIS",
+			"subgroup":     "SITEXZ",
 			"tags":         bson.M{"infrastructure": "Production", "certification": "Certified"},
+		},
+		bson.M{
+			"date":         "2020-01-11",
+			"date_integer": 20200111,
+			"group":        "NGIX",
+			"type":         "NGIS",
+			"subgroup":     "SITEX",
+			"tags":         bson.M{"infrastructure": "Production", "certification": "Uncertified"},
 		},
 		bson.M{
 			"date":         "2020-01-11",
@@ -1024,9 +1091,29 @@ func (suite *topologyTestSuite) TestListFilterGroupsByReport() {
    "date": "2020-01-11",
    "group": "NGIX",
    "type": "NGIS",
-   "subgroup": "SITEX",
+   "subgroup": "SITEXYZ",
+   "tags": {
+    "certification": "Uncertified",
+    "infrastructure": "Devel"
+   }
+  },
+  {
+   "date": "2020-01-11",
+   "group": "NGIX",
+   "type": "NGIS",
+   "subgroup": "SITEXZ",
    "tags": {
     "certification": "Certified",
+    "infrastructure": "Production"
+   }
+  },
+  {
+   "date": "2020-01-11",
+   "group": "NGIX",
+   "type": "NGIS",
+   "subgroup": "SITEX",
+   "tags": {
+    "certification": "Uncertified",
     "infrastructure": "Production"
    }
   }
@@ -1056,6 +1143,50 @@ func (suite *topologyTestSuite) TestListFilterGroupsByReport() {
 
 		TestReq{
 			Path: "/api/v2/topology/groups/by_report/Critical4",
+			Code: 200,
+			JSON: `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "date": "2012-01-11",
+   "group": "PR01",
+   "type": "PROJECT",
+   "subgroup": "SITEPROJECT",
+   "tags": {
+    "certification": "Certified",
+    "infrastructure": "Devel"
+   }
+  }
+ ]
+}`},
+
+		TestReq{
+			Path: "/api/v2/topology/groups/by_report/Critical5",
+			Code: 200,
+			JSON: `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "date": "2012-01-11",
+   "group": "PR01",
+   "type": "PROJECT",
+   "subgroup": "SITEPROJECT",
+   "tags": {
+    "certification": "Certified",
+    "infrastructure": "Devel"
+   }
+  }
+ ]
+}`},
+
+		TestReq{
+			Path: "/api/v2/topology/groups/by_report/Critical6",
 			Code: 200,
 			JSON: `{
  "status": {
@@ -1735,9 +1866,29 @@ func (suite *topologyTestSuite) TestListGroups() {
    "date": "2020-01-11",
    "group": "NGIX",
    "type": "NGIS",
-   "subgroup": "SITEX",
+   "subgroup": "SITEXYZ",
+   "tags": {
+    "certification": "Uncertified",
+    "infrastructure": "Devel"
+   }
+  },
+  {
+   "date": "2020-01-11",
+   "group": "NGIX",
+   "type": "NGIS",
+   "subgroup": "SITEXZ",
    "tags": {
     "certification": "Certified",
+    "infrastructure": "Production"
+   }
+  },
+  {
+   "date": "2020-01-11",
+   "group": "NGIX",
+   "type": "NGIS",
+   "subgroup": "SITEX",
+   "tags": {
+    "certification": "Uncertified",
     "infrastructure": "Production"
    }
   },

--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -1899,6 +1899,44 @@ paths:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Status_error'
+            
+  /topology/groups/by_report/{report_name}:
+    get:
+      summary: List group topology per date and filter by report
+      operationId: topology_groups_report.list
+      description: List group topology per date and filter by report
+      tags:
+        - Topology
+      consumes:
+        - "application/json"
+      produces:
+        - "application/json"
+      parameters:
+        - in: path
+          name: report_name
+          type: string
+          description: filter results based on selected report
+          required: true
+        - $ref: "#/parameters/apiKey"
+        - $ref: "#/parameters/profDate"
+      responses:
+        '200':
+          description: filtered topology resources listed based on report
+          schema:
+            $ref: '#/definitions/Self_reference'
+        '401':
+          description: Unauthorized user
+          schema:
+            $ref: '#/definitions/Status_error'
+        '406':
+          description: Content Not acceptable
+          schema:
+            $ref: '#/definitions/Status_error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Status_error'
+      
           
   /topology/endpoints:
     post:

--- a/doc/v2/docs/topology_groups.md
+++ b/doc/v2/docs/topology_groups.md
@@ -7,6 +7,7 @@ API calls for handling topology group resources
 | POST: Create group topology for specific date   | Creates a daily group topology mapping endpoints to endpoint groups | <a href="#1">Description</a> |
 | GET: List group topology for specific date      | Lists group topology for a specific date                            | <a href="#2">Description</a> |
 | DELETE: Delete group topology for specific date | Delete group topology items for specific date                       | <a href="#3">Description</a> |
+| GET: List group topology for specific report    | Lists group topology for a specific report                          | <a href="#4">Description</a> |
 
 <a id="1"></a>
 
@@ -58,8 +59,8 @@ Accept: application/json
         }
     },
     {
-        "group": "NGIZ",
-        "type": "NGIS",
+        "group": "PROJECTZ",
+        "type": "PROJECT",
         "service": "SITEZ",
         "tags": {
             "scope": "FEDERATION",
@@ -108,7 +109,7 @@ User can proceed with either updating the existing topology OR deleting before t
 
 <a id="2"></a>
 
-## POST: List group topology for specific date
+## GET: List group topology for specific date
 
 Lists group topology items for specific date
 
@@ -180,16 +181,6 @@ Status: 200 OK
                 "certification": "Certified",
                 "infrastructure": "Production"
             }
-        },
-        {
-            "date": "2015-07-22",
-            "group": "NGIX",
-            "type": "NGIS",
-            "subgroup": "SITEX",
-            "tags": {
-                "certification": "Certified",
-                "infrastructure": "Production"
-            }
         }
     ]
 }
@@ -227,5 +218,86 @@ Json Response
 {
     "message": "Topology of 3 groups deleted for date: 2019-12-12",
     "code": "200"
+}
+```
+
+<a id="4"></a>
+
+## GET: List group topology for specific report
+
+Lists group topology items for specific report
+
+### Input
+
+```
+GET /topology/groups/by_report/{report-name}?date=YYYY-MM-DD
+```
+
+#### Url Parameters
+
+| Type          | Description              | Required | Default value |
+| ------------- | ------------------------ | -------- | ------------- |
+| `report-name` | target a specific report | YES      | none          |
+| `date`        | target a specific date   | NO       | today's date  |
+
+#### Headers
+
+```
+x-api-key: secret_key_value
+Accept: application/json
+```
+
+#### Example Request
+
+```
+GET /topology/groups/by_report/Critical?date=2015-07-22
+```
+
+#### Response Code
+
+```
+Status: 200 OK
+```
+
+### Response body
+
+```json
+{
+    "status": {
+        "message": "Success",
+        "code": "200"
+    },
+    "data": [
+        {
+            "date": "2015-07-22",
+            "group": "NGIA",
+            "type": "NGIS",
+            "subgroup": "SITEA",
+            "tags": {
+                "certification": "Certified",
+                "infrastructure": "Production"
+            }
+        },
+        {
+            "date": "2015-07-22",
+            "group": "NGIA",
+            "type": "NGIS",
+            "subgroup": "SITEB",
+            "tags": {
+                "certification": "Certified",
+                "infrastructure": "Production"
+            }
+        },
+        {
+            "date": "2015-07-22",
+            "group": "NGIX",
+            "type": "NGIS",
+            "subgroup": "SITEX",
+            "tags": {
+                "certification": "Certified",
+                "infrastructure": "Production"
+            }
+        }
+    ]
 }
 ```

--- a/scripts/mongodb/populate_default_roles.js
+++ b/scripts/mongodb/populate_default_roles.js
@@ -176,6 +176,10 @@ function populate_default_roles() {
         {
             resource: "topology_groups.delete",
             roles: ["admin", "editor"]
+        },
+        {
+            resource: "topology_groups_report.list",
+            roles: ["admin", "editor"]
         }
     ]);
     print("INFO\tPolulated default roles in 'roles' collection");


### PR DESCRIPTION
### Goal 
When filtering group topology by calling `GET /api/v2/topology/groups/by_report/{report_name}` apply report's filter tags as filters to the topology

Each report definition has a filter dictionary named `filter_tags` like the following
```json
{
  "filter_tags": [
    {
      "name": "infrastructure",
      "value": "Production",
      "context": "argo.group.filter.tags"
    },
    {
      "name": "certification",
      "value": "Certified",
      "context": "argo.group.filter.tags"
    }
  ]
}
```
Argo-web-api will check for filter tags containing a specific context = "argo.group.filter.tags" and apply the filters correctly to the topology

### Implementation

- [x] Extend handler that filters group topology by report to read report filter tags that belong to "argo.group.filter.tags" context
- [x] Add unit tests
