### PR TITLE
ARGO-2305 Flat list of status results by metric type

### DIFF
--- a/app/statusFlatMetrics/controller.go
+++ b/app/statusFlatMetrics/controller.go
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) 2015 GRNET S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS
+ * IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ *
+ * The views and conclusions contained in the software and
+ * documentation are those of the authors and should not be
+ * interpreted as representing official policies, either expressed
+ * or implied, of GRNET S.A.
+ *
+ */
+
+package statusFlatMetrics
+
+import (
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/ARGOeu/argo-web-api/utils/config"
+	"github.com/ARGOeu/argo-web-api/utils/mongo"
+	"github.com/gorilla/context"
+	"github.com/gorilla/mux"
+	"gopkg.in/mgo.v2/bson"
+)
+
+// parseZuluDate is used to parse a zulu formatted date to integer
+func parseZuluDate(dateStr string) (int, error) {
+	parsedTime, _ := time.Parse(zuluForm, dateStr)
+	return strconv.Atoi(parsedTime.Format(ymdForm))
+}
+
+// getPrevDay returns the previous day
+func getPrevDay(dateStr string) (int, error) {
+	parsedTime, _ := time.Parse(zuluForm, dateStr)
+	prevTime := parsedTime.AddDate(0, 0, -1)
+	return strconv.Atoi(prevTime.Format(ymdForm))
+}
+
+// FlatListMetricTimelines returns a list of metric timelines
+func FlatListMetricTimelines(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
+
+	//STANDARD DECLARATIONS START
+
+	code := http.StatusOK
+	h := http.Header{}
+	output := []byte("List Metric Timelines")
+	err := error(nil)
+	charset := "utf-8"
+
+	//STANDARD DECLARATIONS END
+
+	// Set Content-Type response Header value
+	contentType := r.Header.Get("Accept")
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+
+	// Parse the request into the input
+	urlValues := r.URL.Query()
+	vars := mux.Vars(r)
+
+	skip := 0
+	tkStr := urlValues.Get("nextPageToken")
+	if tkStr != "" {
+		tk, err := base64.StdEncoding.DecodeString(tkStr)
+		if err != nil {
+			code = http.StatusInternalServerError
+			return code, h, output, err
+		}
+		skip, err = strconv.Atoi(string(tk))
+		if err != nil {
+			code = http.StatusInternalServerError
+			return code, h, output, err
+		}
+	}
+
+	limit := -1
+	limStr := urlValues.Get("pageSize")
+	if limStr != "" {
+		limit, err = strconv.Atoi(limStr)
+		if err != nil {
+			code = http.StatusInternalServerError
+			return code, h, output, err
+		}
+	}
+
+	parsedStart, _ := parseZuluDate(urlValues.Get("start_time"))
+	parsedEnd, _ := parseZuluDate(urlValues.Get("end_time"))
+
+	input := InputParams{
+		parsedStart,
+		parsedEnd,
+		vars["report_name"],
+		vars["group_type"],
+		vars["group_name"],
+		vars["service_name"],
+		vars["endpoint_name"],
+		vars["metric_name"],
+		contentType,
+	}
+
+	// Grab Tenant DB configuration from context
+	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
+
+	// Mongo Session
+	results := []DataOutput{}
+
+	session, err := mongo.OpenSession(tenantDbConfig)
+	defer mongo.CloseSession(session)
+
+	metricCollection := session.DB(tenantDbConfig.Db).C("status_metrics")
+
+	// Query the detailed metric results
+	reportID, err := mongo.GetReportID(session, tenantDbConfig.Db, input.report)
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	err = metricCollection.Pipe(prepareFlatQuery(input, reportID, limit, skip)).All(&results)
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	parsedPrev, _ := getPrevDay(urlValues.Get("start_time"))
+
+	//if no status results yet show previous days results
+	if len(results) == 0 {
+		// Zero query results
+		input.startTime = parsedPrev
+		err = metricCollection.Pipe(prepareFlatQuery(input, reportID, limit, skip)).All(&results)
+		if err != nil {
+			code = http.StatusInternalServerError
+			return code, h, output, err
+		}
+	}
+
+	output, err = createFlatView(results, input, urlValues.Get("end_time"), limit, skip) //Render the results into JSON/XML format
+
+	return code, h, output, err
+}
+
+func prepareFlatQuery(input InputParams, reportID string, limit int, skip int) []bson.M {
+
+	// prepare the match filter
+	match := bson.M{
+		"date_integer": bson.M{"$gte": input.startTime, "$lte": input.endTime},
+		"report":       reportID,
+		"metric":       input.metric,
+	}
+
+	if len(input.hostname) > 0 {
+		match["host"] = input.hostname
+	}
+
+	query := []bson.M{
+		bson.M{"$match": match},
+	}
+
+	if limit > 0 {
+		query = append(query, bson.M{"$skip": skip})
+		query = append(query, bson.M{"$limit": limit + 1})
+
+	}
+
+	return query
+}
+
+// Options implements the option request on resource
+func Options(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
+
+	//STANDARD DECLARATIONS START
+
+	code := http.StatusOK
+	h := http.Header{}
+	output := []byte("")
+	err := error(nil)
+	contentType := "text/plain"
+	charset := "utf-8"
+
+	//STANDARD DECLARATIONS END
+
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+	h.Set("Allow", fmt.Sprintf("GET, OPTIONS"))
+	return code, h, output, err
+
+}

