### PR TITLE
ARGO-2187 Use report topology to filter endpoint items

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,7 +30,10 @@ pipeline {
             steps {
                 echo 'Test & Coverage...'
                 sh """
-                sudo /etc/init.d/mongod restart
+                mkdir /home/jenkins/mongo_data
+                mkdir /home/jenkins/mongo_log
+                mkdir /home/jenkins/mongo_run
+                mongod --dbpath /home/jenkins/mongo_data --logpath /home/jenkins/mongo_log/mongo.log --pidfilepath /home/jenkins/mongo_run/mongo.pid --fork
                 cd ${WORKSPACE}/go/src/github.com/ARGOeu/${PROJECT_DIR}
                 gocov test -p 1 \$(go list ./... | grep -v /vendor/) | gocov-xml > ${WORKSPACE}/coverage.xml
                 go test -p 1 \$(go list ./... | grep -v /vendor/) -v=1 | go-junit-report > ${WORKSPACE}/junit.xml

--- a/app/aggregationProfiles/aggregationProfiles_test.go
+++ b/app/aggregationProfiles/aggregationProfiles_test.go
@@ -419,49 +419,6 @@ func (suite *AggregationProfilesTestSuite) TestList() {
  },
  "data": [
   {
-   "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50c",
-   "date": "2019-05-04",
-   "name": "cloud",
-   "namespace": "test",
-   "endpoint_group": "sites",
-   "metric_operation": "AND",
-   "profile_operation": "AND",
-   "metric_profile": {
-    "name": "roc.critical",
-    "id": "5637d684-1f8e-4a02-a502-720e8f11e432"
-   },
-   "groups": [
-    {
-     "name": "compute2",
-     "operation": "OR",
-     "services": [
-      {
-       "name": "SERVICEA",
-       "operation": "AND"
-      },
-      {
-       "name": "SERVICEB",
-       "operation": "AND"
-      }
-     ]
-    },
-    {
-     "name": "images2",
-     "operation": "OR",
-     "services": [
-      {
-       "name": "SERVICEC",
-       "operation": "AND"
-      },
-      {
-       "name": "SERVICED",
-       "operation": "AND"
-      }
-     ]
-    }
-   ]
-  },
-  {
    "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50b",
    "date": "2019-11-04",
    "name": "critical",
@@ -498,6 +455,49 @@ func (suite *AggregationProfilesTestSuite) TestList() {
       },
       {
        "name": "SRM",
+       "operation": "AND"
+      }
+     ]
+    }
+   ]
+  },
+  {
+   "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50c",
+   "date": "2019-05-04",
+   "name": "cloud",
+   "namespace": "test",
+   "endpoint_group": "sites",
+   "metric_operation": "AND",
+   "profile_operation": "AND",
+   "metric_profile": {
+    "name": "roc.critical",
+    "id": "5637d684-1f8e-4a02-a502-720e8f11e432"
+   },
+   "groups": [
+    {
+     "name": "compute2",
+     "operation": "OR",
+     "services": [
+      {
+       "name": "SERVICEA",
+       "operation": "AND"
+      },
+      {
+       "name": "SERVICEB",
+       "operation": "AND"
+      }
+     ]
+    },
+    {
+     "name": "images2",
+     "operation": "OR",
+     "services": [
+      {
+       "name": "SERVICEC",
+       "operation": "AND"
+      },
+      {
+       "name": "SERVICED",
        "operation": "AND"
       }
      ]

--- a/app/aggregationProfiles/controller.go
+++ b/app/aggregationProfiles/controller.go
@@ -77,6 +77,9 @@ func prepMultiQuery(dt int, name string) interface{} {
 				"groups":            bson.M{"$first": "$groups"},
 			},
 		},
+		{
+			"$sort": bson.M{"id": 1},
+		},
 	}
 
 }

--- a/app/downtimes/controller.go
+++ b/app/downtimes/controller.go
@@ -45,6 +45,9 @@ func prepMultiQuery(dt int, name string) interface{} {
 				"endpoints": bson.M{"$first": "$endpoints"},
 			},
 		},
+		{
+			"$sort": bson.M{"id": 1},
+		},
 	}
 
 }

--- a/app/downtimes/downtimes_test.go
+++ b/app/downtimes/downtimes_test.go
@@ -411,19 +411,6 @@ func (suite *DowntimesTestSuite) TestList() {
  },
  "data": [
   {
-   "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50c",
-   "date": "2019-10-13",
-   "name": "NonCritical",
-   "endpoints": [
-    {
-     "hostname": "host-01",
-     "service": "service-01",
-     "start_time": "2019-10-13T02:00:33Z",
-     "end_time": "2019-10-13T23:33:00Z"
-    }
-   ]
-  },
-  {
    "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50b",
    "date": "2019-10-13",
    "name": "Critical",
@@ -445,6 +432,19 @@ func (suite *DowntimesTestSuite) TestList() {
      "service": "service-C",
      "start_time": "2019-10-13T20:00:33Z",
      "end_time": "2019-10-13T22:15:00Z"
+    }
+   ]
+  },
+  {
+   "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50c",
+   "date": "2019-10-13",
+   "name": "NonCritical",
+   "endpoints": [
+    {
+     "hostname": "host-01",
+     "service": "service-01",
+     "start_time": "2019-10-13T02:00:33Z",
+     "end_time": "2019-10-13T23:33:00Z"
     }
    ]
   }
@@ -476,25 +476,6 @@ func (suite *DowntimesTestSuite) TestListPast() {
  },
  "data": [
   {
-   "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50c",
-   "date": "2019-10-11",
-   "name": "NonCritical",
-   "endpoints": [
-    {
-     "hostname": "host-01",
-     "service": "service-01",
-     "start_time": "2019-10-11T02:00:33Z",
-     "end_time": "2019-10-11T23:33:00Z"
-    },
-    {
-     "hostname": "host-02",
-     "service": "service-02",
-     "start_time": "2019-10-11T16:00:33Z",
-     "end_time": "2019-10-11T16:45:00Z"
-    }
-   ]
-  },
-  {
    "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50b",
    "date": "2019-10-11",
    "name": "Critical",
@@ -516,6 +497,25 @@ func (suite *DowntimesTestSuite) TestListPast() {
      "service": "service-C",
      "start_time": "2019-10-11T20:00:33Z",
      "end_time": "2019-10-11T22:15:00Z"
+    }
+   ]
+  },
+  {
+   "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50c",
+   "date": "2019-10-11",
+   "name": "NonCritical",
+   "endpoints": [
+    {
+     "hostname": "host-01",
+     "service": "service-01",
+     "start_time": "2019-10-11T02:00:33Z",
+     "end_time": "2019-10-11T23:33:00Z"
+    },
+    {
+     "hostname": "host-02",
+     "service": "service-02",
+     "start_time": "2019-10-11T16:00:33Z",
+     "end_time": "2019-10-11T16:45:00Z"
     }
    ]
   }

--- a/app/metricProfiles/controller.go
+++ b/app/metricProfiles/controller.go
@@ -72,6 +72,9 @@ func prepMultiQuery(dt int, name string) interface{} {
 				"services": bson.M{"$first": "$services"},
 			},
 		},
+		{
+			"$sort": bson.M{"id": 1},
+		},
 	}
 
 }

--- a/app/metricProfiles/metricProfiles_test.go
+++ b/app/metricProfiles/metricProfiles_test.go
@@ -338,9 +338,9 @@ func (suite *MetricProfilesTestSuite) TestList() {
  },
  "data": [
   {
-   "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50c",
-   "date": "2019-06-04",
-   "name": "ch.cern.SAM.ROC",
+   "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50b",
+   "date": "2019-11-04",
+   "name": "ch.cern.SAM.ROC_CRITICAL",
    "services": [
     {
      "service": "CREAM-CE2",
@@ -348,8 +348,6 @@ func (suite *MetricProfilesTestSuite) TestList() {
       "emi.cream.CREAMCE-JobSubmit",
       "emi.wn.WN-Bi",
       "emi.wn.WN-Csh",
-      "hr.srce.CADist-Check",
-      "hr.srce.CREAMCE-CertLifetime",
       "emi.wn.WN-SoftVer"
      ]
     },
@@ -369,9 +367,9 @@ func (suite *MetricProfilesTestSuite) TestList() {
    ]
   },
   {
-   "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50b",
-   "date": "2019-11-04",
-   "name": "ch.cern.SAM.ROC_CRITICAL",
+   "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50c",
+   "date": "2019-06-04",
+   "name": "ch.cern.SAM.ROC",
    "services": [
     {
      "service": "CREAM-CE2",
@@ -379,6 +377,8 @@ func (suite *MetricProfilesTestSuite) TestList() {
       "emi.cream.CREAMCE-JobSubmit",
       "emi.wn.WN-Bi",
       "emi.wn.WN-Csh",
+      "hr.srce.CADist-Check",
+      "hr.srce.CREAMCE-CertLifetime",
       "emi.wn.WN-SoftVer"
      ]
     },

--- a/app/operationsProfiles/controller.go
+++ b/app/operationsProfiles/controller.go
@@ -74,6 +74,9 @@ func prepMultiQuery(dt int, name string) interface{} {
 				"operations":       bson.M{"$first": "$operations"},
 			},
 		},
+		{
+			"$sort": bson.M{"id": 1},
+		},
 	}
 
 }

--- a/app/operationsProfiles/operationsProfiles_test.go
+++ b/app/operationsProfiles/operationsProfiles_test.go
@@ -431,61 +431,6 @@ func (suite *OperationsProfilesTestSuite) TestList() {
  },
  "data": [
   {
-   "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50c",
-   "date": "2019-08-04",
-   "name": "ops2",
-   "available_states": [
-    "X,Y,Z"
-   ],
-   "defaults": {
-    "down": "Y",
-    "missing": "X",
-    "unknown": "Z"
-   },
-   "operations": [
-    {
-     "name": "AND2",
-     "truth_table": [
-      {
-       "a": "X",
-       "b": "Y",
-       "x": "Y"
-      },
-      {
-       "a": "X",
-       "b": "Z",
-       "x": "Z"
-      },
-      {
-       "a": "Y",
-       "b": "Z",
-       "x": "Z"
-      }
-     ]
-    },
-    {
-     "name": "OR2",
-     "truth_table": [
-      {
-       "a": "X",
-       "b": "Y",
-       "x": "X"
-      },
-      {
-       "a": "X",
-       "b": "Z",
-       "x": "X"
-      },
-      {
-       "a": "Y",
-       "b": "Z",
-       "x": "Y"
-      }
-     ]
-    }
-   ]
-  },
-  {
    "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50b",
    "date": "2019-11-04",
    "name": "ops1",
@@ -535,6 +480,61 @@ func (suite *OperationsProfilesTestSuite) TestList() {
        "a": "B",
        "b": "C",
        "x": "B"
+      }
+     ]
+    }
+   ]
+  },
+  {
+   "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50c",
+   "date": "2019-08-04",
+   "name": "ops2",
+   "available_states": [
+    "X,Y,Z"
+   ],
+   "defaults": {
+    "down": "Y",
+    "missing": "X",
+    "unknown": "Z"
+   },
+   "operations": [
+    {
+     "name": "AND2",
+     "truth_table": [
+      {
+       "a": "X",
+       "b": "Y",
+       "x": "Y"
+      },
+      {
+       "a": "X",
+       "b": "Z",
+       "x": "Z"
+      },
+      {
+       "a": "Y",
+       "b": "Z",
+       "x": "Z"
+      }
+     ]
+    },
+    {
+     "name": "OR2",
+     "truth_table": [
+      {
+       "a": "X",
+       "b": "Y",
+       "x": "X"
+      },
+      {
+       "a": "X",
+       "b": "Z",
+       "x": "X"
+      },
+      {
+       "a": "Y",
+       "b": "Z",
+       "x": "Y"
       }
      ]
     }

--- a/app/thresholdsProfiles/controller.go
+++ b/app/thresholdsProfiles/controller.go
@@ -68,6 +68,9 @@ func prepMultiQuery(dt int, name string) interface{} {
 				"rules": bson.M{"$first": "$rules"},
 			},
 		},
+		{
+			"$sort": bson.M{"id": 1},
+		},
 	}
 
 }

--- a/app/thresholdsProfiles/thresholdsProfiles_test.go
+++ b/app/thresholdsProfiles/thresholdsProfiles_test.go
@@ -23,7 +23,6 @@
 package thresholdsProfiles
 
 import (
-	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -282,14 +281,14 @@ func (suite *ThresholdsProfilesTestSuite) TestList() {
  },
  "data": [
   {
-   "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50b",
+   "id": "6ac7d222-1f8e-4a02-a502-720e8f11e50b",
    "date": "2019-10-04",
-   "name": "thr01",
+   "name": "thr02",
    "rules": [
     {
      "host": "hostFoo",
      "metric": "metricA",
-     "thresholds": "freshnesss=1s;10;9:;0;25 entries=1;3;2:0;10"
+     "thresholds": "freshness=1s;10;9:;0;25 entries=1;3;2:0;10"
     }
    ]
   },
@@ -306,14 +305,14 @@ func (suite *ThresholdsProfilesTestSuite) TestList() {
    ]
   },
   {
-   "id": "6ac7d222-1f8e-4a02-a502-720e8f11e50b",
+   "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50b",
    "date": "2019-10-04",
-   "name": "thr02",
+   "name": "thr01",
    "rules": [
     {
      "host": "hostFoo",
      "metric": "metricA",
-     "thresholds": "freshness=1s;10;9:;0;25 entries=1;3;2:0;10"
+     "thresholds": "freshnesss=1s;10;9:;0;25 entries=1;3;2:0;10"
     }
    ]
   }
@@ -548,7 +547,7 @@ func (suite *ThresholdsProfilesTestSuite) TestCreate() {
 	c := session.DB(suite.tenantDbConf.Db).C("thresholds_profiles")
 
 	c.Find(bson.M{"name": "thr04"}).One(&result)
-	fmt.Println(result)
+
 	id := result["id"].(string)
 
 	// Apply id to output template and check

--- a/app/topology/routing.go
+++ b/app/topology/routing.go
@@ -44,6 +44,7 @@ func HandleSubrouter(s *mux.Router, confhandler *respond.ConfHandler) {
 }
 
 var appRoutesV2 = []respond.AppRoutes{
+	{"topology_endpoints_report.list", "GET", "/endpoints/by_report/{report}", ListEndpointsByReport},
 	{"topology_groups_report.list", "GET", "/groups/by_report/{report}", ListGroupsByReport},
 	{"topology_groups.delete", "DELETE", "/groups", DeleteGroups},
 	{"topology_groups.list", "GET", "/groups", ListGroups},

--- a/app/topology/topology_test.go
+++ b/app/topology/topology_test.go
@@ -164,6 +164,11 @@ func (suite *topologyTestSuite) SetupTest() {
 	c = session.DB(suite.cfg.MongoDB.Db).C("roles")
 	c.Insert(
 		bson.M{
+			"resource": "topology_endpoints_report.list",
+			"roles":    []string{"editor", "viewer"},
+		})
+	c.Insert(
+		bson.M{
 			"resource": "topology_groups_report.list",
 			"roles":    []string{"editor", "viewer"},
 		})
@@ -611,11 +616,136 @@ func (suite *topologyTestSuite) SetupTest() {
 				"name":    "certification",
 				"value":   "Certified"},
 		}})
+	c.Insert(bson.M{
+		"id": "eba61a9e-22e9-4521-9e47-ecaa4a4943z",
+		"info": bson.M{
+			"name":        "Critical7",
+			"description": "lalalallala",
+		},
+		"topology_schema": bson.M{
+			"group": bson.M{
+				"type": "NGIS",
+				"group": bson.M{
+					"type": "SITES",
+				},
+			},
+		},
+		"profiles": []bson.M{
+			bson.M{
+				"type": "metric",
+				"name": "ch.cern.SAM.ROC_CRITICAL"},
+		},
+		"filter_tags": []bson.M{
+			bson.M{
+				"context": "argo.group.filter.fields",
+				"name":    "group",
+				"value":   "NGI0"},
+		}})
+	c.Insert(bson.M{
+		"id": "eba61a9e-22e9-4521-9e47-ecaa4a4943z",
+		"info": bson.M{
+			"name":        "Critical8",
+			"description": "lalalallala",
+		},
+		"topology_schema": bson.M{
+			"group": bson.M{
+				"type": "NGIS",
+				"group": bson.M{
+					"type": "SITES",
+				},
+			},
+		},
+		"profiles": []bson.M{
+			bson.M{
+				"type": "metric",
+				"name": "ch.cern.SAM.ROC_CRITICAL"},
+		},
+		"filter_tags": []bson.M{
+			bson.M{
+				"context": "argo.group.filter.fields",
+				"name":    "group",
+				"value":   "NGI0"},
+			bson.M{
+				"context": "argo.endpoint.filter.fields",
+				"name":    "service",
+				"value":   "service_1"},
+		}})
+
+	c.Insert(bson.M{
+		"id": "eba61a9e-22e9-4521-9e47-ecaa4a4943z",
+		"info": bson.M{
+			"name":        "Critical9",
+			"description": "lalalallala",
+		},
+		"topology_schema": bson.M{
+			"group": bson.M{
+				"type": "NGIS",
+				"group": bson.M{
+					"type": "SITES",
+				},
+			},
+		},
+		"profiles": []bson.M{
+			bson.M{
+				"type": "metric",
+				"name": "ch.cern.SAM.ROC_CRITICAL"},
+		},
+		"filter_tags": []bson.M{
+			bson.M{
+				"context": "argo.group.filter.fields",
+				"name":    "group",
+				"value":   "NGI0"},
+			bson.M{
+				"context": "argo.endpoint.filter.fields",
+				"name":    "service",
+				"value":   "service_1"},
+			bson.M{
+				"context": "argo.endpoint.filter.tags",
+				"name":    "monitored",
+				"value":   "YesNo"},
+		}})
 	// Seed database with endpoint topology
 	c = session.DB(suite.tenantDbConf.Db).C(endpointColName)
 	c.EnsureIndexKey("-date_integer", "group")
 	// Insert seed data
+
 	c.Insert(
+		bson.M{
+			"date":         "2015-01-11",
+			"date_integer": 20150111,
+			"group":        "SITEA",
+			"type":         "SITES",
+			"hostname":     "host1.site_a.foo",
+			"service":      "service_1",
+			"tags":         bson.M{"production": "1", "monitored": "Yes"},
+		},
+		bson.M{
+			"date":         "2015-01-11",
+			"date_integer": 20150111,
+			"group":        "SITEA",
+			"type":         "SITES",
+			"hostname":     "host2.site_a.foo",
+			"service":      "service_2",
+			"tags":         bson.M{"production": "0", "monitored": "Y"},
+		},
+		bson.M{
+			"date":         "2015-01-11",
+			"date_integer": 20150111,
+			"group":        "SITEB",
+			"type":         "SITES",
+			"hostname":     "host1.site_b.foo",
+			"service":      "service_1",
+			"tags":         bson.M{"production": "Prod", "monitored": "YesNo"},
+		},
+		bson.M{
+			"date":         "2015-01-11",
+			"date_integer": 20150111,
+			"group":        "SITEC",
+			"type":         "SITES",
+			"hostname":     "host1.site_c.foo",
+			"service":      "service_3",
+			"tags":         bson.M{"production": "Prod", "monitored": "No"},
+		},
 		bson.M{
 			"date":         "2015-06-11",
 			"date_integer": 20150611,
@@ -720,6 +850,30 @@ func (suite *topologyTestSuite) SetupTest() {
 	c.EnsureIndexKey("-date_integer", "group")
 	// Insert seed data
 	c.Insert(
+		bson.M{
+			"date":         "2015-01-11",
+			"date_integer": 20150111,
+			"group":        "NGI0",
+			"type":         "NGIS",
+			"subgroup":     "SITEA",
+			"tags":         bson.M{"infrastructure": "devtest", "certification": "uncertified"},
+		},
+		bson.M{
+			"date":         "2015-01-11",
+			"date_integer": 20150111,
+			"group":        "NGI0",
+			"type":         "NGIS",
+			"subgroup":     "SITEB",
+			"tags":         bson.M{"infrastructure": "devel", "certification": "CertNot"},
+		},
+		bson.M{
+			"date":         "2015-01-11",
+			"date_integer": 20150111,
+			"group":        "NGI1",
+			"type":         "NGIS",
+			"subgroup":     "SITEC",
+			"tags":         bson.M{"infrastructure": "production", "certification": "Certified"},
+		},
 		bson.M{
 			"date":         "2015-06-10",
 			"date_integer": 20150610,
@@ -1202,6 +1356,169 @@ func (suite *topologyTestSuite) TestListFilterGroupsByReport() {
    "tags": {
     "certification": "Certified",
     "infrastructure": "Devel"
+   }
+  }
+ ]
+}`},
+
+		TestReq{
+			Path: "/api/v2/topology/groups/by_report/Critical7?date=2015-01-11",
+			Code: 200,
+			JSON: `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "date": "2015-01-11",
+   "group": "NGI0",
+   "type": "NGIS",
+   "subgroup": "SITEA",
+   "tags": {
+    "certification": "uncertified",
+    "infrastructure": "devtest"
+   }
+  },
+  {
+   "date": "2015-01-11",
+   "group": "NGI0",
+   "type": "NGIS",
+   "subgroup": "SITEB",
+   "tags": {
+    "certification": "CertNot",
+    "infrastructure": "devel"
+   }
+  }
+ ]
+}`},
+	}
+
+	for _, exp := range expected {
+		request, _ := http.NewRequest("GET", exp.Path, strings.NewReader(""))
+		request.Header.Set("x-api-key", suite.clientkey)
+		request.Header.Set("Accept", "application/json")
+		response := httptest.NewRecorder()
+
+		suite.router.ServeHTTP(response, request)
+
+		code := response.Code
+		output := response.Body.String()
+
+		// Check that we must have a 200 ok code
+		suite.Equal(exp.Code, code, "Response Code Mismatch on call:"+exp.Path)
+		// Compare the expected and actual json response
+		suite.Equal(exp.JSON, output, "Response body mismatch on call:"+exp.Path)
+
+	}
+}
+
+func (suite *topologyTestSuite) TestListFilterEndpointsByReport() {
+
+	type TestReq struct {
+		Path string
+		Code int
+		JSON string
+	}
+
+	expected := []TestReq{
+		TestReq{
+			Path: "/api/v2/topology/endpoints/by_report/Critical7?date=2015-01-11",
+			Code: 200,
+			JSON: `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "date": "2015-01-11",
+   "group": "SITEA",
+   "type": "SITES",
+   "service": "service_1",
+   "hostname": "host1.site_a.foo",
+   "tags": {
+    "monitored": "Yes",
+    "production": "1"
+   }
+  },
+  {
+   "date": "2015-01-11",
+   "group": "SITEA",
+   "type": "SITES",
+   "service": "service_2",
+   "hostname": "host2.site_a.foo",
+   "tags": {
+    "monitored": "Y",
+    "production": "0"
+   }
+  },
+  {
+   "date": "2015-01-11",
+   "group": "SITEB",
+   "type": "SITES",
+   "service": "service_1",
+   "hostname": "host1.site_b.foo",
+   "tags": {
+    "monitored": "YesNo",
+    "production": "Prod"
+   }
+  }
+ ]
+}`},
+
+		TestReq{
+			Path: "/api/v2/topology/endpoints/by_report/Critical8?date=2015-01-11",
+			Code: 200,
+			JSON: `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "date": "2015-01-11",
+   "group": "SITEA",
+   "type": "SITES",
+   "service": "service_1",
+   "hostname": "host1.site_a.foo",
+   "tags": {
+    "monitored": "Yes",
+    "production": "1"
+   }
+  },
+  {
+   "date": "2015-01-11",
+   "group": "SITEB",
+   "type": "SITES",
+   "service": "service_1",
+   "hostname": "host1.site_b.foo",
+   "tags": {
+    "monitored": "YesNo",
+    "production": "Prod"
+   }
+  }
+ ]
+}`},
+
+		TestReq{
+			Path: "/api/v2/topology/endpoints/by_report/Critical9?date=2015-01-11",
+			Code: 200,
+			JSON: `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "date": "2015-01-11",
+   "group": "SITEB",
+   "type": "SITES",
+   "service": "service_1",
+   "hostname": "host1.site_b.foo",
+   "tags": {
+    "monitored": "YesNo",
+    "production": "Prod"
    }
   }
  ]
@@ -1815,7 +2132,7 @@ func (suite *topologyTestSuite) TestListEndpoints4() {
 
 func (suite *topologyTestSuite) TestListEndpoints5() {
 
-	request, _ := http.NewRequest("GET", "/api/v2/topology/endpoints?date=2015-02-15", strings.NewReader(""))
+	request, _ := http.NewRequest("GET", "/api/v2/topology/endpoints?date=2015-01-01", strings.NewReader(""))
 	request.Header.Set("x-api-key", suite.clientkey)
 	request.Header.Set("Accept", "application/json")
 	response := httptest.NewRecorder()
@@ -2027,7 +2344,7 @@ func (suite *topologyTestSuite) TestListGroups3() {
 
 func (suite *topologyTestSuite) TestListGroups5() {
 
-	request, _ := http.NewRequest("GET", "/api/v2/topology/groups?date=2015-02-15", strings.NewReader(""))
+	request, _ := http.NewRequest("GET", "/api/v2/topology/groups?date=2015-01-01", strings.NewReader(""))
 	request.Header.Set("x-api-key", suite.clientkey)
 	request.Header.Set("Accept", "application/json")
 	response := httptest.NewRecorder()

--- a/app/weights/controller.go
+++ b/app/weights/controller.go
@@ -47,6 +47,9 @@ func prepMultiQuery(dt int, name string) interface{} {
 				"groups":      bson.M{"$first": "$groups"},
 			},
 		},
+		{
+			"$sort": bson.M{"id": 1},
+		},
 	}
 
 }

--- a/app/weights/weights_test.go
+++ b/app/weights/weights_test.go
@@ -552,23 +552,6 @@ func (suite *WeightsTestSuite) TestListPast() {
  },
  "data": [
   {
-   "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50c",
-   "date": "2019-10-04",
-   "name": "NonCritical",
-   "weight_type": "hepsepc",
-   "group_type": "SERVICEGROUPS",
-   "groups": [
-    {
-     "name": "SVGROUP-A",
-     "value": 334
-    },
-    {
-     "name": "SVGROUP-B",
-     "value": 588
-    }
-   ]
-  },
-  {
    "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50b",
    "date": "2019-10-04",
    "name": "Critical",
@@ -590,6 +573,23 @@ func (suite *WeightsTestSuite) TestListPast() {
     {
      "name": "SITE-D",
      "value": 2
+    }
+   ]
+  },
+  {
+   "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50c",
+   "date": "2019-10-04",
+   "name": "NonCritical",
+   "weight_type": "hepsepc",
+   "group_type": "SERVICEGROUPS",
+   "groups": [
+    {
+     "name": "SVGROUP-A",
+     "value": 334
+    },
+    {
+     "name": "SVGROUP-B",
+     "value": 588
     }
    ]
   }

--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -1936,6 +1936,8 @@ paths:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Status_error'
+            
+  
       
           
   /topology/endpoints:
@@ -2049,6 +2051,43 @@ paths:
             $ref: '#/definitions/Status_error'
         '404':
           description: Item not found
+          schema:
+            $ref: '#/definitions/Status_error'
+        '406':
+          description: Content Not acceptable
+          schema:
+            $ref: '#/definitions/Status_error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Status_error'
+            
+  /topology/endpoints/by_report/{report_name}:
+    get:
+      summary: List endpoint topology per date and filter by report
+      operationId: topology_endpoints_report.list
+      description: List endpoint topology per date and filter by report
+      tags:
+        - Topology
+      consumes:
+        - "application/json"
+      produces:
+        - "application/json"
+      parameters:
+        - in: path
+          name: report_name
+          type: string
+          description: filter results based on selected report
+          required: true
+        - $ref: "#/parameters/apiKey"
+        - $ref: "#/parameters/profDate"
+      responses:
+        '200':
+          description: filtered topology resources listed based on report
+          schema:
+            $ref: '#/definitions/Self_reference'
+        '401':
+          description: Unauthorized user
           schema:
             $ref: '#/definitions/Status_error'
         '406':

--- a/doc/v2/docs/reports.md
+++ b/doc/v2/docs/reports.md
@@ -1,5 +1,5 @@
 ---
-title: 'API documentation | ARGO'
+title: "API documentation | ARGO"
 page_title: API - Reports
 font_title: fa fa-cogs
 description: API Calls for listing existing and creating new Reports
@@ -7,19 +7,21 @@ description: API Calls for listing existing and creating new Reports
 
 # API Calls
 
-Name                               | Description                                                    | Shortcut
----------------------------------- | -------------------------------------------------------------- | ------------------
-GET: List reports or single report | This method can be used to retrieve a list of existing reports | [ Description](#1)
-POST: Create a new report          | This method can be used to create a new report.                | [ Description](#2)
-PUT: Update an existing report     | This method can be used to update an existing report.          | [ Description](#3)
-DELETE: Delete an existing Report  | This method can be used to delete an existing report.          | [ Description](#4)
+| Name                               | Description                                                    | Shortcut           |
+| ---------------------------------- | -------------------------------------------------------------- | ------------------ |
+| GET: List reports or single report | This method can be used to retrieve a list of existing reports | [ Description](#1) |
+| POST: Create a new report          | This method can be used to create a new report.                | [ Description](#2) |
+| PUT: Update an existing report     | This method can be used to update an existing report.          | [ Description](#3) |
+| DELETE: Delete an existing Report  | This method can be used to delete an existing report.          | [ Description](#4) |
 
 <a id='1'></a>
 
 ## [GET]: List Reports
+
 This method can be used to retrieve a list of existing reports or a single report according to its ID.
 
 ### Input
+
 #### URL
 
 ```
@@ -36,9 +38,11 @@ Accept: application/json
 ```
 
 ### Response
+
 Headers: `Status: 200 OK`
 
 #### Response body
+
 Json Response
 
 ```json
@@ -67,11 +71,11 @@ Json Response
                 }
             },
             "thresholds": {
-                "availability": 80.00,
-                "reliability": 85.00,
-                "uptime": 80.00,
-                "unknown": 10.00,
-                "downtime": 10.00
+                "availability": 80.0,
+                "reliability": 85.0,
+                "uptime": 80.0,
+                "unknown": 10.0,
+                "downtime": 10.0
             },
             "profiles": [
                 {
@@ -107,10 +111,10 @@ Json Response
 }
 ```
 
-
 <a id='2'></a>
 
 ## [POST]: Create a new report
+
 This method can be used to create a new report
 
 ### Input
@@ -145,15 +149,15 @@ Accept: application/json
         }
     },
     "thresholds": {
-        "availability": 80.00,
-        "reliability": 85.00,
-        "uptime": 80.00,
-        "unknown": 10.00,
-        "downtime": 10.00
+        "availability": 80.0,
+        "reliability": 85.0,
+        "uptime": 80.0,
+        "unknown": 10.0,
+        "downtime": 10.0
     },
     "profiles": [
         {
-            "id":"422985a7-6386-4964-bc99-5ebd5d7b0aef",
+            "id": "422985a7-6386-4964-bc99-5ebd5d7b0aef",
             "type": "metric"
         },
         {
@@ -179,6 +183,7 @@ Accept: application/json
 ```
 
 ### Response
+
 Headers: `Status: 201 Created`
 
 #### Response Body
@@ -201,9 +206,11 @@ Headers: `Status: 201 Created`
 <a id='3'></a>
 
 ## [PUT]: Update an existing report
+
 This method can be used to update an existing report. This will replace all the fields in the record so all the old fields that need to be kept must be included in the json of the update request body
 
 ### Input
+
 #### URL
 
 ```
@@ -225,7 +232,7 @@ Accept: application/json
     "weight": "hepspec",
     "info": {
         "name": "newname",
-        "description": "newdescription",
+        "description": "newdescription"
     },
     "topology_schema": {
         "group": {
@@ -236,11 +243,11 @@ Accept: application/json
         }
     },
     "thresholds": {
-        "availability": 90.00,
-        "reliability": 95.00,
-        "uptime": 90.00,
-        "unknown": 15.00,
-        "downtime": 15.00
+        "availability": 90.0,
+        "reliability": 95.0,
+        "uptime": 90.0,
+        "unknown": 15.0,
+        "downtime": 15.0
     },
     "profiles": [
         {
@@ -273,6 +280,7 @@ Accept: application/json
 ```
 
 ### Response
+
 Headers: `Status: 200 OK`
 
 #### Response Body
@@ -289,9 +297,11 @@ Headers: `Status: 200 OK`
 <a id='4'></a>
 
 ## [DELETE]: Delete an existing report
+
 This method can be used to update an existing report
 
 ### Input
+
 #### URL
 
 ```
@@ -306,6 +316,7 @@ Accept: application/json
 ```
 
 ### Response
+
 Headers: `Status: 200 OK`
 
 #### Response Body
@@ -318,3 +329,28 @@ Headers: `Status: 200 OK`
     }
 }
 ```
+
+<a id='5'></a>
+
+## Notes on Report Filter tags and topology
+
+As we seen before a report can host a list of filter tags using the following list under the filed `filter_tags`:
+
+```json
+{
+    "filter_tags": [
+        {
+            "context": "a context description to define where the filter applies",
+            "name": "what to be filter",
+            "value": "filter pattern described here"
+        }
+    ]
+}
+```
+
+There are special argo contextes that are automatically picked up to filter group and endpoint topology. These contexts are described below:
+
+-   _context:_ `argo.group.filter.fields` - Used to apply filter on basic fields of group topology. Under this context the `name` targets the group field name and the `value` holds the actual field pattern
+-   _context:_ `argo.group.filter.tags` - Used to apply filter on tags of group topology. Under this context the `name` targets the group tag name and the `value` holds the actual field pattern
+-   _context:_ `argo.endpoint.filter.fields` - Used to apply filter on basic fields of endpoint topology. Under this context the `name` targets the endpoint field name and the `value` holds the actual field pattern
+-   _context:_ `argo.endpoint.filter.tags` - Used to apply filter on tags of endpoint topology. Under this context the `name` targets the endpoint tag name and the `value` holds the actual field pattern

--- a/doc/v2/docs/topology_endpoints.md
+++ b/doc/v2/docs/topology_endpoints.md
@@ -7,6 +7,7 @@ API calls for handling topology endpoint resources
 | POST: Create endpoint topology for specific date   | Creates a daily endpoint topology mapping endpoints to endpoint groups | <a href="#1">Description</a> |
 | GET: List endpoint topology for specific date      | Lists endpoint topology for a specific date                            | <a href="#2">Description</a> |
 | DELETE: delete endpoint topology for specific date | Deletes all endpoint items (topology) for a specific date              | <a href="#3">Description</a> |
+| GET: List endpoint topology for specific report    | Lists endpoint topology for a specific report                          | <a href="#4">Description</a> |
 
 <a id="1"></a>
 
@@ -141,32 +142,50 @@ Status: 200 OK
 ### Response body
 
 ```json
-[
-    {
-        "date": "2019-12-12",
-        "group": "SITE_A",
-        "hostname": "host1.site-a.foo",
-        "type": "SITES",
-        "service": "a.service.foo",
-        "tags": { "scope": "TENANT", "production": "1", "monitored": "1" }
+{
+    "status": {
+        "message": "Success",
+        "code": "200"
     },
-    {
-        "date": "2019-12-12",
-        "group": "SITE_A",
-        "hostname": "host2.site-b.foo",
-        "type": "SITES",
-        "service": "b.service.foo",
-        "tags": { "scope": "TENANT", "production": "1", "monitored": "1" }
-    },
-    {
-        "date": "2019-12-12",
-        "group": "SITE_B",
-        "hostname": "host1.site-a.foo",
-        "type": "SITES",
-        "service": "c.service.foo",
-        "tags": { "scope": "TENANT", "production": "1", "monitored": "1" }
-    }
-]
+    "data": [
+        {
+            "date": "2019-12-12",
+            "group": "SITE_A",
+            "hostname": "host1.site-a.foo",
+            "type": "SITES",
+            "service": "a.service.foo",
+            "tags": {
+                "scope": "TENANT",
+                "production": "1",
+                "monitored": "1"
+            }
+        },
+        {
+            "date": "2019-12-12",
+            "group": "SITE_A",
+            "hostname": "host2.site-b.foo",
+            "type": "SITES",
+            "service": "b.service.foo",
+            "tags": {
+                "scope": "TENANT",
+                "production": "1",
+                "monitored": "1"
+            }
+        },
+        {
+            "date": "2019-12-12",
+            "group": "SITE_B",
+            "hostname": "host1.site-a.foo",
+            "type": "SITES",
+            "service": "c.service.foo",
+            "tags": {
+                "scope": "TENANT",
+                "production": "1",
+                "monitored": "1"
+            }
+        }
+    ]
+}
 ```
 
 <a id='3'></a>
@@ -201,5 +220,92 @@ Json Response
 {
     "message": "Topology of 3 endpoints deleted for date: 2019-12-12",
     "code": "200"
+}
+```
+
+<a id="4"></a>
+
+## GET: List endpoint topology for specific report
+
+Lists endpoint topology items for specific report
+
+### Input
+
+```
+GET /topology/endpoint/by_report/{report-name}?date=YYYY-MM-DD
+```
+
+#### Url Parameters
+
+| Type          | Description              | Required | Default value |
+| ------------- | ------------------------ | -------- | ------------- |
+| `report-name` | target a specific report | YES      | none          |
+| `date`        | target a specific date   | NO       | today's date  |
+
+#### Headers
+
+```
+x-api-key: secret_key_value
+Accept: application/json
+```
+
+#### Example Request
+
+```
+GET /topology/endpoints/by_report/Critical?date=2015-07-22
+```
+
+#### Response Code
+
+```
+Status: 200 OK
+```
+
+### Response body
+
+```json
+{
+    "status": {
+        "message": "Success",
+        "code": "200"
+    },
+    "data": [
+        {
+            "date": "2019-12-12",
+            "group": "SITE_A",
+            "hostname": "host1.site-a.foo",
+            "type": "SITES",
+            "service": "a.service.foo",
+            "tags": {
+                "scope": "TENANT",
+                "production": "1",
+                "monitored": "1"
+            }
+        },
+        {
+            "date": "2019-12-12",
+            "group": "SITE_A",
+            "hostname": "host2.site-b.foo",
+            "type": "SITES",
+            "service": "b.service.foo",
+            "tags": {
+                "scope": "TENANT",
+                "production": "1",
+                "monitored": "1"
+            }
+        },
+        {
+            "date": "2019-12-12",
+            "group": "SITE_B",
+            "hostname": "host1.site-a.foo",
+            "type": "SITES",
+            "service": "c.service.foo",
+            "tags": {
+                "scope": "TENANT",
+                "production": "1",
+                "monitored": "1"
+            }
+        }
+    ]
 }
 ```


### PR DESCRIPTION
ARGO-2188 Use report's filter tags field to filter endpoint topology by tags

## Goal 
Allow filtering of endpoint topology using a report reference. To filter endpoint topology correctly we must first apply report's filtering options to the top level groups and from there keep only the endpoints that are part of those groups. We apply further endpoint related filters to the resulting endpoint dataset

## Implementation
Use mongo aggreagation and specifically a `$lookup` pipeline stage to perform a left join between filtered groups and endpoints. The aggregation pipeline can be summarized in the following steps:
1) start aggregation on group topology collection
2) $match stage: match groups by applying report's group related filters 
3) $lookup stage: for each group record in result, lookup the endpoint collection and find endpoints that have the same group value as the group's subgroup value and also have the same date value. 
4) $unwind stage: unwind the result so to have a flat mapping of each group to each endpoint included
5) $replaceRoot stage: replace document root with the nested endpoint document so as to have only endpoint records in the results (_note_: replaced $replaceRoot with $group stage for the time being)

- [x] Add api handler to list endpoints per report using path `GET /v2/api/topology/endpoints/by_report?date=YYYY-MM-DD`
- [x] Add getReportFilters method to quickly extract filter_tags from report definition and construct group and endpoint Filter structures
- [x] Update unit tests
- [x] Update swagger
- [x] Update documentation