### PR TITLE
ARGO-2630 Implement weights feed resource

### DIFF
--- a/app/feeds/controller.go
+++ b/app/feeds/controller.go
@@ -16,6 +16,7 @@ import (
 
 //Create a new feeds resource
 const feedsTopoCol = "feeds_topology"
+const feedsWeightsCol = "feeds_weights"
 
 // Update request handler creates a new feed topo resource
 func UpdateTopo(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
@@ -46,15 +47,17 @@ func UpdateTopo(r *http.Request, cfg config.Config) (int, http.Header, []byte, e
 		return code, h, output, err
 	}
 
-	incoming := FeedsTopo{}
+	incoming := Topo{}
 
 	// Try ingest request body
 	body, err := ioutil.ReadAll(io.LimitReader(r.Body, cfg.Server.ReqSizeLimit))
 	if err != nil {
-		panic(err)
+		code = http.StatusInternalServerError
+		return code, h, output, err
 	}
 	if err := r.Body.Close(); err != nil {
-		panic(err)
+		code = http.StatusInternalServerError
+		return code, h, output, err
 	}
 
 	// Parse body json
@@ -66,22 +69,92 @@ func UpdateTopo(r *http.Request, cfg config.Config) (int, http.Header, []byte, e
 
 	_, err = mongo.Remove(session, tenantDbConfig.Db, feedsTopoCol, bson.M{})
 	if err != nil {
-		panic(err)
+		code = http.StatusInternalServerError
+		return code, h, output, err
 	}
 
 	err = mongo.Insert(session, tenantDbConfig.Db, feedsTopoCol, incoming)
 
 	if err != nil {
-		panic(err)
+		code = http.StatusInternalServerError
+		return code, h, output, err
 	}
 
 	// Create view of the results
-	output, err = createListView([]FeedsTopo{incoming}, "Feeds resource succesfully updated", 200) //Render the results into JSON
+	output, err = createTopoListView([]Topo{incoming}, "Feeds resource succesfully updated", 200) //Render the results into JSON
 	code = 200
 	return code, h, output, err
 }
 
-// List Topology Results
+// UpdateWeights request handler creates a new weights feed resource
+func UpdateWeights(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
+	//STANDARD DECLARATIONS START
+	code := http.StatusOK
+	h := http.Header{}
+	output := []byte("")
+	err := error(nil)
+	charset := "utf-8"
+	//STANDARD DECLARATIONS END
+
+	// Set Content-Type response Header value
+	contentType := r.Header.Get("Accept")
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+
+	// Grab Tenant DB configuration from context
+	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
+
+	if err != nil {
+		code = http.StatusBadRequest
+		output, _ = respond.MarshalContent(respond.ErrBadRequestDetails(err.Error()), contentType, "", " ")
+		return code, h, output, err
+	}
+	session, err := mongo.OpenSession(tenantDbConfig)
+	defer mongo.CloseSession(session)
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	incoming := Weights{}
+
+	// Try ingest request body
+	body, err := ioutil.ReadAll(io.LimitReader(r.Body, cfg.Server.ReqSizeLimit))
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+	if err := r.Body.Close(); err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	// Parse body json
+	if err := json.Unmarshal(body, &incoming); err != nil {
+		output, _ = respond.MarshalContent(respond.BadRequestInvalidJSON, contentType, "", " ")
+		code = 400
+		return code, h, output, err
+	}
+
+	_, err = mongo.Remove(session, tenantDbConfig.Db, feedsWeightsCol, bson.M{})
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	err = mongo.Insert(session, tenantDbConfig.Db, feedsWeightsCol, incoming)
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	// Create view of the results
+	output, err = createWeightsListView([]Weights{incoming}, "Feeds resource succesfully updated", 200) //Render the results into JSON
+	code = 200
+	return code, h, output, err
+}
+
+// ListTopo lists topology Results
 func ListTopo(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
 
 	//STANDARD DECLARATIONS START
@@ -111,7 +184,7 @@ func ListTopo(r *http.Request, cfg config.Config) (int, http.Header, []byte, err
 	}
 
 	// Retrieve Results from database
-	result := FeedsTopo{}
+	result := Topo{}
 
 	if err != nil {
 		code = http.StatusBadRequest
@@ -132,7 +205,69 @@ func ListTopo(r *http.Request, cfg config.Config) (int, http.Header, []byte, err
 	}
 
 	// Create view of the results
-	output, err = createListView([]FeedsTopo{result}, "Success", code) //Render the results into JSON
+	output, err = createTopoListView([]Topo{result}, "Success", code) //Render the results into JSON
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+	return code, h, output, err
+}
+
+// ListWeight list weights feeds results
+func ListWeights(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
+
+	//STANDARD DECLARATIONS START
+
+	code := http.StatusOK
+	h := http.Header{}
+	output := []byte("")
+	err := error(nil)
+	charset := "utf-8"
+
+	//STANDARD DECLARATIONS END
+
+	// Set Content-Type response Header value
+	contentType := r.Header.Get("Accept")
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+
+	// Grab Tenant DB configuration from context
+	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
+
+	// Open session to tenant database
+	session, err := mongo.OpenSession(tenantDbConfig)
+	defer mongo.CloseSession(session)
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	// Retrieve Results from database
+	result := Weights{}
+
+	if err != nil {
+		code = http.StatusBadRequest
+		output, _ = respond.MarshalContent(respond.ErrBadRequestDetails(err.Error()), contentType, "", " ")
+		return code, h, output, err
+	}
+
+	ftCol := session.DB(tenantDbConfig.Db).C(feedsWeightsCol)
+	err = ftCol.Find(bson.M{}).One(&result)
+	if err != nil {
+		if err.Error() == "not found" {
+			output, _ = respond.MarshalContent(respond.ErrNotFound, contentType, "", " ")
+			code = 404
+			return code, h, output, err
+		}
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	// Create view of the results
+	output, err = createWeightsListView([]Weights{result}, "Success", code) //Render the results into JSON
 
 	if err != nil {
 		code = http.StatusInternalServerError

--- a/app/feeds/model.go
+++ b/app/feeds/model.go
@@ -1,10 +1,22 @@
 package feeds
 
-//FeedsTopo holds a list of topology feed parameters
-type FeedsTopo struct {
+//Topo holds a list of topology feed parameters
+type Topo struct {
 	TopoType     string   `bson:"type" json:"type"`
 	FeedURL      string   `bson:"feed_url" json:"feed_url"`
 	Paginated    string   `bson:"paginated" json:"paginated"`
 	FetchType    []string `bson:"fetch_type" json:"fetch_type"`
 	UIDendpoints string   `bson:"uid_endpoints" json:"uid_endpoints"`
+}
+
+// Weights holds a list of weight feed parameters
+type Weights struct {
+	// name-type of service that provides weights
+	FeedType string `bson:"type" json:"type"`
+	// url of the feed
+	FeedURL string `bson:"feed_url" json:"feed_url"`
+	// weight factor hepspec cpu, mem etch
+	WeightType string `bson:"weight_type" json:"weight_type"`
+	// group type that the weight affects
+	GroupType string `bson:"group_type" json:"group_type"`
 }

--- a/app/feeds/routing.go
+++ b/app/feeds/routing.go
@@ -17,4 +17,7 @@ var appRoutesV2 = []respond.AppRoutes{
 	{Name: "feeds.topo.update", Verb: "PUT", Path: "/topology", SubrouterHandler: UpdateTopo},
 	{Name: "feeds.topo.get", Verb: "GET", Path: "/topology", SubrouterHandler: ListTopo},
 	{Name: "feeds.topo.options", Verb: "OPTIONS", Path: "/topology", SubrouterHandler: Options},
+	{Name: "feeds.weights.update", Verb: "PUT", Path: "/weights", SubrouterHandler: UpdateWeights},
+	{Name: "feeds.weights.get", Verb: "GET", Path: "/weights", SubrouterHandler: ListWeights},
+	{Name: "feeds.weights.options", Verb: "OPTIONS", Path: "/weights", SubrouterHandler: Options},
 }

--- a/app/feeds/view.go
+++ b/app/feeds/view.go
@@ -7,8 +7,24 @@ import (
 	"github.com/ARGOeu/argo-web-api/respond"
 )
 
-// createListView constructs the list response template and exports it as json
-func createListView(results []FeedsTopo, msg string, code int) ([]byte, error) {
+// createTopoListView constructs the list response template and exports it as json
+func createTopoListView(results []Topo, msg string, code int) ([]byte, error) {
+
+	docRoot := &respond.ResponseMessage{
+		Status: respond.StatusResponse{
+			Message: msg,
+			Code:    strconv.Itoa(code),
+		},
+	}
+	docRoot.Data = results
+
+	output, err := json.MarshalIndent(docRoot, "", " ")
+	return output, err
+
+}
+
+// createWeightsListView constructs the list response template and exports it as json
+func createWeightsListView(results []Weights, msg string, code int) ([]byte, error) {
 
 	docRoot := &respond.ResponseMessage{
 		Status: respond.StatusResponse{

--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -2353,6 +2353,8 @@ paths:
           $ref: "#/responses/422"
         500:
           $ref: "#/responses/ServerError"
+          
+  
 
   /status/{report_name}/{lgroup_type}/{lgroup_name}:
     get:
@@ -3402,6 +3404,158 @@ paths:
           $ref: "#/responses/422"
         500:
           $ref: "#/responses/ServerError"
+          
+  /feeds/topology:
+    get:
+      summary: List of topology feed parameters
+      operationId: feeds.topology.list
+      description: list of topology feed parameters
+      tags:
+        - Feeds
+      produces:
+        - "application/json"
+      parameters:
+        - $ref: "#/parameters/apiKey"
+      responses:
+        '200':
+          description: A list with a topology feed parameters
+          schema:
+            $ref: '#/definitions/FeedsTopo'
+        '401':
+          description: Unauthorized user
+          schema:
+            $ref: '#/definitions/Status_error'
+        '404':
+          description: Item not found
+          schema:
+            $ref: '#/definitions/Status_error'
+        '406':
+          description: Content Not acceptable
+          schema:
+            $ref: '#/definitions/Status_error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Status_error'
+    put:
+      summary: update toplogy feed parameters
+      operationId: feeds.topo.update
+      description: update topology feeds parameters
+      tags:
+        - Feeds
+      consumes:
+        - "application/json"
+      produces:
+        - "application/json"
+      parameters:
+        - $ref: "#/parameters/apiKey"
+        - name: "feeds_topo_resource"
+          in: "body"
+          description: "Json description of the feeds topology resource to be updated"
+          required: true
+          schema:
+            $ref: '#/definitions/FeedsTopo'
+      responses:
+        '201':
+          description: Feeds topology resource Updated
+          schema:
+            $ref: '#/definitions/Status'
+        '400':
+          description: Bad request due to malformed JSON in put body
+          schema:
+            $ref: '#/definitions/Status_error'
+        '401':
+          description: Unauthorized user
+          schema:
+            $ref: '#/definitions/Status_error'
+        '404':
+          description: Item not found
+          schema:
+            $ref: '#/definitions/Status_error'
+        '406':
+          description: Content Not acceptable
+          schema:
+            $ref: '#/definitions/Status_error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Status_error'
+  
+  /feeds/weights:
+    get:
+      summary: List of weights feed parameters
+      operationId: feeds.weights.list
+      description: list of weights feed parameters
+      tags:
+        - Feeds
+      produces:
+        - "application/json"
+      parameters:
+        - $ref: "#/parameters/apiKey"
+      responses:
+        '200':
+          description: A list with weights feed parameters
+          schema:
+            $ref: '#/definitions/FeedsTopo'
+        '401':
+          description: Unauthorized user
+          schema:
+            $ref: '#/definitions/Status_error'
+        '404':
+          description: Item not found
+          schema:
+            $ref: '#/definitions/Status_error'
+        '406':
+          description: Content Not acceptable
+          schema:
+            $ref: '#/definitions/Status_error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Status_error'
+    put:
+      summary: update weights feeds parameters
+      operationId: feeds.weights.update
+      description: update weights feeds parameters
+      tags:
+        - Feeds
+      consumes:
+        - "application/json"
+      produces:
+        - "application/json"
+      parameters:
+        - $ref: "#/parameters/apiKey"
+        - name: "feeds_topo_resource"
+          in: "body"
+          description: "Json description of the feeds weights resource to be updated"
+          required: true
+          schema:
+            $ref: '#/definitions/FeedsTopo'
+      responses:
+        '201':
+          description: Feeds weights resource Updated
+          schema:
+            $ref: '#/definitions/Status'
+        '400':
+          description: Bad request due to malformed JSON in put body
+          schema:
+            $ref: '#/definitions/Status_error'
+        '401':
+          description: Unauthorized user
+          schema:
+            $ref: '#/definitions/Status_error'
+        '404':
+          description: Item not found
+          schema:
+            $ref: '#/definitions/Status_error'
+        '406':
+          description: Content Not acceptable
+          schema:
+            $ref: '#/definitions/Status_error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Status_error'  
           
   /recomputations/{ID}/status:
     post:
@@ -4846,6 +5000,34 @@ definitions:
               type: string
             context:
               type: string
+  
+  FeedsTopo:
+    type: object
+    properties:
+      type:
+        type: string
+      feed_url: 
+        type: string
+      paginated:
+        type: string
+      fetch_type:
+        type: array
+        items:
+          type: string
+      uid_endpoints:
+        type: string
+        
+  FeedsWeights:
+    type: object
+    properties:
+      type:
+        type: string
+      feed_url: 
+        type: string
+      weight_type:
+        type: string
+      group_type:
+        type: string
 
   TopologyResponse:
     type: object

--- a/website/docs/feeds.md
+++ b/website/docs/feeds.md
@@ -8,6 +8,8 @@ title: Feeds
 | ------------------------------------- | ------------------------------------------------------------------------------- | ------------------ |
 | GET: Feed Topology information   | This method can be used to retrieve a list of feed topology parameters         | [ Description](#1) |
 | PUT: Update feed topology info | This method can be used to update feed topology information parameters | [ Description](#2) |
+| GET: Feed Weights information   | This method can be used to retrieve a list of feed weights parameters         | [ Description](#3) |
+| PUT: Update feed weights info | This method can be used to update feed weights information parameters | [ Description](#4) |
 
 <a id='1'></a>
 
@@ -116,6 +118,105 @@ Json Response
    "uid_endpoints": "endpointA"
   }
  ]
+}
+```
+
+
+<a id='3'></a>
+
+## [GET]: List Feed weights parameters
+
+This method can be used to retrieve a list of feed weights parameters
+
+### Input
+
+```
+GET /feeds/weights
+```
+
+
+### Request headers
+
+```
+x-api-key: shared_key_value
+Accept: application/json
+```
+
+### Response
+
+Headers: `Status: 200 OK`
+
+#### Response body
+
+Json Response
+
+```json
+{
+  "status": {
+    "message": "Success",
+    "code": "200"
+  },
+  "data": [
+    {
+      "type": "vapor",
+      "feed_url": "https://somewhere.foo.bar/weight/feed",
+      "weight_type": "hepspec2006 cpu",
+      "group_type": "SITES"
+    }
+  ]
+}
+```
+
+<a id='2'></a>
+
+## [PUT]: Update topology feed parameters
+This method is used to upadte topology feed parameters
+
+### Input
+
+```
+PUT /feeds/topology
+```
+
+#### PUT BODY
+```json
+ {
+      "type": "item2",
+      "feed_url": "https://somewhere.foo.bar/weight/feed",
+      "weight_type": "weight_type2",
+      "group_type": "group2"
+}
+```
+
+#### Request headers
+
+```
+x-api-key: shared_key_value
+Accept: application/json
+```
+
+### Response
+
+Headers: `Status: 200 OK`
+
+#### Response body
+
+Json Response
+
+```json
+{
+  "status": {
+    "message": "Feeds resource succesfully updated",
+    "code": "200"
+  },
+  "data": [
+    {
+      "type": "item2",
+      "feed_url": "https://somewhere2.foo.bar/weights/feed",
+      "weight_type": "weight_type2",
+      "group_type": "group2"
+    }
+  ]
 }
 ```
 


### PR DESCRIPTION
Give tha ability to argo-web-api to store and serve information about weights feeds in the following path
/api/v2/feeds/weights

Give the ability to

- Update feed weights params with HTTP PUT
- Get feed weights params with HTTP GET

Feed weights information body in json:
```
  {
   "type": "vapor",
   "feed_url": "https://somewhere.foo.bar/weights/feed",
   "weight_type" : "hepspec2016 cpu",
   "group_type" : "SITES"
  }
```