--- a/app/statusFlatMetrics/model.go
+++ b/app/statusFlatMetrics/model.go
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2015 GRNET S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS
+ * IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ *
+ * The views and conclusions contained in the software and
+ * documentation are those of the authors and should not be
+ * interpreted as representing official policies, either expressed
+ * or implied, of GRNET S.A.
+ *
+ */
+
+package statusFlatMetrics
+
+import "encoding/xml"
+
+const zuluForm = "2006-01-02T15:04:05Z"
+const ymdForm = "20060102"
+
+// InputParams struct holds as input all the url params of the request
+type InputParams struct {
+	startTime int // UTC time in W3C format
+	endTime   int
+	report    string
+	groupType string
+	group     string
+	service   string
+	hostname  string
+	metric    string
+	format    string
+}
+
+// DataOutput struct holds the queried data from datastore
+type DataOutput struct {
+	Report        string            `bson:"report"`
+	Timestamp     string            `bson:"timestamp"`
+	EndpointGroup string            `bson:"endpoint_group"`
+	Service       string            `bson:"service"`
+	Hostname      string            `bson:"host"`
+	Status        string            `bson:"status"`
+	Metric        string            `bson:"metric"`
+	DateInt       string            `bson:"date_integer"`
+	Info          map[string]string `bson:"info"`
+	PrevTimestamp string            `bson:"previous_timestamp"`
+	PrevStatus    string            `bson:"previous_state"`
+}
+
+// json/xml response related structs
+
+type rootPagedOUT struct {
+	XMLName   xml.Name       `xml:"root" json:"-"`
+	Endpoints []*endpointOUT `json:"endpoint_metrics"`
+	PageToken string         `json:"nextPageToken,omitempty"`
+	PageSize  int            `json:"pageSize,omitempty"`
+}
+
+type endpointOUT struct {
+	XMLName    xml.Name          `xml:"endpoint_metric" json:"-"`
+	Name       string            `xml:"name,attr" json:"name"`
+	Service    string            `xml:"service,attr,omitempty" json:"service,omitempty"`
+	SuperGroup string            `xml:"supergroup,attr,omitempty" json:"supergroup,omitempty"`
+	Metric     string            `xml:"metric,attr,omitempty" json:"metric,omitempty"`
+	Info       map[string]string `xml:"-" json:"info,omitempty"`
+	Statuses   []*statusOUT      `json:"statuses"`
+}
+
+type statusOUT struct {
+	XMLName   xml.Name `xml:"status" json:"-"`
+	Timestamp string   `xml:"timestamp,attr" json:"timestamp"`
+	Value     string   `xml:"value,attr" json:"value"`
+}
+
+// Message struct to hold the json/xml response
+type messageOUT struct {
+	XMLName xml.Name `xml:"root" json:"-"`
+	Message string   `xml:"message" json:"message"`
+	Code    string   `xml:"code,omitempty" json:"code,omitempty"`
+}

--- a/app/statusFlatMetrics/routing.go
+++ b/app/statusFlatMetrics/routing.go
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2015 GRNET S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS
+ * IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ *
+ * The views and conclusions contained in the software and
+ * documentation are those of the authors and should not be
+ * interpreted as representing official policies, either expressed
+ * or implied, of GRNET S.A.
+ *
+ */
+
+package statusFlatMetrics
+
+import (
+	"github.com/ARGOeu/argo-web-api/respond"
+	"github.com/gorilla/mux"
+)
+
+// HandleSubrouter contains the different paths to follow during subrouting
+func HandleSubrouter(s *mux.Router, confhandler *respond.ConfHandler) {
+
+	s = respond.PrepAppRoutes(s, confhandler, appRoutesV2)
+}
+
+var appRoutesV2 = []respond.AppRoutes{
+
+	{"status.get", "GET", "/{report_name}/metrics/{metric_name}", FlatListMetricTimelines},
+	{"status.options", "OPTIONS", "/{report_name}/metrics/{metric_name}", Options},
+}

