### PR TITLE
ARGO-2496 Provide profile and report postman tests

### DIFF
--- a/postman/argo-web-api_tests.json
+++ b/postman/argo-web-api_tests.json
@@ -1,398 +1,6099 @@
 {
 	"info": {
-		"_postman_id": "ae7504e3-d702-4f91-aea9-0fe4053de9f0",
-		"name": "web-api",
-		"schema": "https://schema.getpostman.com/json/collection/v2.0.0/collection.json"
+		"_postman_id": "e100b58e-12bb-4430-8ce1-1575715e276e",
+		"name": "argo-web-api tests",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
 	"item": [
 		{
-			"name": "test version",
-			"event": [
+			"name": "version_tests",
+			"item": [
 				{
-					"listen": "test",
-					"script": {
-						"id": "e783b1c8-d2da-4ed9-95bf-73b4ecdc3662",
-						"exec": [
-							"",
-							"pm.test(\"Verify version\", function () {",
-							"    let jsonData = pm.response.json();",
-							"    let commit = pm.environment.get(\"last_commit\");",
-							"    pm.expect(jsonData.commit).to.eql(commit);",
-							"});",
-							"",
-							"pm.test(\"Status code is 200\", function () {",
-							"    pm.response.to.have.status(200);",
-							"});"
+					"name": "test version",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "bd577975-2c24-454d-809a-95c85f82e25d",
+								"exec": [
+									"",
+									"pm.test(\"Verify version\", function () {",
+									"    let jsonData = pm.response.json();",
+									"    let commit = pm.environment.get(\"last_commit\");",
+									"    pm.expect(jsonData.commit).to.eql(commit);",
+									"});",
+									"",
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/json",
+								"type": "text"
+							},
+							{
+								"key": "x-api-key",
+								"value": "{{api_key}}",
+								"type": "text",
+								"disabled": true
+							}
 						],
-						"type": "text/javascript"
-					}
+						"url": {
+							"raw": "https://{{api_host}}/api/v2/version",
+							"protocol": "https",
+							"host": [
+								"{{api_host}}"
+							],
+							"path": [
+								"api",
+								"v2",
+								"version"
+							],
+							"query": [
+								{
+									"key": "Accept",
+									"value": "application/json",
+									"disabled": true
+								}
+							]
+						},
+						"description": "test web api\t"
+					},
+					"response": []
 				}
 			],
-			"request": {
-				"method": "GET",
-				"header": [
-					{
-						"key": "Accept",
-						"value": "application/json",
-						"type": "text"
-					},
-					{
-						"key": "x-api-key",
-						"value": "{{api_key}}",
-						"type": "text",
-						"disabled": true
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": ""
-				},
-				"url": {
-					"raw": "https://{{api_host}}/api/v2/version?",
-					"protocol": "https",
-					"host": [
-						"{{api_host}}"
-					],
-					"path": [
-						"api",
-						"v2",
-						"version"
-					],
-					"query": [
-						{
-							"key": "Accept",
-							"value": "application/json",
-							"disabled": true
-						}
-					]
-				},
-				"description": "test web api\t"
-			},
-			"response": []
+			"protocolProfileBehavior": {}
 		},
 		{
-			"name": "list tenants",
-			"event": [
+			"name": "tenant tests",
+			"item": [
 				{
-					"listen": "test",
-					"script": {
-						"id": "f65f4d0e-0e13-454a-94b3-c08b449a184f",
-						"exec": [
-							"pm.test(\"Status code is 200\", function () {",
-							"    pm.response.to.have.status(200);",
-							"});"
+					"name": "list tenants",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "9f92c89b-6310-4e6b-b3c3-f17cd16172b9",
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Accept",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "x-api-key",
+								"type": "text",
+								"value": "{{api_key}}"
+							}
 						],
-						"type": "text/javascript"
-					}
+						"url": {
+							"raw": "https://{{api_host}}/api/v2/admin/tenants",
+							"protocol": "https",
+							"host": [
+								"{{api_host}}"
+							],
+							"path": [
+								"api",
+								"v2",
+								"admin",
+								"tenants"
+							],
+							"query": [
+								{
+									"key": "Accept",
+									"value": "application/json",
+									"disabled": true
+								},
+								{
+									"key": "x-api-key",
+									"value": "{{api_key}}",
+									"disabled": true
+								}
+							]
+						},
+						"description": "test web api\t"
+					},
+					"response": []
+				},
+				{
+					"name": "create new tenant",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "19d660f4-9cfb-47e0-a5b3-bf4abf784e87",
+								"exec": [
+									"",
+									"pm.test(\"Get tenant uuid\", function () {",
+									"    let jsonData = pm.response.json();",
+									"    pm.environment.set(\"tenant_uuid\",jsonData.data.id);",
+									"});",
+									"",
+									"pm.test(\"Status code is 201\", function () {",
+									"    pm.response.to.have.status(201);",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Accept",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "x-api-key",
+								"type": "text",
+								"value": "{{api_key}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"info\": {\n    \"website\": \"foo.example.com\",\n    \"description\": \"a test tenant\",\n    \"image\": \"string\",\n    \"email\": \"info@foo.example.com\",\n    \"name\": \"FOO\"\n  },\n  \"topology\": {\n    \"feed\": \"string\",\n    \"type\": \"string\"\n  },\n  \"db_conf\": [\n    {\n      \"username\": \"string\",\n      \"password\": \"string\",\n      \"port\": 0,\n      \"store\": \"string\",\n      \"server\": \"string\"\n    }\n  ],\n  \"users\": [\n    {\n      \"name\": \"test-admin\",\n      \"api-key\": \"foo.test.secret.key\",\n      \"roles\": [\n        \"admin\"\n      ],\n      \"email\": \"foo@example.com\"\n    }\n  ]\n}"
+						},
+						"url": {
+							"raw": "https://{{api_host}}/api/v2/admin/tenants",
+							"protocol": "https",
+							"host": [
+								"{{api_host}}"
+							],
+							"path": [
+								"api",
+								"v2",
+								"admin",
+								"tenants"
+							],
+							"query": [
+								{
+									"key": "Accept",
+									"value": "application/json",
+									"disabled": true
+								},
+								{
+									"key": "x-api-key",
+									"value": "{{api_key}}",
+									"disabled": true
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "get a specific tenant",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "80546e41-ed1f-4152-9876-8785f31dd476",
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Accept",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "x-api-key",
+								"type": "text",
+								"value": "{{api_key}}"
+							}
+						],
+						"url": {
+							"raw": "https://{{api_host}}/api/v2/admin/tenants/{{tenant_uuid}}",
+							"protocol": "https",
+							"host": [
+								"{{api_host}}"
+							],
+							"path": [
+								"api",
+								"v2",
+								"admin",
+								"tenants",
+								"{{tenant_uuid}}"
+							],
+							"query": [
+								{
+									"key": "Accept",
+									"value": "application/json",
+									"disabled": true
+								},
+								{
+									"key": "x-api-key",
+									"value": "{{api_key}}",
+									"disabled": true
+								}
+							]
+						},
+						"description": "test web api\t"
+					},
+					"response": []
+				},
+				{
+					"name": "update specific tenant",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "9e33fdbf-9b13-4d05-ae84-bf572a6ec56c",
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Accept",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "x-api-key",
+								"type": "text",
+								"value": "{{api_key}}"
+							}
+						],
+						"url": {
+							"raw": "https://{{api_host}}/api/v2/admin/tenants/{{tenant_uuid}}",
+							"protocol": "https",
+							"host": [
+								"{{api_host}}"
+							],
+							"path": [
+								"api",
+								"v2",
+								"admin",
+								"tenants",
+								"{{tenant_uuid}}"
+							],
+							"query": [
+								{
+									"key": "Accept",
+									"value": "application/json",
+									"disabled": true
+								},
+								{
+									"key": "x-api-key",
+									"value": "{{api_key}}",
+									"disabled": true
+								}
+							]
+						},
+						"description": "test web api\t"
+					},
+					"response": []
+				},
+				{
+					"name": "delete specific tenant",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "74d45c54-73de-4a2d-8b58-b2bb4093b084",
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "Accept",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "x-api-key",
+								"type": "text",
+								"value": "{{api_key}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "https://{{api_host}}/api/v2/admin/tenants/{{tenant_uuid}}",
+							"protocol": "https",
+							"host": [
+								"{{api_host}}"
+							],
+							"path": [
+								"api",
+								"v2",
+								"admin",
+								"tenants",
+								"{{tenant_uuid}}"
+							],
+							"query": [
+								{
+									"key": "Accept",
+									"value": "application/json",
+									"disabled": true
+								},
+								{
+									"key": "x-api-key",
+									"value": "{{api_key}}",
+									"disabled": true
+								}
+							]
+						},
+						"description": "test web api\t"
+					},
+					"response": []
 				}
 			],
