### PR TITLE
⚠ don't merge yet ~ ARGO-2251 Allow web-api to combine extra endpoint information from to…

### DIFF
--- a/app/results/View.go
+++ b/app/results/View.go
@@ -72,10 +72,18 @@ func createEndpointResultView(results []EndpointInterface, report reports.MongoI
 
 		if prevEndpoint != row.Name {
 			prevEndpoint = row.Name
+			infoItems := make(map[string]string)
+			for info := range row.Info {
+				if strings.HasPrefix(info, "info.") {
+					value := row.Info[info]
+					key := strings.Replace(info, "info.", "", 1)
+					infoItems[key] = value
+				}
+			}
 			endpoint = &Endpoint{
 				Name: row.Name,
 				Type: fmt.Sprintf("endpoint"),
-				Info: row.Info,
+				Info: infoItems,
 			}
 			serviceEndpointGroup.Endpoints = append(serviceEndpointGroup.Endpoints, endpoint)
 		}

--- a/app/results/endpoint_test.go
+++ b/app/results/endpoint_test.go
@@ -172,6 +172,30 @@ func (suite *endpointAvailabilityTestSuite) SetupTest() {
 			"roles":    []string{"editor", "viewer"},
 		})
 
+	c = session.DB(suite.tenantDbConf.Db).C("topology_endpoints")
+	c.EnsureIndexKey("-date_integer", "group")
+	// Insert seed data
+
+	c.Insert(
+		bson.M{
+			"date":         "2015-01-11",
+			"date_integer": 20150622,
+			"group":        "ST01",
+			"type":         "SITES",
+			"hostname":     "e01",
+			"service":      "service_a",
+			"tags":         bson.M{"production": "1", "monitored": "Yes", "info.Url": "https://foo.example.url"},
+		},
+		bson.M{
+			"date":         "2015-01-11",
+			"date_integer": 20150622,
+			"group":        "SITEA",
+			"type":         "SITES",
+			"hostname":     "host2.site_a.foo",
+			"service":      "service_2",
+			"tags":         bson.M{"production": "0", "monitored": "Y"},
+		})
+
 	c = session.DB(suite.tenantDbConf.Db).C("endpoint_ar")
 
 	// Insert seed data
@@ -192,9 +216,6 @@ func (suite *endpointAvailabilityTestSuite) SetupTest() {
 					"name":  "production",
 					"value": "Y",
 				},