--- a/app/statusFlatMetrics/statusFlatMetrics_test.go
+++ b/app/statusFlatMetrics/statusFlatMetrics_test.go
@@ -1,0 +1,814 @@
+/*
+ * Copyright (c) 2015 GRNET S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS
+ * IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ *
+ * The views and conclusions contained in the software and
+ * documentation are those of the authors and should not be
+ * interpreted as representing official policies, either expressed
+ * or implied, of GRNET S.A.
+ *
+ */
+
+package statusFlatMetrics
+
+import (
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/ARGOeu/argo-web-api/respond"
+	"github.com/ARGOeu/argo-web-api/utils/authentication"
+	"github.com/ARGOeu/argo-web-api/utils/config"
+	"github.com/ARGOeu/argo-web-api/utils/mongo"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/suite"
+	"gopkg.in/gcfg.v1"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+)
+
+// This is a util. suite struct used in tests (see pkg "testify")
+type StatusFlatMetricsTestSuite struct {
+	suite.Suite
+	cfg          config.Config
+	router       *mux.Router
+	confHandler  respond.ConfHandler
+	tenantDbConf config.MongoConfig
+}
+
+// Setup the Test Environment
+// This function runs before any test and setups the environment
+// A test configuration object is instantiated using a reference
+// to testdb: argo_test_details. Also here is are instantiated some expected
+// xml response validation messages (authorization,crud responses).
+// Also the testdb is seeded with tenants,reports,metric_profiles and status_metrics
+func (suite *StatusFlatMetricsTestSuite) SetupTest() {
+
+	log.SetOutput(ioutil.Discard)
+
+	const testConfig = `
+    [server]
+    bindip = ""
+    port = 8080
+    maxprocs = 4
+    cache = false
+    lrucache = 700000000
+    gzip = true
+    [mongodb]
+    host = "127.0.0.1"
+    port = 27017
+    db = "argotest_flatmetrics"
+`
+
+	_ = gcfg.ReadStringInto(&suite.cfg, testConfig)
+
+	// Create router and confhandler for test
+	suite.confHandler = respond.ConfHandler{suite.cfg}
+	suite.router = mux.NewRouter().StrictSlash(true).PathPrefix("/api/v2/status").Subrouter()
+	HandleSubrouter(suite.router, &suite.confHandler)
+
+	// Connect to mongo testdb
+	session, _ := mongo.OpenSession(suite.cfg.MongoDB)
+
+	// Add authentication token to mongo testdb
+	seedAuth := bson.M{"api_key": "S3CR3T"}
+	_ = mongo.Insert(session, suite.cfg.MongoDB.Db, "authentication", seedAuth)
+
+	// seed mongo
+	session, err := mgo.Dial(suite.cfg.MongoDB.Host)
+	if err != nil {
+		panic(err)
+	}
+	defer session.Close()
+
+	// seed a tenant to use
+	c := session.DB(suite.cfg.MongoDB.Db).C("tenants")
+	c.Insert(bson.M{
+		"id": "6ac7d684-1f8e-4a02-a502-720e8f11e50c",
+		"info": bson.M{
+			"name":    "GUARDIANS",
+			"email":   "email@something2",
+			"website": "www.gotg.com",
+			"created": "2015-10-20 02:08:04",
+			"updated": "2015-10-20 02:08:04"},
+		"db_conf": []bson.M{
+			bson.M{
+				"store":    "main",
+				"server":   "localhost",
+				"port":     27017,
+				"database": "argotest_flatmetrics_egi",
+				"username": "",
+				"password": ""},
+		},
+		"users": []bson.M{
+			bson.M{
+				"name":    "egi_user",
+				"email":   "egi_user@email.com",
+				"roles":   []string{"viewer"},
+				"api_key": "KEY1"},
+		}})
+
+	c.Insert(bson.M{
+		"id": "6ac7d684-1f8e-4a02-a502-720e8f11e50d",
+		"info": bson.M{
+			"name":    "AVENGERS",
+			"email":   "email@something2",
+			"website": "www.gotg.com",
+			"created": "2015-10-20 02:08:04",
+			"updated": "2015-10-20 02:08:04"},
+		"db_conf": []bson.M{
+			bson.M{
+				"store":    "main",
+				"server":   "localhost",
+				"port":     27017,
+				"database": "argotest_flatmetrics_eudat",
+				"username": "",
+				"password": ""},
+		},
+		"users": []bson.M{
+			bson.M{
+				"name":    "eudat_user",
+				"email":   "eudat_user@email.com",
+				"roles":   []string{"viewer"},
+				"api_key": "KEY2"},
+		}})
+	c = session.DB(suite.cfg.MongoDB.Db).C("roles")
+	c.Insert(
+		bson.M{
+			"resource": "status.list",
+			"roles":    []string{"editor", "viewer"},
+		})
+	c.Insert(
+		bson.M{
+			"resource": "status.get",
+			"roles":    []string{"editor", "viewer"},
+		})
+	// get dbconfiguration based on the tenant
+	// Prepare the request object
+	request, _ := http.NewRequest("GET", "", strings.NewReader(""))
+	// add the content-type header to application/json
+	request.Header.Set("Content-Type", "application/json")
+	// add the authentication token which is seeded in testdb
+	request.Header.Set("x-api-key", "KEY1")
+	// authenticate user's api key and find corresponding tenant
+	suite.tenantDbConf, _, err = authentication.AuthenticateTenant(request.Header, suite.cfg)
+
+	// Now seed the report DEFINITIONS
+	c = session.DB(suite.tenantDbConf.Db).C("reports")
+	c.Insert(bson.M{
+		"id": "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"info": bson.M{
+			"name":        "Report_A",
+			"description": "report aaaaa",
+			"created":     "2015-9-10 13:43:00",
+			"updated":     "2015-10-11 13:43:00",
+		},
+		"topology_schema": bson.M{
+			"group": bson.M{
+				"type": "NGI",
+				"group": bson.M{
+					"type": "SITES",
+				},
+			},
+		},
+		"profiles": []bson.M{
+			bson.M{
+				"id":   "6ac7d684-1f8e-4a02-a502-720e8f11e50b",
+				"type": "metric",
+				"name": "profile1"},
+			bson.M{
+				"id":   "6ac7d684-1f8e-4a02-a502-720e8f11e523",
+				"type": "operations",
+				"name": "profile2"},
+			bson.M{
+				"id":   "6ac7d684-1f8e-4a02-a502-720e8f11e50q",
+				"type": "aggregation",
+				"name": "profile3"},
+		},
+		"filter_tags": []bson.M{
+			bson.M{
+				"name":  "name1",
+				"value": "value1"},
+			bson.M{
+				"name":  "name2",
+				"value": "value2"},
+		}})
+
+	// seed the status detailed metric data
+	c = session.DB(suite.tenantDbConf.Db).C("status_metrics")
+	c.Insert(bson.M{
+		"report":             "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"monitoring_box":     "nagios3.hellasgrid.gr",
+		"date_integer":       20150501,
+		"timestamp":          "2015-05-01T00:00:00Z",
+		"service":            "CREAM-CE",
+		"host":               "cream01.afroditi.gr",
+		"endpoint_group":     "HG-03-AUTH",
+		"metric":             "emi.cream.CREAMCE-JobSubmit",
+		"status":             "OK",
+		"time_integer":       0,
+		"previous_state":     "OK",
+		"previous_timestamp": "2015-04-30T23:59:00Z",
+		"summary":            "Cream status is ok",
+		"message":            "Cream job submission test return value of ok",
+	})
+	c.Insert(bson.M{
+		"report":             "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"monitoring_box":     "nagios3.hellasgrid.gr",
+		"date_integer":       20150501,
+		"timestamp":          "2015-05-01T01:00:00Z",
+		"service":            "CREAM-CE",
+		"host":               "cream01.afroditi.gr",
+		"endpoint_group":     "HG-03-AUTH",
+		"metric":             "emi.cream.CREAMCE-JobSubmit",
+		"status":             "CRITICAL",
+		"time_integer":       10000,
+		"previous_state":     "OK",
+		"previous_timestamp": "2015-05-01T00:00:00Z",
+		"summary":            "Cream status is CRITICAL",
+		"message":            "Cream job submission test failed",
+	})
+	c.Insert(bson.M{
+		"report":             "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"monitoring_box":     "nagios3.hellasgrid.gr",
+		"date_integer":       20150501,
+		"timestamp":          "2015-05-01T05:00:00Z",
+		"service":            "CREAM-CE",
+		"host":               "cream01.afroditi.gr",
+		"endpoint_group":     "HG-03-AUTH",
+		"metric":             "emi.cream.CREAMCE-JobSubmit",
+		"status":             "OK",
+		"time_integer":       50000,
+		"previous_state":     "CRITICAL",
+		"previous_timestamp": "2015-05-01T01:00:00Z",
+		"summary":            "Cream status is ok",
+		"message":            "Cream job submission test return value of ok",
+	})
+	c.Insert(bson.M{
+		"report":             "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"monitoring_box":     "nagios3.hellasgrid.gr",
+		"date_integer":       20150501,
+		"timestamp":          "2015-05-01T00:00:00Z",
+		"service":            "CREAM-CE",
+		"host":               "cream01.afroditi.gr",
+		"endpoint_group":     "HG-03-AUTH",
+		"metric":             "emi.cream.CREAMCE-JobCancel",
+		"status":             "OK",
+		"time_integer":       0,
+		"previous_state":     "OK",
+		"previous_timestamp": "2015-04-30T23:59:00Z",
+		"summary":            "Cream status is ok",
+		"message":            "Cream job submission test return value of ok",
+	})
+	c.Insert(bson.M{
+		"report":             "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"monitoring_box":     "nagios3.hellasgrid.gr",
+		"date_integer":       20150501,
+		"timestamp":          "2015-05-01T01:00:00Z",
+		"service":            "CREAM-CE",
+		"host":               "cream01.afroditi.gr",
+		"endpoint_group":     "HG-03-AUTH",
+		"metric":             "emi.cream.CREAMCE-JobCancel",
+		"status":             "CRITICAL",
+		"time_integer":       10000,
+		"previous_state":     "OK",
+		"previous_timestamp": "2015-05-01T00:00:00Z",
+		"summary":            "Cream status is CRITICAL",
+		"message":            "Cream job submission test failed",
+	})
+	c.Insert(bson.M{
+		"report":             "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"monitoring_box":     "nagios3.hellasgrid.gr",
+		"date_integer":       20150501,
+		"timestamp":          "2015-05-01T05:00:00Z",
+		"service":            "CREAM-CE",
+		"host":               "cream01.afroditi.gr",
+		"endpoint_group":     "HG-03-AUTH",
+		"metric":             "emi.cream.CREAMCE-JobCancel",
+		"status":             "OK",
+		"time_integer":       50000,
+		"previous_state":     "CRITICAL",
+		"previous_timestamp": "2015-05-01T01:00:00Z",
+		"summary":            "Cream status is ok",
+		"message":            "Cream job submission test return value of ok",
+	})
+
+	// get dbconfiguration based on the tenant
+	// Prepare the request object
+	request, _ = http.NewRequest("GET", "", strings.NewReader(""))
+	// add the content-type header to application/json
+	request.Header.Set("Content-Type", "application/json")
+	// add the authentication token which is seeded in testdb
+	request.Header.Set("x-api-key", "KEY2")
+	// authenticate user's api key and find corresponding tenant
+	suite.tenantDbConf, _, err = authentication.AuthenticateTenant(request.Header, suite.cfg)
+
+	// Now seed the reports DEFINITIONS
+	c = session.DB(suite.tenantDbConf.Db).C("reports")
+	c.Insert(bson.M{
+		"id": "eba61a9e-22e9-4521-9e47-ecaa4a494365",
+		"info": bson.M{
+			"name":        "Report_B",
+			"description": "report aaaaa",
+			"created":     "2015-9-10 13:43:00",
+			"updated":     "2015-10-11 13:43:00",
+		},
+		"topology_schema": bson.M{
+			"group": bson.M{
+				"type": "EUDAT_GROUPS",
+				"group": bson.M{
+					"type": "EUDAT_SITES",
+				},
+			},
+		},
+		"profiles": []bson.M{
+			bson.M{
+				"id":   "6ac7d684-1f8e-4a02-a502-720e8f11e50b",
+				"type": "metric",
+				"name": "eudat.CRITICAL"},
+			bson.M{
+				"id":   "6ac7d684-1f8e-4a02-a502-720e8f11e523",
+				"type": "operations",
+				"name": "profile2"},
+			bson.M{
+				"id":   "6ac7d684-1f8e-4a02-a502-720e8f11e50q",
+				"type": "aggregation",
+				"name": "profile3"},
+		},
+		"filter_tags": []bson.M{
+			bson.M{
+				"name":  "name1",
+				"value": "value1"},
+			bson.M{
+				"name":  "name2",
+				"value": "value2"},
+		}})
+
+	// seed the status detailed metric data
+	c = session.DB(suite.tenantDbConf.Db).C("status_metrics")
+	c.Insert(bson.M{
+		"report":             "eba61a9e-22e9-4521-9e47-ecaa4a494365",
+		"monitoring_box":     "nagios3.tenant2.eu",
+		"date_integer":       20150501,
+		"timestamp":          "2015-05-01T00:00:00Z",
+		"service":            "someService",
+		"host":               "someservice.example.gr",
+		"endpoint_group":     "EL-01-AUTH",
+		"metric":             "someService-FileTransfer",
+		"status":             "OK",
+		"time_integer":       0,
+		"previous_state":     "OK",
+		"previous_timestamp": "2015-04-30T23:59:00Z",
+		"summary":            "someService status is ok",
+		"message":            "someService data upload test return value of ok",
+	})
+	c.Insert(bson.M{
+		"report":             "eba61a9e-22e9-4521-9e47-ecaa4a494365",
+		"monitoring_box":     "nagios3.tenant2.eu",
+		"date_integer":       20150501,
+		"timestamp":          "2015-05-01T01:00:00Z",
+		"service":            "someService",
+		"host":               "someservice.example.gr",
+		"endpoint_group":     "EL-01-AUTH",
+		"metric":             "someService-FileTransfer",
+		"status":             "CRITICAL",
+		"time_integer":       10000,
+		"previous_state":     "OK",
+		"previous_timestamp": "2015-05-01T00:00:00Z",
+		"summary":            "someService status is CRITICAL",
+		"message":            "someService data upload test failed",
+	})
+	c.Insert(bson.M{
+		"report":             "eba61a9e-22e9-4521-9e47-ecaa4a494365",
+		"monitoring_box":     "nagios3.tenant2.eu",
+		"date_integer":       20150501,
+		"timestamp":          "2015-05-01T05:00:00Z",
+		"service":            "someService",
+		"host":               "someservice.example.gr",
+		"endpoint_group":     "EL-01-AUTH",
+		"metric":             "someService-FileTransfer",
+		"status":             "OK",
+		"time_integer":       50000,
+		"previous_state":     "CRITICAL",
+		"previous_timestamp": "2015-05-01T01:00:00Z",
+		"summary":            "someService status is ok",
+		"message":            "someService data upload test return value of ok",
+	})
+	c.Insert(bson.M{
+		"report":             "eba61a9e-22e9-4521-9e47-ecaa4a494365",
+		"monitoring_box":     "nagios3.tenant2.eu",
+		"date_integer":       20150501,
+		"timestamp":          "2015-05-01T00:00:00Z",
+		"service":            "someService",
+		"host":               "someservice2.example.gr",
+		"endpoint_group":     "EL-01-AUTH",
+		"metric":             "someService-FileTransfer",
+		"status":             "OK",
+		"time_integer":       0,
+		"previous_state":     "OK",
+		"previous_timestamp": "2015-04-30T23:59:00Z",
+		"summary":            "someService status is ok",
+		"message":            "someService data upload test return value of ok",
+	})
+	c.Insert(bson.M{
+		"report":             "eba61a9e-22e9-4521-9e47-ecaa4a494365",
+		"monitoring_box":     "nagios3.tenant2.eu",
+		"date_integer":       20150501,
+		"timestamp":          "2015-05-01T01:00:00Z",
+		"service":            "someService",
+		"host":               "someservice2.example.gr",
+		"endpoint_group":     "EL-01-AUTH",
+		"metric":             "someService-FileTransfer",
+		"status":             "CRITICAL",
+		"time_integer":       10000,
+		"previous_state":     "OK",
+		"previous_timestamp": "2015-05-01T00:00:00Z",
+		"summary":            "someService status is CRITICAL",
+		"message":            "someService data upload test failed",
+	})
+	c.Insert(bson.M{
+		"report":             "eba61a9e-22e9-4521-9e47-ecaa4a494365",
+		"monitoring_box":     "nagios3.tenant2.eu",
+		"date_integer":       20150501,
+		"timestamp":          "2015-05-01T05:00:00Z",
+		"service":            "someService",
+		"host":               "someservice2.example.gr",
+		"endpoint_group":     "EL-01-AUTH",
+		"metric":             "someService-FileTransfer",
+		"status":             "OK",
+		"time_integer":       50000,
+		"previous_state":     "CRITICAL",
+		"previous_timestamp": "2015-05-01T01:00:00Z",
+		"summary":            "someService status is ok",
+		"message":            "someService data upload test return value of ok",
+	})
+
+}
+
+func (suite *StatusFlatMetricsTestSuite) TestFlatListStatusMetrics() {
+
+	type expReq struct {
+		method string
+		url    string
+		code   int
+		result string
+		key    string
+	}
+
+	expReqs := []expReq{
+		expReq{
+			method: "GET",
+			url: "/api/v2/status/Report_A/metrics/emi.cream.CREAMCE-JobSubmit" +
+				"?start_time=2015-05-01T00:00:00Z&end_time=2015-05-01T23:00:00Z",
+			code: 200,
+			key:  "KEY1",
+			result: `{
+ "endpoint_metrics": [
+  {
+   "name": "cream01.afroditi.gr",
+   "service": "CREAM-CE",
+   "supergroup": "HG-03-AUTH",
+   "metric": "emi.cream.CREAMCE-JobSubmit",
+   "statuses": [
+    {
+     "timestamp": "2015-04-30T23:59:00Z",
+     "value": "OK"
+    },
+    {
+     "timestamp": "2015-05-01T00:00:00Z",
+     "value": "OK"
+    },
+    {
+     "timestamp": "2015-05-01T01:00:00Z",
+     "value": "CRITICAL"
+    },
+    {
+     "timestamp": "2015-05-01T05:00:00Z",
+     "value": "OK"
+    }
+   ]
+  }
+ ]
+}`},
+		expReq{
+			method: "GET",
+			url: "/api/v2/status/Report_A/metrics/emi.cream.CREAMCE-JobCancel" +
+				"?start_time=2015-05-01T00:00:00Z&end_time=2015-05-01T23:00:00Z",
+			code: 200,
+			key:  "KEY1",
+			result: `{
+ "endpoint_metrics": [
+  {
+   "name": "cream01.afroditi.gr",
+   "service": "CREAM-CE",
+   "supergroup": "HG-03-AUTH",
+   "metric": "emi.cream.CREAMCE-JobCancel",
+   "statuses": [
+    {
+     "timestamp": "2015-04-30T23:59:00Z",
+     "value": "OK"
+    },
+    {
+     "timestamp": "2015-05-01T00:00:00Z",
+     "value": "OK"
+    },
+    {
+     "timestamp": "2015-05-01T01:00:00Z",
+     "value": "CRITICAL"
+    },
+    {
+     "timestamp": "2015-05-01T05:00:00Z",
+     "value": "OK"
+    }
+   ]
+  }
+ ]
+}`},
+
+		expReq{
+			method: "GET",
+			url: "/api/v2/status/Report_B/metrics/someService-FileTransfer" +
+				"?start_time=2015-05-01T00:00:00Z&end_time=2015-05-01T23:00:00Z",
+			code: 200,
+			key:  "KEY2",
+			result: `{
+ "endpoint_metrics": [
+  {
+   "name": "someservice.example.gr",
+   "service": "someService",
+   "supergroup": "EL-01-AUTH",
+   "metric": "someService-FileTransfer",
+   "statuses": [
+    {
+     "timestamp": "2015-04-30T23:59:00Z",
+     "value": "OK"
+    },
+    {
+     "timestamp": "2015-05-01T00:00:00Z",
+     "value": "OK"
+    },
+    {
+     "timestamp": "2015-05-01T01:00:00Z",
+     "value": "CRITICAL"
+    },
+    {
+     "timestamp": "2015-05-01T05:00:00Z",
+     "value": "OK"
+    }
+   ]
+  },
+  {
+   "name": "someservice2.example.gr",
+   "service": "someService",
+   "supergroup": "EL-01-AUTH",
+   "metric": "someService-FileTransfer",
+   "statuses": [
+    {
+     "timestamp": "2015-04-30T23:59:00Z",
+     "value": "OK"
+    },
+    {
+     "timestamp": "2015-05-01T00:00:00Z",
+     "value": "OK"
+    },
+    {
+     "timestamp": "2015-05-01T01:00:00Z",
+     "value": "CRITICAL"
+    },
+    {
+     "timestamp": "2015-05-01T05:00:00Z",
+     "value": "OK"
+    }
+   ]
+  }
+ ]
+}`,
+		},
+
+		expReq{
+			method: "GET",
+			url: "/api/v2/status/Report_A/metrics/emi.cream.CREAMCE-JobSubmit" +
+				"?start_time=2015-05-01T00:00:00Z&end_time=2015-05-01T23:00:00Z&pageSize=2",
+			code: 200,
+			key:  "KEY1",
+			result: `{
+ "endpoint_metrics": [
+  {
+   "name": "cream01.afroditi.gr",
+   "service": "CREAM-CE",
+   "supergroup": "HG-03-AUTH",
+   "metric": "emi.cream.CREAMCE-JobSubmit",
+   "statuses": [
+    {
+     "timestamp": "2015-04-30T23:59:00Z",
+     "value": "OK"
+    },
+    {
+     "timestamp": "2015-05-01T00:00:00Z",
+     "value": "OK"
+    },
+    {
+     "timestamp": "2015-05-01T01:00:00Z",
+     "value": "CRITICAL"
+    }
+   ]
+  }
+ ],
+ "nextPageToken": "Mg==",
+ "pageSize": 2
+}`,
+		},
+
+		expReq{
+			method: "GET",
+			url: "/api/v2/status/Report_A/metrics/emi.cream.CREAMCE-JobSubmit" +
+				"?start_time=2015-05-01T00:00:00Z&end_time=2015-05-01T23:00:00Z&pageSize=2&nextPageToken=Mg==",
+			code: 200,
+			key:  "KEY1",
+			result: `{
+ "endpoint_metrics": [
+  {
+   "name": "cream01.afroditi.gr",
+   "service": "CREAM-CE",
+   "supergroup": "HG-03-AUTH",
+   "metric": "emi.cream.CREAMCE-JobSubmit",
+   "statuses": [
+    {
+     "timestamp": "2015-05-01T05:00:00Z",
+     "value": "OK"
+    }
+   ]
+  }
+ ],
+ "pageSize": 2
+}`,
+		},
+
+		expReq{
+			method: "GET",
+			url: "/api/v2/status/Report_B/metrics/someService-FileTransfer" +
+				"?start_time=2015-05-01T00:00:00Z&end_time=2015-05-01T23:00:00Z&pageSize=2",
+			code: 200,
+			key:  "KEY2",
+			result: `{
+ "endpoint_metrics": [
+  {
+   "name": "someservice.example.gr",
+   "service": "someService",
+   "supergroup": "EL-01-AUTH",
+   "metric": "someService-FileTransfer",
+   "statuses": [
+    {
+     "timestamp": "2015-04-30T23:59:00Z",
+     "value": "OK"
+    },
+    {
+     "timestamp": "2015-05-01T00:00:00Z",
+     "value": "OK"
+    },
+    {
+     "timestamp": "2015-05-01T01:00:00Z",
+     "value": "CRITICAL"
+    }
+   ]
+  }
+ ],
+ "nextPageToken": "Mg==",
+ "pageSize": 2
+}`,
+		},
+
+		expReq{
+			method: "GET",
+			url: "/api/v2/status/Report_B/metrics/someService-FileTransfer" +
+				"?start_time=2015-05-01T00:00:00Z&end_time=2015-05-01T23:00:00Z&pageSize=2&nextPageToken=Mg==",
+			code: 200,
+			key:  "KEY2",
+			result: `{
+ "endpoint_metrics": [
+  {
+   "name": "someservice.example.gr",
+   "service": "someService",
+   "supergroup": "EL-01-AUTH",
+   "metric": "someService-FileTransfer",
+   "statuses": [
+    {
+     "timestamp": "2015-05-01T05:00:00Z",
+     "value": "OK"
+    }
+   ]
+  },
+  {
+   "name": "someservice2.example.gr",
+   "service": "someService",
+   "supergroup": "EL-01-AUTH",
+   "metric": "someService-FileTransfer",
+   "statuses": [
+    {
+     "timestamp": "2015-04-30T23:59:00Z",
+     "value": "OK"
+    },
+    {
+     "timestamp": "2015-05-01T00:00:00Z",
+     "value": "OK"
+    }
+   ]
+  }
+ ],
+ "nextPageToken": "NA==",
+ "pageSize": 2
+}`,
+		},
+
+		expReq{
+			method: "GET",
+			url: "/api/v2/status/Report_A/metrics/unknown" +
+				"?start_time=2015-05-01T00:00:00Z&end_time=2015-05-01T23:00:00Z&pageSize=4&nextPageToken=OA==",
+			code: 200,
+			key:  "KEY1",
+			result: `{
+   "endpoint_metrics": []
+ }`,
+		},
+
+		expReq{
+			method: "GET",
+			url: "/api/v2/status/Report_B/metrics/unknown" +
+				"?start_time=2015-05-01T00:00:00Z&end_time=2015-05-01T23:00:00Z&pageSize=4&nextPageToken=OA==",
+			code: 401,
+			key:  "KEYWRONG",
+			result: `{
+ "status": {
+  "message": "Unauthorized",
+  "code": "401",
+  "details": "You need to provide a correct authentication token using the header 'x-api-key'"
+ }
+}`,
+		},
+	}
+
+	for _, expReq := range expReqs {
+		request, _ := http.NewRequest(expReq.method, expReq.url, strings.NewReader(""))
+		request.Header.Set("x-api-key", expReq.key)
+		request.Header.Set("Accept", "application/json")
+
+		response := httptest.NewRecorder()
+
+		suite.router.ServeHTTP(response, request)
+
+		suite.Equal(expReq.code, response.Code, "Incorrect HTTP response code")
+		// Compare the expected and actual xml response
+		suite.Equal(expReq.result, response.Body.String(), "Response body mismatch")
+
+	}
+
+}
+
+func (suite *StatusFlatMetricsTestSuite) TestOptionsStatusFlatMetrics() {
+	request, _ := http.NewRequest("OPTIONS", "/api/v2/status/Report_A/metrics/met01", strings.NewReader(""))
+
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code := response.Code
+	output := response.Body.String()
+	headers := response.HeaderMap
+
+	suite.Equal(200, code, "Error in response code")
+	suite.Equal("", output, "Expected empty response body")
+	suite.Equal("GET, OPTIONS", headers.Get("Allow"), "Error in Allow header response (supported resource verbs of resource)")
+	suite.Equal("text/plain; charset=utf-8", headers.Get("Content-Type"), "Error in Content-Type header response")
+
+}
+
+// This function is actually called in the end of all tests
+// and clears the test environment.
+// Mainly it's purpose is to drop the testdb
+func (suite *StatusFlatMetricsTestSuite) TearDownTest() {
+
+	session, _ := mongo.OpenSession(suite.cfg.MongoDB)
+
+	session.DB("argotest_flatmetrics").DropDatabase()
+	session.DB("argotest_flatmetrics_eudat").DropDatabase()
+	session.DB("argotest_flatmetrics_egi").DropDatabase()
+}
+
+// This is the first function called when go test is issued
+func TestStatusEndpointsSuite(t *testing.T) {
+	suite.Run(t, new(StatusFlatMetricsTestSuite))
+}

