### PR TITLE
ARGO-2651 Remove name,id namespacing from daily downtimes

### DIFF
--- a/app/downtimes/model.go
+++ b/app/downtimes/model.go
@@ -2,10 +2,8 @@ package downtimes
 
 //Downtimes holds a list of downtimes for endpoints for a specific day
 type Downtimes struct {
-	ID        string     `bson:"id" json:"id"`
 	DateInt   int        `bson:"date_integer" json:"-"`
 	Date      string     `bson:"date" json:"date"`
-	Name      string     `bson:"name" json:"name"`
 	Endpoints []Downtime `bson:"endpoints" json:"endpoints"`
 }
 
@@ -15,12 +13,6 @@ type Downtime struct {
 	Service   string `bson:"service" json:"service"`
 	StartTime string `bson:"start_time" json:"start_time"`
 	EndTime   string `bson:"end_time" json:"end_time"`
-}
-
-// SelfReference to hold links and id
-type SelfReference struct {
-	ID    string `json:"id" bson:"id,omitempty"`
-	Links Links  `json:"links"`
 }
 
 // Links struct to hold links

--- a/app/downtimes/routing.go
+++ b/app/downtimes/routing.go
@@ -15,10 +15,7 @@ func HandleSubrouter(s *mux.Router, confhandler *respond.ConfHandler) {
 
 var appRoutesV2 = []respond.AppRoutes{
 	{Name: "downtimes.create", Verb: "POST", Path: "/downtimes", SubrouterHandler: Create},
-	{Name: "downtimes.update", Verb: "PUT", Path: "/downtimes/{ID}", SubrouterHandler: Update},
 	{Name: "downtimes.list", Verb: "GET", Path: "/downtimes", SubrouterHandler: List},
-	{Name: "downtimes.get", Verb: "GET", Path: "/downtimes/{ID}", SubrouterHandler: ListOne},
-	{Name: "downtimes.delete", Verb: "DELETE", Path: "/downtimes/{ID}", SubrouterHandler: Delete},
+	{Name: "downtimes.delete", Verb: "DELETE", Path: "/downtimes", SubrouterHandler: Delete},
 	{Name: "downtimes.options", Verb: "OPTIONS", Path: "/downtimes", SubrouterHandler: Options},
-	{Name: "downtimes.options", Verb: "OPTIONS", Path: "/downtimes/{ID}", SubrouterHandler: Options},
 }

--- a/app/downtimes/view.go
+++ b/app/downtimes/view.go
@@ -2,27 +2,10 @@ package downtimes
 
 import (
 	"encoding/json"
-	"net/http"
 	"strconv"
 
 	"github.com/ARGOeu/argo-web-api/respond"
 )
-
-func createRefView(inserted Downtimes, msg string, code int, r *http.Request) ([]byte, error) {
-	docRoot := &respond.ResponseMessage{
-		Status: respond.StatusResponse{
-			Message: msg,
-			Code:    strconv.Itoa(code),
-		},
-		Data: SelfReference{
-			ID:    inserted.ID,
-			Links: Links{Self: "https://" + r.Host + r.URL.Path + "/" + inserted.ID},
-		},
-	}
-
-	output, err := json.MarshalIndent(docRoot, "", " ")
-	return output, err
-}
 
 // createListView constructs the list response template and exports it as json
 func createListView(results []Downtimes, msg string, code int) ([]byte, error) {

--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -1627,131 +1627,12 @@ paths:
           schema:
             $ref: '#/definitions/Status_error'
             
-  /downtimes/{PROFILE_ID}:
-    get:
-      summary: List a specific downtimes resource
-      operationId: downtimes.ListOne
-      description: List one specific downtimes resource targeted by it's unique id
-      tags:
-        - Downtimes
-      produces:
-        - "application/json"
-      parameters:
-        - $ref: "#/parameters/apiKey"
-        - name: "PROFILE_ID"
-          in: "path"
-          description: "id of the downtimes resource"
-          required: true
-          type: string
-      responses:
-        '200':
-          description: A list with a downtimes resource
-          schema:
-            $ref: '#/definitions/Downtimes_list'
-        '401':
-          description: Unauthorized user
-          schema:
-            $ref: '#/definitions/Status_error'
-        '404':
-          description: Item not found
-          schema:
-            $ref: '#/definitions/Status_error'
-        '406':
-          description: Content Not acceptable
-          schema:
-            $ref: '#/definitions/Status_error'
-        default:
-          description: Unexpected error
-          schema:
-            $ref: '#/definitions/Status_error'
-    put:
-      summary: update an existing downtimes resource
-      operationId: downtimes.Update
-      description: update information on a specific downtimes resource which is targeted by it's unique id
-      tags:
-        - Downtimes
-      consumes:
-        - "application/json"
-      produces:
-        - "application/json"
-      parameters:
-        - $ref: "#/parameters/apiKey"
-        - name: "PROFILE_ID"
-          in: "path"
-          description: "id of the downtimes resource"
-          required: true
-          type: string
-        - name: "weights_resource"
-          in: "body"
-          description: "Json description of the dowtimes resource to be updated"
-          required: true
-          schema:
-            $ref: '#/definitions/Weights'
-      responses:
-        '201':
-          description: Downtimes resource Updated
-          schema:
-            $ref: '#/definitions/Status'
-        '400':
-          description: Bad request due to malformed JSON in put body
-          schema:
-            $ref: '#/definitions/Status_error'
-        '401':
-          description: Unauthorized user
-          schema:
-            $ref: '#/definitions/Status_error'
-        '404':
-          description: Item not found
-          schema:
-            $ref: '#/definitions/Status_error'
-        '406':
-          description: Content Not acceptable
-          schema:
-            $ref: '#/definitions/Status_error'
-        default:
-          description: Unexpected error
-          schema:
-            $ref: '#/definitions/Status_error'
-    delete:
-      summary: Delete a downtimes resource
-      operationId: downtimes.Delete
-      description: Delete a specific downtimes resource which is targeted by it's unique id
-      tags:
-        - Downtimes
-      produces:
-        - "application/json"
-      parameters:
-        - $ref: "#/parameters/apiKey"
-        - name: "PROFILE_ID"
-          in: "path"
-          description: "id of the downtimes resource"
-          required: true
-          type: string
-      responses:
-        '200':
-          description: Downtimes resource deleted
-          schema:
-            $ref: '#/definitions/Status'
-        '401':
-          description: Unauthorized user
-          schema:
-            $ref: '#/definitions/Status_error'
-        '404':
-          description: Item not found
-          schema:
-            $ref: '#/definitions/Status_error'
-        '406':
-          description: Content Not acceptable
-          schema:
-            $ref: '#/definitions/Status_error'
-        default:
-          description: Unexpected error
-          schema:
-            $ref: '#/definitions/Status_error'
+
+    
 
   /downtimes:
     get:
-      summary: List all downtimes resource
+      summary: List all downtimes resources for specific name
       operationId: downtimes.List
       description: List available downtimes resources
       tags:
@@ -1760,6 +1641,7 @@ paths:
         - "application/json"
       parameters:
         - $ref: "#/parameters/apiKey"
+        - $ref: "#/parameters/profDate"
       responses:
         '200':
           description: A list of downtimes resources
@@ -1793,8 +1675,9 @@ paths:
           description: "Json description of the downtimes resource to be created"
           required: true
           schema:
-            $ref: '#/definitions/Weights'
+            $ref: '#/definitions/Downtimes'
         - $ref: "#/parameters/apiKey"
+        - $ref: "#/parameters/profDate"
       responses:
         '200':
           description: Downtimes resource Created
@@ -1806,6 +1689,39 @@ paths:
             $ref: '#/definitions/Status_error'
         '401':
           description: Unauthorized user
+          schema:
+            $ref: '#/definitions/Status_error'
+        '406':
+          description: Content Not acceptable
+          schema:
+            $ref: '#/definitions/Status_error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Status_error'
+    delete:
+      summary: Delete a downtimes resource
+      operationId: downtimes.Delete
+      description: Delete a specific downtimes resource which is targeted by it's unique id
+      tags:
+        - Downtimes
+      produces:
+        - "application/json"
+      parameters:
+        - $ref: "#/parameters/apiKey"
+        - $ref: "#/parameters/profDate"
+
+      responses:
+        '200':
+          description: Downtimes resource deleted
+          schema:
+            $ref: '#/definitions/Status'
+        '401':
+          description: Unauthorized user
+          schema:
+            $ref: '#/definitions/Status_error'
+        '404':
+          description: Item not found
           schema:
             $ref: '#/definitions/Status_error'
         '406':
@@ -4756,9 +4672,7 @@ definitions:
   Downtimes:
     type: object
     properties:
-      id:
-        type: string
-      name:
+      date:
         type: string
       endpoints:
         type: array

--- a/scripts/mongodb/populate_default_roles.js
+++ b/scripts/mongodb/populate_default_roles.js
@@ -198,6 +198,18 @@ function populate_default_roles() {
         {
             resource: "issues.list_endpoints",
             roles: ["admin", "editor", "viewer"]
+        },
+        {
+            resource: "downtimes.list",
+            roles: ["admin", "editor", "viewer"]
+        },
+        {
+            resource: "downtimes.delete",
+            roles: ["admin", "editor"]
+        },
+        {
+            resource: "downtimes.create",
+            roles: ["admin", "editor"]
         }
     ]);
     print("INFO\tPolulated default roles in 'roles' collection");

--- a/website/docs/downtimes.md
+++ b/website/docs/downtimes.md
@@ -7,29 +7,26 @@ title: Downtimes
 
 | Name                                    | Description                                                                       | Shortcut           |
 | --------------------------------------- | --------------------------------------------------------------------------------- | ------------------ |
-| GET: List Downtimes resources Request   | This method can be used to retrieve a list of current downtime resources.         | [ Description](#1) |
-| GET: List a specific Downtimes resource | This method can be used to retrieve a specific downtime resource based on its id. | [ Description](#2) |
-| POST: Create a new downtime resource    | This method can be used to create a new downtime resource                         | [ Description](#3) |
-| PUT: Update a downtime resource         | This method can be used to update information on an existing downtime resource    | [ Description](#4) |
-| DELETE: Delete a downtime resource      | This method can be used to delete an existing downtime resource                   | [ Description](#5) |
+| GET: List Downtimes resources Request   | This method can be used to retrieve a list of current downtime resources per date.         | [ Description](#1) |
+| POST: Create a new downtime resource    | This method can be used to create a new downtime resource                         | [ Description](#2) |
+| DELETE: Delete a downtime resource      | This method can be used to delete an existing downtime resource                   | [ Description](#3) |
 
 <a id='1'></a>
 
 ## [GET]: List downtime resources
 
-This method can be used to retrieve a list of current downtime resources
+This method can be used to retrieve a list of current downtime resources per date
 
 ### Input
 
 ```
-GET /downtimes
+GET /downtimes?date=YYYY-MM-DD
 ```
 
 #### Optional Query Parameters
 
 | Type   | Description                                                                                                                               | Required |
-| ------ | ----------------------------------------------------------------------------------------------------------------------------------------- | -------- |
-| `name` | downtime resource name to be used as query                                                                                                | NO       |
+| ------ | ----------------------------------------------------------------------------------------------------------------------------------------- | --------                                                                                           | NO       |
 | `date` | Date to retrieve a historic version of the downtime resource. If no date parameter is provided the most current resource will be returned | NO       |
 
 ### Request headers
@@ -55,9 +52,7 @@ Json Response
     },
     "data": [
         {
-            "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50b",
             "date": "2019-11-04",
-            "name": "Critical",
             "endpoints": [
                 {
                     "hostname": "host-A",
@@ -78,100 +73,14 @@ Json Response
                     "end_time": "2019-10-11T22:15:00Z"
                 }
             ]
-        },
-        {
-            "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50c",
-            "date": "2019-11-02",
-            "name": "NonCritical",
-            "endpoints": [
-                {
-                    "hostname": "host-01",
-                    "service": "service-01",
-                    "start_time": "2019-10-11T02:00:33Z",
-                    "end_time": "2019-10-11T23:33:00Z"
-                },
-                {
-                    "hostname": "host-02",
-                    "service": "service-02",
-                    "start_time": "2019-10-11T16:00:33Z",
-                    "end_time": "2019-10-11T16:45:00Z"
-                }
-            ]
         }
     ]
 }
 ```
+
+
 
 <a id='2'></a>
-
-## [GET]: List A Specific downtime resource
-
-This method can be used to retrieve specific downtime resource based on its id
-
-### Input
-
-```
-GET /downtimes/{ID}
-```
-
-#### Optional Query Parameters
-
-| Type   | Description                                                                                                                                        | Required |
-| ------ | -------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
-| `date` | Date to retrieve a historic version of the downtime resource. If no date parameter is provided the most current downtime resource will be returned | NO       |
-
-#### Request headers
-
-```
-x-api-key: shared_key_value
-Accept: application/json
-```
-
-### Response
-
-Headers: `Status: 200 OK`
-
-#### Response body
-
-Json Response
-
-```json
-{
-    "status": {
-        "message": "Success",
-        "code": "200"
-    },
-    "data": [
-        {
-            "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50b",
-            "date": "2019-11-04",
-            "name": "Critical",
-            "endpoints": [
-                {
-                    "hostname": "host-A",
-                    "service": "service-A",
-                    "start_time": "2019-10-11T04:00:33Z",
-                    "end_time": "2019-10-11T15:33:00Z"
-                },
-                {
-                    "hostname": "host-B",
-                    "service": "service-B",
-                    "start_time": "2019-10-11T12:00:33Z",
-                    "end_time": "2019-10-11T12:33:00Z"
-                },
-                {
-                    "hostname": "host-C",
-                    "service": "service-C",
-                    "start_time": "2019-10-11T20:00:33Z",
-                    "end_time": "2019-10-11T22:15:00Z"
-                }
-            ]
-        }
-    ]
-}
-```
-
-<a id='3'></a>
 
 ## [POST]: Create a new downtime resource
 
@@ -180,7 +89,7 @@ This method can be used to insert a new downtime resource
 ### Input
 
 ```
-POST /downtimes
+POST /downtimes?date=YYYY-MM-DD
 ```
 
 #### Optional Query Parameters
@@ -200,7 +109,6 @@ Accept: application/json
 
 ```json
 {
-    "name": "downtimes_set",
     "endpoints": [
         {
             "hostname": "host-foo",
@@ -228,90 +136,14 @@ Json Response
 
 ```json
 {
-    "status": {
-        "message": "Downtimes resource succesfully created",
-        "code": "201"
-    },
-    "data": {
-        "id": "{{id}}",
-        "links": {
-            "self": "https:///api/v2/downtimes/{{id}}"
-        }
-    }
+ "status": {
+  "message": "Downtimes set created for date: 2019-11-29",
+  "code": "201"
+ }
 }
 ```
 
-<a id='4'></a>
-
-## [PUT]: Update information on an existing downtime resource
-
-This method can be used to update information on an existing downtime resource
-
-### Input
-
-```
-PUT /downtimes/{ID}
-```
-
-#### Optional Query Parameters
-
-| Type   | Description                                                                                                                                  | Required |
-| ------ | -------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
-| `date` | Date to update a historic version of the downtime resource. If no date parameter is provided the current date will be supplied automatically | NO       |
-
-#### Request headers
-
-```
-x-api-key: shared_key_value
-Accept: application/json
-```
-
-#### PUT BODY
-
-```json
-{
-    "name": "downtimes_set",
-    "endpoints": [
-        {
-            "hostname": "updated-host-foo",
-            "service": "service-new-foo",
-            "start_time": "2019-10-11T23:10:00Z",
-            "end_time": "2019-10-11T23:25:00Z"
-        },
-        {
-            "hostname": "updated-host-bar",
-            "service": "service-new-bar",
-            "start_time": "2019-10-11T23:40:00Z",
-            "end_time": "2019-10-11T23:55:00Z"
-        }
-    ]
-}
-```
-
-### Response
-
-Headers: `Status: 200 OK`
-
-#### Response body
-
-Json Response
-
-```json
-{
-    "status": {
-        "message": "Downtimes resource successfully updated",
-        "code": "200"
-    },
-    "data": {
-        "id": "{{ID}}",
-        "links": {
-            "self": "https:///api/v2/downtimes/{{ID}}"
-        }
-    }
-}
-```
-
-<a id='5'></a>
+<a id='3'></a>
 
 ## [DELETE]: Delete an existing downtime resource
 
@@ -320,7 +152,7 @@ This method can be used to delete an existing downtime resource
 ### Input
 
 ```
-DELETE /downtimes/{ID}
+DELETE /downtimes?date=YYYY-MM-DD
 ```
 
 #### Request headers
@@ -339,11 +171,10 @@ Headers: `Status: 200 OK`
 Json Response
 
 ```json
-
 {
-    "status": {
-        "message": "Downtimes resource Successfully Deleted",
-        "code": "200"
-    }
+ "status": {
+  "message": "Downtimes set deleted for date: 2019-10-11",
+  "code": "200"
+ }
 }
 ```


### PR DESCRIPTION
Change downtime management:
 - Make downtimes global per day (no namespacing with specific name or id per downtime set)
 - Treat downtime resource as topology resources (updates with failsafe: verify by clearing a downtime set of a specific date before creating a new downtime set for that particular date)
- Update unit tests
- Update routing
- Update docs
- Update swagger