-			},
-			"info": bson.M{
-				"Url": "https://foo.example.url",
 			},
 		},
 		bson.M{
@@ -307,7 +328,7 @@ func (suite *endpointAvailabilityTestSuite) SetupTest() {
 // TestListEndpointAvailabilityMonthly tests if monthly results are returned correctly
 func (suite *endpointAvailabilityTestSuite) TestListEndpointAvailabilityMonthly() {
 
-	request, _ := http.NewRequest("GET", "/api/v2/results/Report_A/SITE/ST01/services/service_a/endpoints?start_time=2015-06-22T00:00:00Z&end_time=2015-06-23T23:59:59Z&granularity=monthly", strings.NewReader(""))
+	request, _ := http.NewRequest("GET", "/api/v2/results/Report_A/SITE/ST01/services/service_a/endpoints?start_time=2015-06-22T00:00:00Z&end_time=2015-06-23T23:59:59Z&granularity=monthly&info=true", strings.NewReader(""))
 	request.Header.Set("x-api-key", suite.clientkey)
 	request.Header.Set("Accept", "application/xml")
 
@@ -333,7 +354,7 @@ func (suite *endpointAvailabilityTestSuite) TestListEndpointAvailabilityMonthly(
 	// Compare the expected and actual xml response
 	suite.Equal(endpointAvailabilityXML, responseBody, "Response body mismatch")
 
-	request, _ = http.NewRequest("GET", "/api/v2/results/Report_A/SITE/ST01/services/service_a/endpoints?start_time=2015-06-22T00:00:00Z&end_time=2015-06-23T23:59:59Z&granularity=monthly", strings.NewReader(""))
+	request, _ = http.NewRequest("GET", "/api/v2/results/Report_A/SITE/ST01/services/service_a/endpoints?start_time=2015-06-22T00:00:00Z&end_time=2015-06-23T23:59:59Z&granularity=monthly&info=true", strings.NewReader(""))
 	request.Header.Set("x-api-key", suite.clientkey)
 	request.Header.Set("Accept", "application/json")
 
@@ -396,7 +417,7 @@ func (suite *endpointAvailabilityTestSuite) TestListEndpointAvailabilityMonthly(
 	suite.Equal(endpointAvailabilityJSON, responseBody, "Response body mismatch")
 
 	// Test the quick path to site endpoint a/r
-	request, _ = http.NewRequest("GET", "/api/v2/results/Report_A/SITE/ST01/endpoints?start_time=2015-06-22T00:00:00Z&end_time=2015-06-23T23:59:59Z&granularity=monthly", strings.NewReader(""))
+	request, _ = http.NewRequest("GET", "/api/v2/results/Report_A/SITE/ST01/endpoints?start_time=2015-06-22T00:00:00Z&end_time=2015-06-23T23:59:59Z&granularity=monthly&info=true", strings.NewReader(""))
 	request.Header.Set("x-api-key", suite.clientkey)
 	request.Header.Set("Accept", "application/json")
 
@@ -443,7 +464,7 @@ func (suite *endpointAvailabilityTestSuite) TestListEndpointAvailabilityDaily() 
 	// Compare the expected and actual xml response
 	suite.Equal(endpointAvailabilityXML, response.Body.String(), "Response body mismatch")
 
-	request, _ = http.NewRequest("GET", "/api/v2/results/Report_A/SITE/ST01/services/service_a/endpoints?start_time=2015-06-22T00:00:00Z&end_time=2015-06-23T23:59:59Z", strings.NewReader(""))
+	request, _ = http.NewRequest("GET", "/api/v2/results/Report_A/SITE/ST01/services/service_a/endpoints?start_time=2015-06-22T00:00:00Z&end_time=2015-06-23T23:59:59Z&info=true", strings.NewReader(""))
 	request.Header.Set("x-api-key", suite.clientkey)
 	request.Header.Set("Accept", "application/json")
 

--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -2675,6 +2675,7 @@ paths:
         - $ref: "#/parameters/endDate"
         - $ref: "#/parameters/Granularity"
         - $ref: "#/parameters/service_name"
+        - $ref: "#/parameters/info"
       responses:
         200:
           description: "Successful retrieval of results"
@@ -2713,6 +2714,7 @@ paths:
         - $ref: "#/parameters/endDate"
         - $ref: "#/parameters/Granularity"
         - $ref: "#/parameters/endpoint_name"
+        - $ref: "#/parameters/info"
       responses:
         200:
           description: "Successful retrieval of results"
@@ -3277,6 +3279,11 @@ paths:
 
 
 parameters:
+  info:
+    name: "info"
+    in: "query"
+    type: boolean
+    description: "if true show additional info about each endpoint"
   profDate:
     name: "date"
     in: "query"

--- a/doc/v2/docs/results.md
+++ b/doc/v2/docs/results.md
@@ -227,25 +227,25 @@ The following methods can be used to obtain a tenant's Availability and Reliabil
 Request endpoint a/r under specific service:
 
 ```
-/results/{report_name}/{group_type}/{group_name}/{endpoint_group_type}/{endpoint_group_name}/services/{service_name}/endpoints?[start_time]&[end_time]&[granularity]
+/results/{report_name}/{group_type}/{group_name}/{endpoint_group_type}/{endpoint_group_name}/services/{service_name}/endpoints?[start_time]&[end_time]&[granularity]&[info]
 or
-/results/{report_name}/{group_type}/{group_name}/{endpoint_group_type}/{endpoint_group_name}/services/{service_name}/endpoints/{endpoint_name}?[start_time]&[end_time]&[granularity]
+/results/{report_name}/{group_type}/{group_name}/{endpoint_group_type}/{endpoint_group_name}/services/{service_name}/endpoints/{endpoint_name}?[start_time]&[end_time]&[granularity]&[info]
 or
-/results/{report_name}/{endpoint_group_type}/{endpoint_group_name}/services/{service_name}/endpoints?[start_time]&[end_time]&[granularity]
+/results/{report_name}/{endpoint_group_type}/{endpoint_group_name}/services/{service_name}/endpoints?[start_time]&[end_time]&[granularity]&[info]
 or
-/results/{report_name}/{endpoint_group_type}/{endpoint_group_name}/services/{service_name}/endpoints/{endpoint_name}?[start_time]&[end_time]&[granularity]
+/results/{report_name}/{endpoint_group_type}/{endpoint_group_name}/services/{service_name}/endpoints/{endpoint_name}?[start_time]&[end_time]&[granularity]&[info]
 ```
 
 Request endpoint a/r under specific endpoint group:
 
 ```
-/results/{report_name}/{group_type}/{group_name}/{endpoint_group_type}/{endpoint_group_name}/endpoints?[start_time]&[end_time]&[granularity]
+/results/{report_name}/{group_type}/{group_name}/{endpoint_group_type}/{endpoint_group_name}/endpoints?[start_time]&[end_time]&[granularity]&[info]
 or
-/results/{report_name}/{group_type}/{group_name}/{endpoint_group_type}/{endpoint_group_name}/endpoints/{endpoint_name}?[start_time]&[end_time]&[granularity]
+/results/{report_name}/{group_type}/{group_name}/{endpoint_group_type}/{endpoint_group_name}/endpoints/{endpoint_name}?[start_time]&[end_time]&[granularity]&[info]
 or
-/results/{report_name}/{endpoint_group_type}/{endpoint_group_name}/endpoints?[start_time]&[end_time]&[granularity]
+/results/{report_name}/{endpoint_group_type}/{endpoint_group_name}/endpoints?[start_time]&[end_time]&[granularity]&[info]
 or
-/results/{report_name}/{endpoint_group_type}/{endpoint_group_name}/endpoints/{endpoint_name}?[start_time]&[end_time]&[granularity]
+/results/{report_name}/{endpoint_group_type}/{endpoint_group_name}/endpoints/{endpoint_name}?[start_time]&[end_time]&[granularity]&[info]
 ```
 
 #### Query Parameters
@@ -255,6 +255,7 @@ or
 | `[start_time]`  | UTC time in W3C format                                                                          | YES      |
 | `[end_time]`    | UTC time in W3C format                                                                          | YES      |
 | `[granularity]` | Granularity of time that will be used to present data. Possible values are `monthly` or `daily` | NO       | `daily`       |
+| `[info]` | True or false, display additional info for each endpoint if its available in topology information | NO       | `daily`       |
 
 #### Path Parameters
 
@@ -474,7 +475,8 @@ Status: 200 OK
 
 ### Extra information for a specific endpoint on endpoint a/r
 
-Some service endpoint a/r have additional information regarding the specific service endpoint such as it's Url, certificat DN etc... If this information is available it will be displayed under each service endpoint along with the a/r results. For example:
+Some service endpoint a/r have additional information regarding the specific service endpoint such as it's Url, certificat DN etc... If this information is available it will be displayed under each service endpoint along with the a/r results explicitly when url parameter info=true is set during request. For example:
+
 
 ```
 {


### PR DESCRIPTION
…pology with endpoint a/r results

## Goal 
When endpoint topology is available on argo-web-api (`/api/v2/topology/endpoints`) and has extra information regarding endpoints (`url`, `DN`, etc...) it can be used on the fly by argo-web-api to enrich endpoint a/r results. The enrichment of the results with additional information is controlled by a new url parameter `?info=true`

## Implementation
- [x] Add new Daily and Monthly Endpoint queries that combine endpoint topology information in the results by leveraging mongodb's $lookup aggregation operatior
- [x] Modify Endpoint AR results controller to accept a new url parameter `?info=true`. When `info=true` controller uses the new queries to enrich data with extra information. When `info=false` the old traditional queries are used to display a/r results
- [x] Update swagger
- [x] Update docs
- [x] Update unit tests