--- a/app/statusFlatMetrics/view.go
+++ b/app/statusFlatMetrics/view.go
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2015 GRNET S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS
+ * IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ *
+ * The views and conclusions contained in the software and
+ * documentation are those of the authors and should not be
+ * interpreted as representing official policies, either expressed
+ * or implied, of GRNET S.A.
+ *
+ */
+
+package statusFlatMetrics
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"encoding/xml"
+	"strconv"
+	"strings"
+
+	"github.com/ARGOeu/argo-web-api/respond"
+)
+
+func createFlatView(results []DataOutput, input InputParams, endDate string, limit int, skip int) ([]byte, error) {
+
+	output := []byte("reponse output")
+	err := error(nil)
+
+	docRoot := &rootPagedOUT{}
+
+	if len(results) == 0 {
+		var elist = make([]*endpointOUT, 0)
+		docRoot.Endpoints = elist
+		if strings.EqualFold(input.format, "application/json") {
+			output, err = json.MarshalIndent(docRoot, " ", "  ")
+		} else {
+			output, err = xml.MarshalIndent(docRoot, " ", "  ")
+		}
+		return output, err
+	}
+
+	prevHostname := ""
+	prevEndpointGroup := ""
+	prevService := ""
+
+	var ppHost *endpointOUT
+
+	endloop := len(results)
+
+	if len(results) > limit && limit > 0 {
+		endloop = len(results) - 1
+
+	}
+
+	for i := 0; i < endloop; i++ {
+
+		row := results[i]
+
+		if (row.Hostname != prevHostname && row.Hostname != "") ||
+			(row.EndpointGroup != prevEndpointGroup && row.EndpointGroup != "") ||
+			(row.Service != prevService && row.Service != "") {
+
+			host := &endpointOUT{} //create new host
+			host.Name = row.Hostname
+			host.Info = row.Info
+			host.Service = row.Service
+			host.SuperGroup = row.EndpointGroup
+			host.Metric = row.Metric
+			docRoot.Endpoints = append(docRoot.Endpoints, host)
+			prevHostname = row.Hostname
+			prevEndpointGroup = row.EndpointGroup
+			prevService = row.Service
+			ppHost = host
+
+			if row.Timestamp[0:10] != row.PrevTimestamp[0:10] {
+				prevStatus := &statusOUT{}
+				prevStatus.Timestamp = row.PrevTimestamp
+				prevStatus.Value = row.PrevStatus
+				ppHost.Statuses = append(ppHost.Statuses, prevStatus)
+			}
+
+		}
+
+		status := &statusOUT{}
+		status.Timestamp = row.Timestamp
+		status.Value = row.Status
+		ppHost.Statuses = append(ppHost.Statuses, status)
+
+	}
+
+	if limit > 0 {
+		if len(results) > limit {
+			docRoot.PageToken = base64.StdEncoding.EncodeToString([]byte(strconv.Itoa(skip + limit)))
+
+		}
+		docRoot.PageSize = limit
+	}
+
+	output, err = respond.MarshalContent(docRoot, input.format, "", " ")
+	return output, err
+
+}
+
+func createMessageOUT(message string, code int, format string) ([]byte, error) {
+
+	output := []byte("message placeholder")
+	err := error(nil)
+	docRoot := &messageOUT{}
+
+	docRoot.Message = message
+	docRoot.Code = strconv.Itoa(code)
+	output, err = respond.MarshalContent(docRoot, format, "", " ")
+	return output, err
+}

