### PR TITLE
ARGO-2274 Fix date input validation checks in historic profiles

### DIFF
--- a/app/aggregationProfiles/aggregationProfiles_test.go
+++ b/app/aggregationProfiles/aggregationProfiles_test.go
@@ -513,6 +513,55 @@ func (suite *AggregationProfilesTestSuite) TestList() {
 
 }
 
+func (suite *AggregationProfilesTestSuite) TestBadDate() {
+
+	badDate := `{
+ "status": {
+  "message": "Bad Request",
+  "code": "400"
+ },
+ "errors": [
+  {
+   "message": "Bad Request",
+   "code": "400",
+   "details": "date parameter value: 2020-02 is not in the valid form of YYYY-MM-DD"
+  }
+ ]
+}`
+
+	type reqHeader struct {
+		Method string
+		Path   string
+		Data   string
+	}
+
+	requests := []reqHeader{
+		reqHeader{Method: "GET", Path: "/api/v2/aggregation_profiles?date=2020-02", Data: ""},
+		reqHeader{Method: "GET", Path: "/api/v2/aggregation_profiles/some-uuid?date=2020-02", Data: ""},
+		reqHeader{Method: "POST", Path: "/api/v2/aggregation_profiles?date=2020-02", Data: ""},
+		reqHeader{Method: "PUT", Path: "/api/v2/aggregation_profiles/some-id?date=2020-02", Data: ""},
+	}
+
+	for _, r := range requests {
+		request, _ := http.NewRequest(r.Method, r.Path, strings.NewReader(r.Data))
+		request.Header.Set("x-api-key", suite.clientkey)
+		request.Header.Set("Accept", "application/json")
+		response := httptest.NewRecorder()
+
+		suite.router.ServeHTTP(response, request)
+
+		code := response.Code
+		output := response.Body.String()
+
+		// Check that we must have a 200 ok code
+		suite.Equal(400, code, "Internal Server Error")
+		// Compare the expected and actual json response
+		suite.Equal(badDate, output, "Response body mismatch")
+
+	}
+
+}
+
 func (suite *AggregationProfilesTestSuite) TestListEmpty() {
 
 	session, err := mgo.Dial(suite.cfg.MongoDB.Host)

--- a/app/aggregationProfiles/controller.go
+++ b/app/aggregationProfiles/controller.go
@@ -128,6 +128,7 @@ func ListOne(r *http.Request, cfg config.Config) (int, http.Header, []byte, erro
 	dt, dateStr, err := utils.ParseZuluDate(dateStr)
 	if err != nil {
 		code = http.StatusBadRequest
+		output, _ = respond.MarshalContent(respond.ErrBadRequestDetails(err.Error()), contentType, "", " ")
 		return code, h, output, err
 	}
 	aggQuery := prepQuery(dt, vars["ID"])
@@ -151,7 +152,6 @@ func ListOne(r *http.Request, cfg config.Config) (int, http.Header, []byte, erro
 		return code, h, output, err
 	}
 
-	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
 	return code, h, output, err
 }
 
@@ -187,6 +187,7 @@ func List(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) 
 	dt, dateStr, err := utils.ParseZuluDate(dateStr)
 	if err != nil {
 		code = http.StatusBadRequest
+		output, _ = respond.MarshalContent(respond.ErrBadRequestDetails(err.Error()), contentType, "", " ")
 		return code, h, output, err
 	}
 	aggQuery := prepMultiQuery(dt, name)
@@ -238,6 +239,7 @@ func Create(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 	dt, dateStr, err := utils.ParseZuluDate(dateStr)
 	if err != nil {
 		code = http.StatusBadRequest
+		output, _ = respond.MarshalContent(respond.ErrBadRequestDetails(err.Error()), contentType, "", " ")
 		return code, h, output, err
 	}
 
@@ -321,18 +323,19 @@ func Update(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 	charset := "utf-8"
 	//STANDARD DECLARATIONS END
 
+	// Set Content-Type response Header value
+	contentType := r.Header.Get("Accept")
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+
 	vars := mux.Vars(r)
 	urlValues := r.URL.Query()
 	dateStr := urlValues.Get("date")
 	dt, dateStr, err := utils.ParseZuluDate(dateStr)
 	if err != nil {
 		code = http.StatusBadRequest
+		output, _ = respond.MarshalContent(respond.ErrBadRequestDetails(err.Error()), contentType, "", " ")
 		return code, h, output, err
 	}
-
-	// Set Content-Type response Header value
-	contentType := r.Header.Get("Accept")
-	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
 
 	// Grab Tenant DB configuration from context
 	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)

--- a/app/downtimes/controller.go
+++ b/app/downtimes/controller.go
@@ -79,6 +79,7 @@ func Create(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 	dt, dateStr, err := utils.ParseZuluDate(dateStr)
 	if err != nil {
 		code = http.StatusBadRequest
+		output, _ = respond.MarshalContent(respond.ErrBadRequestDetails(err.Error()), contentType, "", " ")
 		return code, h, output, err
 	}
 
@@ -182,6 +183,7 @@ func ListOne(r *http.Request, cfg config.Config) (int, http.Header, []byte, erro
 	dt, dateStr, err := utils.ParseZuluDate(dateStr)
 	if err != nil {
 		code = http.StatusBadRequest
+		output, _ = respond.MarshalContent(respond.ErrBadRequestDetails(err.Error()), contentType, "", " ")
 		return code, h, output, err
 	}
 	dQuery := prepQuery(dt, vars["ID"])
@@ -246,6 +248,7 @@ func List(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) 
 	dt, dateStr, err := utils.ParseZuluDate(dateStr)
 	if err != nil {
 		code = http.StatusBadRequest
+		output, _ = respond.MarshalContent(respond.ErrBadRequestDetails(err.Error()), contentType, "", " ")
 		return code, h, output, err
 	}
 	dQuery := prepMultiQuery(dt, name)
@@ -286,18 +289,19 @@ func Update(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 	charset := "utf-8"
 	//STANDARD DECLARATIONS END
 
+	// Set Content-Type response Header value
+	contentType := r.Header.Get("Accept")
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+
 	vars := mux.Vars(r)
 	urlValues := r.URL.Query()
 	dateStr := urlValues.Get("date")
 	dt, dateStr, err := utils.ParseZuluDate(dateStr)
 	if err != nil {
 		code = http.StatusBadRequest
+		output, _ = respond.MarshalContent(respond.ErrBadRequestDetails(err.Error()), contentType, "", " ")
 		return code, h, output, err
 	}
-
-	// Set Content-Type response Header value
-	contentType := r.Header.Get("Accept")
-	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
 
 	// Grab Tenant DB configuration from context
 	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)

--- a/app/metricProfiles/controller.go
+++ b/app/metricProfiles/controller.go
@@ -128,6 +128,7 @@ func ListOne(r *http.Request, cfg config.Config) (int, http.Header, []byte, erro
 	dt, dateStr, err := utils.ParseZuluDate(dateStr)
 	if err != nil {
 		code = http.StatusBadRequest
+		output, _ = respond.MarshalContent(respond.ErrBadRequestDetails(err.Error()), contentType, "", " ")
 		return code, h, output, err
 	}
 	mpQuery := prepQuery(dt, vars["ID"])
@@ -195,6 +196,7 @@ func List(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) 
 	dt, dateStr, err := utils.ParseZuluDate(dateStr)
 	if err != nil {
 		code = http.StatusBadRequest
+		output, _ = respond.MarshalContent(respond.ErrBadRequestDetails(err.Error()), contentType, "", " ")
 		return code, h, output, err
 	}
 	mpQuery := prepMultiQuery(dt, name)
@@ -246,6 +248,7 @@ func Create(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 	dt, dateStr, err := utils.ParseZuluDate(dateStr)
 	if err != nil {
 		code = http.StatusBadRequest
+		output, _ = respond.MarshalContent(respond.ErrBadRequestDetails(err.Error()), contentType, "", " ")
 		return code, h, output, err
 	}
 
@@ -322,18 +325,19 @@ func Update(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 	charset := "utf-8"
 	//STANDARD DECLARATIONS END
 
+	// Set Content-Type response Header value
+	contentType := r.Header.Get("Accept")
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+
 	vars := mux.Vars(r)
 	urlValues := r.URL.Query()
 	dateStr := urlValues.Get("date")
 	dt, dateStr, err := utils.ParseZuluDate(dateStr)
 	if err != nil {
 		code = http.StatusBadRequest
+		output, _ = respond.MarshalContent(respond.ErrBadRequestDetails(err.Error()), contentType, "", " ")
 		return code, h, output, err
 	}
-
-	// Set Content-Type response Header value
-	contentType := r.Header.Get("Accept")
-	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
 
 	// Grab Tenant DB configuration from context
 	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)

--- a/app/metricProfiles/metricProfiles_test.go
+++ b/app/metricProfiles/metricProfiles_test.go
@@ -87,6 +87,55 @@ func (suite *MetricProfilesTestSuite) SetupSuite() {
 	HandleSubrouter(suite.router, &suite.confHandler)
 }
 
+func (suite *MetricProfilesTestSuite) TestBadDate() {
+
+	badDate := `{
+ "status": {
+  "message": "Bad Request",
+  "code": "400"
+ },
+ "errors": [
+  {
+   "message": "Bad Request",
+   "code": "400",
+   "details": "date parameter value: 2020-02 is not in the valid form of YYYY-MM-DD"
+  }
+ ]
+}`
+
+	type reqHeader struct {
+		Method string
+		Path   string
+		Data   string
+	}
+
+	requests := []reqHeader{
+		reqHeader{Method: "GET", Path: "/api/v2/metric_profiles?date=2020-02", Data: ""},
+		reqHeader{Method: "GET", Path: "/api/v2/metric_profiles/some-uuid?date=2020-02", Data: ""},
+		reqHeader{Method: "POST", Path: "/api/v2/metric_profiles?date=2020-02", Data: ""},
+		reqHeader{Method: "PUT", Path: "/api/v2/metric_profiles/some-id?date=2020-02", Data: ""},
+	}
+
+	for _, r := range requests {
+		request, _ := http.NewRequest(r.Method, r.Path, strings.NewReader(r.Data))
+		request.Header.Set("x-api-key", suite.clientkey)
+		request.Header.Set("Accept", "application/json")
+		response := httptest.NewRecorder()
+
+		suite.router.ServeHTTP(response, request)
+
+		code := response.Code
+		output := response.Body.String()
+
+		// Check that we must have a 200 ok code
+		suite.Equal(400, code, "Internal Server Error")
+		// Compare the expected and actual json response
+		suite.Equal(badDate, output, "Response body mismatch")
+
+	}
+
+}
+
 // This function runs before any test and setups the environment
 func (suite *MetricProfilesTestSuite) SetupTest() {
 

--- a/app/operationsProfiles/controller.go
+++ b/app/operationsProfiles/controller.go
@@ -124,6 +124,7 @@ func ListOne(r *http.Request, cfg config.Config) (int, http.Header, []byte, erro
 	dt, dateStr, err := utils.ParseZuluDate(dateStr)
 	if err != nil {
 		code = http.StatusBadRequest
+		output, _ = respond.MarshalContent(respond.ErrBadRequestDetails(err.Error()), contentType, "", " ")
 		return code, h, output, err
 	}
 	opsQuery := prepQuery(dt, vars["ID"])
@@ -189,6 +190,7 @@ func List(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) 
 	dt, dateStr, err := utils.ParseZuluDate(dateStr)
 	if err != nil {
 		code = http.StatusBadRequest
+		output, _ = respond.MarshalContent(respond.ErrBadRequestDetails(err.Error()), contentType, "", " ")
 		return code, h, output, err
 	}
 	opsQuery := prepMultiQuery(dt, name)
@@ -240,6 +242,7 @@ func Create(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 	dt, dateStr, err := utils.ParseZuluDate(dateStr)
 	if err != nil {
 		code = http.StatusBadRequest
+		output, _ = respond.MarshalContent(respond.ErrBadRequestDetails(err.Error()), contentType, "", " ")
 		return code, h, output, err
 	}
 
@@ -326,18 +329,19 @@ func Update(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 	charset := "utf-8"
 	//STANDARD DECLARATIONS END
 
+	// Set Content-Type response Header value
+	contentType := r.Header.Get("Accept")
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+
 	vars := mux.Vars(r)
 	urlValues := r.URL.Query()
 	dateStr := urlValues.Get("date")
 	dt, dateStr, err := utils.ParseZuluDate(dateStr)
 	if err != nil {
 		code = http.StatusBadRequest
+		output, _ = respond.MarshalContent(respond.ErrBadRequestDetails(err.Error()), contentType, "", " ")
 		return code, h, output, err
 	}
-
-	// Set Content-Type response Header value
-	contentType := r.Header.Get("Accept")
-	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
 
 	// Grab Tenant DB configuration from context
 	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)

--- a/app/operationsProfiles/operationsProfiles_test.go
+++ b/app/operationsProfiles/operationsProfiles_test.go
@@ -412,6 +412,54 @@ func (suite *OperationsProfilesTestSuite) SetupTest() {
 			}})
 }
 
+func (suite *OperationsProfilesTestSuite) TestBadDate() {
+
+	badDate := `{
+ "status": {
+  "message": "Bad Request",
+  "code": "400"
+ },
+ "errors": [
+  {
+   "message": "Bad Request",
+   "code": "400",
+   "details": "date parameter value: 2020-02 is not in the valid form of YYYY-MM-DD"
+  }
+ ]
+}`
+
+	type reqHeader struct {
+		Method string
+		Path   string
+		Data   string
+	}
+
+	requests := []reqHeader{
+		reqHeader{Method: "GET", Path: "/api/v2/operations_profiles?date=2020-02", Data: ""},
+		reqHeader{Method: "GET", Path: "/api/v2/operations_profiles/some-uuid?date=2020-02", Data: ""},
+		reqHeader{Method: "POST", Path: "/api/v2/operations_profiles?date=2020-02", Data: ""},
+		reqHeader{Method: "PUT", Path: "/api/v2/operations_profiles/some-id?date=2020-02", Data: ""},
+	}
+
+	for _, r := range requests {
+		request, _ := http.NewRequest(r.Method, r.Path, strings.NewReader(r.Data))
+		request.Header.Set("x-api-key", suite.clientkey)
+		request.Header.Set("Accept", "application/json")
+		response := httptest.NewRecorder()
+
+		suite.router.ServeHTTP(response, request)
+
+		code := response.Code
+		output := response.Body.String()
+
+		// Check that we must have a 200 ok code
+		suite.Equal(400, code, "Internal Server Error")
+		// Compare the expected and actual json response
+		suite.Equal(badDate, output, "Response body mismatch")
+
+	}
+
+}
 func (suite *OperationsProfilesTestSuite) TestList() {
 
 	request, _ := http.NewRequest("GET", "/api/v2/operations_profiles", strings.NewReader(""))

--- a/app/thresholdsProfiles/controller.go
+++ b/app/thresholdsProfiles/controller.go
@@ -117,6 +117,7 @@ func ListOne(r *http.Request, cfg config.Config) (int, http.Header, []byte, erro
 	dt, dateStr, err := utils.ParseZuluDate(dateStr)
 	if err != nil {
 		code = http.StatusBadRequest
+		output, _ = respond.MarshalContent(respond.ErrBadRequestDetails(err.Error()), contentType, "", " ")
 		return code, h, output, err
 	}
 	thQuery := prepQuery(dt, vars["ID"])
@@ -184,6 +185,7 @@ func List(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) 
 	dt, dateStr, err := utils.ParseZuluDate(dateStr)
 	if err != nil {
 		code = http.StatusBadRequest
+		output, _ = respond.MarshalContent(respond.ErrBadRequestDetails(err.Error()), contentType, "", " ")
 		return code, h, output, err
 	}
 	thQuery := prepMultiQuery(dt, name)
@@ -235,6 +237,7 @@ func Create(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 	dt, dateStr, err := utils.ParseZuluDate(dateStr)
 	if err != nil {
 		code = http.StatusBadRequest
+		output, _ = respond.MarshalContent(respond.ErrBadRequestDetails(err.Error()), contentType, "", " ")
 		return code, h, output, err
 	}
 
@@ -319,18 +322,19 @@ func Update(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 	charset := "utf-8"
 	//STANDARD DECLARATIONS END
 
+	// Set Content-Type response Header value
+	contentType := r.Header.Get("Accept")
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+
 	vars := mux.Vars(r)
 	urlValues := r.URL.Query()
 	dateStr := urlValues.Get("date")
 	dt, dateStr, err := utils.ParseZuluDate(dateStr)
 	if err != nil {
 		code = http.StatusBadRequest
+		output, _ = respond.MarshalContent(respond.ErrBadRequestDetails(err.Error()), contentType, "", " ")
 		return code, h, output, err
 	}
-
-	// Set Content-Type response Header value
-	contentType := r.Header.Get("Accept")
-	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
 
 	// Grab Tenant DB configuration from context
 	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)

--- a/app/thresholdsProfiles/thresholdsProfiles_test.go
+++ b/app/thresholdsProfiles/thresholdsProfiles_test.go
@@ -262,6 +262,54 @@ func (suite *ThresholdsProfilesTestSuite) SetupTest() {
 		})
 }
 
+func (suite *ThresholdsProfilesTestSuite) TestBadDate() {
+
+	badDate := `{
+ "status": {
+  "message": "Bad Request",
+  "code": "400"
+ },
+ "errors": [
+  {
+   "message": "Bad Request",
+   "code": "400",
+   "details": "date parameter value: 2020-02 is not in the valid form of YYYY-MM-DD"
+  }
+ ]
+}`
+
+	type reqHeader struct {
+		Method string
+		Path   string
+		Data   string
+	}
+
+	requests := []reqHeader{
+		reqHeader{Method: "GET", Path: "/api/v2/thresholds_profiles?date=2020-02", Data: ""},
+		reqHeader{Method: "GET", Path: "/api/v2/thresholds_profiles/some-uuid?date=2020-02", Data: ""},
+		reqHeader{Method: "POST", Path: "/api/v2/thresholds_profiles?date=2020-02", Data: ""},
+		reqHeader{Method: "PUT", Path: "/api/v2/thresholds_profiles/some-id?date=2020-02", Data: ""},
+	}
+
+	for _, r := range requests {
+		request, _ := http.NewRequest(r.Method, r.Path, strings.NewReader(r.Data))
+		request.Header.Set("x-api-key", suite.clientkey)
+		request.Header.Set("Accept", "application/json")
+		response := httptest.NewRecorder()
+
+		suite.router.ServeHTTP(response, request)
+
+		code := response.Code
+		output := response.Body.String()
+
+		// Check that we must have a 200 ok code
+		suite.Equal(400, code, "Internal Server Error")
+		// Compare the expected and actual json response
+		suite.Equal(badDate, output, "Response body mismatch")
+
+	}
+
+}
 func (suite *ThresholdsProfilesTestSuite) TestList() {
 
 	request, _ := http.NewRequest("GET", "/api/v2/thresholds_profiles", strings.NewReader(""))

--- a/app/topology/controller.go
+++ b/app/topology/controller.go
@@ -28,9 +28,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
-	"strconv"
 	"strings"
-	"time"
 
 	"github.com/ARGOeu/argo-web-api/app/reports"
 
@@ -88,15 +86,12 @@ func ListTopoStats(r *http.Request, cfg config.Config) (int, http.Header, []byte
 	//Time Related
 	dateStr := urlValues.Get("date")
 
-	const zuluForm = "2006-01-02"
-	const ymdForm = "20060102"
-
-	ts := time.Now().UTC()
-	if dateStr != "" {
-		ts, _ = time.Parse(zuluForm, dateStr)
+	dt, dateStr, err := utils.ParseZuluDate(dateStr)
+	if err != nil {
+		code = http.StatusBadRequest
+		output, _ = respond.MarshalContent(respond.ErrBadRequestDetails(err.Error()), contentType, "", " ")
+		return code, h, output, err
 	}
-
-	tsYMD, _ := strconv.Atoi(ts.Format(ymdForm))
 
 	session, err := mongo.OpenSession(tenantDbConfig)
 	defer mongo.CloseSession(session)
@@ -120,17 +115,17 @@ func ListTopoStats(r *http.Request, cfg config.Config) (int, http.Header, []byte
 	serviceCol := session.DB(tenantDbConfig.Db).C("service_ar")
 	eGroupCol := session.DB(tenantDbConfig.Db).C("endpoint_group_ar")
 
-	err = serviceCol.Find(bson.M{"report": reportID, "date": tsYMD}).Distinct("name", &serviceResults)
+	err = serviceCol.Find(bson.M{"report": reportID, "date": dt}).Distinct("name", &serviceResults)
 	if err != nil {
 		code = http.StatusInternalServerError
 		return code, h, output, err
 	}
-	err = eGroupCol.Find(bson.M{"report": reportID, "date": tsYMD}).Distinct("name", &egroupResults)
+	err = eGroupCol.Find(bson.M{"report": reportID, "date": dt}).Distinct("name", &egroupResults)
 	if err != nil {
 		code = http.StatusInternalServerError
 		return code, h, output, err
 	}
-	err = eGroupCol.Find(bson.M{"report": reportID, "date": tsYMD}).Distinct("supergroup", &groupResults)
+	err = eGroupCol.Find(bson.M{"report": reportID, "date": dt}).Distinct("supergroup", &groupResults)
 	if err != nil {
 		code = http.StatusInternalServerError
 		return code, h, output, err
@@ -188,6 +183,7 @@ func ListEndpoints(r *http.Request, cfg config.Config) (int, http.Header, []byte
 	dt, dateStr, err := utils.ParseZuluDate(dateStr)
 	if err != nil {
 		code = http.StatusBadRequest
+		output, _ = respond.MarshalContent(respond.ErrBadRequestDetails(err.Error()), contentType, "", " ")
 		return code, h, output, err
 	}
 
@@ -249,6 +245,7 @@ func CreateEndpoints(r *http.Request, cfg config.Config) (int, http.Header, []by
 	dt, dateStr, err := utils.ParseZuluDate(dateStr)
 	if err != nil {
 		code = http.StatusBadRequest
+		output, _ = respond.MarshalContent(respond.ErrBadRequestDetails(err.Error()), contentType, "", " ")
 		return code, h, output, err
 	}
 
@@ -336,9 +333,9 @@ func DeleteEndpoints(r *http.Request, cfg config.Config) (int, http.Header, []by
 	dt, dateStr, err := utils.ParseZuluDate(dateStr)
 	if err != nil {
 		code = http.StatusBadRequest
+		output, _ = respond.MarshalContent(respond.ErrBadRequestDetails(err.Error()), contentType, "", " ")
 		return code, h, output, err
 	}
-
 	session, err := mongo.OpenSession(tenantDbConfig)
 	defer mongo.CloseSession(session)
 	if err != nil {
@@ -386,6 +383,7 @@ func CreateGroups(r *http.Request, cfg config.Config) (int, http.Header, []byte,
 	dt, dateStr, err := utils.ParseZuluDate(dateStr)
 	if err != nil {
 		code = http.StatusBadRequest
+		output, _ = respond.MarshalContent(respond.ErrBadRequestDetails(err.Error()), contentType, "", " ")
 		return code, h, output, err
 	}
 
@@ -890,6 +888,7 @@ func ListEndpointsByReport(r *http.Request, cfg config.Config) (int, http.Header
 	dt, dateStr, err := utils.ParseZuluDate(dateStr)
 	if err != nil {
 		code = http.StatusBadRequest
+		output, _ = respond.MarshalContent(respond.ErrBadRequestDetails(err.Error()), contentType, "", " ")
 		return code, h, output, err
 	}
 
@@ -984,9 +983,9 @@ func ListGroupsByReport(r *http.Request, cfg config.Config) (int, http.Header, [
 	dt, dateStr, err := utils.ParseZuluDate(dateStr)
 	if err != nil {
 		code = http.StatusBadRequest
+		output, _ = respond.MarshalContent(respond.ErrBadRequestDetails(err.Error()), contentType, "", " ")
 		return code, h, output, err
 	}
-
 	fGroup := fltrGroup{}
 	fGroup, _ = getReportFilters(report)
 
@@ -1054,6 +1053,7 @@ func ListGroups(r *http.Request, cfg config.Config) (int, http.Header, []byte, e
 	dt, dateStr, err := utils.ParseZuluDate(dateStr)
 	if err != nil {
 		code = http.StatusBadRequest
+		output, _ = respond.MarshalContent(respond.ErrBadRequestDetails(err.Error()), contentType, "", " ")
 		return code, h, output, err
 	}
 
@@ -1113,6 +1113,7 @@ func DeleteGroups(r *http.Request, cfg config.Config) (int, http.Header, []byte,
 	dt, dateStr, err := utils.ParseZuluDate(dateStr)
 	if err != nil {
 		code = http.StatusBadRequest
+		output, _ = respond.MarshalContent(respond.ErrBadRequestDetails(err.Error()), contentType, "", " ")
 		return code, h, output, err
 	}
 

--- a/app/topology/routing.go
+++ b/app/topology/routing.go
@@ -49,6 +49,7 @@ var appRoutesV2 = []respond.AppRoutes{
 	{"topology_groups.delete", "DELETE", "/groups", DeleteGroups},
 	{"topology_groups.list", "GET", "/groups", ListGroups},
 	{"topology_groups.insert", "POST", "/groups", CreateGroups},
+	{"topology_groups.options", "OPTIONS", "/groups", Options},
 	{"topology_endpoints.insert", "POST", "/endpoints", CreateEndpoints},
 	{"topology_endpoints.list", "GET", "/endpoints", ListEndpoints},
 	{"topology_endpoints.delete", "DELETE", "/endpoints", DeleteEndpoints},

--- a/app/topology/topology_test.go
+++ b/app/topology/topology_test.go
@@ -1026,6 +1026,60 @@ func (suite *topologyTestSuite) SetupTest() {
 
 }
 
+func (suite *topologyTestSuite) TestBadDate() {
+
+	badDate := `{
+ "status": {
+  "message": "Bad Request",
+  "code": "400"
+ },
+ "errors": [
+  {
+   "message": "Bad Request",
+   "code": "400",
+   "details": "date parameter value: 2020-02 is not in the valid form of YYYY-MM-DD"
+  }
+ ]
+}`
+
+	type reqHeader struct {
+		Method string
+		Path   string
+		Data   string
+	}
+
+	requests := []reqHeader{
+		reqHeader{Method: "GET", Path: "/api/v2/topology/endpoints?date=2020-02", Data: ""},
+		reqHeader{Method: "GET", Path: "/api/v2/topology/endpoints/by_report/Critical?date=2020-02", Data: ""},
+		reqHeader{Method: "POST", Path: "/api/v2/topology/endpoints?date=2020-02", Data: ""},
+		reqHeader{Method: "DELETE", Path: "/api/v2/topology/endpoints?date=2020-02", Data: ""},
+		reqHeader{Method: "GET", Path: "/api/v2/topology/groups?date=2020-02", Data: ""},
+		reqHeader{Method: "GET", Path: "/api/v2/topology/groups/by_report/Critical?date=2020-02", Data: ""},
+		reqHeader{Method: "POST", Path: "/api/v2/topology/groups?date=2020-02", Data: ""},
+		reqHeader{Method: "DELETE", Path: "/api/v2/topology/groups?date=2020-02", Data: ""},
+		reqHeader{Method: "GET", Path: "/api/v2/topology/stats/Critical?date=2020-02", Data: ""},
+	}
+
+	for _, r := range requests {
+		request, _ := http.NewRequest(r.Method, r.Path, strings.NewReader(r.Data))
+		request.Header.Set("x-api-key", suite.clientkey)
+		request.Header.Set("Accept", "application/json")
+		response := httptest.NewRecorder()
+
+		suite.router.ServeHTTP(response, request)
+
+		code := response.Code
+		output := response.Body.String()
+
+		// Check that we must have a 200 ok code
+		suite.Equal(400, code, "Internal Server Error")
+		// Compare the expected and actual json response
+		suite.Equal(badDate, output, "Response body mismatch")
+
+	}
+
+}
+
 func (suite *topologyTestSuite) TestCreateEndpointGroupTopology() {
 
 	expJSON := `{

--- a/app/weights/controller.go
+++ b/app/weights/controller.go
@@ -81,6 +81,7 @@ func Create(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 	dt, dateStr, err := utils.ParseZuluDate(dateStr)
 	if err != nil {
 		code = http.StatusBadRequest
+		output, _ = respond.MarshalContent(respond.ErrBadRequestDetails(err.Error()), contentType, "", " ")
 		return code, h, output, err
 	}
 	session, err := mongo.OpenSession(tenantDbConfig)
@@ -183,6 +184,7 @@ func ListOne(r *http.Request, cfg config.Config) (int, http.Header, []byte, erro
 	dt, dateStr, err := utils.ParseZuluDate(dateStr)
 	if err != nil {
 		code = http.StatusBadRequest
+		output, _ = respond.MarshalContent(respond.ErrBadRequestDetails(err.Error()), contentType, "", " ")
 		return code, h, output, err
 	}
 	wQuery := prepQuery(dt, vars["ID"])
@@ -247,6 +249,7 @@ func List(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) 
 	dt, dateStr, err := utils.ParseZuluDate(dateStr)
 	if err != nil {
 		code = http.StatusBadRequest
+		output, _ = respond.MarshalContent(respond.ErrBadRequestDetails(err.Error()), contentType, "", " ")
 		return code, h, output, err
 	}
 	wQuery := prepMultiQuery(dt, name)
@@ -290,11 +293,16 @@ func Update(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 	vars := mux.Vars(r)
 	urlValues := r.URL.Query()
 	dateStr := urlValues.Get("date")
-	dt, dateStr, err := utils.ParseZuluDate(dateStr)
-
 	// Set Content-Type response Header value
 	contentType := r.Header.Get("Accept")
 	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+
+	dt, dateStr, err := utils.ParseZuluDate(dateStr)
+	if err != nil {
+		code = http.StatusBadRequest
+		output, _ = respond.MarshalContent(respond.ErrBadRequestDetails(err.Error()), contentType, "", " ")
+		return code, h, output, err
+	}
 
 	// Grab Tenant DB configuration from context
 	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)

--- a/app/weights/weights_test.go
+++ b/app/weights/weights_test.go
@@ -258,6 +258,55 @@ func (suite *WeightsTestSuite) SetupTest() {
 
 }
 
+func (suite *WeightsTestSuite) TestBadDate() {
+
+	badDate := `{
+ "status": {
+  "message": "Bad Request",
+  "code": "400"
+ },
+ "errors": [
+  {
+   "message": "Bad Request",
+   "code": "400",
+   "details": "date parameter value: 2020-02 is not in the valid form of YYYY-MM-DD"
+  }
+ ]
+}`
+
+	type reqHeader struct {
+		Method string
+		Path   string
+		Data   string
+	}
+
+	requests := []reqHeader{
+		reqHeader{Method: "GET", Path: "/api/v2/weights?date=2020-02", Data: ""},
+		reqHeader{Method: "GET", Path: "/api/v2/weights/some-uuid?date=2020-02", Data: ""},
+		reqHeader{Method: "POST", Path: "/api/v2/weights?date=2020-02", Data: ""},
+		reqHeader{Method: "PUT", Path: "/api/v2/weights/some-id?date=2020-02", Data: ""},
+	}
+
+	for _, r := range requests {
+		request, _ := http.NewRequest(r.Method, r.Path, strings.NewReader(r.Data))
+		request.Header.Set("x-api-key", suite.clientkey)
+		request.Header.Set("Accept", "application/json")
+		response := httptest.NewRecorder()
+
+		suite.router.ServeHTTP(response, request)
+
+		code := response.Code
+		output := response.Body.String()
+
+		// Check that we must have a 200 ok code
+		suite.Equal(400, code, "Internal Server Error")
+		// Compare the expected and actual json response
+		suite.Equal(badDate, output, "Response body mismatch")
+
+	}
+
+}
+
 func (suite *WeightsTestSuite) TestCreateBadJson() {
 
 	jsonInput := `{

--- a/respond/respond.go
+++ b/respond/respond.go
@@ -326,6 +326,19 @@ var BadRequestSimple = ResponseMessage{
 		Code:    "400",
 	}}
 
+// ErrBadRequestDetails provides an error messsage with specific details
+var ErrBadRequestDetails = func(details string) ResponseMessage {
+	return ResponseMessage{
+		Status: StatusResponse{
+			Message: "Bad Request",
+			Code:    "400",
+		},
+		Errors: []StatusResponse{
+			{Message: "Bad Request", Code: "400", Details: details},
+		},
+	}
+}
+
 // BadRequestBadJson is used to inform the user about malformed json body
 var BadRequestBadJSON = ResponseMessage{
 	Status: StatusResponse{

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"fmt"
 	"strconv"
 	"time"
 )
@@ -12,8 +13,12 @@ const ymdForm = "20060102"
 // ParseZuluDate returns a Zulu representation of current time
 func ParseZuluDate(dateStr string) (int, string, error) {
 	parsedTime := time.Now().UTC()
+	var err error
 	if dateStr != "" {
-		parsedTime, _ = time.Parse(zuluDateOnly, dateStr)
+		parsedTime, err = time.Parse(zuluDateOnly, dateStr)
+		if err != nil {
+			return -1, dateStr, fmt.Errorf("date parameter value: %s is not in the valid form of YYYY-MM-DD", dateStr)
+		}
 	} else {
 		dateStr = parsedTime.Format(zuluDateOnly)
 	}


### PR DESCRIPTION
# Issue 
Date optional query param in historic profile request was not validated properly due to err handling bug

# Fix 
- [x] Fix err handling in utils.ParseZuluDate method
- [x] Add a common BadRequestDetails error structure for describing bad requests due to invalid parameters
- [x] Update err responses in controllers of historic profiles (metric,operations,aggregations,weights,topology,downtimes,thresholds)
- [x] Add unit tests