### PR TITLE
ARGO-2227 Feature: argo-web-api flat endpoint list a/r

### DIFF
--- a/app/results/Controller.go
+++ b/app/results/Controller.go
@@ -23,8 +23,10 @@
 package results
 
 import (
+	"encoding/base64"
 	"fmt"
 	"net/http"
+	"strconv"
 
 	"github.com/ARGOeu/argo-web-api/app/reports"
 	"github.com/ARGOeu/argo-web-api/respond"
@@ -34,6 +36,154 @@ import (
 	"github.com/gorilla/mux"
 	"gopkg.in/mgo.v2/bson"
 )
+
+// FlatListEndpointResults is responsible for handling request to flat list all available endpoint results
+func FlatListEndpointResults(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
+	//STANDARD DECLARATIONS START
+	code := http.StatusOK
+	h := http.Header{}
+	output := []byte("")
+	err := error(nil)
+	charset := "utf-8"
+	//STANDARD DECLARATIONS END
+
+	// Set Content-Type response Header value
+	contentType := r.Header.Get("Accept")
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+
+	// Parse the request into the input
+	urlValues := r.URL.Query()
+	vars := mux.Vars(r)
+	supergroup := urlValues.Get("supergroup")
+	service := urlValues.Get("service")
+
+	skip := 0
+	tkStr := urlValues.Get("nextPageToken")
+	if tkStr != "" {
+		tk, err := base64.StdEncoding.DecodeString(tkStr)
+		if err != nil {
+			code = http.StatusInternalServerError
+			return code, h, output, err
+		}
+		skip, err = strconv.Atoi(string(tk))
+		if err != nil {
+			code = http.StatusInternalServerError
+			return code, h, output, err
+		}
+	}
+
+	limit := -1
+	limStr := urlValues.Get("pageSize")
+	if limStr != "" {
+		limit, err = strconv.Atoi(limStr)
+		if err != nil {
+			code = http.StatusInternalServerError
+			return code, h, output, err
+		}
+	}
+
+	// Grab Tenant DB configuration from context
+	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
+
+	session, err := mongo.OpenSession(tenantDbConfig)
+	defer mongo.CloseSession(session)
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	report := reports.MongoInterface{}
+	err = mongo.FindOne(session, tenantDbConfig.Db, "reports", bson.M{"info.name": vars["report_name"]}, &report)
+
+	if err != nil {
+		code = http.StatusNotFound
+		message := "The report with the name " + vars["report_name"] + " does not exist"
+		output, err := createErrorMessage(message, code, contentType) //Render the response into XML or JSON
+		return code, h, output, err
+	}
+
+	input := endpointResultQuery{
+		basicQuery: basicQuery{
+			Name: vars["endpoint_name"],
+
+			Granularity: urlValues.Get("granularity"),
+			Format:      contentType,
+			StartTime:   urlValues.Get("start_time"),
+			EndTime:     urlValues.Get("end_time"),
+			Report:      report,
+			Vars:        vars,
+		},
+		EndpointGroup: supergroup,
+		Service:       service,
+	}
+
+	tenantDB := session.DB(tenantDbConfig.Db)
+	errs := input.Validate(tenantDB)
+	if len(errs) > 0 {
+		out := respond.BadRequestSimple
+		out.Errors = errs
+		output = out.MarshalTo(contentType)
+		code = 400
+		return code, h, output, err
+	}
+
+	results := []EndpointInterface{}
+
+	// Construct the query to mongodb based on the input
+	filter := bson.M{
+		"date":   bson.M{"$gte": input.StartTimeInt, "$lte": input.EndTimeInt},
+		"report": report.ID,
+	}
+
+	if input.Name != "" {
+		filter["name"] = input.Name
+	}
+
+	if input.Service != "" {
+		filter["service"] = input.Service
+	}
+
+	if input.EndpointGroup != "" {
+		filter["supergroup"] = input.EndpointGroup
+	}
+
+	// Select the granularity of the search daily/monthly
+	if input.Granularity == "daily" {
+		customForm[0] = "20060102"
+		customForm[1] = "2006-01-02"
+		query := FlatDailyEndpoint(filter, limit, skip)
+		err = mongo.Pipe(session, tenantDbConfig.Db, "endpoint_ar", query, &results)
+	} else if input.Granularity == "monthly" {
+		customForm[0] = "200601"
+		customForm[1] = "2006-01"
+		query := FlatMonthlyEndpoint(filter, limit, skip)
+		err = mongo.Pipe(session, tenantDbConfig.Db, "endpoint_ar", query, &results)
+
+	}
+
+	// mongo.Find(session, tenantDbConfig.Db, "endpoint_group_ar", bson.M{}, "_id", &results)
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	if len(results) == 0 {
+		code = http.StatusNotFound
+		message := "No results found for given query"
+		output, err = createErrorMessage(message, code, contentType)
+		return code, h, output, err
+	}
+
+	output, err = createFlatEndpointResultView(results, report, input.Format, limit, skip)
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	return code, h, output, err
+
+}
 
 // ListEndpointResults is responsible for handling request to list service flavor results
 func ListEndpointResults(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
@@ -168,12 +318,47 @@ func ListEndpointResults(r *http.Request, cfg config.Config) (int, http.Header, 
 
 }
 
+// FlatDailyEndpoint query to aggregate daily endpoint a/r results from mongoDB
+func FlatDailyEndpoint(filter bson.M, limit int, skip int) []bson.M {
+
+	query := []bson.M{
+		{"$match": filter},
+		{"$project": bson.M{
+			"_id":          1,
+			"date":         bson.D{{"$substr", list{"$date", 0, 8}}},
+			"name":         1,
+			"availability": 1,
+			"reliability":  1,
+			"unknown":      1,
+			"up":           1,
+			"down":         1,
+			"supergroup":   1,
+			"service":      1,
+			"info":         1,
+			"report":       1}},
+		{"$sort": bson.D{
+			{"name", 1},
+			{"service", 1},
+			{"supergroup", 1},
+			{"date", 1},
+		}}}
+
+	if limit > 0 {
+		query = append(query, bson.M{"$skip": skip})
+		query = append(query, bson.M{"$limit": limit + 1})
+
+	}
+
+	return query
+}
+
 // DailyEndpoint query to aggregate daily endpoint a/r results from mongoDB
 func DailyEndpoint(filter bson.M) []bson.M {
 	query := []bson.M{
 		{"$match": filter},
 		{"$group": bson.M{
 			"_id": bson.M{
+				"id":           "$_id",
 				"date":         bson.D{{"$substr", list{"$date", 0, 8}}},
 				"name":         "$name",
 				"supergroup":   "$supergroup",
@@ -188,6 +373,7 @@ func DailyEndpoint(filter bson.M) []bson.M {
 		}},
 
 		{"$project": bson.M{
+			"_id":          "$_id.id",
 			"date":         "$_id.date",
 			"name":         "$_id.name",
 			"availability": "$_id.availability",
@@ -204,6 +390,56 @@ func DailyEndpoint(filter bson.M) []bson.M {
 			{"service", 1},
 			{"name", 1},
 			{"date", 1}}}}
+
+	return query
+}
+
+// FlatMonthlyEndpoint query to aggregate monthly a/r results from mongoDB
+func FlatMonthlyEndpoint(filter bson.M, limit int, skip int) []bson.M {
+	query := []bson.M{
+		{"$match": filter},
+		{"$group": bson.M{
+			"_id": bson.M{
+				"date":       bson.D{{"$substr", list{"$date", 0, 6}}},
+				"name":       "$name",
+				"supergroup": "$supergroup",
+				"service":    "$service",
+				"report":     "$report"},
+			"avgup":      bson.M{"$avg": "$up"},
+			"avgunknown": bson.M{"$avg": "$unknown"},
+			"avgdown":    bson.M{"$avg": "$down"},
+			"info":       bson.M{"$first": "$info"}}},
+		{"$project": bson.M{
+			"date":       "$_id.date",
+			"name":       "$_id.name",
+			"supergroup": "$_id.supergroup",
+			"service":    "$_id.service",
+			"report":     "$_id.report",
+			"info":       "$info",
+			"unknown":    "$avgunknown",
+			"up":         "$avgup",
+			"down":       "$avgdown",
+			"availability": bson.M{
+				"$multiply": list{
+					bson.M{"$divide": list{
+						"$avgup", bson.M{"$subtract": list{1.00000001, "$avgunknown"}}}},
+					100}},
+			"reliability": bson.M{
+				"$multiply": list{
+					bson.M{"$divide": list{
+						"$avgup", bson.M{"$subtract": list{bson.M{"$subtract": list{1.00000001, "$avgunknown"}}, "$avgdown"}}}},
+					100}}}},
+		{"$sort": bson.D{
+			{"name", 1},
+			{"service", 1},
+			{"supergroup", 1},
+			{"date", 1}}}}
+
+	if limit > 0 {
+		query = append(query, bson.M{"$skip": skip})
+		query = append(query, bson.M{"$limit": limit + 1})
+
+	}
 
 	return query
 }

--- a/app/results/Model.go
+++ b/app/results/Model.go
@@ -163,6 +163,8 @@ type ServiceEndpointGroup struct {
 type Endpoint struct {
 	XMLName      xml.Name          `xml:"group" json:"-"`
 	Name         string            `xml:"name,attr" json:"name"`
+	Service      string            `xml:"service,attr,omitempty" json:"service,omitempty"`
+	SuperGroup   string            `xml:"supergroup,attr,omitempty" json:"supergroup,omitempty"`
 	Type         string            `xml:"type,attr" json:"type"`
 	Info         map[string]string `xml:"-" json:"info,omitempty"`
 	Availability []interface{}     `json:"results"`
@@ -199,6 +201,13 @@ type SuperGroup struct {
 	Type      string        `xml:"type,attr" json:"type"`
 	Endpoints []interface{} `json:"endpoints,omitempty"`
 	Results   []interface{} `json:"results,omitempty"`
+}
+
+type pageRoot struct {
+	XMLName   xml.Name      `xml:"root" json:"-"`
+	Result    []interface{} `json:"results"`
+	PageToken string        `json:"nextPageToken,omitempty"`
+	PageSize  int           `json:"pageSize,omitempty"`
 }
 
 type root struct {

--- a/app/results/endpoint_test.go
+++ b/app/results/endpoint_test.go
@@ -235,6 +235,42 @@ func (suite *endpointAvailabilityTestSuite) SetupTest() {
 		},
 		bson.M{
 			"report":       "eba61a9e-22e9-4521-9e47-ecaa4a49436",
+			"date":         20150622,
+			"name":         "e03",
+			"supergroup":   "ST02",
+			"service":      "service_x",
+			"up":           0.96875,
+			"down":         0,
+			"unknown":      0,
+			"availability": 96.875,
+			"reliability":  96.875,
+			"tags": []bson.M{
+				bson.M{
+					"name":  "production",
+					"value": "Y",
+				},
+			},
+		},
+		bson.M{
+			"report":       "eba61a9e-22e9-4521-9e47-ecaa4a49436",
+			"date":         20150622,
+			"name":         "e03",
+			"supergroup":   "STX",
+			"service":      "service_b",
+			"up":           0.96875,
+			"down":         0,
+			"unknown":      0,
+			"availability": 96.875,
+			"reliability":  96.875,
+			"tags": []bson.M{
+				bson.M{
+					"name":  "production",
+					"value": "Y",
+				},
+			},
+		},
+		bson.M{
+			"report":       "eba61a9e-22e9-4521-9e47-ecaa4a49436",
 			"date":         20150623,
 			"name":         "e01",
 			"supergroup":   "ST01",
@@ -409,6 +445,909 @@ func (suite *endpointAvailabilityTestSuite) TestListEndpointAvailabilityMonthly(
 	suite.Equal(200, response.Code, "Incorrect HTTP response code")
 	// Compare the expected and actual xml response
 	suite.Equal(endpointAvailabilityJSON, responseBody, "Response body mismatch")
+
+}
+func (suite *endpointAvailabilityTestSuite) TestFlatAllEndpoints() {
+
+	request, _ := http.NewRequest("GET", "/api/v2/results/Report_A/endpoints?start_time=2015-06-20T12:00:00Z&end_time=2015-06-23T23:00:00Z&granularity=daily", strings.NewReader(""))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	resultsJSON := `{
+   "results": [
+     {
+       "name": "e01",
+       "service": "service_a",
+       "supergroup": "ST01",
+       "type": "endpoint",
+       "info": {
+         "Url": "https://foo.example.url"
+       },
+       "results": [
+         {
+           "timestamp": "2015-06-22",
+           "availability": "98.26389",
+           "reliability": "98.26389",
+           "unknown": "0",
+           "uptime": "0.98264",
+           "downtime": "0"
+         },
+         {
+           "timestamp": "2015-06-23",
+           "availability": "54.03509",
+           "reliability": "81.48148",
+           "unknown": "0.01042",
+           "uptime": "0.53472",
+           "downtime": "0.33333"
+         }
+       ]
+     },
+     {
+       "name": "e02",
+       "service": "service_a",
+       "supergroup": "ST01",
+       "type": "endpoint",
+       "results": [
+         {
+           "timestamp": "2015-06-22",
+           "availability": "96.875",
+           "reliability": "96.875",
+           "unknown": "0",
+           "uptime": "0.96875",
+           "downtime": "0"
+         },
+         {
+           "timestamp": "2015-06-23",
+           "availability": "100",
+           "reliability": "100",
+           "unknown": "0",
+           "uptime": "1",
+           "downtime": "0"
+         }
+       ]
+     },
+     {
+       "name": "e03",
+       "service": "service_b",
+       "supergroup": "ST02",
+       "type": "endpoint",
+       "results": [
+         {
+           "timestamp": "2015-06-22",
+           "availability": "96.875",
+           "reliability": "96.875",
+           "unknown": "0",
+           "uptime": "0.96875",
+           "downtime": "0"
+         }
+       ]
+     },
+     {
+       "name": "e03",
+       "service": "service_b",
+       "supergroup": "STX",
+       "type": "endpoint",
+       "results": [
+         {
+           "timestamp": "2015-06-22",
+           "availability": "96.875",
+           "reliability": "96.875",
+           "unknown": "0",
+           "uptime": "0.96875",
+           "downtime": "0"
+         }
+       ]
+     },
+     {
+       "name": "e03",
+       "service": "service_x",
+       "supergroup": "ST02",
+       "type": "endpoint",
+       "results": [
+         {
+           "timestamp": "2015-06-22",
+           "availability": "96.875",
+           "reliability": "96.875",
+           "unknown": "0",
+           "uptime": "0.96875",
+           "downtime": "0"
+         }
+       ]
+     }
+   ]
+ }`
+
+	// Check that we must have a 200 ok code
+	suite.Equal(200, response.Code, "Incorrect HTTP response code")
+	// Compare the expected and actual xml response
+	suite.Equal(resultsJSON, response.Body.String(), "Response body mismatch")
+
+}
+
+func (suite *endpointAvailabilityTestSuite) TestFlatAllEndpointsPaginated() {
+
+	type expReq struct {
+		method string
+		url    string
+		code   int
+		result string
+	}
+
+	expReqs := []expReq{
+		expReq{
+			method: "GET",
+			url:    "/api/v2/results/Report_A/endpoints?start_time=2015-06-20T12:00:00Z&end_time=2015-06-23T23:00:00Z&granularity=daily&pageSize=1",
+			result: `{
+   "results": [
+     {
+       "name": "e01",
+       "service": "service_a",
+       "supergroup": "ST01",
+       "type": "endpoint",
+       "info": {
+         "Url": "https://foo.example.url"
+       },
+       "results": [
+         {
+           "timestamp": "2015-06-22",
+           "availability": "98.26389",
+           "reliability": "98.26389",
+           "unknown": "0",
+           "uptime": "0.98264",
+           "downtime": "0"
+         }
+       ]
+     }
+   ],
+   "nextPageToken": "MQ==",
+   "pageSize": 1
+ }`,
+			code: 200,
+		},
+		expReq{
+			method: "GET",
+			url:    "/api/v2/results/Report_A/endpoints?start_time=2015-06-20T12:00:00Z&end_time=2015-06-23T23:00:00Z&granularity=daily&pageSize=1&nextPageToken=MQ==",
+			result: `{
+   "results": [
+     {
+       "name": "e01",
+       "service": "service_a",
+       "supergroup": "ST01",
+       "type": "endpoint",
+       "info": {
+         "Url": "https://foo.example.url"
+       },
+       "results": [
+         {
+           "timestamp": "2015-06-23",
+           "availability": "54.03509",
+           "reliability": "81.48148",
+           "unknown": "0.01042",
+           "uptime": "0.53472",
+           "downtime": "0.33333"
+         }
+       ]
+     }
+   ],
+   "nextPageToken": "Mg==",
+   "pageSize": 1
+ }`,
+			code: 200,
+		},
+
+		expReq{
+			method: "GET",
+			url:    "/api/v2/results/Report_A/endpoints?start_time=2015-06-20T12:00:00Z&end_time=2015-06-23T23:00:00Z&granularity=daily&pageSize=1&nextPageToken=Mg==",
+			result: `{
+   "results": [
+     {
+       "name": "e02",
+       "service": "service_a",
+       "supergroup": "ST01",
+       "type": "endpoint",
+       "results": [
+         {
+           "timestamp": "2015-06-22",
+           "availability": "96.875",
+           "reliability": "96.875",
+           "unknown": "0",
+           "uptime": "0.96875",
+           "downtime": "0"
+         }
+       ]
+     }
+   ],
+   "nextPageToken": "Mw==",
+   "pageSize": 1
+ }`,
+			code: 200,
+		},
+
+		expReq{
+			method: "GET",
+			url:    "/api/v2/results/Report_A/endpoints?start_time=2015-06-20T12:00:00Z&end_time=2015-06-23T23:00:00Z&granularity=daily&pageSize=1&nextPageToken=Mw==",
+			result: `{
+   "results": [
+     {
+       "name": "e02",
+       "service": "service_a",
+       "supergroup": "ST01",
+       "type": "endpoint",
+       "results": [
+         {
+           "timestamp": "2015-06-23",
+           "availability": "100",
+           "reliability": "100",
+           "unknown": "0",
+           "uptime": "1",
+           "downtime": "0"
+         }
+       ]
+     }
+   ],
+   "nextPageToken": "NA==",
+   "pageSize": 1
+ }`,
+			code: 200,
+		},
+
+		expReq{
+			method: "GET",
+			url:    "/api/v2/results/Report_A/endpoints?start_time=2015-06-20T12:00:00Z&end_time=2015-06-23T23:00:00Z&granularity=daily&pageSize=1&nextPageToken=NA==",
+			result: `{
+   "results": [
+     {
+       "name": "e03",
+       "service": "service_b",
+       "supergroup": "ST02",
+       "type": "endpoint",
+       "results": [
+         {
+           "timestamp": "2015-06-22",
+           "availability": "96.875",
+           "reliability": "96.875",
+           "unknown": "0",
+           "uptime": "0.96875",
+           "downtime": "0"
+         }
+       ]
+     }
+   ],
+   "nextPageToken": "NQ==",
+   "pageSize": 1
+ }`,
+			code: 200,
+		},
+
+		expReq{
+			method: "GET",
+			url:    "/api/v2/results/Report_A/endpoints?start_time=2015-06-20T12:00:00Z&end_time=2015-06-23T23:00:00Z&granularity=daily&pageSize=1&nextPageToken=NQ==",
+			result: `{
+   "results": [
+     {
+       "name": "e03",
+       "service": "service_b",
+       "supergroup": "STX",
+       "type": "endpoint",
+       "results": [
+         {
+           "timestamp": "2015-06-22",
+           "availability": "96.875",
+           "reliability": "96.875",
+           "unknown": "0",
+           "uptime": "0.96875",
+           "downtime": "0"
+         }
+       ]
+     }
+   ],
+   "nextPageToken": "Ng==",
+   "pageSize": 1
+ }`,
+			code: 200,
+		},
+
+		expReq{
+			method: "GET",
+			url:    "/api/v2/results/Report_A/endpoints?start_time=2015-06-20T12:00:00Z&end_time=2015-06-23T23:00:00Z&granularity=daily&pageSize=1&nextPageToken=Ng==",
+			result: `{
+   "results": [
+     {
+       "name": "e03",
+       "service": "service_x",
+       "supergroup": "ST02",
+       "type": "endpoint",
+       "results": [
+         {
+           "timestamp": "2015-06-22",
+           "availability": "96.875",
+           "reliability": "96.875",
+           "unknown": "0",
+           "uptime": "0.96875",
+           "downtime": "0"
+         }
+       ]
+     }
+   ],
+   "pageSize": 1
+ }`,
+			code: 200,
+		},
+	}
+
+	for _, expReq := range expReqs {
+		request, _ := http.NewRequest(expReq.method, expReq.url, strings.NewReader(""))
+		request.Header.Set("x-api-key", suite.clientkey)
+		request.Header.Set("Accept", "application/json")
+
+		response := httptest.NewRecorder()
+
+		suite.router.ServeHTTP(response, request)
+
+		suite.Equal(expReq.code, response.Code, "Incorrect HTTP response code")
+		// Compare the expected and actual xml response
+		suite.Equal(expReq.result, response.Body.String(), "Response body mismatch")
+
+	}
+
+}
+
+func (suite *endpointAvailabilityTestSuite) TestFlatAllEndpointsPaginated3() {
+
+	type expReq struct {
+		method string
+		url    string
+		code   int
+		result string
+	}
+
+	expReqs := []expReq{
+		expReq{
+			method: "GET",
+			url:    "/api/v2/results/Report_A/endpoints?start_time=2015-06-20T12:00:00Z&end_time=2015-06-23T23:00:00Z&granularity=daily&pageSize=3",
+			result: `{
+   "results": [
+     {
+       "name": "e01",
+       "service": "service_a",
+       "supergroup": "ST01",
+       "type": "endpoint",
+       "info": {
+         "Url": "https://foo.example.url"
+       },
+       "results": [
+         {
+           "timestamp": "2015-06-22",
+           "availability": "98.26389",
+           "reliability": "98.26389",
+           "unknown": "0",
+           "uptime": "0.98264",
+           "downtime": "0"
+         },
+         {
+           "timestamp": "2015-06-23",
+           "availability": "54.03509",
+           "reliability": "81.48148",
+           "unknown": "0.01042",
+           "uptime": "0.53472",
+           "downtime": "0.33333"
+         }
+       ]
+     },
+     {
+       "name": "e02",
+       "service": "service_a",
+       "supergroup": "ST01",
+       "type": "endpoint",
+       "results": [
+         {
+           "timestamp": "2015-06-22",
+           "availability": "96.875",
+           "reliability": "96.875",
+           "unknown": "0",
+           "uptime": "0.96875",
+           "downtime": "0"
+         }
+       ]
+     }
+   ],
+   "nextPageToken": "Mw==",
+   "pageSize": 3
+ }`,
+			code: 200,
+		},
+		expReq{
+			method: "GET",
+			url:    "/api/v2/results/Report_A/endpoints?start_time=2015-06-20T12:00:00Z&end_time=2015-06-23T23:00:00Z&granularity=daily&pageSize=3&nextPageToken=Mw==",
+			result: `{
+   "results": [
+     {
+       "name": "e02",
+       "service": "service_a",
+       "supergroup": "ST01",
+       "type": "endpoint",
+       "results": [
+         {
+           "timestamp": "2015-06-23",
+           "availability": "100",
+           "reliability": "100",
+           "unknown": "0",
+           "uptime": "1",
+           "downtime": "0"
+         }
+       ]
+     },
+     {
+       "name": "e03",
+       "service": "service_b",
+       "supergroup": "ST02",
+       "type": "endpoint",
+       "results": [
+         {
+           "timestamp": "2015-06-22",
+           "availability": "96.875",
+           "reliability": "96.875",
+           "unknown": "0",
+           "uptime": "0.96875",
+           "downtime": "0"
+         }
+       ]
+     },
+     {
+       "name": "e03",
+       "service": "service_b",
+       "supergroup": "STX",
+       "type": "endpoint",
+       "results": [
+         {
+           "timestamp": "2015-06-22",
+           "availability": "96.875",
+           "reliability": "96.875",
+           "unknown": "0",
+           "uptime": "0.96875",
+           "downtime": "0"
+         }
+       ]
+     }
+   ],
+   "nextPageToken": "Ng==",
+   "pageSize": 3
+ }`,
+			code: 200,
+		},
+		expReq{
+			method: "GET",
+			url:    "/api/v2/results/Report_A/endpoints?start_time=2015-06-20T12:00:00Z&end_time=2015-06-23T23:00:00Z&granularity=daily&pageSize=3&nextPageToken=Ng==",
+			result: `{
+   "results": [
+     {
+       "name": "e03",
+       "service": "service_x",
+       "supergroup": "ST02",
+       "type": "endpoint",
+       "results": [
+         {
+           "timestamp": "2015-06-22",
+           "availability": "96.875",
+           "reliability": "96.875",
+           "unknown": "0",
+           "uptime": "0.96875",
+           "downtime": "0"
+         }
+       ]
+     }
+   ],
+   "pageSize": 3
+ }`,
+			code: 200,
+		},
+	}
+
+	for _, expReq := range expReqs {
+		request, _ := http.NewRequest(expReq.method, expReq.url, strings.NewReader(""))
+		request.Header.Set("x-api-key", suite.clientkey)
+		request.Header.Set("Accept", "application/json")
+
+		response := httptest.NewRecorder()
+
+		suite.router.ServeHTTP(response, request)
+
+		suite.Equal(expReq.code, response.Code, "Incorrect HTTP response code")
+		// Compare the expected and actual xml response
+		suite.Equal(expReq.result, response.Body.String(), "Response body mismatch")
+
+	}
+
+}
+
+func (suite *endpointAvailabilityTestSuite) TestMonthlyFlatAllEndpointsPaginatedMonthly() {
+
+	type expReq struct {
+		method string
+		url    string
+		code   int
+		result string
+	}
+
+	expReqs := []expReq{
+		expReq{
+			method: "GET",
+			url:    "/api/v2/results/Report_A/endpoints?start_time=2015-06-20T12:00:00Z&end_time=2015-06-23T23:00:00Z&granularity=monthly&pageSize=-1",
+			result: `{
+   "results": [
+     {
+       "name": "e01",
+       "service": "service_a",
+       "supergroup": "ST01",
+       "type": "endpoint",
+       "info": {
+         "Url": "https://foo.example.url"
+       },
+       "results": [
+         {
+           "timestamp": "2015-06",
+           "availability": "76.26534166743393",
+           "reliability": "91.61418757296076",
+           "unknown": "0.00521",
+           "uptime": "0.75868",
+           "downtime": "0.166665"
+         }
+       ]
+     },
+     {
+       "name": "e02",
+       "service": "service_a",
+       "supergroup": "ST01",
+       "type": "endpoint",
+       "results": [
+         {
+           "timestamp": "2015-06",
+           "availability": "98.43749901562502",
+           "reliability": "98.43749901562502",
+           "unknown": "0",
+           "uptime": "0.984375",
+           "downtime": "0"
+         }
+       ]
+     },
+     {
+       "name": "e03",
+       "service": "service_b",
+       "supergroup": "ST02",
+       "type": "endpoint",
+       "results": [
+         {
+           "timestamp": "2015-06",
+           "availability": "96.87499903125001",
+           "reliability": "96.87499903125001",
+           "unknown": "0",
+           "uptime": "0.96875",
+           "downtime": "0"
+         }
+       ]
+     },
+     {
+       "name": "e03",
+       "service": "service_b",
+       "supergroup": "STX",
+       "type": "endpoint",
+       "results": [
+         {
+           "timestamp": "2015-06",
+           "availability": "96.87499903125001",
+           "reliability": "96.87499903125001",
+           "unknown": "0",
+           "uptime": "0.96875",
+           "downtime": "0"
+         }
+       ]
+     },
+     {
+       "name": "e03",
+       "service": "service_x",
+       "supergroup": "ST02",
+       "type": "endpoint",
+       "results": [
+         {
+           "timestamp": "2015-06",
+           "availability": "96.87499903125001",
+           "reliability": "96.87499903125001",
+           "unknown": "0",
+           "uptime": "0.96875",
+           "downtime": "0"
+         }
+       ]
+     }
+   ]
+ }`,
+			code: 200,
+		},
+		expReq{
+			method: "GET",
+			url:    "/api/v2/results/Report_A/endpoints?start_time=2015-06-20T12:00:00Z&end_time=2015-06-23T23:00:00Z&granularity=monthly&pageSize=2",
+			result: `{
+   "results": [
+     {
+       "name": "e01",
+       "service": "service_a",
+       "supergroup": "ST01",
+       "type": "endpoint",
+       "info": {
+         "Url": "https://foo.example.url"
+       },
+       "results": [
+         {
+           "timestamp": "2015-06",
+           "availability": "76.26534166743393",
+           "reliability": "91.61418757296076",
+           "unknown": "0.00521",
+           "uptime": "0.75868",
+           "downtime": "0.166665"
+         }
+       ]
+     },
+     {
+       "name": "e02",
+       "service": "service_a",
+       "supergroup": "ST01",
+       "type": "endpoint",
+       "results": [
+         {
+           "timestamp": "2015-06",
+           "availability": "98.43749901562502",
+           "reliability": "98.43749901562502",
+           "unknown": "0",
+           "uptime": "0.984375",
+           "downtime": "0"
+         }
+       ]
+     }
+   ],
+   "nextPageToken": "Mg==",
+   "pageSize": 2
+ }`,
+			code: 200,
+		},
+
+		expReq{
+			method: "GET",
+			url:    "/api/v2/results/Report_A/endpoints?start_time=2015-06-20T12:00:00Z&end_time=2015-06-23T23:00:00Z&granularity=monthly&pageSize=2&nextPageToken=Mg==",
+			result: `{
+   "results": [
+     {
+       "name": "e03",
+       "service": "service_b",
+       "supergroup": "ST02",
+       "type": "endpoint",
+       "results": [
+         {
+           "timestamp": "2015-06",
+           "availability": "96.87499903125001",
+           "reliability": "96.87499903125001",
+           "unknown": "0",
+           "uptime": "0.96875",
+           "downtime": "0"
+         }
+       ]
+     },
+     {
+       "name": "e03",
+       "service": "service_b",
+       "supergroup": "STX",
+       "type": "endpoint",
+       "results": [
+         {
+           "timestamp": "2015-06",
+           "availability": "96.87499903125001",
+           "reliability": "96.87499903125001",
+           "unknown": "0",
+           "uptime": "0.96875",
+           "downtime": "0"
+         }
+       ]
+     }
+   ],
+   "nextPageToken": "NA==",
+   "pageSize": 2
+ }`,
+			code: 200,
+		},
+
+		expReq{
+			method: "GET",
+			url:    "/api/v2/results/Report_A/endpoints?start_time=2015-06-20T12:00:00Z&end_time=2015-06-23T23:00:00Z&granularity=monthly&pageSize=2&nextPageToken=NA==",
+			result: `{
+   "results": [
+     {
+       "name": "e03",
+       "service": "service_x",
+       "supergroup": "ST02",
+       "type": "endpoint",
+       "results": [
+         {
+           "timestamp": "2015-06",
+           "availability": "96.87499903125001",
+           "reliability": "96.87499903125001",
+           "unknown": "0",
+           "uptime": "0.96875",
+           "downtime": "0"
+         }
+       ]
+     }
+   ],
+   "pageSize": 2
+ }`,
+			code: 200,
+		},
+	}
+
+	for _, expReq := range expReqs {
+		request, _ := http.NewRequest(expReq.method, expReq.url, strings.NewReader(""))
+		request.Header.Set("x-api-key", suite.clientkey)
+		request.Header.Set("Accept", "application/json")
+
+		response := httptest.NewRecorder()
+
+		suite.router.ServeHTTP(response, request)
+
+		suite.Equal(expReq.code, response.Code, "Incorrect HTTP response code")
+		// Compare the expected and actual xml response
+		suite.Equal(expReq.result, response.Body.String(), "Response body mismatch")
+
+	}
+
+}
+
+func (suite *endpointAvailabilityTestSuite) TestFlatAllEndpointsPaginated4() {
+
+	type expReq struct {
+		method string
+		url    string
+		code   int
+		result string
+	}
+
+	expReqs := []expReq{
+		expReq{
+			method: "GET",
+			url:    "/api/v2/results/Report_A/endpoints?start_time=2015-06-20T12:00:00Z&end_time=2015-06-23T23:00:00Z&granularity=daily&pageSize=4",
+			result: `{
+   "results": [
+     {
+       "name": "e01",
+       "service": "service_a",
+       "supergroup": "ST01",
+       "type": "endpoint",
+       "info": {
+         "Url": "https://foo.example.url"
+       },
+       "results": [
+         {
+           "timestamp": "2015-06-22",
+           "availability": "98.26389",
+           "reliability": "98.26389",
+           "unknown": "0",
+           "uptime": "0.98264",
+           "downtime": "0"
+         },
+         {
+           "timestamp": "2015-06-23",
+           "availability": "54.03509",
+           "reliability": "81.48148",
+           "unknown": "0.01042",
+           "uptime": "0.53472",
+           "downtime": "0.33333"
+         }
+       ]
+     },
+     {
+       "name": "e02",
+       "service": "service_a",
+       "supergroup": "ST01",
+       "type": "endpoint",
+       "results": [
+         {
+           "timestamp": "2015-06-22",
+           "availability": "96.875",
+           "reliability": "96.875",
+           "unknown": "0",
+           "uptime": "0.96875",
+           "downtime": "0"
+         },
+         {
+           "timestamp": "2015-06-23",
+           "availability": "100",
+           "reliability": "100",
+           "unknown": "0",
+           "uptime": "1",
+           "downtime": "0"
+         }
+       ]
+     }
+   ],
+   "nextPageToken": "NA==",
+   "pageSize": 4
+ }`,
+			code: 200,
+		},
+		expReq{
+			method: "GET",
+			url:    "/api/v2/results/Report_A/endpoints?start_time=2015-06-20T12:00:00Z&end_time=2015-06-23T23:00:00Z&granularity=daily&pageSize=4&nextPageToken=NA==",
+			result: `{
+   "results": [
+     {
+       "name": "e03",
+       "service": "service_b",
+       "supergroup": "ST02",
+       "type": "endpoint",
+       "results": [
+         {
+           "timestamp": "2015-06-22",
+           "availability": "96.875",
+           "reliability": "96.875",
+           "unknown": "0",
+           "uptime": "0.96875",
+           "downtime": "0"
+         }
+       ]
+     },
+     {
+       "name": "e03",
+       "service": "service_b",
+       "supergroup": "STX",
+       "type": "endpoint",
+       "results": [
+         {
+           "timestamp": "2015-06-22",
+           "availability": "96.875",
+           "reliability": "96.875",
+           "unknown": "0",
+           "uptime": "0.96875",
+           "downtime": "0"
+         }
+       ]
+     },
+     {
+       "name": "e03",
+       "service": "service_x",
+       "supergroup": "ST02",
+       "type": "endpoint",
+       "results": [
+         {
+           "timestamp": "2015-06-22",
+           "availability": "96.875",
+           "reliability": "96.875",
+           "unknown": "0",
+           "uptime": "0.96875",
+           "downtime": "0"
+         }
+       ]
+     }
+   ],
+   "pageSize": 4
+ }`,
+			code: 200,
+		},
+	}
+
+	for _, expReq := range expReqs {
+		request, _ := http.NewRequest(expReq.method, expReq.url, strings.NewReader(""))
+		request.Header.Set("x-api-key", suite.clientkey)
+		request.Header.Set("Accept", "application/json")
+
+		response := httptest.NewRecorder()
+
+		suite.router.ServeHTTP(response, request)
+
+		suite.Equal(expReq.code, response.Code, "Incorrect HTTP response code")
+		// Compare the expected and actual xml response
+		suite.Equal(expReq.result, response.Body.String(), "Response body mismatch")
+
+	}
 
 }
 

--- a/app/results/routing.go
+++ b/app/results/routing.go
@@ -53,6 +53,7 @@ func HandleSubrouter(s *mux.Router, confhandler *respond.ConfHandler) {
 }
 
 var appEndpointRoutes = []respond.AppRoutes{
+
 	{"results.get", "GET", "/{group_type}/{group_name}/{lgroup_type}/{lgroup_name}/services/{service_type}/endpoints/{endpoint_name}", ListEndpointResults},
 	{"results.get", "GET", "/{group_type}/{group_name}/{lgroup_type}/{lgroup_name}/services/{service_type}/endpoints", ListEndpointResults},
 	{"results.get", "GET", "/{lgroup_type}/{lgroup_name}/services/{service_type}/endpoints/{endpoint_name}", ListEndpointResults},
@@ -62,6 +63,7 @@ var appEndpointRoutes = []respond.AppRoutes{
 	{"results.get", "GET", "/{group_type}/{group_name}/{lgroup_type}/{lgroup_name}/endpoints", ListEndpointResults},
 	{"results.get", "GET", "/{lgroup_type}/{lgroup_name}/endpoints/{endpoint_name}", ListEndpointResults},
 	{"results.get", "GET", "/{lgroup_type}/{lgroup_name}/endpoints", ListEndpointResults},
+	{"results.get", "GET", "/endpoints", FlatListEndpointResults},
 	// normal routes to get endpoints included in a service
 
 }
@@ -82,6 +84,7 @@ var appGroupRoutes = []respond.AppRoutes{
 }
 
 var appRoutesV2 = []respond.AppRoutes{
+	{"results.options", "OPTIONS", "/{report_name}/endpoints", Options},
 	{"results.options", "OPTIONS", "/{report_name}/{group_type}", Options},
 	{"results.options", "OPTIONS", "/{report_name}/{group_type}/{group_name}/{lgroup_type}", Options},
 	{"results.options", "OPTIONS", "/{report_name}/{group_type}/{group_name}/{lgroup_type}/{lgroup_name}", Options},

--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -2941,6 +2941,39 @@ paths:
           $ref: "#/responses/422"
         500:
           $ref: "#/responses/ServerError"
+          
+  /results/{report_name}/endpoints:
+    get:
+      summary: "Flat List A/R results of all endpoints"
+      description: "This method returns a flat list of all endpoint a/r results based on a given report. Results can be retrieved on daily or monthly granularity."
+      operationId: resultsFlatEndpoints
+      tags:
+        - Results
+      produces:
+        - "application/json"
+        - "application/xml"
+      parameters:
+        - $ref: "#/parameters/apiKey"
+        - $ref: "#/parameters/reportName"
+        - $ref: "#/parameters/startDate"
+        - $ref: "#/parameters/endDate"
+        - $ref: "#/parameters/Granularity"
+      
+      responses:
+        200:
+          description: "Successful retrieval of results"
+          schema:
+            $ref: "#/definitions/FlatEndpointResultsResponse"
+        400:
+          $ref: "#/responses/404"
+        401:
+          $ref: "#/responses/Unauthorized"
+        406:
+          $ref: "#/responses/406"
+        422:
+          $ref: "#/responses/422"
+        500:
+          $ref: "#/responses/ServerError"
 
   /results/{report_name}/{group_type}/{group_name}/{lgroup_type}/{lgroup_name}:
     get:
@@ -3611,6 +3644,31 @@ definitions:
                     type: string
                   results:
                     $ref: "#/definitions/results"
+                    
+                    
+  FlatEndpointResultsResponse:
+    type: object
+    properties:
+      endpoints:
+        type: array
+        items:
+          type: object
+          properties:
+            name:
+              type: string
+            type:
+              type: string
+            service:
+              type: string
+            supergroup:
+              type: string
+            results:
+              $ref: "#/definitions/results"
+      pageSize:
+        type: integer
+      nextPageToken:
+        type: string
+                        
 
   EndpointResultsResponse:
     type: object

--- a/doc/v2/docs/results.md
+++ b/doc/v2/docs/results.md
@@ -6,6 +6,7 @@
 | GET: List Availability and Reliability results for an endpoint group          | This method retrieves the results of a specified endpoint group or multiple endpoint groups of a specific type that where computed based on a given report. Results can be retrieved on daily or monthly granularity.                    | [Description](#2) |
 | GET: List Availability and Reliability results for a Service Flavor           | This method retrieves the results of a specified service flavor that where computed based on a given report. Results can be retrieved on daily or monthly granularity.                                                                   | [Description](#3) |
 | GET: List Availability and Reliability results for an Endpoint                | This method retrieves the results of a specified service endpoint that where computed based on a given report. Results can be retrieved on daily or monthly granularity.                                                                 | [Description](#4) |
+| GET: Flat List of all endpoints Availability and Reliability results                | This method retrieves the results in a flat list of all service endpoints that where computed based on a given report. Results can be retrieved on daily or monthly granularity. Pagination is supported.                                                                 | [Description](#5) |
 
 <a id="1"></a>
 
@@ -517,5 +518,140 @@ Some service endpoint a/r have additional information regarding the specific ser
       ]
     }
   ]
+}
+```
+
+<a id="5"></a>
+
+# [GET]: Flat List Availabilities and Reliabilities for all service Endpoints
+
+The following methods can be used to obtain a tenant's flat list of all service endpoints Availability and Reliability result. The api authenticates the tenant using the api-key within the x-api-key header. The user can specify time granularity (`monthly` or `daily`) for retrieved results and also format using the `Accept` header. Pagination is also supported by using the optional parameters `pageSize` to define the size of each result page and `nextPageToken` to proceed to the next available page of results.
+## [GET] Endpoints A/R
+
+### Input
+
+Request a flat list of all endpoint a/r 
+
+```
+/results/{report_name}/endpoints?[start_time]&[end_time]&[granularity]&[pageSize]&[nextPageToken]
+```
+
+
+#### Query Parameters
+
+| Type            | Description                                                                                     | Required | Default value |
+| --------------- | ----------------------------------------------------------------------------------------------- | -------- | ------------- |
+| `[start_time]`  | UTC time in W3C format                                                                          | YES      |
+| `[end_time]`    | UTC time in W3C format                                                                          | YES      |
+| `[granularity]` | Granularity of time that will be used to present data. Possible values are `monthly` or `daily` | NO       | `daily`       |
+| `[pageSize]` | How many results to return per request (-1 means return all results) | NO       | -1       |
+| `[nextPageToken]` | token to proceed to the next page | NO       |  |
+
+#### Path Parameters
+
+| Name                    | Description                                                                                           | Required | Default value |
+| ----------------------- | ----------------------------------------------------------------------------------------------------- | -------- | ------------- |
+| `{report_name}`         | Name of the report that contains all the information about the profile, filter tags, group types etc. | YES      |
+
+#### Headers
+
+```
+x-api-key: "tenant_key_value"
+Accept: "application/xml" or "application/json"
+```
+
+##### Response
+
+```
+Status: 200 OK
+```
+
+## Request endpoint a/r under service: `service_a`
+
+#### URL
+
+`/api/v2/endpoints?start_time=2015-06-22T00:00:00Z&end_time=2015-06-23T23:23:59Z&granularity=daily&pageSize=2`
+
+#### Response Body
+
+```
+{
+  "results": [
+    {
+      "name": "e01",
+      "type": "endpoint",
+      "service": "service_a",
+      "supergroup": "ST01",
+      "results": [
+        {
+          "timestamp": "2015-06-22",
+          "availability": "98.26389",
+          "reliability": "98.26389",
+          "unknown": "0",
+          "uptime": "0.98264",
+          "downtime": "0"
+        },
+        {
+          "timestamp": "2015-06-23",
+          "availability": "54.03509",
+          "reliability": "81.48148",
+          "unknown": "0.01042",
+          "uptime": "0.53472",
+          "downtime": "0.33333"
+        }
+      ]
+    },
+    {
+      "name": "e02",
+      "type": "endpoint",
+      "service": "service_a",
+      "supergroup": "ST01",
+      "results": [
+        {
+          "timestamp": "2015-06-22",
+          "availability": "96.875",
+          "reliability": "96.875",
+          "unknown": "0",
+          "uptime": "0.96875",
+          "downtime": "0"
+        }
+      ]
+    }
+  ],
+  "pageSize": 2,
+  "nextPageToken": "Mg=="
+}
+```
+
+## Request to see next page of results
+
+#### URL
+
+`/api/v2/endpoints?start_time=2015-06-22T00:00:00Z&end_time=2015-06-23T23:23:59Z&granularity=daily&pageSize=2&nextPageToken=Mg==`
+
+#### Response Body
+
+```
+{
+{
+  "results": [
+    {
+      "name": "e02",
+      "type": "endpoint",
+      "service": "service_a",
+      "supergroup": "ST01",
+      "results": [
+        {
+          "timestamp": "2015-06-22",
+          "availability": "96.875",
+          "reliability": "96.875",
+          "unknown": "0",
+          "uptime": "0.96875",
+          "downtime": "0"
+        }
+      ]
+    }
+  ],
+  "pageSize": 2,
 }
 ```


### PR DESCRIPTION
# Goal
Give the ability to argo-web-api to display a flat list of all available endpoint a/r results per report (without having to navigate through endpoint groups and services)

# Implementation
- [x] In package resulst implement a FlatEndpointResults controller method for daily and monthly results
- [x] Implement a query for retrieving flat endpoint daily results
- [x] Implement a query for retrieving flat endpoint monthly results
- [x] Implement paging metchanism on aggregated results
- [x] Update unit tests
- [x] Update swagger
- [x] Update docs