--- a/app/statusMetrics/statusMetrics_test.go
+++ b/app/statusMetrics/statusMetrics_test.go
@@ -421,7 +421,6 @@ func (suite *StatusMetricsTestSuite) TestListStatusMetrics() {
      <status timestamp="2015-05-01T00:00:00Z" value="OK"></status>
      <status timestamp="2015-05-01T01:00:00Z" value="CRITICAL"></status>
      <status timestamp="2015-05-01T05:00:00Z" value="OK"></status>
-     <status timestamp="2015-05-01T23:59:59Z" value="OK"></status>
     </metric>
    </endpoint>
   </group>
@@ -437,7 +436,6 @@ func (suite *StatusMetricsTestSuite) TestListStatusMetrics() {
      <status timestamp="2015-05-01T00:00:00Z" value="OK"></status>
      <status timestamp="2015-05-01T01:00:00Z" value="CRITICAL"></status>
      <status timestamp="2015-05-01T05:00:00Z" value="OK"></status>
-     <status timestamp="2015-05-01T23:59:59Z" value="OK"></status>
     </metric>
    </endpoint>
   </group>
@@ -474,10 +472,6 @@ func (suite *StatusMetricsTestSuite) TestListStatusMetrics() {
           },
           {
            "timestamp": "2015-05-01T05:00:00Z",
-           "value": "OK"
-          },
-          {
-           "timestamp": "2015-05-01T23:59:59Z",
            "value": "OK"
           }
          ]
@@ -521,10 +515,6 @@ func (suite *StatusMetricsTestSuite) TestListStatusMetrics() {
           },
           {
            "timestamp": "2015-05-01T05:00:00Z",
-           "value": "OK"
-          },
-          {
-           "timestamp": "2015-05-01T23:59:59Z",
            "value": "OK"
           }
          ]