-			"request": {
-				"method": "GET",
-				"header": [
-					{
-						"key": "Accept",
-						"type": "text",
-						"value": "application/json"
-					},
-					{
-						"key": "x-api-key",
-						"type": "text",
-						"value": "{{api_key}}"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": ""
-				},
-				"url": {
-					"raw": "https://{{api_host}}/api/v2/admin/tenants?",
-					"protocol": "https",
-					"host": [
-						"{{api_host}}"
-					],
-					"path": [
-						"api",
-						"v2",
-						"admin",
-						"tenants"
-					],
-					"query": [
+			"protocolProfileBehavior": {}
+		},
+		{
+			"name": "ops-profiles tests",
+			"item": [
+				{
+					"name": "create new tenant",
+					"event": [
 						{
-							"key": "Accept",
-							"value": "application/json",
-							"disabled": true
+							"listen": "test",
+							"script": {
+								"id": "426fcc5f-21ae-4195-a62c-19238edf21eb",
+								"exec": [
+									"const schema = {",
+									"  \"type\": \"object\",",
+									"  \"properties\": {",
+									"    \"status\": {",
+									"      \"type\": \"object\",",
+									"      \"properties\": {",
+									"        \"message\": {",
+									"          \"type\": \"string\"",
+									"        },",
+									"        \"code\": {",
+									"          \"type\": \"string\"",
+									"        }",
+									"      },",
+									"      \"required\": [",
+									"        \"message\",",
+									"        \"code\"",
+									"      ]",
+									"    },",
+									"    \"data\": {",
+									"      \"type\": \"object\",",
+									"      \"properties\": {",
+									"        \"id\": {",
+									"          \"type\": \"string\"",
+									"        },",
+									"        \"links\": {",
+									"          \"type\": \"object\",",
+									"          \"properties\": {",
+									"            \"self\": {",
+									"              \"type\": \"string\"",
+									"            }",
+									"          },",
+									"          \"required\": [",
+									"            \"self\"",
+									"          ]",
+									"        }",
+									"      },",
+									"      \"required\": [",
+									"        \"id\",",
+									"        \"links\"",
+									"      ]",
+									"    }",
+									"  },",
+									"  \"required\": [",
+									"    \"status\",",
+									"    \"data\"",
+									"  ]",
+									"}",
+									"",
+									"pm.test(\"Validate schema\", () => {",
+									"    pm.response.to.have.jsonSchema(schema);",
+									"});",
+									"",
+									"",
+									"pm.test(\"Get tenant uuid\", function () {",
+									"    let jsonData = pm.response.json();",
+									"    pm.environment.set(\"tenant_uuid\",jsonData.data.id);",
+									"});",
+									"",
+									"pm.test(\"Status code is 201\", function () {",
+									"    pm.response.to.have.status(201);",
+									"});",
+									"",
+									"// set test tenant api key",
+									"pm.environment.set(\"tenant_api_key\", \"foo.test.secret.key\");"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Accept",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "x-api-key",
+								"type": "text",
+								"value": "{{api_key}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"info\": {\n    \"website\": \"foo.example.com\",\n    \"description\": \"a test tenant\",\n    \"image\": \"string\",\n    \"email\": \"info@foo.example.com\",\n    \"name\": \"FOO\"\n  },\n  \"topology\": {\n    \"feed\": \"string\",\n    \"type\": \"string\"\n  },\n  \"db_conf\": [\n    {\n      \"username\": \"\",\n      \"password\": \"\",\n      \"port\": 27017,\n      \"store\": \"argo_FOO\",\n      \"server\": \"localhost\"\n    }\n  ],\n  \"users\": [\n    {\n      \"name\": \"test-admin\",\n      \"api_key\": \"foo.test.secret.key\",\n      \"roles\": [\n        \"admin\"\n      ],\n      \"email\": \"foo@example.com\"\n    }\n  ]\n}"
+						},
+						"url": {
+							"raw": "https://{{api_host}}/api/v2/admin/tenants",
+							"protocol": "https",
+							"host": [
+								"{{api_host}}"
+							],
+							"path": [
+								"api",
+								"v2",
+								"admin",
+								"tenants"
+							],
+							"query": [
+								{
+									"key": "Accept",
+									"value": "application/json",
+									"disabled": true
+								},
+								{
+									"key": "x-api-key",
+									"value": "{{api_key}}",
+									"disabled": true
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Create operation profile",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "0ff38fea-fb23-472c-a523-8337ddbd91c4",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
 						},
 						{
-							"key": "x-api-key",
-							"value": "{{api_key}}",
-							"disabled": true
+							"listen": "test",
+							"script": {
+								"id": "3f2dced6-eab6-479d-a2de-581dccf4cdf0",
+								"exec": [
+									"const schema = {",
+									"  \"type\": \"object\",",
+									"  \"properties\": {",
+									"    \"status\": {",
+									"      \"type\": \"object\",",
+									"      \"properties\": {",
+									"        \"message\": {",
+									"          \"type\": \"string\"",
+									"        },",
+									"        \"code\": {",
+									"          \"type\": \"string\"",
+									"        }",
+									"      },",
+									"      \"required\": [",
+									"        \"message\",",
+									"        \"code\"",
+									"      ]",
+									"    },",
+									"    \"data\": {",
+									"      \"type\": \"object\",",
+									"      \"properties\": {",
+									"        \"id\": {",
+									"          \"type\": \"string\"",
+									"        },",
+									"        \"links\": {",
+									"          \"type\": \"object\",",
+									"          \"properties\": {",
+									"            \"self\": {",
+									"              \"type\": \"string\"",
+									"            }",
+									"          },",
+									"          \"required\": [",
+									"            \"self\"",
+									"          ]",
+									"        }",
+									"      },",
+									"      \"required\": [",
+									"        \"id\",",
+									"        \"links\"",
+									"      ]",
+									"    }",
+									"  },",
+									"  \"required\": [",
+									"    \"status\",",
+									"    \"data\"",
+									"  ]",
+									"}",
+									"",
+									"pm.test(\"Validate schema\", () => {",
+									"    pm.response.to.have.jsonSchema(schema);",
+									"});",
+									"",
+									"",
+									"pm.test(\"Get ops uuid\", function () {",
+									"    let jsonData = pm.response.json();",
+									"    pm.environment.set(\"ops_uuid\",jsonData.data.id);",
+									"});",
+									"",
+									"pm.test(\"Status code is 201\", function () {",
+									"    pm.response.to.have.status(201);",
+									"});",
+									"",
+									"pm.test(\"check_respone_data\", function() {",
+									"    let jsonData = pm.response.json();",
+									"    let apiHost = pm.environment.get(\"api_host\");",
+									"    let opsUUID = pm.environment.get(\"ops_uuid\");",
+									"    pm.expect(jsonData.status.message).to.eql(\"Operations Profile successfully created\");",
+									"    pm.expect(jsonData.status.code).to.eql(\"201\");",
+									"    pm.expect(jsonData.data.id).to.eql(opsUUID);",
+									"    pm.expect(jsonData.data.links.self).to.eql(\"https://\"+apiHost+\"/api/v2/operations_profiles/\"+opsUUID);",
+									"",
+									"});",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
 						}
-					]
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Accept",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "x-api-key",
+								"type": "text",
+								"value": "{{tenant_api_key}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "    {\n            \"name\": \"test_deploy_ops\",\n            \"available_states\": [\n                \"OK\",\n                \"WARNING\",\n                \"UNKNOWN\",\n                \"MISSING\",\n                \"CRITICAL\",\n                \"DOWNTIME\"\n            ],\n            \"defaults\": {\n                \"down\": \"DOWNTIME\",\n                \"missing\": \"MISSING\",\n                \"unknown\": \"UNKNOWN\"\n            },\n            \"operations\": [\n                {\n                    \"name\": \"AND\",\n                    \"truth_table\": [\n                        {\n                            \"a\": \"OK\",\n                            \"b\": \"OK\",\n                            \"x\": \"OK\"\n                        },\n                        {\n                            \"a\": \"OK\",\n                            \"b\": \"WARNING\",\n                            \"x\": \"WARNING\"\n                        },\n                        {\n                            \"a\": \"OK\",\n                            \"b\": \"UNKNOWN\",\n                            \"x\": \"UNKNOWN\"\n                        },\n                        {\n                            \"a\": \"OK\",\n                            \"b\": \"MISSING\",\n                            \"x\": \"MISSING\"\n                        },\n                        {\n                            \"a\": \"OK\",\n                            \"b\": \"CRITICAL\",\n                            \"x\": \"CRITICAL\"\n                        },\n                        {\n                            \"a\": \"OK\",\n                            \"b\": \"DOWNTIME\",\n                            \"x\": \"DOWNTIME\"\n                        },\n                        {\n                            \"a\": \"WARNING\",\n                            \"b\": \"WARNING\",\n                            \"x\": \"WARNING\"\n                        },\n                        {\n                            \"a\": \"WARNING\",\n                            \"b\": \"UNKNOWN\",\n                            \"x\": \"UNKNOWN\"\n                        },\n                        {\n                            \"a\": \"WARNING\",\n                            \"b\": \"MISSING\",\n                            \"x\": \"MISSING\"\n                        },\n                        {\n                            \"a\": \"WARNING\",\n                            \"b\": \"CRITICAL\",\n                            \"x\": \"CRITICAL\"\n                        },\n                        {\n                            \"a\": \"WARNING\",\n                            \"b\": \"DOWNTIME\",\n                            \"x\": \"DOWNTIME\"\n                        },\n                        {\n                            \"a\": \"UNKNOWN\",\n                            \"b\": \"UNKNOWN\",\n                            \"x\": \"UNKNOWN\"\n                        },\n                        {\n                            \"a\": \"UNKNOWN\",\n                            \"b\": \"MISSING\",\n                            \"x\": \"MISSING\"\n                        },\n                        {\n                            \"a\": \"UNKNOWN\",\n                            \"b\": \"CRITICAL\",\n                            \"x\": \"CRITICAL\"\n                        },\n                        {\n                            \"a\": \"UNKNOWN\",\n                            \"b\": \"DOWNTIME\",\n                            \"x\": \"DOWNTIME\"\n                        },\n                        {\n                            \"a\": \"MISSING\",\n                            \"b\": \"MISSING\",\n                            \"x\": \"MISSING\"\n                        },\n                        {\n                            \"a\": \"MISSING\",\n                            \"b\": \"CRITICAL\",\n                            \"x\": \"CRITICAL\"\n                        },\n                        {\n                            \"a\": \"MISSING\",\n                            \"b\": \"DOWNTIME\",\n                            \"x\": \"DOWNTIME\"\n                        },\n                        {\n                            \"a\": \"CRITICAL\",\n                            \"b\": \"CRITICAL\",\n                            \"x\": \"CRITICAL\"\n                        },\n                        {\n                            \"a\": \"CRITICAL\",\n                            \"b\": \"DOWNTIME\",\n                            \"x\": \"CRITICAL\"\n                        },\n                        {\n                            \"a\": \"DOWNTIME\",\n                            \"b\": \"DOWNTIME\",\n                            \"x\": \"DOWNTIME\"\n                        }\n                    ]\n                },\n                {\n                    \"name\": \"OR\",\n                    \"truth_table\": [\n                        {\n                            \"a\": \"OK\",\n                            \"b\": \"OK\",\n                            \"x\": \"OK\"\n                        },\n                        {\n                            \"a\": \"OK\",\n                            \"b\": \"WARNING\",\n                            \"x\": \"OK\"\n                        },\n                        {\n                            \"a\": \"OK\",\n                            \"b\": \"UNKNOWN\",\n                            \"x\": \"OK\"\n                        },\n                        {\n                            \"a\": \"OK\",\n                            \"b\": \"MISSING\",\n                            \"x\": \"OK\"\n                        },\n                        {\n                            \"a\": \"OK\",\n                            \"b\": \"CRITICAL\",\n                            \"x\": \"OK\"\n                        },\n                        {\n                            \"a\": \"OK\",\n                            \"b\": \"DOWNTIME\",\n                            \"x\": \"OK\"\n                        },\n                        {\n                            \"a\": \"WARNING\",\n                            \"b\": \"WARNING\",\n                            \"x\": \"WARNING\"\n                        },\n                        {\n                            \"a\": \"WARNING\",\n                            \"b\": \"UNKNOWN\",\n                            \"x\": \"WARNING\"\n                        },\n                        {\n                            \"a\": \"WARNING\",\n                            \"b\": \"MISSING\",\n                            \"x\": \"WARNING\"\n                        },\n                        {\n                            \"a\": \"WARNING\",\n                            \"b\": \"CRITICAL\",\n                            \"x\": \"WARNING\"\n                        },\n                        {\n                            \"a\": \"WARNING\",\n                            \"b\": \"DOWNTIME\",\n                            \"x\": \"WARNING\"\n                        },\n                        {\n                            \"a\": \"UNKNOWN\",\n                            \"b\": \"UNKNOWN\",\n                            \"x\": \"UNKNOWN\"\n                        },\n                        {\n                            \"a\": \"UNKNOWN\",\n                            \"b\": \"MISSING\",\n                            \"x\": \"UNKNOWN\"\n                        },\n                        {\n                            \"a\": \"UNKNOWN\",\n                            \"b\": \"CRITICAL\",\n                            \"x\": \"CRITICAL\"\n                        },\n                        {\n                            \"a\": \"UNKNOWN\",\n                            \"b\": \"DOWNTIME\",\n                            \"x\": \"UNKNOWN\"\n                        },\n                        {\n                            \"a\": \"MISSING\",\n                            \"b\": \"MISSING\",\n                            \"x\": \"MISSING\"\n                        },\n                        {\n                            \"a\": \"MISSING\",\n                            \"b\": \"CRITICAL\",\n                            \"x\": \"CRITICAL\"\n                        },\n                        {\n                            \"a\": \"MISSING\",\n                            \"b\": \"DOWNTIME\",\n                            \"x\": \"DOWNTIME\"\n                        },\n                        {\n                            \"a\": \"CRITICAL\",\n                            \"b\": \"CRITICAL\",\n                            \"x\": \"CRITICAL\"\n                        },\n                        {\n                            \"a\": \"CRITICAL\",\n                            \"b\": \"DOWNTIME\",\n                            \"x\": \"CRITICAL\"\n                        },\n                        {\n                            \"a\": \"DOWNTIME\",\n                            \"b\": \"DOWNTIME\",\n                            \"x\": \"DOWNTIME\"\n                        }\n                    ]\n                }\n            ]\n        }"
+						},
+						"url": {
+							"raw": "https://{{api_host}}/api/v2/operations_profiles",
+							"protocol": "https",
+							"host": [
+								"{{api_host}}"
+							],
+							"path": [
+								"api",
+								"v2",
+								"operations_profiles"
+							]
+						}
+					},
+					"response": []
 				},
-				"description": "test web api\t"
-			},
-			"response": []
+				{
+					"name": "Get operation profiles",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "7a297ae6-aa37-4f41-a272-d9396e0ad49a",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "1edb1ca9-cb56-43d1-956d-5fd09fc7cc43",
+								"exec": [
+									"const schema = {",
+									"",
+									"  \"type\": \"object\",",
+									"  \"properties\": {",
+									"    \"status\": {",
+									"      \"type\": \"object\",",
+									"      \"properties\": {",
+									"        \"message\": {",
+									"          \"type\": \"string\"",
+									"        },",
+									"        \"code\": {",
+									"          \"type\": \"string\"",
+									"        }",
+									"      },",
+									"      \"required\": [",
+									"        \"message\",",
+									"        \"code\"",
+									"      ]",
+									"    },",
+									"    \"data\": {",
+									"      \"type\": \"array\",",
+									"      \"items\": [",
+									"        {",
+									"          \"type\": \"object\",",
+									"          \"properties\": {",
+									"            \"id\": {",
+									"              \"type\": \"string\"",
+									"            },",
+									"            \"date\": {",
+									"              \"type\": \"string\"",
+									"            },",
+									"            \"name\": {",
+									"              \"type\": \"string\"",
+									"            },",
+									"            \"available_states\": {",
+									"              \"type\": \"array\",",
+									"              \"items\": ",
+									"                {",
+									"                  \"type\": \"string\"",
+									"                }",
+									"            },",
+									"            \"defaults\": {",
+									"              \"type\": \"object\",",
+									"              \"properties\": {",
+									"                \"down\": {",
+									"                  \"type\": \"string\"",
+									"                },",
+									"                \"missing\": {",
+									"                  \"type\": \"string\"",
+									"                },",
+									"                \"unknown\": {",
+									"                  \"type\": \"string\"",
+									"                }",
+									"              },",
+									"              \"required\": [",
+									"                \"down\",",
+									"                \"missing\",",
+									"                \"unknown\"",
+									"              ]",
+									"            },",
+									"            \"operations\": {",
+									"              \"type\": \"array\",",
+									"              \"items\": ",
+									"                {",
+									"                  \"type\": \"object\",",
+									"                  \"properties\": {",
+									"                    \"name\": {",
+									"                      \"type\": \"string\"",
+									"                    },",
+									"                    \"truth_table\": {",
+									"                      \"type\": \"array\",",
+									"                      \"items\": ",
+									"                        {",
+									"                          \"type\": \"object\",",
+									"                          \"properties\": {",
+									"                            \"a\": {",
+									"                              \"type\": \"string\"",
+									"                            },",
+									"                            \"b\": {",
+									"                              \"type\": \"string\"",
+									"                            },",
+									"                            \"x\": {",
+									"                              \"type\": \"string\"",
+									"                            }",
+									"                          },",
+									"                          \"required\": [",
+									"                            \"a\",",
+									"                            \"b\",",
+									"                            \"x\"",
+									"                          ]",
+									"                        }",
+									"                    }",
+									"                  },",
+									"                  \"required\": [",
+									"                    \"name\",",
+									"                    \"truth_table\"",
+									"                  ]",
+									"                }",
+									"            }",
+									"          },",
+									"          \"required\": [",
+									"            \"id\",",
+									"            \"date\",",
+									"            \"name\",",
+									"            \"available_states\",",
+									"            \"defaults\",",
+									"            \"operations\"",
+									"          ]",
+									"        }",
+									"      ]",
+									"    }",
+									"  },",
+									"  \"required\": [",
+									"    \"status\",",
+									"    \"data\"",
+									"  ]",
+									"}",
+									"",
+									"pm.test(\"Validate schema\", () => {",
+									"    pm.response.to.have.jsonSchema(schema);",
+									"});",
+									"",
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"check_respone_data\", function() {",
+									"    let jsonData = pm.response.json();",
+									"    let apiHost = pm.environment.get(\"api_host\");",
+									"    let opsUUID = pm.environment.get(\"ops_uuid\");",
+									"    pm.environment.set(\"ops_UUID\", opsUUID);",
+									"    pm.expect(jsonData.status.message).to.eql(\"Success\");",
+									"    pm.expect(jsonData.status.code).to.eql(\"200\");",
+									"    let profile = jsonData.data[0];",
+									"",
+									"    pm.expect(profile.id).to.eql(opsUUID);",
+									"    pm.expect(profile.name).to.eql(\"test_deploy_ops\");",
+									"    pm.expect(profile.operations[0].name).to.eql(\"AND\");",
+									"    pm.expect(profile.operations[1].name).to.eql(\"OR\");",
+									"    pm.expect(profile.available_states).to.eql([\"OK\",\"WARNING\",\"UNKNOWN\",\"MISSING\",\"CRITICAL\",\"DOWNTIME\"])",
+									"",
+									"",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Accept",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "x-api-key",
+								"type": "text",
+								"value": "{{tenant_api_key}}"
+							}
+						],
+						"url": {
+							"raw": "https://{{api_host}}/api/v2/operations_profiles",
+							"protocol": "https",
+							"host": [
+								"{{api_host}}"
+							],
+							"path": [
+								"api",
+								"v2",
+								"operations_profiles"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get specific operation profile",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "e617d2c0-4629-430b-8e98-69b60ed51797",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "7cdd759b-b464-4e5d-be77-3ca3b14d9bfd",
+								"exec": [
+									"const schema = {",
+									"",
+									"  \"type\": \"object\",",
+									"  \"properties\": {",
+									"    \"status\": {",
+									"      \"type\": \"object\",",
+									"      \"properties\": {",
+									"        \"message\": {",
+									"          \"type\": \"string\"",
+									"        },",
+									"        \"code\": {",
+									"          \"type\": \"string\"",
+									"        }",
+									"      },",
+									"      \"required\": [",
+									"        \"message\",",
+									"        \"code\"",
+									"      ]",
+									"    },",
+									"    \"data\": {",
+									"      \"type\": \"array\",",
+									"      \"items\": [",
+									"        {",
+									"          \"type\": \"object\",",
+									"          \"properties\": {",
+									"            \"id\": {",
+									"              \"type\": \"string\"",
+									"            },",
+									"            \"date\": {",
+									"              \"type\": \"string\"",
+									"            },",
+									"            \"name\": {",
+									"              \"type\": \"string\"",
+									"            },",
+									"            \"available_states\": {",
+									"              \"type\": \"array\",",
+									"              \"items\": ",
+									"                {",
+									"                  \"type\": \"string\"",
+									"                }",
+									"            },",
+									"            \"defaults\": {",
+									"              \"type\": \"object\",",
+									"              \"properties\": {",
+									"                \"down\": {",
+									"                  \"type\": \"string\"",
+									"                },",
+									"                \"missing\": {",
+									"                  \"type\": \"string\"",
+									"                },",
+									"                \"unknown\": {",
+									"                  \"type\": \"string\"",
+									"                }",
+									"              },",
+									"              \"required\": [",
+									"                \"down\",",
+									"                \"missing\",",
+									"                \"unknown\"",
+									"              ]",
+									"            },",
+									"            \"operations\": {",
+									"              \"type\": \"array\",",
+									"              \"items\": ",
+									"                {",
+									"                  \"type\": \"object\",",
+									"                  \"properties\": {",
+									"                    \"name\": {",
+									"                      \"type\": \"string\"",
+									"                    },",
+									"                    \"truth_table\": {",
+									"                      \"type\": \"array\",",
+									"                      \"items\": ",
+									"                        {",
+									"                          \"type\": \"object\",",
+									"                          \"properties\": {",
+									"                            \"a\": {",
+									"                              \"type\": \"string\"",
+									"                            },",
+									"                            \"b\": {",
+									"                              \"type\": \"string\"",
+									"                            },",
+									"                            \"x\": {",
+									"                              \"type\": \"string\"",
+									"                            }",
+									"                          },",
+									"                          \"required\": [",
+									"                            \"a\",",
+									"                            \"b\",",
+									"                            \"x\"",
+									"                          ]",
+									"                        }",
+									"                    }",
+									"                  },",
+									"                  \"required\": [",
+									"                    \"name\",",
+									"                    \"truth_table\"",
+									"                  ]",
+									"                }",
+									"            }",
+									"          },",
+									"          \"required\": [",
+									"            \"id\",",
+									"            \"date\",",
+									"            \"name\",",
+									"            \"available_states\",",
+									"            \"defaults\",",
+									"            \"operations\"",
+									"          ]",
+									"        }",
+									"      ]",
+									"    }",
+									"  },",
+									"  \"required\": [",
+									"    \"status\",",
+									"    \"data\"",
+									"  ]",
+									"}",
+									"",
+									"pm.test(\"Validate schema\", () => {",
+									"    pm.response.to.have.jsonSchema(schema);",
+									"});",
+									"",
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"check_respone_data\", function() {",
+									"    let jsonData = pm.response.json();",
+									"    let apiHost = pm.environment.get(\"api_host\");",
+									"    let opsUUID = pm.environment.get(\"ops_uuid\");",
+									"    pm.expect(jsonData.status.message).to.eql(\"Success\");",
+									"    pm.expect(jsonData.status.code).to.eql(\"200\");",
+									"    let profile = jsonData.data[0];",
+									"",
+									"    pm.expect(profile.id).to.eql(opsUUID);",
+									"    pm.expect(profile.name).to.eql(\"test_deploy_ops\");",
+									"    pm.expect(profile.operations[0].name).to.eql(\"AND\");",
+									"    pm.expect(profile.operations[1].name).to.eql(\"OR\");",
+									"    pm.expect(profile.available_states).to.eql([\"OK\",\"WARNING\",\"UNKNOWN\",\"MISSING\",\"CRITICAL\",\"DOWNTIME\"])",
+									"",
+									"",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Accept",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "x-api-key",
+								"type": "text",
+								"value": "{{tenant_api_key}}"
+							}
+						],
+						"url": {
+							"raw": "https://{{api_host}}/api/v2/operations_profiles/{{ops_uuid}}",
+							"protocol": "https",
+							"host": [
+								"{{api_host}}"
+							],
+							"path": [
+								"api",
+								"v2",
+								"operations_profiles",
+								"{{ops_uuid}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Update operations profile",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "dca55832-8dad-480c-b9b1-4e593f1e8b11",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "75384f72-3a9b-486b-b6e1-f8c01e754245",
+								"exec": [
+									"const schema = {",
+									"  \"type\": \"object\",",
+									"  \"properties\": {",
+									"    \"status\": {",
+									"      \"type\": \"object\",",
+									"      \"properties\": {",
+									"        \"message\": {",
+									"          \"type\": \"string\"",
+									"        },",
+									"        \"code\": {",
+									"          \"type\": \"string\"",
+									"        }",
+									"      },",
+									"      \"required\": [",
+									"        \"message\",",
+									"        \"code\"",
+									"      ]",
+									"    }",
+									"  },",
+									"  \"required\": [",
+									"    \"status\"",
+									"  ]",
+									"}",
+									"",
+									"pm.test(\"Validate schema\", () => {",
+									"    pm.response.to.have.jsonSchema(schema);",
+									"});",
+									"",
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"check_respone_data\", function() {",
+									"    let jsonData = pm.response.json();",
+									"    let apiHost = pm.environment.get(\"api_host\");",
+									"    let opsUUID = pm.environment.get(\"ops_uuid\");",
+									"    pm.expect(jsonData.status.message).to.eql(\"Operations Profile successfully updated\");",
+									"    pm.expect(jsonData.status.code).to.eql(\"200\");",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "PUT",
+						"header": [
+							{
+								"key": "Accept",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "x-api-key",
+								"type": "text",
+								"value": "{{tenant_api_key}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": " {\n            \"name\": \"test_deploy_ops\",\n            \"available_states\": [\n                \"OK\",\n                \"WARNING\",\n                \"UNKNOWN\",\n                \"MISSING\",\n                \"CRITICAL\",\n                \"DOWNTIME\"\n            ],\n            \"defaults\": {\n                \"down\": \"DOWNTIME\",\n                \"missing\": \"MISSING\",\n                \"unknown\": \"UNKNOWN\"\n            },\n            \"operations\": [\n                {\n                    \"name\": \"AND2\",\n                    \"truth_table\": [\n                        {\n                            \"a\": \"OK\",\n                            \"b\": \"OK\",\n                            \"x\": \"OK\"\n                        },\n                        {\n                            \"a\": \"OK\",\n                            \"b\": \"WARNING\",\n                            \"x\": \"WARNING\"\n                        },\n                        {\n                            \"a\": \"OK\",\n                            \"b\": \"UNKNOWN\",\n                            \"x\": \"UNKNOWN\"\n                        },\n                        {\n                            \"a\": \"OK\",\n                            \"b\": \"MISSING\",\n                            \"x\": \"MISSING\"\n                        },\n                        {\n                            \"a\": \"OK\",\n                            \"b\": \"CRITICAL\",\n                            \"x\": \"CRITICAL\"\n                        },\n                        {\n                            \"a\": \"OK\",\n                            \"b\": \"DOWNTIME\",\n                            \"x\": \"DOWNTIME\"\n                        },\n                        {\n                            \"a\": \"WARNING\",\n                            \"b\": \"WARNING\",\n                            \"x\": \"WARNING\"\n                        },\n                        {\n                            \"a\": \"WARNING\",\n                            \"b\": \"UNKNOWN\",\n                            \"x\": \"UNKNOWN\"\n                        },\n                        {\n                            \"a\": \"WARNING\",\n                            \"b\": \"MISSING\",\n                            \"x\": \"MISSING\"\n                        },\n                        {\n                            \"a\": \"WARNING\",\n                            \"b\": \"CRITICAL\",\n                            \"x\": \"CRITICAL\"\n                        },\n                        {\n                            \"a\": \"WARNING\",\n                            \"b\": \"DOWNTIME\",\n                            \"x\": \"DOWNTIME\"\n                        },\n                        {\n                            \"a\": \"UNKNOWN\",\n                            \"b\": \"UNKNOWN\",\n                            \"x\": \"UNKNOWN\"\n                        },\n                        {\n                            \"a\": \"UNKNOWN\",\n                            \"b\": \"MISSING\",\n                            \"x\": \"MISSING\"\n                        },\n                        {\n                            \"a\": \"UNKNOWN\",\n                            \"b\": \"CRITICAL\",\n                            \"x\": \"CRITICAL\"\n                        },\n                        {\n                            \"a\": \"UNKNOWN\",\n                            \"b\": \"DOWNTIME\",\n                            \"x\": \"DOWNTIME\"\n                        },\n                        {\n                            \"a\": \"MISSING\",\n                            \"b\": \"MISSING\",\n                            \"x\": \"MISSING\"\n                        },\n                        {\n                            \"a\": \"MISSING\",\n                            \"b\": \"CRITICAL\",\n                            \"x\": \"CRITICAL\"\n                        },\n                        {\n                            \"a\": \"MISSING\",\n                            \"b\": \"DOWNTIME\",\n                            \"x\": \"DOWNTIME\"\n                        },\n                        {\n                            \"a\": \"CRITICAL\",\n                            \"b\": \"CRITICAL\",\n                            \"x\": \"CRITICAL\"\n                        },\n                        {\n                            \"a\": \"CRITICAL\",\n                            \"b\": \"DOWNTIME\",\n                            \"x\": \"CRITICAL\"\n                        },\n                        {\n                            \"a\": \"DOWNTIME\",\n                            \"b\": \"DOWNTIME\",\n                            \"x\": \"DOWNTIME\"\n                        }\n                    ]\n                },\n                {\n                    \"name\": \"OR2\",\n                    \"truth_table\": [\n                        {\n                            \"a\": \"OK\",\n                            \"b\": \"OK\",\n                            \"x\": \"OK\"\n                        },\n                        {\n                            \"a\": \"OK\",\n                            \"b\": \"WARNING\",\n                            \"x\": \"OK\"\n                        },\n                        {\n                            \"a\": \"OK\",\n                            \"b\": \"UNKNOWN\",\n                            \"x\": \"OK\"\n                        },\n                        {\n                            \"a\": \"OK\",\n                            \"b\": \"MISSING\",\n                            \"x\": \"OK\"\n                        },\n                        {\n                            \"a\": \"OK\",\n                            \"b\": \"CRITICAL\",\n                            \"x\": \"OK\"\n                        },\n                        {\n                            \"a\": \"OK\",\n                            \"b\": \"DOWNTIME\",\n                            \"x\": \"OK\"\n                        },\n                        {\n                            \"a\": \"WARNING\",\n                            \"b\": \"WARNING\",\n                            \"x\": \"WARNING\"\n                        },\n                        {\n                            \"a\": \"WARNING\",\n                            \"b\": \"UNKNOWN\",\n                            \"x\": \"WARNING\"\n                        },\n                        {\n                            \"a\": \"WARNING\",\n                            \"b\": \"MISSING\",\n                            \"x\": \"WARNING\"\n                        },\n                        {\n                            \"a\": \"WARNING\",\n                            \"b\": \"CRITICAL\",\n                            \"x\": \"WARNING\"\n                        },\n                        {\n                            \"a\": \"WARNING\",\n                            \"b\": \"DOWNTIME\",\n                            \"x\": \"WARNING\"\n                        },\n                        {\n                            \"a\": \"UNKNOWN\",\n                            \"b\": \"UNKNOWN\",\n                            \"x\": \"UNKNOWN\"\n                        },\n                        {\n                            \"a\": \"UNKNOWN\",\n                            \"b\": \"MISSING\",\n                            \"x\": \"UNKNOWN\"\n                        },\n                        {\n                            \"a\": \"UNKNOWN\",\n                            \"b\": \"CRITICAL\",\n                            \"x\": \"CRITICAL\"\n                        },\n                        {\n                            \"a\": \"UNKNOWN\",\n                            \"b\": \"DOWNTIME\",\n                            \"x\": \"UNKNOWN\"\n                        },\n                        {\n                            \"a\": \"MISSING\",\n                            \"b\": \"MISSING\",\n                            \"x\": \"MISSING\"\n                        },\n                        {\n                            \"a\": \"MISSING\",\n                            \"b\": \"CRITICAL\",\n                            \"x\": \"CRITICAL\"\n                        },\n                        {\n                            \"a\": \"MISSING\",\n                            \"b\": \"DOWNTIME\",\n                            \"x\": \"DOWNTIME\"\n                        },\n                        {\n                            \"a\": \"CRITICAL\",\n                            \"b\": \"CRITICAL\",\n                            \"x\": \"CRITICAL\"\n                        },\n                        {\n                            \"a\": \"CRITICAL\",\n                            \"b\": \"DOWNTIME\",\n                            \"x\": \"CRITICAL\"\n                        },\n                        {\n                            \"a\": \"DOWNTIME\",\n                            \"b\": \"DOWNTIME\",\n                            \"x\": \"DOWNTIME\"\n                        }\n                    ]\n                }\n            ]\n        }",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "https://{{api_host}}/api/v2/operations_profiles/{{ops_uuid}}",
+							"protocol": "https",
+							"host": [
+								"{{api_host}}"
+							],
+							"path": [
+								"api",
+								"v2",
+								"operations_profiles",
+								"{{ops_uuid}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get specific operation profile modified",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "9340661e-ca07-4246-9b8f-ae1f9d88ec24",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "f640ef3f-e7f4-4fc1-98cf-55c77936aa0d",
+								"exec": [
+									"const schema = {",
+									"",
+									"  \"type\": \"object\",",
+									"  \"properties\": {",
+									"    \"status\": {",
+									"      \"type\": \"object\",",
+									"      \"properties\": {",
+									"        \"message\": {",
+									"          \"type\": \"string\"",
+									"        },",
+									"        \"code\": {",
+									"          \"type\": \"string\"",
+									"        }",
+									"      },",
+									"      \"required\": [",
+									"        \"message\",",
+									"        \"code\"",
+									"      ]",
+									"    },",
+									"    \"data\": {",
+									"      \"type\": \"array\",",
+									"      \"items\": [",
+									"        {",
+									"          \"type\": \"object\",",
+									"          \"properties\": {",
+									"            \"id\": {",
+									"              \"type\": \"string\"",
+									"            },",
+									"            \"date\": {",
+									"              \"type\": \"string\"",
+									"            },",
+									"            \"name\": {",
+									"              \"type\": \"string\"",
+									"            },",
+									"            \"available_states\": {",
+									"              \"type\": \"array\",",
+									"              \"items\": ",
+									"                {",
+									"                  \"type\": \"string\"",
+									"                }",
+									"            },",
+									"            \"defaults\": {",
+									"              \"type\": \"object\",",
+									"              \"properties\": {",
+									"                \"down\": {",
+									"                  \"type\": \"string\"",
+									"                },",
+									"                \"missing\": {",
+									"                  \"type\": \"string\"",
+									"                },",
+									"                \"unknown\": {",
+									"                  \"type\": \"string\"",
+									"                }",
+									"              },",
+									"              \"required\": [",
+									"                \"down\",",
+									"                \"missing\",",
+									"                \"unknown\"",
+									"              ]",
+									"            },",
+									"            \"operations\": {",
+									"              \"type\": \"array\",",
+									"              \"items\": ",
+									"                {",
+									"                  \"type\": \"object\",",
+									"                  \"properties\": {",
+									"                    \"name\": {",
+									"                      \"type\": \"string\"",
+									"                    },",
+									"                    \"truth_table\": {",
+									"                      \"type\": \"array\",",
+									"                      \"items\": ",
+									"                        {",
+									"                          \"type\": \"object\",",
+									"                          \"properties\": {",
+									"                            \"a\": {",
+									"                              \"type\": \"string\"",
+									"                            },",
+									"                            \"b\": {",
+									"                              \"type\": \"string\"",
+									"                            },",
+									"                            \"x\": {",
+									"                              \"type\": \"string\"",
+									"                            }",
+									"                          },",
+									"                          \"required\": [",
+									"                            \"a\",",
+									"                            \"b\",",
+									"                            \"x\"",
+									"                          ]",
+									"                        }",
+									"                    }",
+									"                  },",
+									"                  \"required\": [",
+									"                    \"name\",",
+									"                    \"truth_table\"",
+									"                  ]",
+									"                }",
+									"            }",
+									"          },",
+									"          \"required\": [",
+									"            \"id\",",
+									"            \"date\",",
+									"            \"name\",",
+									"            \"available_states\",",
+									"            \"defaults\",",
+									"            \"operations\"",
+									"          ]",
+									"        }",
+									"      ]",
+									"    }",
+									"  },",
+									"  \"required\": [",
+									"    \"status\",",
+									"    \"data\"",
+									"  ]",
+									"}",
+									"",
+									"pm.test(\"Validate schema\", () => {",
+									"    pm.response.to.have.jsonSchema(schema);",
+									"});",
+									"",
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"check_respone_data\", function() {",
+									"    let jsonData = pm.response.json();",
+									"    let apiHost = pm.environment.get(\"api_host\");",
+									"    let opsUUID = pm.environment.get(\"ops_uuid\");",
+									"    pm.expect(jsonData.status.message).to.eql(\"Success\");",
+									"    pm.expect(jsonData.status.code).to.eql(\"200\");",
+									"    let profile = jsonData.data[0];",
+									"",
+									"    pm.expect(profile.id).to.eql(opsUUID);",
+									"    pm.expect(profile.name).to.eql(\"test_deploy_ops\");",
+									"    pm.expect(profile.operations[0].name).to.eql(\"AND2\");",
+									"    pm.expect(profile.operations[1].name).to.eql(\"OR2\");",
+									"    pm.expect(profile.available_states).to.eql([\"OK\",\"WARNING\",\"UNKNOWN\",\"MISSING\",\"CRITICAL\",\"DOWNTIME\"])",
+									"",
+									"",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Accept",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "x-api-key",
+								"type": "text",
+								"value": "{{tenant_api_key}}"
+							}
+						],
+						"url": {
+							"raw": "https://{{api_host}}/api/v2/operations_profiles/{{ops_uuid}}",
+							"protocol": "https",
+							"host": [
+								"{{api_host}}"
+							],
+							"path": [
+								"api",
+								"v2",
+								"operations_profiles",
+								"{{ops_uuid}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "delete operations profile",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "6fc1e694-0b82-4cd5-b2d2-b0114d860235",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "3ac03cb3-52df-4d33-a7de-1e6c61107d7e",
+								"exec": [
+									"const schema = {",
+									"  \"type\": \"object\",",
+									"  \"properties\": {",
+									"    \"status\": {",
+									"      \"type\": \"object\",",
+									"      \"properties\": {",
+									"        \"message\": {",
+									"          \"type\": \"string\"",
+									"        },",
+									"        \"code\": {",
+									"          \"type\": \"string\"",
+									"        }",
+									"      },",
+									"      \"required\": [",
+									"        \"message\",",
+									"        \"code\"",
+									"      ]",
+									"    }",
+									"  },",
+									"  \"required\": [",
+									"    \"status\"",
+									"  ]",
+									"}",
+									"",
+									"pm.test(\"Validate schema\", () => {",
+									"    pm.response.to.have.jsonSchema(schema);",
+									"});",
+									"",
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"check_respone_data\", function() {",
+									"    let jsonData = pm.response.json();",
+									"",
+									"    pm.expect(jsonData.status.message).to.eql(\"Operations Profile Successfully Deleted\");",
+									"    pm.expect(jsonData.status.code).to.eql(\"200\");",
+									"  ",
+									"",
+									"});",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "Accept",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "x-api-key",
+								"type": "text",
+								"value": "{{tenant_api_key}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "https://{{api_host}}/api/v2/operations_profiles/{{ops_uuid}}",
+							"protocol": "https",
+							"host": [
+								"{{api_host}}"
+							],
+							"path": [
+								"api",
+								"v2",
+								"operations_profiles",
+								"{{ops_uuid}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "delete tenant",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "538427e3-8a84-48a6-aa00-98a3ed8d5baa",
+								"exec": [
+									"const schema = {",
+									"  \"type\": \"object\",",
+									"  \"properties\": {",
+									"    \"status\": {",
+									"      \"type\": \"object\",",
+									"      \"properties\": {",
+									"        \"message\": {",
+									"          \"type\": \"string\"",
+									"        },",
+									"        \"code\": {",
+									"          \"type\": \"string\"",
+									"        }",
+									"      },",
+									"      \"required\": [",
+									"        \"message\",",
+									"        \"code\"",
+									"      ]",
+									"    }",
+									"  },",
+									"  \"required\": [",
+									"    \"status\"",
+									"  ]",
+									"}",
+									"",
+									"pm.test(\"Validate schema\", () => {",
+									"    pm.response.to.have.jsonSchema(schema);",
+									"});",
+									"",
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"pm.globals.set(\"variable_key\", \"variable_value\");"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "Accept",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "x-api-key",
+								"type": "text",
+								"value": "{{api_key}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "https://{{api_host}}/api/v2/admin/tenants/{{tenant_uuid}}",
+							"protocol": "https",
+							"host": [
+								"{{api_host}}"
+							],
+							"path": [
+								"api",
+								"v2",
+								"admin",
+								"tenants",
+								"{{tenant_uuid}}"
+							],
+							"query": [
+								{
+									"key": "Accept",
+									"value": "application/json",
+									"disabled": true
+								},
+								{
+									"key": "x-api-key",
+									"value": "{{api_key}}",
+									"disabled": true
+								}
+							]
+						},
+						"description": "test web api\t"
+					},
+					"response": []
+				}
+			],
+			"protocolProfileBehavior": {}
 		},
 		{
-			"name": "create new tenant",
+			"name": "metric-profiles tests",
+			"item": [
+				{
+					"name": "create new tenant",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "926d45dd-3c03-4ae7-b8ac-fb8c58809a06",
+								"exec": [
+									"const schema = {",
+									"  \"type\": \"object\",",
+									"  \"properties\": {",
+									"    \"status\": {",
+									"      \"type\": \"object\",",
+									"      \"properties\": {",
+									"        \"message\": {",
+									"          \"type\": \"string\"",
+									"        },",
+									"        \"code\": {",
+									"          \"type\": \"string\"",
+									"        }",
+									"      },",
+									"      \"required\": [",
+									"        \"message\",",
+									"        \"code\"",
+									"      ]",
+									"    },",
+									"    \"data\": {",
+									"      \"type\": \"object\",",
+									"      \"properties\": {",
+									"        \"id\": {",
+									"          \"type\": \"string\"",
+									"        },",
+									"        \"links\": {",
+									"          \"type\": \"object\",",
+									"          \"properties\": {",
+									"            \"self\": {",
+									"              \"type\": \"string\"",
+									"            }",
+									"          },",
+									"          \"required\": [",
+									"            \"self\"",
+									"          ]",
+									"        }",
+									"      },",
+									"      \"required\": [",
+									"        \"id\",",
+									"        \"links\"",
+									"      ]",
+									"    }",
+									"  },",
+									"  \"required\": [",
+									"    \"status\",",
+									"    \"data\"",
+									"  ]",
+									"}",
+									"",
+									"pm.test(\"Validate schema\", () => {",
+									"    pm.response.to.have.jsonSchema(schema);",
+									"});",
+									"",
+									"",
+									"pm.test(\"Get tenant uuid\", function () {",
+									"    let jsonData = pm.response.json();",
+									"    pm.environment.set(\"tenant_uuid\",jsonData.data.id);",
+									"});",
+									"",
+									"pm.test(\"Status code is 201\", function () {",
+									"    pm.response.to.have.status(201);",
+									"});",
+									"",
+									"// set test tenant api key",
+									"pm.environment.set(\"tenant_api_key\", \"foo.test.secret.key\");"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Accept",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "x-api-key",
+								"type": "text",
+								"value": "{{api_key}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"info\": {\n    \"website\": \"foo.example.com\",\n    \"description\": \"a test tenant\",\n    \"image\": \"string\",\n    \"email\": \"info@foo.example.com\",\n    \"name\": \"FOO\"\n  },\n  \"topology\": {\n    \"feed\": \"string\",\n    \"type\": \"string\"\n  },\n  \"db_conf\": [\n    {\n      \"username\": \"\",\n      \"password\": \"\",\n      \"port\": 27017,\n      \"store\": \"argo_FOO\",\n      \"server\": \"localhost\"\n    }\n  ],\n  \"users\": [\n    {\n      \"name\": \"test-admin\",\n      \"api_key\": \"foo.test.secret.key\",\n      \"roles\": [\n        \"admin\"\n      ],\n      \"email\": \"foo@example.com\"\n    }\n  ]\n}"
+						},
+						"url": {
+							"raw": "https://{{api_host}}/api/v2/admin/tenants",
+							"protocol": "https",
+							"host": [
+								"{{api_host}}"
+							],
+							"path": [
+								"api",
+								"v2",
+								"admin",
+								"tenants"
+							],
+							"query": [
+								{
+									"key": "Accept",
+									"value": "application/json",
+									"disabled": true
+								},
+								{
+									"key": "x-api-key",
+									"value": "{{api_key}}",
+									"disabled": true
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "create metric profile",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "98e58388-4280-4152-a1b1-b452c1037201",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "3da76097-1515-469e-a7a6-f3363eeaedf2",
+								"exec": [
+									"const schema = {",
+									"  \"type\": \"object\",",
+									"  \"properties\": {",
+									"    \"status\": {",
+									"      \"type\": \"object\",",
+									"      \"properties\": {",
+									"        \"message\": {",
+									"          \"type\": \"string\"",
+									"        },",
+									"        \"code\": {",
+									"          \"type\": \"string\"",
+									"        }",
+									"      },",
+									"      \"required\": [",
+									"        \"message\",",
+									"        \"code\"",
+									"      ]",
+									"    },",
+									"    \"data\": {",
+									"      \"type\": \"object\",",
+									"      \"properties\": {",
+									"        \"id\": {",
+									"          \"type\": \"string\"",
+									"        },",
+									"        \"links\": {",
+									"          \"type\": \"object\",",
+									"          \"properties\": {",
+									"            \"self\": {",
+									"              \"type\": \"string\"",
+									"            }",
+									"          },",
+									"          \"required\": [",
+									"            \"self\"",
+									"          ]",
+									"        }",
+									"      },",
+									"      \"required\": [",
+									"        \"id\",",
+									"        \"links\"",
+									"      ]",
+									"    }",
+									"  },",
+									"  \"required\": [",
+									"    \"status\",",
+									"    \"data\"",
+									"  ]",
+									"}",
+									"",
+									"pm.test(\"Validate schema\", () => {",
+									"    pm.response.to.have.jsonSchema(schema);",
+									"});",
+									"",
+									"",
+									"pm.test(\"Get metric uuid\", function () {",
+									"    let jsonData = pm.response.json();",
+									"    pm.environment.set(\"metric_uuid\",jsonData.data.id);",
+									"});",
+									"",
+									"pm.test(\"Status code is 201\", function () {",
+									"    pm.response.to.have.status(201);",
+									"});",
+									"",
+									"pm.test(\"check_respone_data\", function() {",
+									"    let jsonData = pm.response.json();",
+									"    let apiHost = pm.environment.get(\"api_host\");",
+									"    let mpsUUID = pm.environment.get(\"metric_uuid\");",
+									"    pm.expect(jsonData.status.message).to.eql(\"Metric Profile successfully created\");",
+									"    pm.expect(jsonData.status.code).to.eql(\"201\");",
+									"    pm.expect(jsonData.data.id).to.eql(mpsUUID);",
+									"    pm.expect(jsonData.data.links.self).to.eql(\"https://\"+apiHost+\"/api/v2/metric_profiles/\"+mpsUUID);",
+									"",
+									"});",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Accept",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "x-api-key",
+								"type": "text",
+								"value": "{{tenant_api_key}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n            \"name\": \"test-mon\",\n            \"description\": \"Generic monitoring profile\",\n            \"services\": [\n                {\n                    \"service\": \"ARGO\",\n                    \"metrics\": [\n                        \"org.nagios.ARGOWeb-AR\",\n                        \"org.nagios.ARGOWeb-Status\"\n                    ]\n                },\n                {\n                    \"service\": \"WebPortal\",\n                    \"metrics\": [\n                        \"org.nagios.WebCheck\",\n                        \"eu.egi.CertValidity\"\n                    ]\n                }\n            ]\n        }"
+						},
+						"url": {
+							"raw": "https://{{api_host}}/api/v2/metric_profiles",
+							"protocol": "https",
+							"host": [
+								"{{api_host}}"
+							],
+							"path": [
+								"api",
+								"v2",
+								"metric_profiles"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get metric profiles",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "4219bf62-d585-4371-83a4-a8680d909eb3",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "1e8dee55-7acf-4954-b15b-2303caf9abb4",
+								"exec": [
+									"const schema = {",
+									"  \"type\": \"object\",",
+									"  \"properties\": {",
+									"    \"status\": {",
+									"      \"type\": \"object\",",
+									"      \"properties\": {",
+									"        \"message\": {",
+									"          \"type\": \"string\"",
+									"        },",
+									"        \"code\": {",
+									"          \"type\": \"string\"",
+									"        }",
+									"      },",
+									"      \"required\": [",
+									"        \"message\",",
+									"        \"code\"",
+									"      ]",
+									"    },",
+									"    \"data\": {",
+									"      \"type\": \"array\",",
+									"      \"items\": [",
+									"        {",
+									"          \"type\": \"object\",",
+									"          \"properties\": {",
+									"            \"id\": {",
+									"              \"type\": \"string\"",
+									"            },",
+									"            \"date\": {",
+									"              \"type\": \"string\"",
+									"            },",
+									"            \"name\": {",
+									"              \"type\": \"string\"",
+									"            },",
+									"            \"description\": {",
+									"              \"type\": \"string\"",
+									"            },",
+									"            \"services\": {",
+									"              \"type\": \"array\",",
+									"              \"items\": {",
+									"                \"type\": \"object\",",
+									"                \"properties\": {",
+									"                  \"service\": {",
+									"                    \"type\": \"string\"",
+									"                  },",
+									"                  \"metrics\": {",
+									"                    \"type\": \"array\",",
+									"                    \"items\": {",
+									"                      \"type\": \"string\"",
+									"                    }",
+									"                  }",
+									"                },",
+									"                \"required\": [",
+									"                  \"service\",",
+									"                  \"metrics\"",
+									"                ]",
+									"              }",
+									"            }",
+									"          },",
+									"          \"required\": [",
+									"            \"id\",",
+									"            \"date\",",
+									"            \"name\",",
+									"            \"description\",",
+									"            \"services\"",
+									"          ]",
+									"        }",
+									"      ]",
+									"    }",
+									"  },",
+									"  \"required\": [",
+									"    \"status\",",
+									"    \"data\"",
+									"  ]",
+									"}",
+									"",
+									"pm.test(\"Validate schema\", () => {",
+									"    pm.response.to.have.jsonSchema(schema);",
+									"});",
+									"",
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"check_respone_data\", function() {",
+									"    let jsonData = pm.response.json();",
+									"    let apiHost = pm.environment.get(\"api_host\");",
+									"    let mpsUUID = pm.environment.get(\"metric_uuid\");",
+									"    pm.environment.set(\"metric_UUID\", mpsUUID);",
+									"    pm.expect(jsonData.status.message).to.eql(\"Success\");",
+									"    pm.expect(jsonData.status.code).to.eql(\"200\");",
+									"    let profile = jsonData.data[0];",
+									"",
+									"    pm.expect(profile.id).to.eql(mpsUUID);",
+									"    pm.expect(profile.name).to.eql(\"test-mon\");",
+									"    pm.expect(profile.description).to.eql(\"Generic monitoring profile\");",
+									"    pm.expect(profile.services[0].service).to.eql(\"ARGO\");",
+									"    pm.expect(profile.services[0].metrics).to.eql([\"org.nagios.ARGOWeb-AR\",\"org.nagios.ARGOWeb-Status\"]);",
+									"    pm.expect(profile.services[1].service).to.eql(\"WebPortal\");",
+									"    pm.expect(profile.services[1].metrics).to.eql([\"org.nagios.WebCheck\",\"eu.egi.CertValidity\"]);",
+									"",
+									"",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Accept",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "x-api-key",
+								"type": "text",
+								"value": "{{tenant_api_key}}"
+							}
+						],
+						"url": {
+							"raw": "https://{{api_host}}/api/v2/metric_profiles",
+							"protocol": "https",
+							"host": [
+								"{{api_host}}"
+							],
+							"path": [
+								"api",
+								"v2",
+								"metric_profiles"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get specific metric profile",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "3f01d275-353e-454f-84ac-cb6280cf511f",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "beae68b7-d4bf-4c5e-8c8a-41369f87bdd7",
+								"exec": [
+									"const schema = {",
+									"  \"type\": \"object\",",
+									"  \"properties\": {",
+									"    \"status\": {",
+									"      \"type\": \"object\",",
+									"      \"properties\": {",
+									"        \"message\": {",
+									"          \"type\": \"string\"",
+									"        },",
+									"        \"code\": {",
+									"          \"type\": \"string\"",
+									"        }",
+									"      },",
+									"      \"required\": [",
+									"        \"message\",",
+									"        \"code\"",
+									"      ]",
+									"    },",
+									"    \"data\": {",
+									"      \"type\": \"array\",",
+									"      \"items\": [",
+									"        {",
+									"          \"type\": \"object\",",
+									"          \"properties\": {",
+									"            \"id\": {",
+									"              \"type\": \"string\"",
+									"            },",
+									"            \"date\": {",
+									"              \"type\": \"string\"",
+									"            },",
+									"            \"name\": {",
+									"              \"type\": \"string\"",
+									"            },",
+									"            \"description\": {",
+									"              \"type\": \"string\"",
+									"            },",
+									"            \"services\": {",
+									"              \"type\": \"array\",",
+									"              \"items\": {",
+									"                \"type\": \"object\",",
+									"                \"properties\": {",
+									"                  \"service\": {",
+									"                    \"type\": \"string\"",
+									"                  },",
+									"                  \"metrics\": {",
+									"                    \"type\": \"array\",",
+									"                    \"items\": {",
+									"                      \"type\": \"string\"",
+									"                    }",
+									"                  }",
+									"                },",
+									"                \"required\": [",
+									"                  \"service\",",
+									"                  \"metrics\"",
+									"                ]",
+									"              }",
+									"            }",
+									"          },",
+									"          \"required\": [",
+									"            \"id\",",
+									"            \"date\",",
+									"            \"name\",",
+									"            \"description\",",
+									"            \"services\"",
+									"          ]",
+									"        }",
+									"      ]",
+									"    }",
+									"  },",
+									"  \"required\": [",
+									"    \"status\",",
+									"    \"data\"",
+									"  ]",
+									"}",
+									"",
+									"pm.test(\"Validate schema\", () => {",
+									"    pm.response.to.have.jsonSchema(schema);",
+									"});",
+									"",
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"check_respone_data\", function() {",
+									"    let jsonData = pm.response.json();",
+									"    let apiHost = pm.environment.get(\"api_host\");",
+									"    let mpsUUID = pm.environment.get(\"metric_uuid\");",
+									"    pm.environment.set(\"metric_UUID\", mpsUUID);",
+									"    pm.expect(jsonData.status.message).to.eql(\"Success\");",
+									"    pm.expect(jsonData.status.code).to.eql(\"200\");",
+									"    let profile = jsonData.data[0];",
+									"",
+									"    pm.expect(profile.id).to.eql(mpsUUID);",
+									"    pm.expect(profile.name).to.eql(\"test-mon\");",
+									"    pm.expect(profile.description).to.eql(\"Generic monitoring profile\");",
+									"    pm.expect(profile.services[0].service).to.eql(\"ARGO\");",
+									"    pm.expect(profile.services[0].metrics).to.eql([\"org.nagios.ARGOWeb-AR\",\"org.nagios.ARGOWeb-Status\"]);",
+									"    pm.expect(profile.services[1].service).to.eql(\"WebPortal\");",
+									"    pm.expect(profile.services[1].metrics).to.eql([\"org.nagios.WebCheck\",\"eu.egi.CertValidity\"]);",
+									"",
+									"",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Accept",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "x-api-key",
+								"type": "text",
+								"value": "{{tenant_api_key}}"
+							}
+						],
+						"url": {
+							"raw": "https://{{api_host}}/api/v2/metric_profiles/{{metric_uuid}}",
+							"protocol": "https",
+							"host": [
+								"{{api_host}}"
+							],
+							"path": [
+								"api",
+								"v2",
+								"metric_profiles",
+								"{{metric_uuid}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Update metric profile",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "281d9b9b-38e7-4584-af60-5c60e16590a6",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "2a210fd5-b19f-47e4-a59e-8320d4d43958",
+								"exec": [
+									"const schema = {",
+									"  \"type\": \"object\",",
+									"  \"properties\": {",
+									"    \"status\": {",
+									"      \"type\": \"object\",",
+									"      \"properties\": {",
+									"        \"message\": {",
+									"          \"type\": \"string\"",
+									"        },",
+									"        \"code\": {",
+									"          \"type\": \"string\"",
+									"        }",
+									"      },",
+									"      \"required\": [",
+									"        \"message\",",
+									"        \"code\"",
+									"      ]",
+									"    }",
+									"  },",
+									"  \"required\": [",
+									"    \"status\"",
+									"  ]",
+									"}",
+									"",
+									"pm.test(\"Validate schema\", () => {",
+									"    pm.response.to.have.jsonSchema(schema);",
+									"});",
+									"",
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"check_respone_data\", function() {",
+									"    let jsonData = pm.response.json();",
+									"    let apiHost = pm.environment.get(\"api_host\");",
+									"    let mpsUUID = pm.environment.get(\"metric_uuid\");",
+									"    pm.expect(jsonData.status.message).to.eql(\"Metric Profile successfully updated\");",
+									"    pm.expect(jsonData.status.code).to.eql(\"200\");",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "PUT",
+						"header": [
+							{
+								"key": "Accept",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "x-api-key",
+								"type": "text",
+								"value": "{{tenant_api_key}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n            \"name\": \"test-mon\",\n            \"description\": \"Generic monitoring profile\",\n            \"services\": [\n                {\n                    \"service\": \"ARGO2\",\n                    \"metrics\": [\n                        \"org.nagios.ARGOWeb-AR\"\n                      \n                    ]\n                },\n                {\n                    \"service\": \"WebPortal2\",\n                    \"metrics\": [\n                        \"org.nagios.WebCheck\",\n                        \"eu.egi.CertValidity\",\n                        \"eu.egi.extraCheck\"\n                    ]\n                }\n            ]\n        }",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "https://{{api_host}}/api/v2/metric_profiles/{{metric_uuid}}",
+							"protocol": "https",
+							"host": [
+								"{{api_host}}"
+							],
+							"path": [
+								"api",
+								"v2",
+								"metric_profiles",
+								"{{metric_uuid}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get specific metric profile modified",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "d0cdb6e0-a134-4fa2-ab51-2a20096ea56c",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "8bacb2ab-20d8-4db2-9382-a805d61f6e21",
+								"exec": [
+									"const schema = {",
+									"  \"type\": \"object\",",
+									"  \"properties\": {",
+									"    \"status\": {",
+									"      \"type\": \"object\",",
+									"      \"properties\": {",
+									"        \"message\": {",
+									"          \"type\": \"string\"",
+									"        },",
+									"        \"code\": {",
+									"          \"type\": \"string\"",
+									"        }",
+									"      },",
+									"      \"required\": [",
+									"        \"message\",",
+									"        \"code\"",
+									"      ]",
+									"    },",
+									"    \"data\": {",
+									"      \"type\": \"array\",",
+									"      \"items\": [",
+									"        {",
+									"          \"type\": \"object\",",
+									"          \"properties\": {",
+									"            \"id\": {",
+									"              \"type\": \"string\"",
+									"            },",
+									"            \"date\": {",
+									"              \"type\": \"string\"",
+									"            },",
+									"            \"name\": {",
+									"              \"type\": \"string\"",
+									"            },",
+									"            \"description\": {",
+									"              \"type\": \"string\"",
+									"            },",
+									"            \"services\": {",
+									"              \"type\": \"array\",",
+									"              \"items\": {",
+									"                \"type\": \"object\",",
+									"                \"properties\": {",
+									"                  \"service\": {",
+									"                    \"type\": \"string\"",
+									"                  },",
+									"                  \"metrics\": {",
+									"                    \"type\": \"array\",",
+									"                    \"items\": {",
+									"                      \"type\": \"string\"",
+									"                    }",
+									"                  }",
+									"                },",
+									"                \"required\": [",
+									"                  \"service\",",
+									"                  \"metrics\"",
+									"                ]",
+									"              }",
+									"            }",
+									"          },",
+									"          \"required\": [",
+									"            \"id\",",
+									"            \"date\",",
+									"            \"name\",",
+									"            \"description\",",
+									"            \"services\"",
+									"          ]",
+									"        }",
+									"      ]",
+									"    }",
+									"  },",
+									"  \"required\": [",
+									"    \"status\",",
+									"    \"data\"",
+									"  ]",
+									"}",
+									"",
+									"pm.test(\"Validate schema\", () => {",
+									"    pm.response.to.have.jsonSchema(schema);",
+									"});",
+									"",
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"check_respone_data\", function() {",
+									"    let jsonData = pm.response.json();",
+									"    let apiHost = pm.environment.get(\"api_host\");",
+									"    let mpsUUID = pm.environment.get(\"metric_uuid\");",
+									"    pm.environment.set(\"metric_UUID\", mpsUUID);",
+									"    pm.expect(jsonData.status.message).to.eql(\"Success\");",
+									"    pm.expect(jsonData.status.code).to.eql(\"200\");",
+									"    let profile = jsonData.data[0];",
+									"",
+									"    pm.expect(profile.id).to.eql(mpsUUID);",
+									"    pm.expect(profile.name).to.eql(\"test-mon\");",
+									"    pm.expect(profile.description).to.eql(\"Generic monitoring profile\");",
+									"    pm.expect(profile.services[0].service).to.eql(\"ARGO2\");",
+									"    pm.expect(profile.services[0].metrics).to.eql([\"org.nagios.ARGOWeb-AR\"]);",
+									"    pm.expect(profile.services[1].service).to.eql(\"WebPortal2\");",
+									"    pm.expect(profile.services[1].metrics).to.eql([\"org.nagios.WebCheck\",\"eu.egi.CertValidity\",\"eu.egi.extraCheck\"]);",
+									"",
+									"",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Accept",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "x-api-key",
+								"type": "text",
+								"value": "{{tenant_api_key}}"
+							}
+						],
+						"url": {
+							"raw": "https://{{api_host}}/api/v2/metric_profiles/{{metric_uuid}}",
+							"protocol": "https",
+							"host": [
+								"{{api_host}}"
+							],
+							"path": [
+								"api",
+								"v2",
+								"metric_profiles",
+								"{{metric_uuid}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "delete metric profile",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "81107ff8-ee18-4337-b921-8797cf93ab8f",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "fa390c44-1913-4cda-895b-1dc4fb84cbad",
+								"exec": [
+									"const schema = {",
+									"  \"type\": \"object\",",
+									"  \"properties\": {",
+									"    \"status\": {",
+									"      \"type\": \"object\",",
+									"      \"properties\": {",
+									"        \"message\": {",
+									"          \"type\": \"string\"",
+									"        },",
+									"        \"code\": {",
+									"          \"type\": \"string\"",
+									"        }",
+									"      },",
+									"      \"required\": [",
+									"        \"message\",",
+									"        \"code\"",
+									"      ]",
+									"    }",
+									"  },",
+									"  \"required\": [",
+									"    \"status\"",
+									"  ]",
+									"}",
+									"",
+									"pm.test(\"Validate schema\", () => {",
+									"    pm.response.to.have.jsonSchema(schema);",
+									"});",
+									"",
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"check_respone_data\", function() {",
+									"    let jsonData = pm.response.json();",
+									"",
+									"    pm.expect(jsonData.status.message).to.eql(\"Metric Profile Successfully Deleted\");",
+									"    pm.expect(jsonData.status.code).to.eql(\"200\");",
+									"  ",
+									"",
+									"});",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "Accept",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "x-api-key",
+								"type": "text",
+								"value": "{{tenant_api_key}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "https://{{api_host}}/api/v2/metric_profiles/{{metric_uuid}}",
+							"protocol": "https",
+							"host": [
+								"{{api_host}}"
+							],
+							"path": [
+								"api",
+								"v2",
+								"metric_profiles",
+								"{{metric_uuid}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "delete tenant",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "17d79b2a-8e4f-41fa-93a1-8af4bc84d492",
+								"exec": [
+									"const schema = {",
+									"  \"type\": \"object\",",
+									"  \"properties\": {",
+									"    \"status\": {",
+									"      \"type\": \"object\",",
+									"      \"properties\": {",
+									"        \"message\": {",
+									"          \"type\": \"string\"",
+									"        },",
+									"        \"code\": {",
+									"          \"type\": \"string\"",
+									"        }",
+									"      },",
+									"      \"required\": [",
+									"        \"message\",",
+									"        \"code\"",
+									"      ]",
+									"    }",
+									"  },",
+									"  \"required\": [",
+									"    \"status\"",
+									"  ]",
+									"}",
+									"",
+									"pm.test(\"Validate schema\", () => {",
+									"    pm.response.to.have.jsonSchema(schema);",
+									"});",
+									"",
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"pm.globals.set(\"variable_key\", \"variable_value\");"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "Accept",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "x-api-key",
+								"type": "text",
+								"value": "{{api_key}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "https://{{api_host}}/api/v2/admin/tenants/{{tenant_uuid}}",
+							"protocol": "https",
+							"host": [
+								"{{api_host}}"
+							],
+							"path": [
+								"api",
+								"v2",
+								"admin",
+								"tenants",
+								"{{tenant_uuid}}"
+							],
+							"query": [
+								{
+									"key": "Accept",
+									"value": "application/json",
+									"disabled": true
+								},
+								{
+									"key": "x-api-key",
+									"value": "{{api_key}}",
+									"disabled": true
+								}
+							]
+						},
+						"description": "test web api\t"
+					},
+					"response": []
+				}
+			],
 			"event": [
 				{
-					"listen": "test",
+					"listen": "prerequest",
 					"script": {
-						"id": "a2396416-44ef-443c-87bb-86c09696cded",
+						"id": "41a32dba-25a1-4d96-a3ad-cabbe88a0be0",
+						"type": "text/javascript",
 						"exec": [
-							"",
-							"pm.test(\"Get tenant uuid\", function () {",
-							"    let jsonData = pm.response.json();",
-							"    pm.environment.set(\"tenant_uuid\",jsonData.data.id);",
-							"});",
-							"",
-							"pm.test(\"Status code is 201\", function () {",
-							"    pm.response.to.have.status(201);",
-							"});",
 							""
-						],
-						"type": "text/javascript"
+						]
 					}
-				}
-			],
-			"request": {
-				"method": "POST",
-				"header": [
-					{
-						"key": "Accept",
-						"type": "text",
-						"value": "application/json"
-					},
-					{
-						"key": "x-api-key",
-						"type": "text",
-						"value": "{{api_key}}"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "{\n  \"info\": {\n    \"website\": \"foo.example.com\",\n    \"description\": \"a test tenant\",\n    \"image\": \"string\",\n    \"email\": \"info@foo.example.com\",\n    \"name\": \"FOO\"\n  },\n  \"topology\": {\n    \"feed\": \"string\",\n    \"type\": \"string\"\n  },\n  \"db_conf\": [\n    {\n      \"username\": \"string\",\n      \"password\": \"string\",\n      \"port\": 0,\n      \"store\": \"string\",\n      \"server\": \"string\"\n    }\n  ],\n  \"users\": [\n    {\n      \"name\": \"test-admin\",\n      \"api-key\": \"foo.test.secret.key\",\n      \"roles\": [\n        \"admin\"\n      ],\n      \"email\": \"foo@example.com\"\n    }\n  ]\n}"
 				},
-				"url": {
-					"raw": "https://{{api_host}}/api/v2/admin/tenants?",
-					"protocol": "https",
-					"host": [
-						"{{api_host}}"
-					],
-					"path": [
-						"api",
-						"v2",
-						"admin",
-						"tenants"
-					],
-					"query": [
-						{
-							"key": "Accept",
-							"value": "application/json",
-							"disabled": true
-						},
-						{
-							"key": "x-api-key",
-							"value": "{{api_key}}",
-							"disabled": true
-						}
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "get a specific tenant",
-			"event": [
 				{
 					"listen": "test",
 					"script": {
-						"id": "fa6a71d7-f1f5-45fc-9dc9-bda8cf4c42d3",
+						"id": "f2fa671f-a0f7-4dbe-addc-da5f4a55e362",
+						"type": "text/javascript",
 						"exec": [
-							"pm.test(\"Status code is 200\", function () {",
-							"    pm.response.to.have.status(200);",
-							"});"
-						],
-						"type": "text/javascript"
+							""
+						]
 					}
 				}
 			],
-			"request": {
-				"method": "GET",
-				"header": [
-					{
-						"key": "Accept",
-						"type": "text",
-						"value": "application/json"
-					},
-					{
-						"key": "x-api-key",
-						"type": "text",
-						"value": "{{api_key}}"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": ""
-				},
-				"url": {
-					"raw": "https://{{api_host}}/api/v2/admin/tenants/{{tenant_uuid}}?",
-					"protocol": "https",
-					"host": [
-						"{{api_host}}"
-					],
-					"path": [
-						"api",
-						"v2",
-						"admin",
-						"tenants",
-						"{{tenant_uuid}}"
-					],
-					"query": [
-						{
-							"key": "Accept",
-							"value": "application/json",
-							"disabled": true
-						},
-						{
-							"key": "x-api-key",
-							"value": "{{api_key}}",
-							"disabled": true
-						}
-					]
-				},
-				"description": "test web api\t"
-			},
-			"response": []
+			"protocolProfileBehavior": {}
 		},
 		{
-			"name": "update specific tenant",
+			"name": "agg-profile tests",
+			"item": [
+				{
+					"name": "create new tenant",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "ea32250f-a2ec-4138-96b6-918ed759d01c",
+								"exec": [
+									"const schema = {",
+									"  \"type\": \"object\",",
+									"  \"properties\": {",
+									"    \"status\": {",
+									"      \"type\": \"object\",",
+									"      \"properties\": {",
+									"        \"message\": {",
+									"          \"type\": \"string\"",
+									"        },",
+									"        \"code\": {",
+									"          \"type\": \"string\"",
+									"        }",
+									"      },",
+									"      \"required\": [",
+									"        \"message\",",
+									"        \"code\"",
+									"      ]",
+									"    },",
+									"    \"data\": {",
+									"      \"type\": \"object\",",
+									"      \"properties\": {",
+									"        \"id\": {",
+									"          \"type\": \"string\"",
+									"        },",
+									"        \"links\": {",
+									"          \"type\": \"object\",",
+									"          \"properties\": {",
+									"            \"self\": {",
+									"              \"type\": \"string\"",
+									"            }",
+									"          },",
+									"          \"required\": [",
+									"            \"self\"",
+									"          ]",
+									"        }",
+									"      },",
+									"      \"required\": [",
+									"        \"id\",",
+									"        \"links\"",
+									"      ]",
+									"    }",
+									"  },",
+									"  \"required\": [",
+									"    \"status\",",
+									"    \"data\"",
+									"  ]",
+									"}",
+									"",
+									"pm.test(\"Validate schema\", () => {",
+									"    pm.response.to.have.jsonSchema(schema);",
+									"});",
+									"",
+									"",
+									"pm.test(\"Get tenant uuid\", function () {",
+									"    let jsonData = pm.response.json();",
+									"    pm.environment.set(\"tenant_uuid\",jsonData.data.id);",
+									"});",
+									"",
+									"pm.test(\"Status code is 201\", function () {",
+									"    pm.response.to.have.status(201);",
+									"});",
+									"",
+									"// set test tenant api key",
+									"pm.environment.set(\"tenant_api_key\", \"foo.test.secret.key\");"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Accept",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "x-api-key",
+								"type": "text",
+								"value": "{{api_key}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"info\": {\n    \"website\": \"foo.example.com\",\n    \"description\": \"a test tenant\",\n    \"image\": \"string\",\n    \"email\": \"info@foo.example.com\",\n    \"name\": \"FOO\"\n  },\n  \"topology\": {\n    \"feed\": \"string\",\n    \"type\": \"string\"\n  },\n  \"db_conf\": [\n    {\n      \"username\": \"\",\n      \"password\": \"\",\n      \"port\": 27017,\n      \"store\": \"argo_FOO\",\n      \"server\": \"localhost\"\n    }\n  ],\n  \"users\": [\n    {\n      \"name\": \"test-admin\",\n      \"api_key\": \"foo.test.secret.key\",\n      \"roles\": [\n        \"admin\"\n      ],\n      \"email\": \"foo@example.com\"\n    }\n  ]\n}"
+						},
+						"url": {
+							"raw": "https://{{api_host}}/api/v2/admin/tenants",
+							"protocol": "https",
+							"host": [
+								"{{api_host}}"
+							],
+							"path": [
+								"api",
+								"v2",
+								"admin",
+								"tenants"
+							],
+							"query": [
+								{
+									"key": "Accept",
+									"value": "application/json",
+									"disabled": true
+								},
+								{
+									"key": "x-api-key",
+									"value": "{{api_key}}",
+									"disabled": true
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Recreate metric profile",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "db46a0dd-4c6a-4ac0-91c9-60a49af52729",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "e8fa966f-db0f-41a9-b3bc-6db07ac9a1fa",
+								"exec": [
+									"const schema = {",
+									"  \"type\": \"object\",",
+									"  \"properties\": {",
+									"    \"status\": {",
+									"      \"type\": \"object\",",
+									"      \"properties\": {",
+									"        \"message\": {",
+									"          \"type\": \"string\"",
+									"        },",
+									"        \"code\": {",
+									"          \"type\": \"string\"",
+									"        }",
+									"      },",
+									"      \"required\": [",
+									"        \"message\",",
+									"        \"code\"",
+									"      ]",
+									"    },",
+									"    \"data\": {",
+									"      \"type\": \"object\",",
+									"      \"properties\": {",
+									"        \"id\": {",
+									"          \"type\": \"string\"",
+									"        },",
+									"        \"links\": {",
+									"          \"type\": \"object\",",
+									"          \"properties\": {",
+									"            \"self\": {",
+									"              \"type\": \"string\"",
+									"            }",
+									"          },",
+									"          \"required\": [",
+									"            \"self\"",
+									"          ]",
+									"        }",
+									"      },",
+									"      \"required\": [",
+									"        \"id\",",
+									"        \"links\"",
+									"      ]",
+									"    }",
+									"  },",
+									"  \"required\": [",
+									"    \"status\",",
+									"    \"data\"",
+									"  ]",
+									"}",
+									"",
+									"pm.test(\"Validate schema\", () => {",
+									"    pm.response.to.have.jsonSchema(schema);",
+									"});",
+									"",
+									"",
+									"pm.test(\"Get metric uuid\", function () {",
+									"    let jsonData = pm.response.json();",
+									"    pm.environment.set(\"metric_uuid\",jsonData.data.id);",
+									"});",
+									"",
+									"pm.test(\"Status code is 201\", function () {",
+									"    pm.response.to.have.status(201);",
+									"});",
+									"",
+									"pm.test(\"check_respone_data\", function() {",
+									"    let jsonData = pm.response.json();",
+									"    let apiHost = pm.environment.get(\"api_host\");",
+									"    let mpsUUID = pm.environment.get(\"metric_uuid\");",
+									"    pm.expect(jsonData.status.message).to.eql(\"Metric Profile successfully created\");",
+									"    pm.expect(jsonData.status.code).to.eql(\"201\");",
+									"    pm.expect(jsonData.data.id).to.eql(mpsUUID);",
+									"    pm.expect(jsonData.data.links.self).to.eql(\"https://\"+apiHost+\"/api/v2/metric_profiles/\"+mpsUUID);",
+									"",
+									"});",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Accept",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "x-api-key",
+								"type": "text",
+								"value": "{{tenant_api_key}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n            \"name\": \"test-mon\",\n            \"description\": \"Generic monitoring profile\",\n            \"services\": [\n                {\n                    \"service\": \"ARGO\",\n                    \"metrics\": [\n                        \"org.nagios.ARGOWeb-AR\",\n                        \"org.nagios.ARGOWeb-Status\"\n                    ]\n                },\n                {\n                    \"service\": \"WebPortal\",\n                    \"metrics\": [\n                        \"org.nagios.WebCheck\",\n                        \"eu.egi.CertValidity\"\n                    ]\n                }\n            ]\n        }"
+						},
+						"url": {
+							"raw": "https://{{api_host}}/api/v2/metric_profiles",
+							"protocol": "https",
+							"host": [
+								"{{api_host}}"
+							],
+							"path": [
+								"api",
+								"v2",
+								"metric_profiles"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "create agg profile",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "408d748c-fac2-4dca-9b0f-5525fb496c55",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "1047c60f-5253-46f7-9601-3eadfa31f774",
+								"exec": [
+									"const schema = {",
+									"  \"type\": \"object\",",
+									"  \"properties\": {",
+									"    \"status\": {",
+									"      \"type\": \"object\",",
+									"      \"properties\": {",
+									"        \"message\": {",
+									"          \"type\": \"string\"",
+									"        },",
+									"        \"code\": {",
+									"          \"type\": \"string\"",
+									"        }",
+									"      },",
+									"      \"required\": [",
+									"        \"message\",",
+									"        \"code\"",
+									"      ]",
+									"    },",
+									"    \"data\": {",
+									"      \"type\": \"object\",",
+									"      \"properties\": {",
+									"        \"id\": {",
+									"          \"type\": \"string\"",
+									"        },",
+									"        \"links\": {",
+									"          \"type\": \"object\",",
+									"          \"properties\": {",
+									"            \"self\": {",
+									"              \"type\": \"string\"",
+									"            }",
+									"          },",
+									"          \"required\": [",
+									"            \"self\"",
+									"          ]",
+									"        }",
+									"      },",
+									"      \"required\": [",
+									"        \"id\",",
+									"        \"links\"",
+									"      ]",
+									"    }",
+									"  },",
+									"  \"required\": [",
+									"    \"status\",",
+									"    \"data\"",
+									"  ]",
+									"}",
+									"",
+									"pm.test(\"Validate schema\", () => {",
+									"    pm.response.to.have.jsonSchema(schema);",
+									"});",
+									"",
+									"",
+									"pm.test(\"Get agg uuid\", function () {",
+									"    let jsonData = pm.response.json();",
+									"    pm.environment.set(\"agg_uuid\",jsonData.data.id);",
+									"});",
+									"",
+									"pm.test(\"Status code is 201\", function () {",
+									"    pm.response.to.have.status(201);",
+									"});",
+									"",
+									"pm.test(\"check_respone_data\", function() {",
+									"    let jsonData = pm.response.json();",
+									"    let apiHost = pm.environment.get(\"api_host\");",
+									"    let aggUUID = pm.environment.get(\"agg_uuid\");",
+									"    pm.expect(jsonData.status.message).to.eql(\"Aggregation Profile successfully created\");",
+									"    pm.expect(jsonData.status.code).to.eql(\"201\");",
+									"    pm.expect(jsonData.data.id).to.eql(aggUUID);",
+									"    pm.expect(jsonData.data.links.self).to.eql(\"https://\"+apiHost+\"/api/v2/aggregation_profiles/\"+aggUUID);",
+									"",
+									"});",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Accept",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "x-api-key",
+								"type": "text",
+								"value": "{{tenant_api_key}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "      {\n            \n            \"name\": \"test-agg\",\n            \"namespace\": \"\",\n            \"endpoint_group\": \"servicegroups\",\n            \"metric_operation\": \"AND\",\n            \"profile_operation\": \"AND\",\n            \"metric_profile\": {\n                \"name\": \"MON\",\n                \"id\": \"{{metric_uuid}}\"\n            },\n            \"groups\": [\n                {\n                    \"name\": \"webportal\",\n                    \"operation\": \"AND\",\n                    \"services\": [\n                        {\n                            \"name\": \"WebPortal\",\n                            \"operation\": \"OR\"\n                        }\n                    ]\n                },\n                {\n                    \"name\": \"ARGO\",\n                    \"operation\": \"AND\",\n                    \"services\": [\n                        {\n                            \"name\": \"ARGO\",\n                            \"operation\": \"OR\"\n                        }\n                    ]\n                }\n            ]\n        }"
+						},
+						"url": {
+							"raw": "https://{{api_host}}/api/v2/aggregation_profiles",
+							"protocol": "https",
+							"host": [
+								"{{api_host}}"
+							],
+							"path": [
+								"api",
+								"v2",
+								"aggregation_profiles"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get agg profiles",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "75cfabb5-c0ac-4913-9bde-310080355fd5",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "a179edc1-3627-40d1-bbb3-21b4488d1d7a",
+								"exec": [
+									"const schema = {",
+									"  \"type\": \"object\",",
+									"  \"properties\": {",
+									"    \"status\": {",
+									"      \"type\": \"object\",",
+									"      \"properties\": {",
+									"        \"message\": {",
+									"          \"type\": \"string\"",
+									"        },",
+									"        \"code\": {",
+									"          \"type\": \"string\"",
+									"        }",
+									"      },",
+									"      \"required\": [",
+									"        \"message\",",
+									"        \"code\"",
+									"      ]",
+									"    },",
+									"    \"data\": {",
+									"      \"type\": \"array\",",
+									"      \"items\": [",
+									"        {",
+									"          \"type\": \"object\",",
+									"          \"properties\": {",
+									"            \"id\": {",
+									"              \"type\": \"string\"",
+									"            },",
+									"            \"date\": {",
+									"              \"type\": \"string\"",
+									"            },",
+									"            \"name\": {",
+									"              \"type\": \"string\"",
+									"            },",
+									"            \"namespace\": {",
+									"              \"type\": \"string\"",
+									"            },",
+									"            \"endpoint_group\": {",
+									"              \"type\": \"string\"",
+									"            },",
+									"            \"metric_operation\": {",
+									"              \"type\": \"string\"",
+									"            },",
+									"            \"profile_operation\": {",
+									"              \"type\": \"string\"",
+									"            },",
+									"            \"metric_profile\": {",
+									"              \"type\": \"object\",",
+									"              \"properties\": {",
+									"                \"name\": {",
+									"                  \"type\": \"string\"",
+									"                },",
+									"                \"id\": {",
+									"                  \"type\": \"string\"",
+									"                }",
+									"              },",
+									"              \"required\": [",
+									"                \"name\",",
+									"                \"id\"",
+									"              ]",
+									"            },",
+									"            \"groups\": {",
+									"              \"type\": \"array\",",
+									"              \"items\": {",
+									"                \"type\": \"object\",",
+									"                \"properties\": {",
+									"                  \"name\": {",
+									"                    \"type\": \"string\"",
+									"                  },",
+									"                  \"operation\": {",
+									"                    \"type\": \"string\"",
+									"                  },",
+									"                  \"services\": {",
+									"                    \"type\": \"array\",",
+									"                    \"items\": [",
+									"                      {",
+									"                        \"type\": \"object\",",
+									"                        \"properties\": {",
+									"                          \"name\": {",
+									"                            \"type\": \"string\"",
+									"                          },",
+									"                          \"operation\": {",
+									"                            \"type\": \"string\"",
+									"                          }",
+									"                        },",
+									"                        \"required\": [",
+									"                          \"name\",",
+									"                          \"operation\"",
+									"                        ]",
+									"                      }",
+									"                    ]",
+									"                  }",
+									"                },",
+									"                \"required\": [",
+									"                  \"name\",",
+									"                  \"operation\",",
+									"                  \"services\"",
+									"                ]",
+									"              }",
+									"            }",
+									"          },",
+									"          \"required\": [",
+									"            \"id\",",
+									"            \"date\",",
+									"            \"name\",",
+									"            \"namespace\",",
+									"            \"endpoint_group\",",
+									"            \"metric_operation\",",
+									"            \"profile_operation\",",
+									"            \"metric_profile\",",
+									"            \"groups\"",
+									"          ]",
+									"        }",
+									"      ]",
+									"    }",
+									"  },",
+									"  \"required\": [",
+									"    \"status\",",
+									"    \"data\"",
+									"  ]",
+									"}",
+									"",
+									"pm.test(\"Validate schema\", () => {",
+									"    pm.response.to.have.jsonSchema(schema);",
+									"});",
+									"",
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"check_respone_data\", function() {",
+									"    let jsonData = pm.response.json();",
+									"    let aggUUID = pm.environment.get(\"agg_uuid\");",
+									"    let mpsUUID = pm.environment.get(\"metric_uuid\");",
+									"  ",
+									"    pm.expect(jsonData.status.message).to.eql(\"Success\");",
+									"    pm.expect(jsonData.status.code).to.eql(\"200\");",
+									"    let profile = jsonData.data[0];",
+									"",
+									"    pm.expect(profile.id).to.eql(aggUUID);",
+									"    pm.expect(profile.name).to.eql(\"test-agg\");",
+									"    pm.expect(profile.namespace).to.eql(\"\");",
+									"    pm.expect(profile.endpoint_group).to.eql(\"servicegroups\");",
+									"    pm.expect(profile.metric_operation).to.eql(\"AND\");",
+									"    pm.expect(profile.profile_operation).to.eql(\"AND\");",
+									"    pm.expect(profile.metric_profile.name).to.eql(\"test-mon\");",
+									"    pm.expect(profile.metric_profile.id).to.eql(mpsUUID);",
+									"    pm.expect(profile.groups[0].name).to.eql(\"webportal\");",
+									"    pm.expect(profile.groups[0].operation).to.eql(\"AND\");",
+									"    pm.expect(profile.groups[0].services[0].name).to.eql(\"WebPortal\");",
+									"    pm.expect(profile.groups[0].services[0].operation).to.eql(\"OR\");",
+									"    pm.expect(profile.groups[1].name).to.eql(\"ARGO\");",
+									"    pm.expect(profile.groups[1].operation).to.eql(\"AND\");",
+									"    pm.expect(profile.groups[1].services[0].name).to.eql(\"ARGO\");",
+									"    pm.expect(profile.groups[1].services[0].operation).to.eql(\"OR\");",
+									"",
+									"    ",
+									"",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Accept",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "x-api-key",
+								"type": "text",
+								"value": "{{tenant_api_key}}"
+							}
+						],
+						"url": {
+							"raw": "https://{{api_host}}/api/v2/aggregation_profiles",
+							"protocol": "https",
+							"host": [
+								"{{api_host}}"
+							],
+							"path": [
+								"api",
+								"v2",
+								"aggregation_profiles"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get specific aggr profile",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "32287608-5699-4636-86e2-a903968df3bf",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "fdc1a2ae-97bb-4b9f-bbbf-fb8395a70fd9",
+								"exec": [
+									"const schema = {",
+									"  \"type\": \"object\",",
+									"  \"properties\": {",
+									"    \"status\": {",
+									"      \"type\": \"object\",",
+									"      \"properties\": {",
+									"        \"message\": {",
+									"          \"type\": \"string\"",
+									"        },",
+									"        \"code\": {",
+									"          \"type\": \"string\"",
+									"        }",
+									"      },",
+									"      \"required\": [",
+									"        \"message\",",
+									"        \"code\"",
+									"      ]",
+									"    },",
+									"    \"data\": {",
+									"      \"type\": \"array\",",
+									"      \"items\": [",
+									"        {",
+									"          \"type\": \"object\",",
+									"          \"properties\": {",
+									"            \"id\": {",
+									"              \"type\": \"string\"",
+									"            },",
+									"            \"date\": {",
+									"              \"type\": \"string\"",
+									"            },",
+									"            \"name\": {",
+									"              \"type\": \"string\"",
+									"            },",
+									"            \"namespace\": {",
+									"              \"type\": \"string\"",
+									"            },",
+									"            \"endpoint_group\": {",
+									"              \"type\": \"string\"",
+									"            },",
+									"            \"metric_operation\": {",
+									"              \"type\": \"string\"",
+									"            },",
+									"            \"profile_operation\": {",
+									"              \"type\": \"string\"",
+									"            },",
+									"            \"metric_profile\": {",
+									"              \"type\": \"object\",",
+									"              \"properties\": {",
+									"                \"name\": {",
+									"                  \"type\": \"string\"",
+									"                },",
+									"                \"id\": {",
+									"                  \"type\": \"string\"",
+									"                }",
+									"              },",
+									"              \"required\": [",
+									"                \"name\",",
+									"                \"id\"",
+									"              ]",
+									"            },",
+									"            \"groups\": {",
+									"              \"type\": \"array\",",
+									"              \"items\": {",
+									"                \"type\": \"object\",",
+									"                \"properties\": {",
+									"                  \"name\": {",
+									"                    \"type\": \"string\"",
+									"                  },",
+									"                  \"operation\": {",
+									"                    \"type\": \"string\"",
+									"                  },",
+									"                  \"services\": {",
+									"                    \"type\": \"array\",",
+									"                    \"items\": [",
+									"                      {",
+									"                        \"type\": \"object\",",
+									"                        \"properties\": {",
+									"                          \"name\": {",
+									"                            \"type\": \"string\"",
+									"                          },",
+									"                          \"operation\": {",
+									"                            \"type\": \"string\"",
+									"                          }",
+									"                        },",
+									"                        \"required\": [",
+									"                          \"name\",",
+									"                          \"operation\"",
+									"                        ]",
+									"                      }",
+									"                    ]",
+									"                  }",
+									"                },",
+									"                \"required\": [",
+									"                  \"name\",",
+									"                  \"operation\",",
+									"                  \"services\"",
+									"                ]",
+									"              }",
+									"            }",
+									"          },",
+									"          \"required\": [",
+									"            \"id\",",
+									"            \"date\",",
+									"            \"name\",",
+									"            \"namespace\",",
+									"            \"endpoint_group\",",
+									"            \"metric_operation\",",
+									"            \"profile_operation\",",
+									"            \"metric_profile\",",
+									"            \"groups\"",
+									"          ]",
+									"        }",
+									"      ]",
+									"    }",
+									"  },",
+									"  \"required\": [",
+									"    \"status\",",
+									"    \"data\"",
+									"  ]",
+									"}",
+									"",
+									"pm.test(\"Validate schema\", () => {",
+									"    pm.response.to.have.jsonSchema(schema);",
+									"});",
+									"",
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"check_respone_data\", function() {",
+									"    let jsonData = pm.response.json();",
+									"    let aggUUID = pm.environment.get(\"agg_uuid\");",
+									"    let mpsUUID = pm.environment.get(\"metric_uuid\");",
+									"  ",
+									"    pm.expect(jsonData.status.message).to.eql(\"Success\");",
+									"    pm.expect(jsonData.status.code).to.eql(\"200\");",
+									"    let profile = jsonData.data[0];",
+									"",
+									"    pm.expect(profile.id).to.eql(aggUUID);",
+									"    pm.expect(profile.name).to.eql(\"test-agg\");",
+									"    pm.expect(profile.namespace).to.eql(\"\");",
+									"    pm.expect(profile.endpoint_group).to.eql(\"servicegroups\");",
+									"    pm.expect(profile.metric_operation).to.eql(\"AND\");",
+									"    pm.expect(profile.profile_operation).to.eql(\"AND\");",
+									"    pm.expect(profile.metric_profile.name).to.eql(\"test-mon\");",
+									"    pm.expect(profile.metric_profile.id).to.eql(mpsUUID);",
+									"    pm.expect(profile.groups[0].name).to.eql(\"webportal\");",
+									"    pm.expect(profile.groups[0].operation).to.eql(\"AND\");",
+									"    pm.expect(profile.groups[0].services[0].name).to.eql(\"WebPortal\");",
+									"    pm.expect(profile.groups[0].services[0].operation).to.eql(\"OR\");",
+									"    pm.expect(profile.groups[1].name).to.eql(\"ARGO\");",
+									"    pm.expect(profile.groups[1].operation).to.eql(\"AND\");",
+									"    pm.expect(profile.groups[1].services[0].name).to.eql(\"ARGO\");",
+									"    pm.expect(profile.groups[1].services[0].operation).to.eql(\"OR\");",
+									"",
+									"    ",
+									"",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Accept",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "x-api-key",
+								"type": "text",
+								"value": "{{tenant_api_key}}"
+							}
+						],
+						"url": {
+							"raw": "https://{{api_host}}/api/v2/aggregation_profiles/{{agg_uuid}}",
+							"protocol": "https",
+							"host": [
+								"{{api_host}}"
+							],
+							"path": [
+								"api",
+								"v2",
+								"aggregation_profiles",
+								"{{agg_uuid}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Update agg profile",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "d78a9b46-0bcb-4e36-9b33-528085db0200",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "55236a9f-43bc-429f-9cb0-99e22146e605",
+								"exec": [
+									"const schema = {",
+									"  \"type\": \"object\",",
+									"  \"properties\": {",
+									"    \"status\": {",
+									"      \"type\": \"object\",",
+									"      \"properties\": {",
+									"        \"message\": {",
+									"          \"type\": \"string\"",
+									"        },",
+									"        \"code\": {",
+									"          \"type\": \"string\"",
+									"        }",
+									"      },",
+									"      \"required\": [",
+									"        \"message\",",
+									"        \"code\"",
+									"      ]",
+									"    }",
+									"  },",
+									"  \"required\": [",
+									"    \"status\"",
+									"  ]",
+									"}",
+									"",
+									"pm.test(\"Validate schema\", () => {",
+									"    pm.response.to.have.jsonSchema(schema);",
+									"});",
+									"",
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"check_respone_data\", function() {",
+									"    let jsonData = pm.response.json();",
+									"    let apiHost = pm.environment.get(\"api_host\");",
+									"    let mpsUUID = pm.environment.get(\"metric_uuid\");",
+									"    pm.expect(jsonData.status.message).to.eql(\"Aggregations Profile successfully updated\");",
+									"    pm.expect(jsonData.status.code).to.eql(\"200\");",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "PUT",
+						"header": [
+							{
+								"key": "Accept",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "x-api-key",
+								"type": "text",
+								"value": "{{tenant_api_key}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "      {\n            \n            \"name\": \"test-agg\",\n            \"namespace\": \"\",\n            \"endpoint_group\": \"servicegroups\",\n            \"metric_operation\": \"AND\",\n            \"profile_operation\": \"AND\",\n            \"metric_profile\": {\n                \"id\": \"{{metric_uuid}}\"\n            },\n            \"groups\": [\n                {\n                    \"name\": \"webportal2\",\n                    \"operation\": \"OR\",\n                    \"services\": [\n                        {\n                            \"name\": \"WebPortal\",\n                            \"operation\": \"OR\"\n                        }\n                    ]\n                },\n                {\n                    \"name\": \"ARGO2\",\n                    \"operation\": \"OR\",\n                    \"services\": [\n                        {\n                            \"name\": \"ARGO\",\n                            \"operation\": \"AND\"\n                        }\n                    ]\n                }\n            ]\n        }",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "https://{{api_host}}/api/v2/aggregation_profiles/{{agg_uuid}}",
+							"protocol": "https",
+							"host": [
+								"{{api_host}}"
+							],
+							"path": [
+								"api",
+								"v2",
+								"aggregation_profiles",
+								"{{agg_uuid}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get specific agg profile modified",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "00ce60b7-62cd-4a41-bbbd-a8e627fa7600",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "2dea8b79-899f-4abd-aa8e-5e4451128179",
+								"exec": [
+									"const schema = {",
+									"  \"type\": \"object\",",
+									"  \"properties\": {",
+									"    \"status\": {",
+									"      \"type\": \"object\",",
+									"      \"properties\": {",
+									"        \"message\": {",
+									"          \"type\": \"string\"",
+									"        },",
+									"        \"code\": {",
+									"          \"type\": \"string\"",
+									"        }",
+									"      },",
+									"      \"required\": [",
+									"        \"message\",",
+									"        \"code\"",
+									"      ]",
+									"    },",
+									"    \"data\": {",
+									"      \"type\": \"array\",",
+									"      \"items\": [",
+									"        {",
+									"          \"type\": \"object\",",
+									"          \"properties\": {",
+									"            \"id\": {",
+									"              \"type\": \"string\"",
+									"            },",
+									"            \"date\": {",
+									"              \"type\": \"string\"",
+									"            },",
+									"            \"name\": {",
+									"              \"type\": \"string\"",
+									"            },",
+									"            \"namespace\": {",
+									"              \"type\": \"string\"",
+									"            },",
+									"            \"endpoint_group\": {",
+									"              \"type\": \"string\"",
+									"            },",
+									"            \"metric_operation\": {",
+									"              \"type\": \"string\"",
+									"            },",
+									"            \"profile_operation\": {",
+									"              \"type\": \"string\"",
+									"            },",
+									"            \"metric_profile\": {",
+									"              \"type\": \"object\",",
+									"              \"properties\": {",
+									"                \"name\": {",
+									"                  \"type\": \"string\"",
+									"                },",
+									"                \"id\": {",
+									"                  \"type\": \"string\"",
+									"                }",
+									"              },",
+									"              \"required\": [",
+									"                \"name\",",
+									"                \"id\"",
+									"              ]",
+									"            },",
+									"            \"groups\": {",
+									"              \"type\": \"array\",",
+									"              \"items\": {",
+									"                \"type\": \"object\",",
+									"                \"properties\": {",
+									"                  \"name\": {",
+									"                    \"type\": \"string\"",
+									"                  },",
+									"                  \"operation\": {",
+									"                    \"type\": \"string\"",
+									"                  },",
+									"                  \"services\": {",
+									"                    \"type\": \"array\",",
+									"                    \"items\": [",
+									"                      {",
+									"                        \"type\": \"object\",",
+									"                        \"properties\": {",
+									"                          \"name\": {",
+									"                            \"type\": \"string\"",
+									"                          },",
+									"                          \"operation\": {",
+									"                            \"type\": \"string\"",
+									"                          }",
+									"                        },",
+									"                        \"required\": [",
+									"                          \"name\",",
+									"                          \"operation\"",
+									"                        ]",
+									"                      }",
+									"                    ]",
+									"                  }",
+									"                },",
+									"                \"required\": [",
+									"                  \"name\",",
+									"                  \"operation\",",
+									"                  \"services\"",
+									"                ]",
+									"              }",
+									"            }",
+									"          },",
+									"          \"required\": [",
+									"            \"id\",",
+									"            \"date\",",
+									"            \"name\",",
+									"            \"namespace\",",
+									"            \"endpoint_group\",",
+									"            \"metric_operation\",",
+									"            \"profile_operation\",",
+									"            \"metric_profile\",",
+									"            \"groups\"",
+									"          ]",
+									"        }",
+									"      ]",
+									"    }",
+									"  },",
+									"  \"required\": [",
+									"    \"status\",",
+									"    \"data\"",
+									"  ]",
+									"}",
+									"",
+									"pm.test(\"Validate schema\", () => {",
+									"    pm.response.to.have.jsonSchema(schema);",
+									"});",
+									"",
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"check_respone_data\", function() {",
+									"    let jsonData = pm.response.json();",
+									"    let aggUUID = pm.environment.get(\"agg_uuid\");",
+									"    let mpsUUID = pm.environment.get(\"metric_uuid\");",
+									"  ",
+									"    pm.expect(jsonData.status.message).to.eql(\"Success\");",
+									"    pm.expect(jsonData.status.code).to.eql(\"200\");",
+									"    let profile = jsonData.data[0];",
+									"",
+									"    pm.expect(profile.id).to.eql(aggUUID);",
+									"    pm.expect(profile.name).to.eql(\"test-agg\");",
+									"    pm.expect(profile.namespace).to.eql(\"\");",
+									"    pm.expect(profile.endpoint_group).to.eql(\"servicegroups\");",
+									"    pm.expect(profile.metric_operation).to.eql(\"AND\");",
+									"    pm.expect(profile.profile_operation).to.eql(\"AND\");",
+									"    pm.expect(profile.metric_profile.name).to.eql(\"test-mon\");",
+									"    pm.expect(profile.metric_profile.id).to.eql(mpsUUID);",
+									"    pm.expect(profile.groups[0].name).to.eql(\"webportal2\");",
+									"    pm.expect(profile.groups[0].operation).to.eql(\"OR\");",
+									"    pm.expect(profile.groups[0].services[0].name).to.eql(\"WebPortal\");",
+									"    pm.expect(profile.groups[0].services[0].operation).to.eql(\"OR\");",
+									"    pm.expect(profile.groups[1].name).to.eql(\"ARGO2\");",
+									"    pm.expect(profile.groups[1].operation).to.eql(\"OR\");",
+									"    pm.expect(profile.groups[1].services[0].name).to.eql(\"ARGO\");",
+									"    pm.expect(profile.groups[1].services[0].operation).to.eql(\"AND\");",
+									"",
+									"    ",
+									"",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Accept",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "x-api-key",
+								"type": "text",
+								"value": "{{tenant_api_key}}"
+							}
+						],
+						"url": {
+							"raw": "https://{{api_host}}/api/v2/aggregation_profiles/{{agg_uuid}}",
+							"protocol": "https",
+							"host": [
+								"{{api_host}}"
+							],
+							"path": [
+								"api",
+								"v2",
+								"aggregation_profiles",
+								"{{agg_uuid}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "delete agg profile",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "851898cb-f31c-40c8-9a1a-4c353823a006",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "d985688e-dd9b-4fd0-842f-9f51d605ae93",
+								"exec": [
+									"const schema = {",
+									"  \"type\": \"object\",",
+									"  \"properties\": {",
+									"    \"status\": {",
+									"      \"type\": \"object\",",
+									"      \"properties\": {",
+									"        \"message\": {",
+									"          \"type\": \"string\"",
+									"        },",
+									"        \"code\": {",
+									"          \"type\": \"string\"",
+									"        }",
+									"      },",
+									"      \"required\": [",
+									"        \"message\",",
+									"        \"code\"",
+									"      ]",
+									"    }",
+									"  },",
+									"  \"required\": [",
+									"    \"status\"",
+									"  ]",
+									"}",
+									"",
+									"pm.test(\"Validate schema\", () => {",
+									"    pm.response.to.have.jsonSchema(schema);",
+									"});",
+									"",
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"check_respone_data\", function() {",
+									"    let jsonData = pm.response.json();",
+									"",
+									"    pm.expect(jsonData.status.message).to.eql(\"Aggregation Profile Successfully Deleted\");",
+									"    pm.expect(jsonData.status.code).to.eql(\"200\");",
+									"  ",
+									"",
+									"});",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "Accept",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "x-api-key",
+								"type": "text",
+								"value": "{{tenant_api_key}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "https://{{api_host}}/api/v2/aggregation_profiles/{{agg_uuid}}",
+							"protocol": "https",
+							"host": [
+								"{{api_host}}"
+							],
+							"path": [
+								"api",
+								"v2",
+								"aggregation_profiles",
+								"{{agg_uuid}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "delete recreated metric profile",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "23bd138f-e835-4afb-ac6b-09579b66b0da",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "df289e50-ef64-4338-bd27-eb9d1b3e300b",
+								"exec": [
+									"const schema = {",
+									"  \"type\": \"object\",",
+									"  \"properties\": {",
+									"    \"status\": {",
+									"      \"type\": \"object\",",
+									"      \"properties\": {",
+									"        \"message\": {",
+									"          \"type\": \"string\"",
+									"        },",
+									"        \"code\": {",
+									"          \"type\": \"string\"",
+									"        }",
+									"      },",
+									"      \"required\": [",
+									"        \"message\",",
+									"        \"code\"",
+									"      ]",
+									"    }",
+									"  },",
+									"  \"required\": [",
+									"    \"status\"",
+									"  ]",
+									"}",
+									"",
+									"pm.test(\"Validate schema\", () => {",
+									"    pm.response.to.have.jsonSchema(schema);",
+									"});",
+									"",
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"check_respone_data\", function() {",
+									"    let jsonData = pm.response.json();",
+									"",
+									"    pm.expect(jsonData.status.message).to.eql(\"Metric Profile Successfully Deleted\");",
+									"    pm.expect(jsonData.status.code).to.eql(\"200\");",
+									"  ",
+									"",
+									"});",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "Accept",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "x-api-key",
+								"type": "text",
+								"value": "{{tenant_api_key}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "https://{{api_host}}/api/v2/metric_profiles/{{metric_uuid}}",
+							"protocol": "https",
+							"host": [
+								"{{api_host}}"
+							],
+							"path": [
+								"api",
+								"v2",
+								"metric_profiles",
+								"{{metric_uuid}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "delete tenant",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "ecb5cadf-edb9-47a4-854a-de6cfb277152",
+								"exec": [
+									"const schema = {",
+									"  \"type\": \"object\",",
+									"  \"properties\": {",
+									"    \"status\": {",
+									"      \"type\": \"object\",",
+									"      \"properties\": {",
+									"        \"message\": {",
+									"          \"type\": \"string\"",
+									"        },",
+									"        \"code\": {",
+									"          \"type\": \"string\"",
+									"        }",
+									"      },",
+									"      \"required\": [",
+									"        \"message\",",
+									"        \"code\"",
+									"      ]",
+									"    }",
+									"  },",
+									"  \"required\": [",
+									"    \"status\"",
+									"  ]",
+									"}",
+									"",
+									"pm.test(\"Validate schema\", () => {",
+									"    pm.response.to.have.jsonSchema(schema);",
+									"});",
+									"",
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"pm.globals.set(\"variable_key\", \"variable_value\");"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "Accept",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "x-api-key",
+								"type": "text",
+								"value": "{{api_key}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "https://{{api_host}}/api/v2/admin/tenants/{{tenant_uuid}}",
+							"protocol": "https",
+							"host": [
+								"{{api_host}}"
+							],
+							"path": [
+								"api",
+								"v2",
+								"admin",
+								"tenants",
+								"{{tenant_uuid}}"
+							],
+							"query": [
+								{
+									"key": "Accept",
+									"value": "application/json",
+									"disabled": true
+								},
+								{
+									"key": "x-api-key",
+									"value": "{{api_key}}",
+									"disabled": true
+								}
+							]
+						},
+						"description": "test web api\t"
+					},
+					"response": []
+				}
+			],
 			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"id": "fabbf0d6-5118-46f7-a62a-40c02b1a7e99",
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				},
 				{
 					"listen": "test",
 					"script": {
-						"id": "46e43ff0-fc9f-431a-acdd-500e0a2b4b3b",
+						"id": "ca383d22-69ee-41e1-a2c5-265c38fca6dc",
+						"type": "text/javascript",
 						"exec": [
-							"pm.test(\"Status code is 200\", function () {",
-							"    pm.response.to.have.status(200);",
-							"});"
-						],
-						"type": "text/javascript"
+							""
+						]
 					}
 				}
 			],
-			"request": {
-				"method": "GET",
-				"header": [
-					{
-						"key": "Accept",
-						"type": "text",
-						"value": "application/json"
-					},
-					{
-						"key": "x-api-key",
-						"type": "text",
-						"value": "{{api_key}}"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": ""
-				},
-				"url": {
-					"raw": "https://{{api_host}}/api/v2/admin/tenants/{{tenant_uuid}}?",
-					"protocol": "https",
-					"host": [
-						"{{api_host}}"
-					],
-					"path": [
-						"api",
-						"v2",
-						"admin",
-						"tenants",
-						"{{tenant_uuid}}"
-					],
-					"query": [
-						{
-							"key": "Accept",
-							"value": "application/json",
-							"disabled": true
-						},
-						{
-							"key": "x-api-key",
-							"value": "{{api_key}}",
-							"disabled": true
-						}
-					]
-				},
-				"description": "test web api\t"
-			},
-			"response": []
+			"protocolProfileBehavior": {}
 		},
 		{
-			"name": "delete specific tenant",
+			"name": "report tests",
+			"item": [
+				{
+					"name": "create new tenant",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "b13dc006-f291-4995-bf05-783e90df3942",
+								"exec": [
+									"const schema = {",
+									"  \"type\": \"object\",",
+									"  \"properties\": {",
+									"    \"status\": {",
+									"      \"type\": \"object\",",
+									"      \"properties\": {",
+									"        \"message\": {",
+									"          \"type\": \"string\"",
+									"        },",
+									"        \"code\": {",
+									"          \"type\": \"string\"",
+									"        }",
+									"      },",
+									"      \"required\": [",
+									"        \"message\",",
+									"        \"code\"",
+									"      ]",
+									"    },",
+									"    \"data\": {",
+									"      \"type\": \"object\",",
+									"      \"properties\": {",
+									"        \"id\": {",
+									"          \"type\": \"string\"",
+									"        },",
+									"        \"links\": {",
+									"          \"type\": \"object\",",
+									"          \"properties\": {",
+									"            \"self\": {",
+									"              \"type\": \"string\"",
+									"            }",
+									"          },",
+									"          \"required\": [",
+									"            \"self\"",
+									"          ]",
+									"        }",
+									"      },",
+									"      \"required\": [",
+									"        \"id\",",
+									"        \"links\"",
+									"      ]",
+									"    }",
+									"  },",
+									"  \"required\": [",
+									"    \"status\",",
+									"    \"data\"",
+									"  ]",
+									"}",
+									"",
+									"pm.test(\"Validate schema\", () => {",
+									"    pm.response.to.have.jsonSchema(schema);",
+									"});",
+									"",
+									"",
+									"pm.test(\"Get tenant uuid\", function () {",
+									"    let jsonData = pm.response.json();",
+									"    pm.environment.set(\"tenant_uuid\",jsonData.data.id);",
+									"});",
+									"",
+									"pm.test(\"Status code is 201\", function () {",
+									"    pm.response.to.have.status(201);",
+									"});",
+									"",
+									"// set test tenant api key",
+									"pm.environment.set(\"tenant_api_key\", \"foo.test.secret.key\");"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Accept",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "x-api-key",
+								"type": "text",
+								"value": "{{api_key}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"info\": {\n    \"website\": \"foo.example.com\",\n    \"description\": \"a test tenant\",\n    \"image\": \"string\",\n    \"email\": \"info@foo.example.com\",\n    \"name\": \"FOO\"\n  },\n  \"topology\": {\n    \"feed\": \"string\",\n    \"type\": \"string\"\n  },\n  \"db_conf\": [\n    {\n      \"username\": \"\",\n      \"password\": \"\",\n      \"port\": 27017,\n      \"store\": \"argo_FOO\",\n      \"server\": \"localhost\"\n    }\n  ],\n  \"users\": [\n    {\n      \"name\": \"test-admin\",\n      \"api_key\": \"foo.test.secret.key\",\n      \"roles\": [\n        \"admin\"\n      ],\n      \"email\": \"foo@example.com\"\n    }\n  ]\n}"
+						},
+						"url": {
+							"raw": "https://{{api_host}}/api/v2/admin/tenants",
+							"protocol": "https",
+							"host": [
+								"{{api_host}}"
+							],
+							"path": [
+								"api",
+								"v2",
+								"admin",
+								"tenants"
+							],
+							"query": [
+								{
+									"key": "Accept",
+									"value": "application/json",
+									"disabled": true
+								},
+								{
+									"key": "x-api-key",
+									"value": "{{api_key}}",
+									"disabled": true
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Recreate ops profile",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "4c7d1c3c-085d-40f7-aa8c-586ecb0057d5",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "b6a450ca-479c-44f0-8334-67ae9a42bf97",
+								"exec": [
+									"const schema = {",
+									"  \"type\": \"object\",",
+									"  \"properties\": {",
+									"    \"status\": {",
+									"      \"type\": \"object\",",
+									"      \"properties\": {",
+									"        \"message\": {",
+									"          \"type\": \"string\"",
+									"        },",
+									"        \"code\": {",
+									"          \"type\": \"string\"",
+									"        }",
+									"      },",
+									"      \"required\": [",
+									"        \"message\",",
+									"        \"code\"",
+									"      ]",
+									"    },",
+									"    \"data\": {",
+									"      \"type\": \"object\",",
+									"      \"properties\": {",
+									"        \"id\": {",
+									"          \"type\": \"string\"",
+									"        },",
+									"        \"links\": {",
+									"          \"type\": \"object\",",
+									"          \"properties\": {",
+									"            \"self\": {",
+									"              \"type\": \"string\"",
+									"            }",
+									"          },",
+									"          \"required\": [",
+									"            \"self\"",
+									"          ]",
+									"        }",
+									"      },",
+									"      \"required\": [",
+									"        \"id\",",
+									"        \"links\"",
+									"      ]",
+									"    }",
+									"  },",
+									"  \"required\": [",
+									"    \"status\",",
+									"    \"data\"",
+									"  ]",
+									"}",
+									"",
+									"pm.test(\"Validate schema\", () => {",
+									"    pm.response.to.have.jsonSchema(schema);",
+									"});",
+									"",
+									"",
+									"pm.test(\"Get ops uuid\", function () {",
+									"    let jsonData = pm.response.json();",
+									"    pm.environment.set(\"ops_uuid\",jsonData.data.id);",
+									"});",
+									"",
+									"pm.test(\"Status code is 201\", function () {",
+									"    pm.response.to.have.status(201);",
+									"});",
+									"",
+									"pm.test(\"check_respone_data\", function() {",
+									"    let jsonData = pm.response.json();",
+									"    let apiHost = pm.environment.get(\"api_host\");",
+									"    let opsUUID = pm.environment.get(\"ops_uuid\");",
+									"    pm.expect(jsonData.status.message).to.eql(\"Operations Profile successfully created\");",
+									"    pm.expect(jsonData.status.code).to.eql(\"201\");",
+									"    pm.expect(jsonData.data.id).to.eql(opsUUID);",
+									"    pm.expect(jsonData.data.links.self).to.eql(\"https://\"+apiHost+\"/api/v2/operations_profiles/\"+opsUUID);",
+									"",
+									"});",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Accept",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "x-api-key",
+								"type": "text",
+								"value": "{{tenant_api_key}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "    {\n            \"name\": \"test_deploy_ops\",\n            \"available_states\": [\n                \"OK\",\n                \"WARNING\",\n                \"UNKNOWN\",\n                \"MISSING\",\n                \"CRITICAL\",\n                \"DOWNTIME\"\n            ],\n            \"defaults\": {\n                \"down\": \"DOWNTIME\",\n                \"missing\": \"MISSING\",\n                \"unknown\": \"UNKNOWN\"\n            },\n            \"operations\": [\n                {\n                    \"name\": \"AND\",\n                    \"truth_table\": [\n                        {\n                            \"a\": \"OK\",\n                            \"b\": \"OK\",\n                            \"x\": \"OK\"\n                        },\n                        {\n                            \"a\": \"OK\",\n                            \"b\": \"WARNING\",\n                            \"x\": \"WARNING\"\n                        },\n                        {\n                            \"a\": \"OK\",\n                            \"b\": \"UNKNOWN\",\n                            \"x\": \"UNKNOWN\"\n                        },\n                        {\n                            \"a\": \"OK\",\n                            \"b\": \"MISSING\",\n                            \"x\": \"MISSING\"\n                        },\n                        {\n                            \"a\": \"OK\",\n                            \"b\": \"CRITICAL\",\n                            \"x\": \"CRITICAL\"\n                        },\n                        {\n                            \"a\": \"OK\",\n                            \"b\": \"DOWNTIME\",\n                            \"x\": \"DOWNTIME\"\n                        },\n                        {\n                            \"a\": \"WARNING\",\n                            \"b\": \"WARNING\",\n                            \"x\": \"WARNING\"\n                        },\n                        {\n                            \"a\": \"WARNING\",\n                            \"b\": \"UNKNOWN\",\n                            \"x\": \"UNKNOWN\"\n                        },\n                        {\n                            \"a\": \"WARNING\",\n                            \"b\": \"MISSING\",\n                            \"x\": \"MISSING\"\n                        },\n                        {\n                            \"a\": \"WARNING\",\n                            \"b\": \"CRITICAL\",\n                            \"x\": \"CRITICAL\"\n                        },\n                        {\n                            \"a\": \"WARNING\",\n                            \"b\": \"DOWNTIME\",\n                            \"x\": \"DOWNTIME\"\n                        },\n                        {\n                            \"a\": \"UNKNOWN\",\n                            \"b\": \"UNKNOWN\",\n                            \"x\": \"UNKNOWN\"\n                        },\n                        {\n                            \"a\": \"UNKNOWN\",\n                            \"b\": \"MISSING\",\n                            \"x\": \"MISSING\"\n                        },\n                        {\n                            \"a\": \"UNKNOWN\",\n                            \"b\": \"CRITICAL\",\n                            \"x\": \"CRITICAL\"\n                        },\n                        {\n                            \"a\": \"UNKNOWN\",\n                            \"b\": \"DOWNTIME\",\n                            \"x\": \"DOWNTIME\"\n                        },\n                        {\n                            \"a\": \"MISSING\",\n                            \"b\": \"MISSING\",\n                            \"x\": \"MISSING\"\n                        },\n                        {\n                            \"a\": \"MISSING\",\n                            \"b\": \"CRITICAL\",\n                            \"x\": \"CRITICAL\"\n                        },\n                        {\n                            \"a\": \"MISSING\",\n                            \"b\": \"DOWNTIME\",\n                            \"x\": \"DOWNTIME\"\n                        },\n                        {\n                            \"a\": \"CRITICAL\",\n                            \"b\": \"CRITICAL\",\n                            \"x\": \"CRITICAL\"\n                        },\n                        {\n                            \"a\": \"CRITICAL\",\n                            \"b\": \"DOWNTIME\",\n                            \"x\": \"CRITICAL\"\n                        },\n                        {\n                            \"a\": \"DOWNTIME\",\n                            \"b\": \"DOWNTIME\",\n                            \"x\": \"DOWNTIME\"\n                        }\n                    ]\n                },\n                {\n                    \"name\": \"OR\",\n                    \"truth_table\": [\n                        {\n                            \"a\": \"OK\",\n                            \"b\": \"OK\",\n                            \"x\": \"OK\"\n                        },\n                        {\n                            \"a\": \"OK\",\n                            \"b\": \"WARNING\",\n                            \"x\": \"OK\"\n                        },\n                        {\n                            \"a\": \"OK\",\n                            \"b\": \"UNKNOWN\",\n                            \"x\": \"OK\"\n                        },\n                        {\n                            \"a\": \"OK\",\n                            \"b\": \"MISSING\",\n                            \"x\": \"OK\"\n                        },\n                        {\n                            \"a\": \"OK\",\n                            \"b\": \"CRITICAL\",\n                            \"x\": \"OK\"\n                        },\n                        {\n                            \"a\": \"OK\",\n                            \"b\": \"DOWNTIME\",\n                            \"x\": \"OK\"\n                        },\n                        {\n                            \"a\": \"WARNING\",\n                            \"b\": \"WARNING\",\n                            \"x\": \"WARNING\"\n                        },\n                        {\n                            \"a\": \"WARNING\",\n                            \"b\": \"UNKNOWN\",\n                            \"x\": \"WARNING\"\n                        },\n                        {\n                            \"a\": \"WARNING\",\n                            \"b\": \"MISSING\",\n                            \"x\": \"WARNING\"\n                        },\n                        {\n                            \"a\": \"WARNING\",\n                            \"b\": \"CRITICAL\",\n                            \"x\": \"WARNING\"\n                        },\n                        {\n                            \"a\": \"WARNING\",\n                            \"b\": \"DOWNTIME\",\n                            \"x\": \"WARNING\"\n                        },\n                        {\n                            \"a\": \"UNKNOWN\",\n                            \"b\": \"UNKNOWN\",\n                            \"x\": \"UNKNOWN\"\n                        },\n                        {\n                            \"a\": \"UNKNOWN\",\n                            \"b\": \"MISSING\",\n                            \"x\": \"UNKNOWN\"\n                        },\n                        {\n                            \"a\": \"UNKNOWN\",\n                            \"b\": \"CRITICAL\",\n                            \"x\": \"CRITICAL\"\n                        },\n                        {\n                            \"a\": \"UNKNOWN\",\n                            \"b\": \"DOWNTIME\",\n                            \"x\": \"UNKNOWN\"\n                        },\n                        {\n                            \"a\": \"MISSING\",\n                            \"b\": \"MISSING\",\n                            \"x\": \"MISSING\"\n                        },\n                        {\n                            \"a\": \"MISSING\",\n                            \"b\": \"CRITICAL\",\n                            \"x\": \"CRITICAL\"\n                        },\n                        {\n                            \"a\": \"MISSING\",\n                            \"b\": \"DOWNTIME\",\n                            \"x\": \"DOWNTIME\"\n                        },\n                        {\n                            \"a\": \"CRITICAL\",\n                            \"b\": \"CRITICAL\",\n                            \"x\": \"CRITICAL\"\n                        },\n                        {\n                            \"a\": \"CRITICAL\",\n                            \"b\": \"DOWNTIME\",\n                            \"x\": \"CRITICAL\"\n                        },\n                        {\n                            \"a\": \"DOWNTIME\",\n                            \"b\": \"DOWNTIME\",\n                            \"x\": \"DOWNTIME\"\n                        }\n                    ]\n                }\n            ]\n        }"
+						},
+						"url": {
+							"raw": "https://{{api_host}}/api/v2/operations_profiles",
+							"protocol": "https",
+							"host": [
+								"{{api_host}}"
+							],
+							"path": [
+								"api",
+								"v2",
+								"operations_profiles"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Recreate metric profile",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "cba63420-39a8-4acc-8782-61281837adc8",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "98ce8501-eaa8-4474-b0a2-1dfc0c8f5916",
+								"exec": [
+									"const schema = {",
+									"  \"type\": \"object\",",
+									"  \"properties\": {",
+									"    \"status\": {",
+									"      \"type\": \"object\",",
+									"      \"properties\": {",
+									"        \"message\": {",
+									"          \"type\": \"string\"",
+									"        },",
+									"        \"code\": {",
+									"          \"type\": \"string\"",
+									"        }",
+									"      },",
+									"      \"required\": [",
+									"        \"message\",",
+									"        \"code\"",
+									"      ]",
+									"    },",
+									"    \"data\": {",
+									"      \"type\": \"object\",",
+									"      \"properties\": {",
+									"        \"id\": {",
+									"          \"type\": \"string\"",
+									"        },",
+									"        \"links\": {",
+									"          \"type\": \"object\",",
+									"          \"properties\": {",
+									"            \"self\": {",
+									"              \"type\": \"string\"",
+									"            }",
+									"          },",
+									"          \"required\": [",
+									"            \"self\"",
+									"          ]",
+									"        }",
+									"      },",
+									"      \"required\": [",
+									"        \"id\",",
+									"        \"links\"",
+									"      ]",
+									"    }",
+									"  },",
+									"  \"required\": [",
+									"    \"status\",",
+									"    \"data\"",
+									"  ]",
+									"}",
+									"",
+									"pm.test(\"Validate schema\", () => {",
+									"    pm.response.to.have.jsonSchema(schema);",
+									"});",
+									"",
+									"",
+									"pm.test(\"Get metric uuid\", function () {",
+									"    let jsonData = pm.response.json();",
+									"    pm.environment.set(\"metric_uuid\",jsonData.data.id);",
+									"});",
+									"",
+									"pm.test(\"Status code is 201\", function () {",
+									"    pm.response.to.have.status(201);",
+									"});",
+									"",
+									"pm.test(\"check_respone_data\", function() {",
+									"    let jsonData = pm.response.json();",
+									"    let apiHost = pm.environment.get(\"api_host\");",
+									"    let mpsUUID = pm.environment.get(\"metric_uuid\");",
+									"    pm.expect(jsonData.status.message).to.eql(\"Metric Profile successfully created\");",
+									"    pm.expect(jsonData.status.code).to.eql(\"201\");",
+									"    pm.expect(jsonData.data.id).to.eql(mpsUUID);",
+									"    pm.expect(jsonData.data.links.self).to.eql(\"https://\"+apiHost+\"/api/v2/metric_profiles/\"+mpsUUID);",
+									"",
+									"});",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Accept",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "x-api-key",
+								"type": "text",
+								"value": "{{tenant_api_key}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n            \"name\": \"test-mon\",\n            \"description\": \"Generic monitoring profile\",\n            \"services\": [\n                {\n                    \"service\": \"ARGO\",\n                    \"metrics\": [\n                        \"org.nagios.ARGOWeb-AR\",\n                        \"org.nagios.ARGOWeb-Status\"\n                    ]\n                },\n                {\n                    \"service\": \"WebPortal\",\n                    \"metrics\": [\n                        \"org.nagios.WebCheck\",\n                        \"eu.egi.CertValidity\"\n                    ]\n                }\n            ]\n        }"
+						},
+						"url": {
+							"raw": "https://{{api_host}}/api/v2/metric_profiles",
+							"protocol": "https",
+							"host": [
+								"{{api_host}}"
+							],
+							"path": [
+								"api",
+								"v2",
+								"metric_profiles"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Recreate agg profile",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "dd919a98-5b00-44e9-a316-cb2965d57483",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "bdbc46eb-85a8-4207-a392-dc5d1d153675",
+								"exec": [
+									"const schema = {",
+									"  \"type\": \"object\",",
+									"  \"properties\": {",
+									"    \"status\": {",
+									"      \"type\": \"object\",",
+									"      \"properties\": {",
+									"        \"message\": {",
+									"          \"type\": \"string\"",
+									"        },",
+									"        \"code\": {",
+									"          \"type\": \"string\"",
+									"        }",
+									"      },",
+									"      \"required\": [",
+									"        \"message\",",
+									"        \"code\"",
+									"      ]",
+									"    },",
+									"    \"data\": {",
+									"      \"type\": \"object\",",
+									"      \"properties\": {",
+									"        \"id\": {",
+									"          \"type\": \"string\"",
+									"        },",
+									"        \"links\": {",
+									"          \"type\": \"object\",",
+									"          \"properties\": {",
+									"            \"self\": {",
+									"              \"type\": \"string\"",
+									"            }",
+									"          },",
+									"          \"required\": [",
+									"            \"self\"",
+									"          ]",
+									"        }",
+									"      },",
+									"      \"required\": [",
+									"        \"id\",",
+									"        \"links\"",
+									"      ]",
+									"    }",
+									"  },",
+									"  \"required\": [",
+									"    \"status\",",
+									"    \"data\"",
+									"  ]",
+									"}",
+									"",
+									"pm.test(\"Validate schema\", () => {",
+									"    pm.response.to.have.jsonSchema(schema);",
+									"});",
+									"",
+									"",
+									"pm.test(\"Get agg uuid\", function () {",
+									"    let jsonData = pm.response.json();",
+									"    pm.environment.set(\"agg_uuid\",jsonData.data.id);",
+									"});",
+									"",
+									"pm.test(\"Status code is 201\", function () {",
+									"    pm.response.to.have.status(201);",
+									"});",
+									"",
+									"pm.test(\"check_respone_data\", function() {",
+									"    let jsonData = pm.response.json();",
+									"    let apiHost = pm.environment.get(\"api_host\");",
+									"    let aggUUID = pm.environment.get(\"agg_uuid\");",
+									"    pm.expect(jsonData.status.message).to.eql(\"Aggregation Profile successfully created\");",
+									"    pm.expect(jsonData.status.code).to.eql(\"201\");",
+									"    pm.expect(jsonData.data.id).to.eql(aggUUID);",
+									"    pm.expect(jsonData.data.links.self).to.eql(\"https://\"+apiHost+\"/api/v2/aggregation_profiles/\"+aggUUID);",
+									"",
+									"});",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Accept",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "x-api-key",
+								"type": "text",
+								"value": "{{tenant_api_key}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "      {\n            \n            \"name\": \"test-agg\",\n            \"namespace\": \"\",\n            \"endpoint_group\": \"servicegroups\",\n            \"metric_operation\": \"AND\",\n            \"profile_operation\": \"AND\",\n            \"metric_profile\": {\n                \"name\": \"MON\",\n                \"id\": \"{{metric_uuid}}\"\n            },\n            \"groups\": [\n                {\n                    \"name\": \"webportal\",\n                    \"operation\": \"AND\",\n                    \"services\": [\n                        {\n                            \"name\": \"WebPortal\",\n                            \"operation\": \"OR\"\n                        }\n                    ]\n                },\n                {\n                    \"name\": \"ARGO\",\n                    \"operation\": \"AND\",\n                    \"services\": [\n                        {\n                            \"name\": \"ARGO\",\n                            \"operation\": \"OR\"\n                        }\n                    ]\n                }\n            ]\n        }"
+						},
+						"url": {
+							"raw": "https://{{api_host}}/api/v2/aggregation_profiles",
+							"protocol": "https",
+							"host": [
+								"{{api_host}}"
+							],
+							"path": [
+								"api",
+								"v2",
+								"aggregation_profiles"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Create report",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "07be9118-4ee8-424b-bebe-09ff0800c24a",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "3b56f84d-6c59-4cf9-9734-7cae43c5cff3",
+								"exec": [
+									"const schema = {",
+									"  \"type\": \"object\",",
+									"  \"properties\": {",
+									"    \"status\": {",
+									"      \"type\": \"object\",",
+									"      \"properties\": {",
+									"        \"message\": {",
+									"          \"type\": \"string\"",
+									"        },",
+									"        \"code\": {",
+									"          \"type\": \"string\"",
+									"        }",
+									"      },",
+									"      \"required\": [",
+									"        \"message\",",
+									"        \"code\"",
+									"      ]",
+									"    },",
+									"    \"data\": {",
+									"      \"type\": \"object\",",
+									"      \"properties\": {",
+									"        \"id\": {",
+									"          \"type\": \"string\"",
+									"        },",
+									"        \"links\": {",
+									"          \"type\": \"object\",",
+									"          \"properties\": {",
+									"            \"self\": {",
+									"              \"type\": \"string\"",
+									"            }",
+									"          },",
+									"          \"required\": [",
+									"            \"self\"",
+									"          ]",
+									"        }",
+									"      },",
+									"      \"required\": [",
+									"        \"id\",",
+									"        \"links\"",
+									"      ]",
+									"    }",
+									"  },",
+									"  \"required\": [",
+									"    \"status\",",
+									"    \"data\"",
+									"  ]",
+									"}",
+									"",
+									"pm.test(\"Validate schema\", () => {",
+									"    pm.response.to.have.jsonSchema(schema);",
+									"});",
+									"",
+									"",
+									"pm.test(\"Get agg uuid\", function () {",
+									"    let jsonData = pm.response.json();",
+									"    pm.environment.set(\"report_uuid\",jsonData.data.id);",
+									"});",
+									"",
+									"pm.test(\"Status code is 201\", function () {",
+									"    pm.response.to.have.status(201);",
+									"});",
+									"",
+									"pm.test(\"check_respone_data\", function() {",
+									"    let jsonData = pm.response.json();",
+									"    let apiHost = pm.environment.get(\"api_host\");",
+									"    let reportUUID = pm.environment.get(\"report_uuid\");",
+									"    pm.expect(jsonData.status.message).to.eql(\"Successfully Created Report\");",
+									"    pm.expect(jsonData.status.code).to.eql(\"201\");",
+									"    pm.expect(jsonData.data.id).to.eql(reportUUID);",
+									"    pm.expect(jsonData.data.links.self).to.eql(\"https://\"+apiHost+\"/api/v2/reports/\"+reportUUID);",
+									"",
+									"});",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Accept",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "x-api-key",
+								"type": "text",
+								"value": "{{tenant_api_key}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": " {\n\n            \"disabled\": false,\n            \"info\": {\n                \"name\": \"Test\",\n                \"description\": \"A/R Default report used for test\",\n                \"created\": \"2020-05-14 12:54:44\",\n                \"updated\": \"2020-05-14 13:42:02\"\n            },\n            \"thresholds\": {\n                \"availability\": 80,\n                \"reliability\": 85,\n                \"uptime\": 0.8,\n                \"unknown\": 0.1,\n                \"downtime\": 0.1\n            },\n            \"topology_schema\": {\n                \"group\": {\n                    \"type\": \"NGI\",\n                    \"group\": {\n                        \"type\": \"SITES\"\n                    }\n                }\n            },\n            \"profiles\": [\n                {\n                    \"id\": \"{{metric_uuid}}\",\n                  \n                    \"type\": \"metric\"\n                },\n                {\n                    \"id\": \"{{agg_uuid}}\",\n                   \n                    \"type\": \"aggregation\"\n                },\n                {\n                    \"id\": \"{{ops_uuid}}\",\n                   \n                    \"type\": \"operations\"\n                }\n            ],\n            \"filter_tags\": []\n        }"
+						},
+						"url": {
+							"raw": "https://{{api_host}}/api/v2/reports",
+							"protocol": "https",
+							"host": [
+								"{{api_host}}"
+							],
+							"path": [
+								"api",
+								"v2",
+								"reports"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get reports",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "6e7760d0-fd75-43ab-8a71-5573863a51ac",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "737f0905-2920-4f77-a19d-22edfaec1e5f",
+								"exec": [
+									"const schema = {",
+									"  \"type\": \"object\",",
+									"  \"properties\": {",
+									"    \"status\": {",
+									"      \"type\": \"object\",",
+									"      \"properties\": {",
+									"        \"message\": {",
+									"          \"type\": \"string\"",
+									"        },",
+									"        \"code\": {",
+									"          \"type\": \"string\"",
+									"        }",
+									"      },",
+									"      \"required\": [",
+									"        \"message\",",
+									"        \"code\"",
+									"      ]",
+									"    },",
+									"    \"data\": {",
+									"      \"type\": \"array\",",
+									"      \"items\": [",
+									"        {",
+									"          \"type\": \"object\",",
+									"          \"properties\": {",
+									"            \"id\": {",
+									"              \"type\": \"string\"",
+									"            },",
+									"            \"tenant\": {",
+									"              \"type\": \"string\"",
+									"            },",
+									"            \"disabled\": {",
+									"              \"type\": \"boolean\"",
+									"            },",
+									"            \"info\": {",
+									"              \"type\": \"object\",",
+									"              \"properties\": {",
+									"                \"name\": {",
+									"                  \"type\": \"string\"",
+									"                },",
+									"                \"description\": {",
+									"                  \"type\": \"string\"",
+									"                },",
+									"                \"created\": {",
+									"                  \"type\": \"string\"",
+									"                },",
+									"                \"updated\": {",
+									"                  \"type\": \"string\"",
+									"                }",
+									"              },",
+									"              \"required\": [",
+									"                \"name\",",
+									"                \"description\",",
+									"                \"created\",",
+									"                \"updated\"",
+									"              ]",
+									"            },",
+									"            \"thresholds\": {",
+									"              \"type\": \"object\",",
+									"              \"properties\": {",
+									"                \"availability\": {",
+									"                  \"type\": \"integer\"",
+									"                },",
+									"                \"reliability\": {",
+									"                  \"type\": \"integer\"",
+									"                },",
+									"                \"uptime\": {",
+									"                  \"type\": \"number\"",
+									"                },",
+									"                \"unknown\": {",
+									"                  \"type\": \"number\"",
+									"                },",
+									"                \"downtime\": {",
+									"                  \"type\": \"number\"",
+									"                }",
+									"              },",
+									"              \"required\": [",
+									"                \"availability\",",
+									"                \"reliability\",",
+									"                \"uptime\",",
+									"                \"unknown\",",
+									"                \"downtime\"",
+									"              ]",
+									"            },",
+									"            \"topology_schema\": {",
+									"              \"type\": \"object\",",
+									"              \"properties\": {",
+									"                \"group\": {",
+									"                  \"type\": \"object\",",
+									"                  \"properties\": {",
+									"                    \"type\": {",
+									"                      \"type\": \"string\"",
+									"                    },",
+									"                    \"group\": {",
+									"                      \"type\": \"object\",",
+									"                      \"properties\": {",
+									"                        \"type\": {",
+									"                          \"type\": \"string\"",
+									"                        }",
+									"                      },",
+									"                      \"required\": [",
+									"                        \"type\"",
+									"                      ]",
+									"                    }",
+									"                  },",
+									"                  \"required\": [",
+									"                    \"type\",",
+									"                    \"group\"",
+									"                  ]",
+									"                }",
+									"              },",
+									"              \"required\": [",
+									"                \"group\"",
+									"              ]",
+									"            },",
+									"            \"profiles\": {",
+									"              \"type\": \"array\",",
+									"              \"items\": {",
+									"                \"type\": \"object\",",
+									"                \"properties\": {",
+									"                  \"id\": {",
+									"                    \"type\": \"string\"",
+									"                  },",
+									"                  \"name\": {",
+									"                    \"type\": \"string\"",
+									"                  },",
+									"                  \"type\": {",
+									"                    \"type\": \"string\"",
+									"                  }",
+									"                },",
+									"                \"required\": [",
+									"                  \"id\",",
+									"                  \"name\",",
+									"                  \"type\"",
+									"                ]",
+									"              }",
+									"            },",
+									"            \"filter_tags\": {",
+									"              \"type\": \"array\",",
+									"              \"items\": {}",
+									"            }",
+									"          },",
+									"          \"required\": [",
+									"            \"id\",",
+									"            \"tenant\",",
+									"            \"disabled\",",
+									"            \"info\",",
+									"            \"thresholds\",",
+									"            \"topology_schema\",",
+									"            \"profiles\",",
+									"            \"filter_tags\"",
+									"          ]",
+									"        }",
+									"      ]",
+									"    }",
+									"  },",
+									"  \"required\": [",
+									"    \"status\",",
+									"    \"data\"",
+									"  ]",
+									"}",
+									"",
+									"pm.test(\"Validate schema\", () => {",
+									"    pm.response.to.have.jsonSchema(schema);",
+									"});",
+									"",
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"check_respone_data\", function() {",
+									"    let jsonData = pm.response.json();",
+									"    let reportUUID = pm.environment.get(\"report_uuid\");",
+									"    let aggUUID = pm.environment.get(\"agg_uuid\");",
+									"    let mpsUUID = pm.environment.get(\"metric_uuid\");",
+									"    let opsUUID = pm.environment.get(\"ops_uuid\");",
+									"  ",
+									"    pm.expect(jsonData.status.message).to.eql(\"Success\");",
+									"    pm.expect(jsonData.status.code).to.eql(\"200\");",
+									"    let report = jsonData.data[0];",
+									"",
+									"    pm.expect(report.id).to.eql(reportUUID);",
+									"    pm.expect(report.tenant).to.eql(\"FOO\");",
+									"    pm.expect(report.disabled).to.eql(false);",
+									"    pm.expect(report.info.name).to.eql(\"Test\");",
+									"    pm.expect(report.info.description).to.eql(\"A/R Default report used for test\");",
+									"    let thresholds = report.thresholds;",
+									"    pm.expect(thresholds.availability).to.eql(80);",
+									"    pm.expect(thresholds.reliability).to.eql(85);",
+									"    pm.expect(thresholds.uptime).to.eql(0.8);",
+									"    pm.expect(thresholds.unknown).to.eql(0.1);",
+									"    pm.expect(thresholds.downtime).to.eql(0.1);",
+									"    let profiles = report.profiles;",
+									"    pm.expect(profiles[0].name).to.eql(\"test-mon\");",
+									"    pm.expect(profiles[0].type).to.eql(\"metric\");",
+									"    pm.expect(profiles[0].id).to.eql(mpsUUID);",
+									"    pm.expect(profiles[1].name).to.eql(\"test-agg\");",
+									"    pm.expect(profiles[1].type).to.eql(\"aggregation\");",
+									"    pm.expect(profiles[1].id).to.eql(aggUUID);",
+									"    pm.expect(profiles[2].name).to.eql(\"test_deploy_ops\");",
+									"    pm.expect(profiles[2].type).to.eql(\"operations\");",
+									"    pm.expect(profiles[2].id).to.eql(opsUUID);",
+									"    pm.expect(report.filter_tags.length).to.eq(0);",
+									"",
+									"",
+									"",
+									"    ",
+									"    ",
+									"",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Accept",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "x-api-key",
+								"type": "text",
+								"value": "{{tenant_api_key}}"
+							}
+						],
+						"url": {
+							"raw": "https://{{api_host}}/api/v2/reports",
+							"protocol": "https",
+							"host": [
+								"{{api_host}}"
+							],
+							"path": [
+								"api",
+								"v2",
+								"reports"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get specific report",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "21964e9c-c1c4-41c2-b770-b8347e7cf918",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "ca5c3354-9031-49f4-8611-467ab97ef5ab",
+								"exec": [
+									"const schema = {",
+									"  \"type\": \"object\",",
+									"  \"properties\": {",
+									"    \"status\": {",
+									"      \"type\": \"object\",",
+									"      \"properties\": {",
+									"        \"message\": {",
+									"          \"type\": \"string\"",
+									"        },",
+									"        \"code\": {",
+									"          \"type\": \"string\"",
+									"        }",
+									"      },",
+									"      \"required\": [",
+									"        \"message\",",
+									"        \"code\"",
+									"      ]",
+									"    },",
+									"    \"data\": {",
+									"      \"type\": \"array\",",
+									"      \"items\": [",
+									"        {",
+									"          \"type\": \"object\",",
+									"          \"properties\": {",
+									"            \"id\": {",
+									"              \"type\": \"string\"",
+									"            },",
+									"            \"tenant\": {",
+									"              \"type\": \"string\"",
+									"            },",
+									"            \"disabled\": {",
+									"              \"type\": \"boolean\"",
+									"            },",
+									"            \"info\": {",
+									"              \"type\": \"object\",",
+									"              \"properties\": {",
+									"                \"name\": {",
+									"                  \"type\": \"string\"",
+									"                },",
+									"                \"description\": {",
+									"                  \"type\": \"string\"",
+									"                },",
+									"                \"created\": {",
+									"                  \"type\": \"string\"",
+									"                },",
+									"                \"updated\": {",
+									"                  \"type\": \"string\"",
+									"                }",
+									"              },",
+									"              \"required\": [",
+									"                \"name\",",
+									"                \"description\",",
+									"                \"created\",",
+									"                \"updated\"",
+									"              ]",
+									"            },",
+									"            \"thresholds\": {",
+									"              \"type\": \"object\",",
+									"              \"properties\": {",
+									"                \"availability\": {",
+									"                  \"type\": \"integer\"",
+									"                },",
+									"                \"reliability\": {",
+									"                  \"type\": \"integer\"",
+									"                },",
+									"                \"uptime\": {",
+									"                  \"type\": \"number\"",
+									"                },",
+									"                \"unknown\": {",
+									"                  \"type\": \"number\"",
+									"                },",
+									"                \"downtime\": {",
+									"                  \"type\": \"number\"",
+									"                }",
+									"              },",
+									"              \"required\": [",
+									"                \"availability\",",
+									"                \"reliability\",",
+									"                \"uptime\",",
+									"                \"unknown\",",
+									"                \"downtime\"",
+									"              ]",
+									"            },",
+									"            \"topology_schema\": {",
+									"              \"type\": \"object\",",
+									"              \"properties\": {",
+									"                \"group\": {",
+									"                  \"type\": \"object\",",
+									"                  \"properties\": {",
+									"                    \"type\": {",
+									"                      \"type\": \"string\"",
+									"                    },",
+									"                    \"group\": {",
+									"                      \"type\": \"object\",",
+									"                      \"properties\": {",
+									"                        \"type\": {",
+									"                          \"type\": \"string\"",
+									"                        }",
+									"                      },",
+									"                      \"required\": [",
+									"                        \"type\"",
+									"                      ]",
+									"                    }",
+									"                  },",
+									"                  \"required\": [",
+									"                    \"type\",",
+									"                    \"group\"",
+									"                  ]",
+									"                }",
+									"              },",
+									"              \"required\": [",
+									"                \"group\"",
+									"              ]",
+									"            },",
+									"            \"profiles\": {",
+									"              \"type\": \"array\",",
+									"              \"items\": {",
+									"                \"type\": \"object\",",
+									"                \"properties\": {",
+									"                  \"id\": {",
+									"                    \"type\": \"string\"",
+									"                  },",
+									"                  \"name\": {",
+									"                    \"type\": \"string\"",
+									"                  },",
+									"                  \"type\": {",
+									"                    \"type\": \"string\"",
+									"                  }",
+									"                },",
+									"                \"required\": [",
+									"                  \"id\",",
+									"                  \"name\",",
+									"                  \"type\"",
+									"                ]",
+									"              }",
+									"            },",
+									"            \"filter_tags\": {",
+									"              \"type\": \"array\",",
+									"              \"items\": {}",
+									"            }",
+									"          },",
+									"          \"required\": [",
+									"            \"id\",",
+									"            \"tenant\",",
+									"            \"disabled\",",
+									"            \"info\",",
+									"            \"thresholds\",",
+									"            \"topology_schema\",",
+									"            \"profiles\",",
+									"            \"filter_tags\"",
+									"          ]",
+									"        }",
+									"      ]",
+									"    }",
+									"  },",
+									"  \"required\": [",
+									"    \"status\",",
+									"    \"data\"",
+									"  ]",
+									"}",
+									"",
+									"pm.test(\"Validate schema\", () => {",
+									"    pm.response.to.have.jsonSchema(schema);",
+									"});",
+									"",
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"check_respone_data\", function() {",
+									"    let jsonData = pm.response.json();",
+									"    let reportUUID = pm.environment.get(\"report_uuid\");",
+									"    let aggUUID = pm.environment.get(\"agg_uuid\");",
+									"    let mpsUUID = pm.environment.get(\"metric_uuid\");",
+									"    let opsUUID = pm.environment.get(\"ops_uuid\");",
+									"  ",
+									"    pm.expect(jsonData.status.message).to.eql(\"Success\");",
+									"    pm.expect(jsonData.status.code).to.eql(\"200\");",
+									"    let report = jsonData.data[0];",
+									"",
+									"    pm.expect(report.id).to.eql(reportUUID);",
+									"    pm.expect(report.tenant).to.eql(\"FOO\");",
+									"    pm.expect(report.disabled).to.eql(false);",
+									"    pm.expect(report.info.name).to.eql(\"Test\");",
+									"    pm.expect(report.info.description).to.eql(\"A/R Default report used for test\");",
+									"    let thresholds = report.thresholds;",
+									"    pm.expect(thresholds.availability).to.eql(80);",
+									"    pm.expect(thresholds.reliability).to.eql(85);",
+									"    pm.expect(thresholds.uptime).to.eql(0.8);",
+									"    pm.expect(thresholds.unknown).to.eql(0.1);",
+									"    pm.expect(thresholds.downtime).to.eql(0.1);",
+									"    let profiles = report.profiles;",
+									"    pm.expect(profiles[0].name).to.eql(\"test-mon\");",
+									"    pm.expect(profiles[0].type).to.eql(\"metric\");",
+									"    pm.expect(profiles[0].id).to.eql(mpsUUID);",
+									"    pm.expect(profiles[1].name).to.eql(\"test-agg\");",
+									"    pm.expect(profiles[1].type).to.eql(\"aggregation\");",
+									"    pm.expect(profiles[1].id).to.eql(aggUUID);",
+									"    pm.expect(profiles[2].name).to.eql(\"test_deploy_ops\");",
+									"    pm.expect(profiles[2].type).to.eql(\"operations\");",
+									"    pm.expect(profiles[2].id).to.eql(opsUUID);",
+									"    pm.expect(report.filter_tags.length).to.eq(0);",
+									"",
+									"",
+									"",
+									"    ",
+									"    ",
+									"",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Accept",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "x-api-key",
+								"type": "text",
+								"value": "{{tenant_api_key}}"
+							}
+						],
+						"url": {
+							"raw": "https://{{api_host}}/api/v2/reports/{{report_uuid}}",
+							"protocol": "https",
+							"host": [
+								"{{api_host}}"
+							],
+							"path": [
+								"api",
+								"v2",
+								"reports",
+								"{{report_uuid}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Update report",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "9873e292-3876-4b17-82e7-8ce6d7c6bfd0",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "bcc0614f-5eea-4c4d-bde6-4f48ef393ecb",
+								"exec": [
+									"const schema = {",
+									"  \"type\": \"object\",",
+									"  \"properties\": {",
+									"    \"status\": {",
+									"      \"type\": \"object\",",
+									"      \"properties\": {",
+									"        \"message\": {",
+									"          \"type\": \"string\"",
+									"        },",
+									"        \"code\": {",
+									"          \"type\": \"string\"",
+									"        }",
+									"      },",
+									"      \"required\": [",
+									"        \"message\",",
+									"        \"code\"",
+									"      ]",
+									"    }",
+									"  },",
+									"  \"required\": [",
+									"    \"status\"",
+									"  ]",
+									"}",
+									"",
+									"pm.test(\"Validate schema\", () => {",
+									"    pm.response.to.have.jsonSchema(schema);",
+									"});",
+									"",
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"check_respone_data\", function() {",
+									"    let jsonData = pm.response.json();",
+									"    pm.expect(jsonData.status.message).to.eql(\"Report was successfully updated\");",
+									"    pm.expect(jsonData.status.code).to.eql(\"200\");",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "PUT",
+						"header": [
+							{
+								"key": "Accept",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "x-api-key",
+								"type": "text",
+								"value": "{{tenant_api_key}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": " {\n\n           \n            \"info\": {\n                \"name\": \"Test\",\n                \"description\": \"Modified test\"\n            },\n            \"thresholds\": {\n                \"availability\": 50,\n                \"reliability\": 65,\n                \"uptime\": 0.8,\n                \"unknown\": 0.1,\n                \"downtime\": 0.1\n            },\n            \"topology_schema\": {\n                \"group\": {\n                    \"type\": \"NGI\",\n                    \"group\": {\n                        \"type\": \"SITES\"\n                    }\n                }\n            },\n            \"profiles\": [\n                {\n                    \"id\": \"{{metric_uuid}}\",\n                  \n                    \"type\": \"metric\"\n                },\n                {\n                    \"id\": \"{{agg_uuid}}\",\n                   \n                    \"type\": \"aggregation\"\n                },\n                {\n                    \"id\": \"{{ops_uuid}}\",\n                   \n                    \"type\": \"operations\"\n                }\n            ],\n            \"filter_tags\": []\n        }",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "https://{{api_host}}/api/v2/reports/{{report_uuid}}",
+							"protocol": "https",
+							"host": [
+								"{{api_host}}"
+							],
+							"path": [
+								"api",
+								"v2",
+								"reports",
+								"{{report_uuid}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get specific report modified",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "37ce9e89-19bb-4f1d-93d0-50e3589fdb60",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "5e803754-bbe6-4494-ae72-283fd1951711",
+								"exec": [
+									"const schema = {",
+									"  \"type\": \"object\",",
+									"  \"properties\": {",
+									"    \"status\": {",
+									"      \"type\": \"object\",",
+									"      \"properties\": {",
+									"        \"message\": {",
+									"          \"type\": \"string\"",
+									"        },",
+									"        \"code\": {",
+									"          \"type\": \"string\"",
+									"        }",
+									"      },",
+									"      \"required\": [",
+									"        \"message\",",
+									"        \"code\"",
+									"      ]",
+									"    },",
+									"    \"data\": {",
+									"      \"type\": \"array\",",
+									"      \"items\": [",
+									"        {",
+									"          \"type\": \"object\",",
+									"          \"properties\": {",
+									"            \"id\": {",
+									"              \"type\": \"string\"",
+									"            },",
+									"            \"tenant\": {",
+									"              \"type\": \"string\"",
+									"            },",
+									"            \"disabled\": {",
+									"              \"type\": \"boolean\"",
+									"            },",
+									"            \"info\": {",
+									"              \"type\": \"object\",",
+									"              \"properties\": {",
+									"                \"name\": {",
+									"                  \"type\": \"string\"",
+									"                },",
+									"                \"description\": {",
+									"                  \"type\": \"string\"",
+									"                },",
+									"                \"created\": {",
+									"                  \"type\": \"string\"",
+									"                },",
+									"                \"updated\": {",
+									"                  \"type\": \"string\"",
+									"                }",
+									"              },",
+									"              \"required\": [",
+									"                \"name\",",
+									"                \"description\",",
+									"                \"created\",",
+									"                \"updated\"",
+									"              ]",
+									"            },",
+									"            \"thresholds\": {",
+									"              \"type\": \"object\",",
+									"              \"properties\": {",
+									"                \"availability\": {",
+									"                  \"type\": \"integer\"",
+									"                },",
+									"                \"reliability\": {",
+									"                  \"type\": \"integer\"",
+									"                },",
+									"                \"uptime\": {",
+									"                  \"type\": \"number\"",
+									"                },",
+									"                \"unknown\": {",
+									"                  \"type\": \"number\"",
+									"                },",
+									"                \"downtime\": {",
+									"                  \"type\": \"number\"",
+									"                }",
+									"              },",
+									"              \"required\": [",
+									"                \"availability\",",
+									"                \"reliability\",",
+									"                \"uptime\",",
+									"                \"unknown\",",
+									"                \"downtime\"",
+									"              ]",
+									"            },",
+									"            \"topology_schema\": {",
+									"              \"type\": \"object\",",
+									"              \"properties\": {",
+									"                \"group\": {",
+									"                  \"type\": \"object\",",
+									"                  \"properties\": {",
+									"                    \"type\": {",
+									"                      \"type\": \"string\"",
+									"                    },",
+									"                    \"group\": {",
+									"                      \"type\": \"object\",",
+									"                      \"properties\": {",
+									"                        \"type\": {",
+									"                          \"type\": \"string\"",
+									"                        }",
+									"                      },",
+									"                      \"required\": [",
+									"                        \"type\"",
+									"                      ]",
+									"                    }",
+									"                  },",
+									"                  \"required\": [",
+									"                    \"type\",",
+									"                    \"group\"",
+									"                  ]",
+									"                }",
+									"              },",
+									"              \"required\": [",
+									"                \"group\"",
+									"              ]",
+									"            },",
+									"            \"profiles\": {",
+									"              \"type\": \"array\",",
+									"              \"items\": {",
+									"                \"type\": \"object\",",
+									"                \"properties\": {",
+									"                  \"id\": {",
+									"                    \"type\": \"string\"",
+									"                  },",
+									"                  \"name\": {",
+									"                    \"type\": \"string\"",
+									"                  },",
+									"                  \"type\": {",
+									"                    \"type\": \"string\"",
+									"                  }",
+									"                },",
+									"                \"required\": [",
+									"                  \"id\",",
+									"                  \"name\",",
+									"                  \"type\"",
+									"                ]",
+									"              }",
+									"            },",
+									"            \"filter_tags\": {",
+									"              \"type\": \"array\",",
+									"              \"items\": {}",
+									"            }",
+									"          },",
+									"          \"required\": [",
+									"            \"id\",",
+									"            \"tenant\",",
+									"            \"disabled\",",
+									"            \"info\",",
+									"            \"thresholds\",",
+									"            \"topology_schema\",",
+									"            \"profiles\",",
+									"            \"filter_tags\"",
+									"          ]",
+									"        }",
+									"      ]",
+									"    }",
+									"  },",
+									"  \"required\": [",
+									"    \"status\",",
+									"    \"data\"",
+									"  ]",
+									"}",
+									"",
+									"pm.test(\"Validate schema\", () => {",
+									"    pm.response.to.have.jsonSchema(schema);",
+									"});",
+									"",
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"check_respone_data\", function() {",
+									"    let jsonData = pm.response.json();",
+									"    let reportUUID = pm.environment.get(\"report_uuid\");",
+									"    let aggUUID = pm.environment.get(\"agg_uuid\");",
+									"    let mpsUUID = pm.environment.get(\"metric_uuid\");",
+									"    let opsUUID = pm.environment.get(\"ops_uuid\");",
+									"  ",
+									"    pm.expect(jsonData.status.message).to.eql(\"Success\");",
+									"    pm.expect(jsonData.status.code).to.eql(\"200\");",
+									"    let report = jsonData.data[0];",
+									"",
+									"    pm.expect(report.id).to.eql(reportUUID);",
+									"    pm.expect(report.tenant).to.eql(\"FOO\");",
+									"    pm.expect(report.disabled).to.eql(false);",
+									"    pm.expect(report.info.name).to.eql(\"Test\");",
+									"    pm.expect(report.info.description).to.eql(\"Modified test\");",
+									"    let thresholds = report.thresholds;",
+									"    pm.expect(thresholds.availability).to.eql(50);",
+									"    pm.expect(thresholds.reliability).to.eql(65);",
+									"    pm.expect(thresholds.uptime).to.eql(0.8);",
+									"    pm.expect(thresholds.unknown).to.eql(0.1);",
+									"    pm.expect(thresholds.downtime).to.eql(0.1);",
+									"    let profiles = report.profiles;",
+									"    pm.expect(profiles[0].name).to.eql(\"test-mon\");",
+									"    pm.expect(profiles[0].type).to.eql(\"metric\");",
+									"    pm.expect(profiles[0].id).to.eql(mpsUUID);",
+									"    pm.expect(profiles[1].name).to.eql(\"test-agg\");",
+									"    pm.expect(profiles[1].type).to.eql(\"aggregation\");",
+									"    pm.expect(profiles[1].id).to.eql(aggUUID);",
+									"    pm.expect(profiles[2].name).to.eql(\"test_deploy_ops\");",
+									"    pm.expect(profiles[2].type).to.eql(\"operations\");",
+									"    pm.expect(profiles[2].id).to.eql(opsUUID);",
+									"    pm.expect(report.filter_tags.length).to.eq(0);",
+									"",
+									"",
+									"",
+									"    ",
+									"    ",
+									"",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Accept",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "x-api-key",
+								"type": "text",
+								"value": "{{tenant_api_key}}"
+							}
+						],
+						"url": {
+							"raw": "https://{{api_host}}/api/v2/reports/{{report_uuid}}",
+							"protocol": "https",
+							"host": [
+								"{{api_host}}"
+							],
+							"path": [
+								"api",
+								"v2",
+								"reports",
+								"{{report_uuid}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "delete report",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "a026a62d-1c97-4902-9cc2-34adb3babbcf",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "67640ed5-1aa0-4c8f-9f21-c8e198fba44d",
+								"exec": [
+									"const schema = {",
+									"  \"type\": \"object\",",
+									"  \"properties\": {",
+									"    \"status\": {",
+									"      \"type\": \"object\",",
+									"      \"properties\": {",
+									"        \"message\": {",
+									"          \"type\": \"string\"",
+									"        },",
+									"        \"code\": {",
+									"          \"type\": \"string\"",
+									"        }",
+									"      },",
+									"      \"required\": [",
+									"        \"message\",",
+									"        \"code\"",
+									"      ]",
+									"    }",
+									"  },",
+									"  \"required\": [",
+									"    \"status\"",
+									"  ]",
+									"}",
+									"",
+									"pm.test(\"Validate schema\", () => {",
+									"    pm.response.to.have.jsonSchema(schema);",
+									"});",
+									"",
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"check_respone_data\", function() {",
+									"    let jsonData = pm.response.json();",
+									"",
+									"    pm.expect(jsonData.status.message).to.eql(\"Report was successfully deleted\");",
+									"    pm.expect(jsonData.status.code).to.eql(\"200\");",
+									"  ",
+									"",
+									"});",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "Accept",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "x-api-key",
+								"type": "text",
+								"value": "{{tenant_api_key}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "https://{{api_host}}/api/v2/reports/{{report_uuid}}",
+							"protocol": "https",
+							"host": [
+								"{{api_host}}"
+							],
+							"path": [
+								"api",
+								"v2",
+								"reports",
+								"{{report_uuid}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "delete recraeted agg profile",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "f8ee5cb9-cacc-43f9-a551-9800ed35e6f4",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "c3d266a1-267b-4bf9-935d-45f61b3d9a0c",
+								"exec": [
+									"const schema = {",
+									"  \"type\": \"object\",",
+									"  \"properties\": {",
+									"    \"status\": {",
+									"      \"type\": \"object\",",
+									"      \"properties\": {",
+									"        \"message\": {",
+									"          \"type\": \"string\"",
+									"        },",
+									"        \"code\": {",
+									"          \"type\": \"string\"",
+									"        }",
+									"      },",
+									"      \"required\": [",
+									"        \"message\",",
+									"        \"code\"",
+									"      ]",
+									"    }",
+									"  },",
+									"  \"required\": [",
+									"    \"status\"",
+									"  ]",
+									"}",
+									"",
+									"pm.test(\"Validate schema\", () => {",
+									"    pm.response.to.have.jsonSchema(schema);",
+									"});",
+									"",
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"check_respone_data\", function() {",
+									"    let jsonData = pm.response.json();",
+									"",
+									"    pm.expect(jsonData.status.message).to.eql(\"Aggregation Profile Successfully Deleted\");",
+									"    pm.expect(jsonData.status.code).to.eql(\"200\");",
+									"  ",
+									"",
+									"});",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "Accept",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "x-api-key",
+								"type": "text",
+								"value": "{{tenant_api_key}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "https://{{api_host}}/api/v2/aggregation_profiles/{{agg_uuid}}",
+							"protocol": "https",
+							"host": [
+								"{{api_host}}"
+							],
+							"path": [
+								"api",
+								"v2",
+								"aggregation_profiles",
+								"{{agg_uuid}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "delete recreated metric profile",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "892f2cc6-dcbb-4c26-bdd4-520b525cf6bb",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "9e68b9e6-f23c-4880-807c-125b521612d3",
+								"exec": [
+									"const schema = {",
+									"  \"type\": \"object\",",
+									"  \"properties\": {",
+									"    \"status\": {",
+									"      \"type\": \"object\",",
+									"      \"properties\": {",
+									"        \"message\": {",
+									"          \"type\": \"string\"",
+									"        },",
+									"        \"code\": {",
+									"          \"type\": \"string\"",
+									"        }",
+									"      },",
+									"      \"required\": [",
+									"        \"message\",",
+									"        \"code\"",
+									"      ]",
+									"    }",
+									"  },",
+									"  \"required\": [",
+									"    \"status\"",
+									"  ]",
+									"}",
+									"",
+									"pm.test(\"Validate schema\", () => {",
+									"    pm.response.to.have.jsonSchema(schema);",
+									"});",
+									"",
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"check_respone_data\", function() {",
+									"    let jsonData = pm.response.json();",
+									"",
+									"    pm.expect(jsonData.status.message).to.eql(\"Metric Profile Successfully Deleted\");",
+									"    pm.expect(jsonData.status.code).to.eql(\"200\");",
+									"  ",
+									"",
+									"});",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "Accept",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "x-api-key",
+								"type": "text",
+								"value": "{{tenant_api_key}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "https://{{api_host}}/api/v2/metric_profiles/{{metric_uuid}}",
+							"protocol": "https",
+							"host": [
+								"{{api_host}}"
+							],
+							"path": [
+								"api",
+								"v2",
+								"metric_profiles",
+								"{{metric_uuid}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "delete recreated ops profile",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "85ccbcd7-cfc1-4849-bdd3-3d3e89e38374",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "86c7a1a3-da20-4d1e-a77e-af4127d0c63a",
+								"exec": [
+									"const schema = {",
+									"  \"type\": \"object\",",
+									"  \"properties\": {",
+									"    \"status\": {",
+									"      \"type\": \"object\",",
+									"      \"properties\": {",
+									"        \"message\": {",
+									"          \"type\": \"string\"",
+									"        },",
+									"        \"code\": {",
+									"          \"type\": \"string\"",
+									"        }",
+									"      },",
+									"      \"required\": [",
+									"        \"message\",",
+									"        \"code\"",
+									"      ]",
+									"    }",
+									"  },",
+									"  \"required\": [",
+									"    \"status\"",
+									"  ]",
+									"}",
+									"",
+									"pm.test(\"Validate schema\", () => {",
+									"    pm.response.to.have.jsonSchema(schema);",
+									"});",
+									"",
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"check_respone_data\", function() {",
+									"    let jsonData = pm.response.json();",
+									"",
+									"    pm.expect(jsonData.status.message).to.eql(\"Operations Profile Successfully Deleted\");",
+									"    pm.expect(jsonData.status.code).to.eql(\"200\");",
+									"  ",
+									"",
+									"});",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "Accept",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "x-api-key",
+								"type": "text",
+								"value": "{{tenant_api_key}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "https://{{api_host}}/api/v2/operations_profiles/{{ops_uuid}}",
+							"protocol": "https",
+							"host": [
+								"{{api_host}}"
+							],
+							"path": [
+								"api",
+								"v2",
+								"operations_profiles",
+								"{{ops_uuid}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "delete tenant",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "fa7fec25-4ded-49b2-846d-ea8cc54fba80",
+								"exec": [
+									"const schema = {",
+									"  \"type\": \"object\",",
+									"  \"properties\": {",
+									"    \"status\": {",
+									"      \"type\": \"object\",",
+									"      \"properties\": {",
+									"        \"message\": {",
+									"          \"type\": \"string\"",
+									"        },",
+									"        \"code\": {",
+									"          \"type\": \"string\"",
+									"        }",
+									"      },",
+									"      \"required\": [",
+									"        \"message\",",
+									"        \"code\"",
+									"      ]",
+									"    }",
+									"  },",
+									"  \"required\": [",
+									"    \"status\"",
+									"  ]",
+									"}",
+									"",
+									"pm.test(\"Validate schema\", () => {",
+									"    pm.response.to.have.jsonSchema(schema);",
+									"});",
+									"",
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"pm.globals.set(\"variable_key\", \"variable_value\");"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "Accept",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "x-api-key",
+								"type": "text",
+								"value": "{{api_key}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "https://{{api_host}}/api/v2/admin/tenants/{{tenant_uuid}}",
+							"protocol": "https",
+							"host": [
+								"{{api_host}}"
+							],
+							"path": [
+								"api",
+								"v2",
+								"admin",
+								"tenants",
+								"{{tenant_uuid}}"
+							],
+							"query": [
+								{
+									"key": "Accept",
+									"value": "application/json",
+									"disabled": true
+								},
+								{
+									"key": "x-api-key",
+									"value": "{{api_key}}",
+									"disabled": true
+								}
+							]
+						},
+						"description": "test web api\t"
+					},
+					"response": []
+				}
+			],
 			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"id": "695536d4-8f32-4c88-8cb0-df3952a5a67a",
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				},
 				{
 					"listen": "test",
 					"script": {
-						"id": "4b7ef416-1042-41e4-9f6b-1914e7d8c732",
+						"id": "740c870e-8b11-48cd-b353-95cde631d81b",
+						"type": "text/javascript",
 						"exec": [
-							"pm.test(\"Status code is 200\", function () {",
-							"    pm.response.to.have.status(200);",
-							"});"
-						],
-						"type": "text/javascript"
+							""
+						]
 					}
 				}
 			],
-			"request": {
-				"method": "DELETE",
-				"header": [
-					{
-						"key": "Accept",
-						"type": "text",
-						"value": "application/json"
-					},
-					{
-						"key": "x-api-key",
-						"type": "text",
-						"value": "{{api_key}}"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": ""
-				},
-				"url": {
-					"raw": "https://{{api_host}}/api/v2/admin/tenants/{{tenant_uuid}}?",
-					"protocol": "https",
-					"host": [
-						"{{api_host}}"
-					],
-					"path": [
-						"api",
-						"v2",
-						"admin",
-						"tenants",
-						"{{tenant_uuid}}"
-					],
-					"query": [
-						{
-							"key": "Accept",
-							"value": "application/json",
-							"disabled": true
-						},
-						{
-							"key": "x-api-key",
-							"value": "{{api_key}}",
-							"disabled": true
-						}
-					]
-				},
-				"description": "test web api\t"
-			},
-			"response": []
+			"protocolProfileBehavior": {}
 		}
-	]
+	],
+	"protocolProfileBehavior": {}
 }


### PR DESCRIPTION
- [x] Rearrange argo-web-api test suite in folders
  - [x] Add version testing in `version_tests` folder
  - [x] Add tenant related tests in `tenant tests` folder
- [x] Add Operations profiles tests 
  - [x] Recreate tenant
  - [x] Test operation profiles CRUD
- [x] Add Metric profile tests
  - [x] Recreate tenant
  - [x] Add Metric profile tests
- [x] Add Aggregation tests
  - [x] Recreate tenant
  - [x] Recreate metric profile
  - [x] Add Aggregation profile CRUD tests with reference to metric profile
- [x] Add Report tests
  - [x] Recreate Tenant
  - [x] Recreate ops profile
  - [x] Recreate metric profile
  - [x] Recreate aggregation profile
  - [x] Add Report CRUD tests with references to metric,ops and aggregation profiles
Also:
- [x] Add schema validation checks on each request