### PR TITLE
ARGO-2249 Add description field to metric profiles

### DIFF
--- a/app/metricProfiles/controller.go
+++ b/app/metricProfiles/controller.go
@@ -66,10 +66,11 @@ func prepMultiQuery(dt int, name string) interface{} {
 				// metric_profiles collection is meant to have an index with date_integer:-1 and id:1 so
 				// when searching by date the documents are sorted with the recent timestamp first
 				// so we need the recent item available to our query timepoint which is specific date
-				"id":       bson.M{"$first": "$id"},
-				"date":     bson.M{"$first": "$date"},
-				"name":     bson.M{"$first": "$name"},
-				"services": bson.M{"$first": "$services"},
+				"id":          bson.M{"$first": "$id"},
+				"date":        bson.M{"$first": "$date"},
+				"name":        bson.M{"$first": "$name"},
+				"description": bson.M{"$first": "$description"},
+				"services":    bson.M{"$first": "$services"},
 			},
 		},
 		{

--- a/app/metricProfiles/metricProfiles_test.go
+++ b/app/metricProfiles/metricProfiles_test.go
@@ -214,6 +214,7 @@ func (suite *MetricProfilesTestSuite) SetupTest() {
 			"name":         "ch.cern.SAM.ROC_CRITICAL",
 			"date_integer": 20191004,
 			"date":         "2019-10-04",
+			"description":  "critical profile",
 			"services": []bson.M{
 				bson.M{"service": "CREAM-CE",
 					"metrics": []string{
@@ -240,6 +241,7 @@ func (suite *MetricProfilesTestSuite) SetupTest() {
 			"name":         "ch.cern.SAM.ROC_CRITICAL",
 			"date_integer": 20191104,
 			"date":         "2019-11-04",
+			"description":  "critical profile",
 			"services": []bson.M{
 				bson.M{"service": "CREAM-CE2",
 					"metrics": []string{
@@ -341,6 +343,7 @@ func (suite *MetricProfilesTestSuite) TestList() {
    "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50b",
    "date": "2019-11-04",
    "name": "ch.cern.SAM.ROC_CRITICAL",
+   "description": "critical profile",
    "services": [
     {
      "service": "CREAM-CE2",
@@ -370,6 +373,7 @@ func (suite *MetricProfilesTestSuite) TestList() {
    "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50c",
    "date": "2019-06-04",
    "name": "ch.cern.SAM.ROC",
+   "description": "",
    "services": [
     {
      "service": "CREAM-CE2",
@@ -428,6 +432,7 @@ func (suite *MetricProfilesTestSuite) TestListQueryName() {
    "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50c",
    "date": "2019-06-04",
    "name": "ch.cern.SAM.ROC",
+   "description": "",
    "services": [
     {
      "service": "CREAM-CE2",
@@ -521,6 +526,7 @@ func (suite *MetricProfilesTestSuite) TestListOne() {
    "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50b",
    "date": "2019-11-04",
    "name": "ch.cern.SAM.ROC_CRITICAL",
+   "description": "critical profile",
    "services": [
     {
      "service": "CREAM-CE2",
@@ -654,6 +660,7 @@ func (suite *MetricProfilesTestSuite) TestCreate() {
    "id": "{{id}}",
    "date": "2019-11-08",
    "name": "test_profile",
+   "description": "",
    "services": [
     {
      "service": "Service-A",
@@ -919,6 +926,7 @@ func (suite *MetricProfilesTestSuite) TestUpdate() {
 
 	jsonInput := `{
   "name": "test_profile",
+  "description": "just for testing",
   "services": [
     {
       "service": "Service-AX",
@@ -956,6 +964,7 @@ func (suite *MetricProfilesTestSuite) TestUpdate() {
    "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50c",
    "date": "2019-07-08",
    "name": "test_profile",
+   "description": "just for testing",
    "services": [
     {
      "service": "Service-AX",

--- a/app/metricProfiles/model.go
+++ b/app/metricProfiles/model.go
@@ -28,11 +28,12 @@ package metricProfiles
 
 //MetricProfile struct used to retrieve and insert metricProfiles in mongo
 type MetricProfile struct {
-	ID       string    `bson:"id" json:"id"`
-	DateInt  int       `bson:"date_integer" json:"-"`
-	Date     string    `bson:"date" json:"date"`
-	Name     string    `bson:"name" json:"name"`
-	Services []Service `bson:"services" json:"services"`
+	ID          string    `bson:"id" json:"id"`
+	DateInt     int       `bson:"date_integer" json:"-"`
+	Date        string    `bson:"date" json:"date"`
+	Name        string    `bson:"name" json:"name"`
+	Description string    `bson:"description" json:"description"`
+	Services    []Service `bson:"services" json:"services"`
 }
 
 // Service struct to represent services with their metrics

--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -3968,6 +3968,10 @@ definitions:
     properties:
       id:
         type: string
+      name: 
+        type: string 
+      description: 
+        type: string
       services:
         type: array
         items:

--- a/doc/v2/docs/metric_profiles.md
+++ b/doc/v2/docs/metric_profiles.md
@@ -57,6 +57,7 @@ Json Response
    "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50c",
    "date": "2019-10-10",
    "name": "ch.cern.SAM.ROC",
+   "description": "default profile",
    "services": [
     {
      "service": "CREAM-CE",
@@ -88,6 +89,7 @@ Json Response
    "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50b",
    "date" : "2019-11-01",
    "name": "ch.cern.SAM.ROC_CRITICAL",
+   "description": "",
    "services": [
     {
      "service": "CREAM-CE",
@@ -159,6 +161,7 @@ Json Response
    "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50b",
    "date" : "2019-11-01",
    "name": "ch.cern.SAM.ROC_CRITICAL",
+   "description": "a critical profile",
    "services": [
     {
      "service": "CREAM-CE",
@@ -218,6 +221,7 @@ Type            | Description                                                   
 ```json
 {
   "name": "test_profile",
+  "description": "a profile just for testing",
   "services": [
     {
       "service": "Service-A",
@@ -290,6 +294,7 @@ Type            | Description                                                   
 ```json
 {
   "name": "test_profile",
+  "description": "this profile is just for tests",
   "services": [
     {
       "service": "Service-A",


### PR DESCRIPTION
### Goal 
Add a new field named: `description` in metric profiles

### Implementation
- [x] Update metric profiles model
- [x] Update all metric profiles related handlers to use the new field
- [x] Update unit tests
- [x] Update docs & swagger