@@ -697,10 +687,6 @@ func (suite *StatusMetricsTestSuite) TestLatestResults() {
           {
            "timestamp": "2015-05-01T05:00:00Z",
            "value": "OK"
-          },
-          {
-           "timestamp": "2015-05-01T23:59:59Z",
-           "value": "OK"
           }
          ]
         }
@@ -786,10 +772,6 @@ func (suite *StatusMetricsTestSuite) TestMultipleItems() {
           {
            "timestamp": "2015-05-01T05:00:00Z",
            "value": "OK"
-          },
-          {
-           "timestamp": "2015-05-01T23:59:59Z",
-           "value": "OK"
           }
          ]
         },
@@ -810,10 +792,6 @@ func (suite *StatusMetricsTestSuite) TestMultipleItems() {
           },
           {
            "timestamp": "2015-05-01T05:00:00Z",
-           "value": "OK"
-          },
-          {
-           "timestamp": "2015-05-01T23:59:59Z",
            "value": "OK"
           }
          ]

--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -2472,6 +2472,44 @@ paths:
           $ref: "#/responses/422"
         500:
           $ref: "#/responses/ServerError"
+  
+  /status/{report_name}/metrics/{metric_name}:
+    get:
+      summary: "Flat List endpoint metric results by metric name"
+      description: "This method returns a flat list of all endpoint status results based on a given metric."
+      operationId: statusFlatMetrics
+      tags:
+        - Status
+      produces:
+        - "application/json"
+        - "application/xml"
+      parameters:
+        - $ref: "#/parameters/apiKey"
+        - $ref: "#/parameters/reportName"
+        - name: "metric_name"
+          in: path
+          description: "The name of the probe (metric)"
+          required: true
+          type: string
+        - $ref: "#/parameters/startDate"
+        - $ref: "#/parameters/endDate"
+        - $ref: "#/parameters/Granularity"
+      
+      responses:
+        200:
+          description: "Successful retrieval of results"
+          schema:
+            $ref: "#/definitions/FlatMetricsStatusResponse"
+        400:
+          $ref: "#/responses/404"
+        401:
+          $ref: "#/responses/Unauthorized"
+        406:
+          $ref: "#/responses/406"
+        422:
+          $ref: "#/responses/422"
+        500:
+          $ref: "#/responses/ServerError"
 
   /metric_result/{endpoint}:
     get:
