### PR TITLE
ARGO-2473 Tenant create user

### DIFF
--- a/app/statusEndpoints/statusEndpoints_test.go
+++ b/app/statusEndpoints/statusEndpoints_test.go
@@ -23,7 +23,6 @@
 package statusEndpoints
 
 import (
-	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -783,7 +782,6 @@ func (suite *StatusEndpointsTestSuite) TestMultipleItems() {
 	suite.Equal(200, response.Code, "Internal Server Error")
 	// Compare the expected and actual xml response
 	suite.Equal(respJSON1, response.Body.String(), "Response body mismatch")
-	fmt.Println(response.Body.String())
 
 }
 

--- a/app/statusFlatEndpoints/statusFlatEndpoints_test.go
+++ b/app/statusFlatEndpoints/statusFlatEndpoints_test.go
@@ -71,7 +71,7 @@ func (suite *StatusEndpointsTestSuite) SetupTest() {
     [mongodb]
     host = "127.0.0.1"
     port = 27017
-    db = "argotest_endpoints"
+    db = "argotest_flatendpoints"
 `
 
 	_ = gcfg.ReadStringInto(&suite.cfg, testConfig)
@@ -110,7 +110,7 @@ func (suite *StatusEndpointsTestSuite) SetupTest() {
 				"store":    "main",
 				"server":   "localhost",
 				"port":     27017,
-				"database": "argotest_endpoints_egi",
+				"database": "argotest_flatendpoints_egi",
 				"username": "",
 				"password": ""},
 		},
@@ -135,7 +135,7 @@ func (suite *StatusEndpointsTestSuite) SetupTest() {
 				"store":    "main",
 				"server":   "localhost",
 				"port":     27017,
-				"database": "argotest_endpoints_eudat",
+				"database": "argotest_flatendpoints_eudat",
 				"username": "",
 				"password": ""},
 		},
@@ -814,9 +814,9 @@ func (suite *StatusEndpointsTestSuite) TearDownTest() {
 
 	session, _ := mongo.OpenSession(suite.cfg.MongoDB)
 
-	session.DB("argotest_endpoints").DropDatabase()
-	session.DB("argotest_endpoints_eudat").DropDatabase()
-	session.DB("argotest_endpoints_egi").DropDatabase()
+	session.DB("argotest_flatendpoints").DropDatabase()
+	session.DB("argotest_flatendpoints_eudat").DropDatabase()
+	session.DB("argotest_flatendpoints_egi").DropDatabase()
 }
 
 // This is the first function called when go test is issued

--- a/app/tenants/routing.go
+++ b/app/tenants/routing.go
@@ -41,8 +41,10 @@ var appRoutesV2 = []respond.AppRoutes{
 	{"tenants.get", "GET", "/tenants/{ID}", ListOne},
 	{"tenants.create", "POST", "/tenants", Create},
 	{"tenants.update_status", "PUT", "/tenants/{ID}/status", UpdateStatus},
+	{"tenants.create_user", "POST", "/tenants/{ID}/users", CreateUser},
 	{"tenants.update", "PUT", "/tenants/{ID}", Update},
 	{"tenants.delete", "DELETE", "/tenants/{ID}", Delete},
 	{"tenants.options", "OPTIONS", "/tenants", Options},
 	{"tenants.options", "OPTIONS", "/tenants/{ID}", Options},
+	{"tenants.options", "OPTIONS", "/tenants/{ID}/users", Options},
 }

--- a/app/tenants/view.go
+++ b/app/tenants/view.go
@@ -108,6 +108,23 @@ func createRefView(inserted Tenant, msg string, code int, r *http.Request) ([]by
 	return output, err
 }
 
+// createUserRefView constructs self-reference response for user objects and exports it as json
+func createUserRefView(inserted TenantUser, msg string, code int, r *http.Request) ([]byte, error) {
+	docRoot := &respond.ResponseMessage{
+		Status: respond.StatusResponse{
+			Message: msg,
+			Code:    strconv.Itoa(code),
+		},
+		Data: SelfReference{
+			ID:    inserted.ID,
+			Links: Links{Self: "https://" + r.Host + r.URL.Path + "/" + inserted.ID},
+		},
+	}
+
+	output, err := json.MarshalIndent(docRoot, "", " ")
+	return output, err
+}
+
 // createMsgView constructs a simple message response without data
 func createMsgView(msg string, code int) ([]byte, error) {
 	docRoot := &respond.ResponseMessage{

--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -2,7 +2,7 @@ swagger: '2.0'
 info:
   title: ARGO web api
   description: "ARGO is a lightweight service for Service Level Monitoring designed for medium and large sized e-Infrastructures. This swagger UI interface provides access to the ARGO web api, which in turn can be used for either retrieving Availability/Reliability and status results or for defining profiles and reports that should be used within the SLM computations. The ARGO web api is multitenant and can hence be used by multiple e-Infrastructure providers. To list, add, update or remove tenants use the Tenants resource below. Under all other resources use per given tenant the corresponding api key."
-  version: 1.6.3
+  version: 1.9.1
   contact:
     name: ARGO Developers
     url: http://argoeu.github.io/
@@ -310,6 +310,56 @@ paths:
             $ref: '#/definitions/Status_error'
         '404':
           description: Item not found
+          schema:
+            $ref: '#/definitions/Status_error'
+        '406':
+          description: Content Not acceptable
+          schema:
+            $ref: '#/definitions/Status_error'
+        '422':
+          description: Validation Error
+          schema:
+            $ref: '#/definitions/Status_error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Status_error'
+            
+  /admin/tenants/{TENANT_ID}/users:
+    post:
+      summary: Create a new user on existing tenant
+      operationId: tenants.CreateUser
+      description: Create a new user on existing tenant
+      tags:
+        - Tenants
+      consumes:
+        - "application/json"
+      produces:
+        - "application/json"
+      parameters:
+        - $ref: "#/parameters/apiKey"
+        - name: "TENANT_ID"
+          in: "path"
+          description: "id of the tenant"
+          required: true
+          type: string
+        - name: "user"
+          in: "body"
+          description: "Json description of the user to be created"
+          required: true
+          schema:
+            $ref: '#/definitions/User'
+      responses:
+        '201':
+          description: User Created
+          schema:
+            $ref: '#/definitions/Self_reference'
+        '400':
+          description: Bad request due to malformed JSON in post body
+          schema:
+            $ref: '#/definitions/Status_error'
+        '401':
+          description: Unauthorized user
           schema:
             $ref: '#/definitions/Status_error'
         '406':
@@ -2112,7 +2162,6 @@ paths:
         - $ref: "#/parameters/apiKey"
         - $ref: "#/parameters/reportName"
         - $ref: "#/parameters/lgroupType"
-        - $ref: "#/parameters/lgroupName"
         - $ref: "#/parameters/latestDate"
         - $ref: "#/parameters/latestFilter"
         - $ref: "#/parameters/latestLimit"

--- a/scripts/mongodb/populate_default_roles.js
+++ b/scripts/mongodb/populate_default_roles.js
@@ -129,6 +129,7 @@ function populate_default_roles() {
             roles: ["super_admin", "super_admin_restricted", "super_admin_ui"]
         },
         { resource: "tenants.update_status", roles: ["super_admin"] },
+        { resource: "tenants.create_user", roles: ["super_admin"] },
         {
             resource: "metricResult.get",
             roles: ["admin", "editor", "viewer", "admin_ui"]

--- a/website/docs/tenants.md
+++ b/website/docs/tenants.md
@@ -14,6 +14,9 @@ title: Tenants
 | DELETE: Delete a tenant               | This method can be used to delete an existing tenant                                   | [ Description](#5) |
 | GET: Get a tenant's arg engine status | This method can be used to get status for a specific tenant                            | [ Description](#6) |
 | PUT: Update a tenant's engine status  | This method can be used to update argo engine status information for a specific tenant | [ Description](#7) |
+| POST: Create tenant user  | This method can be used to add a new user to existing tenant| [ Description](#8) |
+
+
 
 <a id='1'></a>
 
@@ -799,5 +802,59 @@ Json Response
         "message": "Tenant successfully updated",
         "code": "200"
     }
+}
+```
+
+<a id='8'></a>
+
+## [POST]: Create new user 
+
+This method can be used to create a new user on existing tenant
+
+### Input
+
+```
+POST /admin/tenants/{ID}/users
+```
+
+#### Request headers
+
+```
+x-api-key: shared_key_value
+Accept: application/json
+```
+
+#### PUT BODY
+
+```json
+  {
+    "name":"new_user",
+    "email":"new_user@email.com",
+    "roles": [
+        "admin"
+    ]
+  }`
+```
+
+### Response
+
+Headers: `Status: 201 OK`
+
+#### Response body
+
+Json Response
+
+```json
+{
+ "status": {
+  "message": "User was successfully created",
+  "code": "201"
+ },
+ "data": {
+  "id": "1cb883eb-8b40-428d-bce6-8ec23a9f3ca8",
+  "links": {
+   "self": "https:///api/v2/admin/tenants/6ac7d684-1f8e-4a02-a502-720e8f11e50b/users/1cb883eb-8b40-428d-bce6-8ec23a9f3ca8"
+  }
+ }
 }
 ```


### PR DESCRIPTION
Add a new web-api call to quick add a new user to an existing tenant:

`POST /api/v2/tenants/{tenant_id}/users`

With the following body:

```json
  {
    "name":"new_user",
    "email":"new_user@email.com",
    "roles": [
        "admin"
    ]
  }`
```

Implementation:
- [x] Add CreateUser method in package tenants
- [x] Update tests and docs

Extras:
- [x] Minor fixes in test temporary db names that caused issues during high parallelism testing