### PR TITLE
ARGO-2238 Support composite filters in topology

### DIFF
--- a/app/topology/model.go
+++ b/app/topology/model.go
@@ -51,17 +51,17 @@ type messageOUT struct {
 }
 
 type fltrEndpoint struct {
-	Group     string
-	GroupType string
-	Service   string
-	Hostname  string
+	Group     []string
+	GroupType []string
+	Service   []string
+	Hostname  []string
 	Tags      string
 }
 
 type fltrGroup struct {
-	Group     string
-	GroupType string
-	Subgroup  string
+	Group     []string
+	GroupType []string
+	Subgroup  []string
 	Tags      string
 }
 


### PR DESCRIPTION
## Goal 
Support composite filters in topology calls. For example give the ability to filter endpoints by multiple field values such as: group="SITEA" and group = "SITEB" by repeating the url query parameters in the following way:
`/api/v2/topology/endpoints?group=SITEA&group=SITEB`

## Implementation
- [x] Refactor controller methods that extracted url parameters and costructed filter structures
- [x] Modify filter structures in models so each field to be an array instead of string (multiple values)
- [x] When multiple values are present for the same field use mongodb regexp (more performant and robust than $in) by constructig the following pattern `^(value1|value2|value3)$`
- [x] Update unit tests