@@ -3702,6 +3740,36 @@ definitions:
         type: integer
       nextPageToken:
         type: string
+
+
+  FlatMetricsStatusResponse:
+    type: object
+    properties:
+      endpoints:
+        type: array
+        items:
+          type: object
+          properties:
+            name:
+              type: string
+            type:
+              type: string
+            service:
+              type: string
+            supergroup:
+              type: string
+            metric:
+              type: string
+            statuses:
+              type: array
+              items:
+                $ref: "#/definitions/timestamp_value"
+      pageSize:
+        type: integer
+      nextPageToken:
+        type: string
+        
+
 
                     
   FlatEndpointResultsResponse:

--- a/doc/v2/docs/status.md
+++ b/doc/v2/docs/status.md
@@ -9,6 +9,8 @@ API calls for retrieving monitoring status results
 | GET: List Service  Status Timelines |This method may be used to retrieve a specific service type status timeline (applies for a specific service endpoint group). | <a href="#3">Description</a>|
 | GET: List Endpoint Group Status Timelines| This method may be used to retrieve endpoint group status timelines. | <a href="#4">Description</a>|
 | GET: Metric Result | This method may be used to retrieve a specific and detailed metric result. | <a href="#5">Description</a>|
+| GET: Flat list of Endpoint timelines | This method may be used to retrieve a flat list of all available endpoint status results | <a href="#6">Description</a>|
+| GET: Flat list of Metric timelines for a specific metric | This method may be used to retrieve a flat list of all available endpoint metric status timelines filtered by a specific metric | <a href="#7">Description</a>|
 
 <a id="1"></a>
 
