### PR TITLE
ARGO-2509 Provide topology feed parameters

### DIFF
--- a/app/feeds/controller.go
+++ b/app/feeds/controller.go
@@ -1,0 +1,164 @@
+package feeds
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/ARGOeu/argo-web-api/respond"
+	"github.com/ARGOeu/argo-web-api/utils/config"
+	"github.com/ARGOeu/argo-web-api/utils/mongo"
+	"github.com/gorilla/context"
+	"gopkg.in/mgo.v2/bson"
+)
+
+//Create a new feeds resource
+const feedsTopoCol = "feeds_topology"
+
+// Update request handler creates a new feed topo resource
+func UpdateTopo(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
+	//STANDARD DECLARATIONS START
+	code := http.StatusOK
+	h := http.Header{}
+	output := []byte("")
+	err := error(nil)
+	charset := "utf-8"
+	//STANDARD DECLARATIONS END
+
+	// Set Content-Type response Header value
+	contentType := r.Header.Get("Accept")
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+
+	// Grab Tenant DB configuration from context
+	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
+
+	if err != nil {
+		code = http.StatusBadRequest
+		output, _ = respond.MarshalContent(respond.ErrBadRequestDetails(err.Error()), contentType, "", " ")
+		return code, h, output, err
+	}
+	session, err := mongo.OpenSession(tenantDbConfig)
+	defer mongo.CloseSession(session)
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	incoming := FeedsTopo{}
+
+	// Try ingest request body
+	body, err := ioutil.ReadAll(io.LimitReader(r.Body, cfg.Server.ReqSizeLimit))
+	if err != nil {
+		panic(err)
+	}
+	if err := r.Body.Close(); err != nil {
+		panic(err)
+	}
+
+	// Parse body json
+	if err := json.Unmarshal(body, &incoming); err != nil {
+		output, _ = respond.MarshalContent(respond.BadRequestInvalidJSON, contentType, "", " ")
+		code = 400
+		return code, h, output, err
+	}
+
+	_, err = mongo.Remove(session, tenantDbConfig.Db, feedsTopoCol, bson.M{})
+	if err != nil {
+		panic(err)
+	}
+
+	err = mongo.Insert(session, tenantDbConfig.Db, feedsTopoCol, incoming)
+
+	if err != nil {
+		panic(err)
+	}
+
+	// Create view of the results
+	output, err = createListView([]FeedsTopo{incoming}, "Feeds resource succesfully updated", 200) //Render the results into JSON
+	code = 200
+	return code, h, output, err
+}
+
+// List Topology Results
+func ListTopo(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
+
+	//STANDARD DECLARATIONS START
+
+	code := http.StatusOK
+	h := http.Header{}
+	output := []byte("")
+	err := error(nil)
+	charset := "utf-8"
+
+	//STANDARD DECLARATIONS END
+
+	// Set Content-Type response Header value
+	contentType := r.Header.Get("Accept")
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+
+	// Grab Tenant DB configuration from context
+	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
+
+	// Open session to tenant database
+	session, err := mongo.OpenSession(tenantDbConfig)
+	defer mongo.CloseSession(session)
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	// Retrieve Results from database
+	result := FeedsTopo{}
+
+	if err != nil {
+		code = http.StatusBadRequest
+		output, _ = respond.MarshalContent(respond.ErrBadRequestDetails(err.Error()), contentType, "", " ")
+		return code, h, output, err
+	}
+
+	ftCol := session.DB(tenantDbConfig.Db).C(feedsTopoCol)
+	err = ftCol.Find(bson.M{}).One(&result)
+	if err != nil {
+		if err.Error() == "not found" {
+			output, _ = respond.MarshalContent(respond.ErrNotFound, contentType, "", " ")
+			code = 404
+			return code, h, output, err
+		}
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	// Create view of the results
+	output, err = createListView([]FeedsTopo{result}, "Success", code) //Render the results into JSON
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+	return code, h, output, err
+}
+
+// Options request handler
+func Options(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
+
+	//STANDARD DECLARATIONS START
+
+	code := http.StatusOK
+	h := http.Header{}
+	output := []byte("")
+	err := error(nil)
+	contentType := "text/plain"
+	charset := "utf-8"
+
+	//STANDARD DECLARATIONS END
+
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+	h.Set("Allow", fmt.Sprintf("GET, POST, DELETE, PUT, OPTIONS"))
+	return code, h, output, err
+
+}

--- a/app/feeds/feeds_test.go
+++ b/app/feeds/feeds_test.go
@@ -1,0 +1,283 @@
+package feeds
+
+import (
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/ARGOeu/argo-web-api/respond"
+	"github.com/ARGOeu/argo-web-api/utils/config"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/suite"
+	"gopkg.in/gcfg.v1"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+)
+
+// This is a util. suite struct used in tests (see pkg "testify")
+type FeedsTestSuite struct {
+	suite.Suite
+	cfg                       config.Config
+	router                    *mux.Router
+	confHandler               respond.ConfHandler
+	tenantDbConf              config.MongoConfig
+	clientkey                 string
+	respRecomputationsCreated string
+	respUnauthorized          string
+}
+
+// Setup the Test Environment
+func (suite *FeedsTestSuite) SetupSuite() {
+	const testConfig = `
+	 [server]
+	 bindip = ""
+	 port = 8080
+	 maxprocs = 4
+	 cache = false
+	 lrucache = 700000000
+	 gzip = true
+	 reqsizelimit = 1073741824
+ 
+	 [mongodb]
+	 host = "127.0.0.1"
+	 port = 27017
+	 db = "AR_test_feeds"
+	 `
+
+	_ = gcfg.ReadStringInto(&suite.cfg, testConfig)
+
+	suite.respUnauthorized = "Unauthorized"
+	suite.tenantDbConf = config.MongoConfig{
+		Host:     "localhost",
+		Port:     27017,
+		Db:       "AR_test_feeds_tenant",
+		Password: "pass",
+		Username: "dbuser",
+		Store:    "ar",
+	}
+	suite.clientkey = "123456"
+
+	suite.confHandler = respond.ConfHandler{Config: suite.cfg}
+	suite.router = mux.NewRouter().StrictSlash(false).PathPrefix("/api/v2").Subrouter()
+	HandleSubrouter(suite.router, &suite.confHandler)
+}
+
+// This function runs before any test and setups the environment
+func (suite *FeedsTestSuite) SetupTest() {
+
+	log.SetOutput(ioutil.Discard)
+
+	// seed mongo
+	session, err := mgo.Dial(suite.cfg.MongoDB.Host)
+	if err != nil {
+		panic(err)
+	}
+	defer session.Close()
+
+	// Seed database with tenants
+	c := session.DB(suite.cfg.MongoDB.Db).C("tenants")
+	c.Insert(
+		bson.M{"id": "6ac7d684-1f8e-4a02-a502-720e8f11e50c",
+			"info": bson.M{
+				"name":    "GUARDIANS",
+				"email":   "email@something2",
+				"website": "www.gotg.com",
+				"created": "2015-10-20 02:08:04",
+				"updated": "2015-10-20 02:08:04"},
+			"db_conf": []bson.M{
+
+				bson.M{
+					"server":   "localhost",
+					"port":     27017,
+					"database": "argo_FOO",
+				},
+				bson.M{
+					"server":   "localhost",
+					"port":     27017,
+					"database": "argo_FOO",
+				},
+			},
+			"users": []bson.M{
+
+				bson.M{
+					"name":    "user1",
+					"email":   "user1@email.com",
+					"api_key": "USER1KEY",
+					"roles":   []string{"editor"},
+				},
+				bson.M{
+					"name":    "user2",
+					"email":   "user2@email.com",
+					"api_key": "USER2KEY",
+					"roles":   []string{"editor"},
+				},
+			}})
+	c.Insert(
+		bson.M{"id": "6ac7d684-1f8e-4a02-a502-720e8f11e50d",
+			"info": bson.M{
+				"name":    "AVENGERS",
+				"email":   "email@something2",
+				"website": "www.gotg.com",
+				"created": "2015-10-20 02:08:04",
+				"updated": "2015-10-20 02:08:04"},
+			"db_conf": []bson.M{
+
+				bson.M{
+					// "store":    "ar",
+					"server":   suite.tenantDbConf.Host,
+					"port":     suite.tenantDbConf.Port,
+					"database": suite.tenantDbConf.Db,
+					"username": suite.tenantDbConf.Username,
+					"password": suite.tenantDbConf.Password,
+				},
+				bson.M{
+					"server":   suite.tenantDbConf.Host,
+					"port":     suite.tenantDbConf.Port,
+					"database": suite.tenantDbConf.Db,
+				},
+			},
+			"users": []bson.M{
+
+				bson.M{
+					"name":    "user3",
+					"email":   "user3@email.com",
+					"api_key": suite.clientkey,
+					"roles":   []string{"editor"},
+				},
+				bson.M{
+					"name":    "user4",
+					"email":   "user4@email.com",
+					"api_key": "VIEWERKEY",
+					"roles":   []string{"viewer"},
+				},
+			}})
+
+	c = session.DB(suite.cfg.MongoDB.Db).C("roles")
+	c.Insert(
+		bson.M{
+			"resource": "feeds.topo.get",
+			"roles":    []string{"editor", "viewer"},
+		})
+	c.Insert(
+		bson.M{
+			"resource": "feeds.topo.update",
+			"roles":    []string{"editor"},
+		})
+
+	// Seed database with feeds
+	c = session.DB(suite.tenantDbConf.Db).C("feeds_topology")
+	c.Insert(
+		bson.M{
+			"type":          "gocdb",
+			"feed_url":      "https://somewhere.foo.bar/topology/feed",
+			"paginated":     "true",
+			"fetch_type":    []string{"item1", "item2"},
+			"uid_endpoints": "endpointA",
+		})
+
+}
+
+func (suite *FeedsTestSuite) TestUpdateFeedTopo() {
+
+	jsonInput := `
+  {
+   "type": "gocdb",
+   "feed_url": "https://somewhere2.foo.bar/topology/feed",
+   "paginated": "true",
+   "fetch_type": [
+    "item4",
+    "item5"
+   ],
+   "uid_endpoints": "endpointA"
+  }
+`
+
+	jsonOutput := `{
+ "status": {
+  "message": "Feeds resource succesfully updated",
+  "code": "200"
+ },
+ "data": [
+  {
+   "type": "gocdb",
+   "feed_url": "https://somewhere2.foo.bar/topology/feed",
+   "paginated": "true",
+   "fetch_type": [
+    "item4",
+    "item5"
+   ],
+   "uid_endpoints": "endpointA"
+  }
+ ]
+}`
+
+	request, _ := http.NewRequest("PUT", "/api/v2/feeds/topology", strings.NewReader(jsonInput))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code := response.Code
+	output := response.Body.String()
+
+	// Check that we must have a 200 ok code
+	suite.Equal(200, code, "Internal Server Error")
+	// Compare the expected and actual json response
+	suite.Equal(jsonOutput, output, "Response body mismatch")
+}
+
+func (suite *FeedsTestSuite) TestListTopo() {
+
+	request, _ := http.NewRequest("GET", "/api/v2/feeds/topology", strings.NewReader(""))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code := response.Code
+	output := response.Body.String()
+
+	feedsTopoJSON := `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "type": "gocdb",
+   "feed_url": "https://somewhere.foo.bar/topology/feed",
+   "paginated": "true",
+   "fetch_type": [
+    "item1",
+    "item2"
+   ],
+   "uid_endpoints": "endpointA"
+  }
+ ]
+}`
+	// Check that we must have a 200 ok code
+	suite.Equal(200, code, "Internal Server Error")
+	// Compare the expected and actual json response
+	suite.Equal(feedsTopoJSON, output, "Response body mismatch")
+
+}
+
+//TearDownTest to tear down every test
+func (suite *FeedsTestSuite) TearDownSuite() {
+
+	session, err := mgo.Dial(suite.cfg.MongoDB.Host)
+	if err != nil {
+		panic(err)
+	}
+	session.DB(suite.tenantDbConf.Db).DropDatabase()
+	session.DB(suite.cfg.MongoDB.Db).DropDatabase()
+}
+
+func TestFeedsTestSuite(t *testing.T) {
+	suite.Run(t, new(FeedsTestSuite))
+}

--- a/app/feeds/model.go
+++ b/app/feeds/model.go
@@ -1,0 +1,10 @@
+package feeds
+
+//FeedsTopo holds a list of topology feed parameters
+type FeedsTopo struct {
+	TopoType     string   `bson:"type" json:"type"`
+	FeedURL      string   `bson:"feed_url" json:"feed_url"`
+	Paginated    string   `bson:"paginated" json:"paginated"`
+	FetchType    []string `bson:"fetch_type" json:"fetch_type"`
+	UIDendpoints string   `bson:"uid_endpoints" json:"uid_endpoints"`
+}

--- a/app/feeds/routing.go
+++ b/app/feeds/routing.go
@@ -1,0 +1,20 @@
+package feeds
+
+import (
+	"github.com/ARGOeu/argo-web-api/respond"
+	"github.com/gorilla/mux"
+)
+
+// HandleSubrouter uses the subrouter for a specific calls and creates a tree of sorts
+// handling each route with a different subrouter
+func HandleSubrouter(s *mux.Router, confhandler *respond.ConfHandler) {
+
+	s = respond.PrepAppRoutes(s, confhandler, appRoutesV2)
+
+}
+
+var appRoutesV2 = []respond.AppRoutes{
+	{Name: "feeds.topo.update", Verb: "PUT", Path: "/feeds/topology", SubrouterHandler: UpdateTopo},
+	{Name: "feeds.topo.get", Verb: "GET", Path: "/feeds/topology", SubrouterHandler: ListTopo},
+	{Name: "feeds.topo.options", Verb: "OPTIONS", Path: "/feeds/topology", SubrouterHandler: Options},
+}

--- a/app/feeds/view.go
+++ b/app/feeds/view.go
@@ -1,0 +1,37 @@
+package feeds
+
+import (
+	"encoding/json"
+	"strconv"
+
+	"github.com/ARGOeu/argo-web-api/respond"
+)
+
+// createListView constructs the list response template and exports it as json
+func createListView(results []FeedsTopo, msg string, code int) ([]byte, error) {
+
+	docRoot := &respond.ResponseMessage{
+		Status: respond.StatusResponse{
+			Message: msg,
+			Code:    strconv.Itoa(code),
+		},
+	}
+	docRoot.Data = results
+
+	output, err := json.MarshalIndent(docRoot, "", " ")
+	return output, err
+
+}
+
+// createMsgView constructs a simple message response without data
+func createMsgView(msg string, code int) ([]byte, error) {
+	docRoot := &respond.ResponseMessage{
+		Status: respond.StatusResponse{
+			Message: msg,
+			Code:    strconv.Itoa(code),
+		},
+	}
+
+	output, err := json.MarshalIndent(docRoot, "", " ")
+	return output, err
+}

--- a/doc/v2/docs/feeds.md
+++ b/doc/v2/docs/feeds.md
@@ -1,0 +1,124 @@
+---
+title: "API documentation | ARGO"
+page_title: API - Feeds requests
+font_title: fa fa-cogs
+description: API Calls for listing existing and updating feeds resource
+---
+
+# API Calls
+
+| Name                                  | Description                                                                     | Shortcut           |
+| ------------------------------------- | ------------------------------------------------------------------------------- | ------------------ |
+| GET: Feed Topology information   | This method can be used to retrieve a list of feed topology parameters         | [ Description](#1) |
+| PUT: Update feed topology info | This method can be used to update feed topology information parameters | [ Description](#2) |
+
+<a id='1'></a>
+
+## [GET]: List Feed topology parameters
+
+This method can be used to retrieve a list of feed topology parameters
+
+### Input
+
+```
+GET /feeds/topology
+```
+
+
+### Request headers
+
+```
+x-api-key: shared_key_value
+Accept: application/json
+```
+
+### Response
+
+Headers: `Status: 200 OK`
+
+#### Response body
+
+Json Response
+
+```json
+{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "type": "gocdb",
+   "feed_url": "https://somewhere.foo.bar/topology/feed",
+   "paginated": "true",
+   "fetch_type": [
+    "item1",
+    "item2"
+   ],
+   "uid_endpoints": "endpointA"
+  }
+ ]
+}
+```
+
+<a id='2'></a>
+
+## [PUT]: Update topology feed parameters
+This method is used to upadte topology feed parameters
+
+### Input
+
+```
+PUT /feeds/topology
+```
+
+#### PUT BODY
+```json
+  {
+   "type": "gocdb",
+   "feed_url": "https://somewhere.foo.bar/topology/feed",
+   "paginated": "true",
+   "fetch_type": [
+    "item1",
+    "item2"
+   ],
+   "uid_endpoints": "endpointA"
+  }
+```
+
+#### Request headers
+
+```
+x-api-key: shared_key_value
+Accept: application/json
+```
+
+### Response
+
+Headers: `Status: 200 OK`
+
+#### Response body
+
+Json Response
+
+```json
+{
+ "status": {
+  "message": "Feeds resource succesfully updated",
+  "code": "200"
+ },
+ "data": [
+  {
+   "type": "gocdb",
+   "feed_url": "https://somewhere2.foo.bar/topology/feed",
+   "paginated": "true",
+   "fetch_type": [
+    "item4",
+    "item5"
+   ],
+   "uid_endpoints": "endpointA"
+  }
+ ]
+}
+```
+

--- a/doc/v2/mkdocs.yml
+++ b/doc/v2/mkdocs.yml
@@ -23,5 +23,6 @@ pages:
     - Topology Endpoints: topology_endpoints.md
     - Topology Groups: topology_groups.md
     - Weights resource: weights.md
+    - Feeds resource: feeds.md
 
 theme: readthedocs

--- a/routing/routes.go
+++ b/routing/routes.go
@@ -26,6 +26,7 @@ import (
 	"github.com/ARGOeu/argo-web-api/app/aggregationProfiles"
 	"github.com/ARGOeu/argo-web-api/app/downtimes"
 	"github.com/ARGOeu/argo-web-api/app/factors"
+	"github.com/ARGOeu/argo-web-api/app/feeds"
 	"github.com/ARGOeu/argo-web-api/app/latest"
 	"github.com/ARGOeu/argo-web-api/app/metricProfiles"
 	"github.com/ARGOeu/argo-web-api/app/metricResult"
@@ -48,6 +49,7 @@ import (
 
 var routesV2 = []RouteV2{
 
+	{"Feeds", "/feeds", feeds.HandleSubrouter},
 	{"Topology", "/topology", topology.HandleSubrouter},
 	{"Latest", "/latest", latest.HandleSubrouter},
 	{"Results", "/results", results.HandleSubrouter},

--- a/scripts/mongodb/populate_default_roles.js
+++ b/scripts/mongodb/populate_default_roles.js
@@ -180,6 +180,14 @@ function populate_default_roles() {
         {
             resource: "topology_groups_report.list",
             roles: ["admin", "editor"]
+        },
+        {
+            resource: "feeds.topo.list",
+            roles: ["admin", "editor"]
+        },
+        {
+            resource: "feeds.topo.update",
+            roles: ["admin", "editor"]
         }
     ]);
     print("INFO\tPolulated default roles in 'roles' collection");


### PR DESCRIPTION
Give tha ability to argo-web-api to store and serve information about topology feeds in the following path
`/api/v2/feeds/topoloy`

Give the ability to
- Update feed topology with HTTP PUT
- Get feed topology with HTTP GET

Feed topology information body in json:
```
  {
   "type": "gocdb",
   "feed_url": "https://somewhere.foo.bar/topology/feed",
   "paginated": "true",
   "fetch_type": [
    "item1",
    "item2"
   ],
   "uid_endpoints": "endpointA"
  }
```