### PR TITLE
ARGO-2572 Fix feeds routing issue

### DIFF
--- a/app/feeds/feeds_test.go
+++ b/app/feeds/feeds_test.go
@@ -61,7 +61,7 @@ func (suite *FeedsTestSuite) SetupSuite() {
 	suite.clientkey = "123456"
 
 	suite.confHandler = respond.ConfHandler{Config: suite.cfg}
-	suite.router = mux.NewRouter().StrictSlash(false).PathPrefix("/api/v2").Subrouter()
+	suite.router = mux.NewRouter().StrictSlash(false).PathPrefix("/api/v2/feeds").Subrouter()
 	HandleSubrouter(suite.router, &suite.confHandler)
 }
 

--- a/app/feeds/routing.go
+++ b/app/feeds/routing.go
@@ -14,7 +14,7 @@ func HandleSubrouter(s *mux.Router, confhandler *respond.ConfHandler) {
 }
 
 var appRoutesV2 = []respond.AppRoutes{
-	{Name: "feeds.topo.update", Verb: "PUT", Path: "/feeds/topology", SubrouterHandler: UpdateTopo},
-	{Name: "feeds.topo.get", Verb: "GET", Path: "/feeds/topology", SubrouterHandler: ListTopo},
-	{Name: "feeds.topo.options", Verb: "OPTIONS", Path: "/feeds/topology", SubrouterHandler: Options},
+	{Name: "feeds.topo.update", Verb: "PUT", Path: "/topology", SubrouterHandler: UpdateTopo},
+	{Name: "feeds.topo.get", Verb: "GET", Path: "/topology", SubrouterHandler: ListTopo},
+	{Name: "feeds.topo.options", Verb: "OPTIONS", Path: "/topology", SubrouterHandler: Options},
 }


### PR DESCRIPTION
Feeds module has the prefix '/feeds/ both declared in the main router and in the modules sub-router resulting in a path such as /api/v2/feeds/feeds/. Remove /feeds prefix from sub-router to resolve the issue