@@ -1154,7 +1156,6 @@ Status: 200 OK
 
 ```
 {
-{
   "results": [
     {
       "name": "e02",
@@ -1177,3 +1178,133 @@ Status: 200 OK
 }
 ```
 
+
+<a id="7"></a>
+
+# [GET]: Flat List of status timelines for all available endpoint metrics filter by a specific metric
+
+The following method can be used to obtain a tenant's flat list of all available service endpoints metric status timelines filtered by a specific metric. The api authenticates the tenant using the api-key within the x-api-key header. Pagination is also supported by using the optional parameters `pageSize` to define the size of each result page and `nextPageToken` to proceed to the next available page of results.
+## [GET] Endpoints Status timelines
+
+### Input
+
+Request a flat list of all endpoint metric status timelines filtered by a specific metric
+
+```
+/status/{report_name}/metrics/{metric_name}?[start_time]&[end_time]&[granularity]&[pageSize]&[nextPageToken]
+```
+
+
+#### Query Parameters
+
+| Type            | Description                                                                                     | Required | Default value |
+| --------------- | ----------------------------------------------------------------------------------------------- | -------- | ------------- |
+| `[start_time]`  | UTC time in W3C format                                                                          | YES      |
+| `[end_time]`    | UTC time in W3C format                                                                          | YES      |
+| `[pageSize]` | How many results to return per request (-1 means return all results) | NO       | -1       |
+| `[nextPageToken]` | token to proceed to the next page | NO       |  |
+
+#### Path Parameters
+
+| Name                    | Description                                                                                           | Required | Default value |
+| ----------------------- | ----------------------------------------------------------------------------------------------------- | -------- | ------------- |
+| `{report_name}`         | Name of the report that contains all the information about the profile, filter tags, group types etc. | YES      |
+| `{metric_name}`         | Name of the metric to filter results by | YES      |
+
+#### Headers
+
+```
+x-api-key: "tenant_key_value"
+Accept: "application/xml" or "application/json"
+```
+
+##### Response
+
+```
+Status: 200 OK
+```
+
+## Request endpoint a/r under service: `service_a`
+
+#### URL
+
+`/api/v2/status/{report_name}/metrics/someService-FileTransfer?start_time=2015-06-22T00:00:00Z&end_time=2015-06-23T23:23:59Z&pageSize=2`
+
+#### Response Body
+
+```
+{
+  "results": [
+    {
+      "type":"endpoint_metric",
+      "name": "someservice.example.gr",
+      "service": "someService",
+      "supergroup": "GROUPA",
+      "metric": "someService-FileTransfer",
+      "statuses": [
+        {
+          "timestamp": "2015-04-30T23:59:00Z",
+          "value": "OK"
+        },
+        {
+          "timestamp": "2015-05-01T00:00:00Z",
+          "value": "OK"
+        },
+        {
+          "timestamp": "2015-05-01T01:00:00Z",
+          "value": "CRITICAL"
+        }
+      ]
+    }
+  ],
+  "nextPageToken": "Mg==",
+  "pageSize": 2
+}
+```
+
+## Request to see next page of results
+
+#### URL
+
+`/api/v2/status/{report_name}/metrics/someService-FileTransfer?start_time=2015-06-22T00:00:00Z&end_time=2015-06-23T23:23:59Z&granularity=daily&pageSize=2&nextPageToken=Mg==`
+
+#### Response Body
+
+```
+{
+  "results": [
+    {
+      "type":"endpoint_metric",
+      "name": "someservice.example.gr",
+      "service": "someService",
+      "supergroup": "GROUPA",
+      "metric": "someService-FileTransfer",
+      "statuses": [
+        {
+          "timestamp": "2015-05-01T05:00:00Z",
+          "value": "OK"
+        }
+      ]
+    },
+    {
+      "type":"endpoint_metric",
+      "name": "someservice2.example.gr",
+      "service": "someService",
+      "supergroup": "GROUPA",
+      "metric": "someService-FileTransfer",
+      "statuses": [
+        {
+          "timestamp": "2015-04-30T23:59:00Z",
+          "value": "OK"
+        },
+        {
+          "timestamp": "2015-05-01T00:00:00Z",
+          "value": "OK"
+        }
+      ]
+    }
+  ],
+  "nextPageToken": "NA==",
+  "pageSize": 2
+}
+```

--- a/routing/routes.go
+++ b/routing/routes.go
@@ -36,6 +36,7 @@ import (
 	"github.com/ARGOeu/argo-web-api/app/statusEndpointGroups"
 	"github.com/ARGOeu/argo-web-api/app/statusEndpoints"
 	"github.com/ARGOeu/argo-web-api/app/statusFlatEndpoints"
+	"github.com/ARGOeu/argo-web-api/app/statusFlatMetrics"
 	"github.com/ARGOeu/argo-web-api/app/statusMetrics"
 	"github.com/ARGOeu/argo-web-api/app/statusServices"
 	"github.com/ARGOeu/argo-web-api/app/tenants"
@@ -52,6 +53,7 @@ var routesV2 = []RouteV2{
 	{"Results", "/results", results.HandleSubrouter},
 	{"Metric Result", "/metric_result", metricResult.HandleSubrouter},
 	{"Status endpoint flat timelines", "/status", statusFlatEndpoints.HandleSubrouter},
+	{"Status metric flat timelines", "/status", statusFlatMetrics.HandleSubrouter},
 	{"Status metric timelines", "/status", statusMetrics.HandleSubrouter},
 	{"Status endpoint timelines", "/status", statusEndpoints.HandleSubrouter},
 	{"Status service timelines", "/status", statusServices.HandleSubrouter},


### PR DESCRIPTION
Goal
====
Provide a flat list of status results for all avaliable service endpoint metrics filtered by a specific metric

Implementation
============
- [x] Add a new pacakge for implementing flat list for status endpoint metrics
- [x]  Add an aggregation query and support pagination
- [x] Add new models for creating flat endpoint metric status view
- [x] Update docs
- [x] Update unit tests