### PR TITLE
ARGO-2703 Implement filter recomputations by date and report

### DIFF
--- a/app/recomputations2/recomputation_test.go
+++ b/app/recomputations2/recomputation_test.go
@@ -432,6 +432,205 @@ func (suite *RecomputationsProfileTestSuite) TestListRecomputations() {
 
 }
 
+func (suite *RecomputationsProfileTestSuite) TestListRecomputationsWithPeriodA() {
+
+	urls := []string{
+		"/api/v2/recomputations?date=2015-01-10",
+		"/api/v2/recomputations?date=2015-01-11",
+		"/api/v2/recomputations?date=2015-01-14",
+		"/api/v2/recomputations?date=2015-01-16",
+		"/api/v2/recomputations?date=2015-01-20",
+		"/api/v2/recomputations?date=2015-01-29",
+		"/api/v2/recomputations?date=2015-01-30",
+	}
+
+	recomputationRequestsJSON := `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50a",
+   "requester_name": "Arya Stark",
+   "requester_email": "astark@shadowguild.com",
+   "reason": "power cuts",
+   "start_time": "2015-01-10T12:00:00Z",
+   "end_time": "2015-01-30T23:00:00Z",
+   "report": "EGI_Critical",
+   "exclude": [
+    "SITE2",
+    "SITE4"
+   ],
+   "status": "running",
+   "timestamp": "2015-02-01T14:58:40Z",
+   "history": [
+    {
+     "status": "pending",
+     "timestamp": "2015-02-01T14:58:40Z"
+    },
+    {
+     "status": "running",
+     "timestamp": "2015-02-01T16:58:40Z"
+    }
+   ]
+  }
+ ]
+}`
+
+	for _, url := range urls {
+		request, _ := http.NewRequest("GET", url, strings.NewReader(""))
+		request.Header.Set("x-api-key", suite.clientkey)
+		request.Header.Set("Accept", "application/json")
+		response := httptest.NewRecorder()
+
+		suite.router.ServeHTTP(response, request)
+
+		code := response.Code
+		output := response.Body.String()
+
+		// Check that we must have a 200 ok code
+		suite.Equal(200, code, "Internal Server Error")
+		// Compare the expected and actual xml response
+		suite.Equal(recomputationRequestsJSON, output, "Response body mismatch")
+
+	}
+
+}
+
+func (suite *RecomputationsProfileTestSuite) TestListRecomputationsWithPeriodB() {
+
+	urls := []string{
+		"/api/v2/recomputations?date=2015-03-10",
+		"/api/v2/recomputations?date=2015-03-11",
+		"/api/v2/recomputations?date=2015-03-14",
+		"/api/v2/recomputations?date=2015-03-16",
+		"/api/v2/recomputations?date=2015-03-20",
+		"/api/v2/recomputations?date=2015-03-29",
+		"/api/v2/recomputations?date=2015-03-30",
+	}
+
+	recomputationRequestsJSON := `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50b",
+   "requester_name": "John Snow",
+   "requester_email": "jsnow@wall.com",
+   "reason": "reasons",
+   "start_time": "2015-03-10T12:00:00Z",
+   "end_time": "2015-03-30T23:00:00Z",
+   "report": "EGI_Critical",
+   "exclude": [
+    "SITE1",
+    "SITE3"
+   ],
+   "status": "pending",
+   "timestamp": "2015-04-01T14:58:40Z",
+   "history": [
+    {
+     "status": "pending",
+     "timestamp": "2015-04-01T14:58:40Z"
+    }
+   ]
+  }
+ ]
+}`
+
+	for _, url := range urls {
+		request, _ := http.NewRequest("GET", url, strings.NewReader(""))
+		request.Header.Set("x-api-key", suite.clientkey)
+		request.Header.Set("Accept", "application/json")
+		response := httptest.NewRecorder()
+
+		suite.router.ServeHTTP(response, request)
+
+		code := response.Code
+		output := response.Body.String()
+
+		// Check that we must have a 200 ok code
+		suite.Equal(200, code, "Internal Server Error")
+		// Compare the expected and actual xml response
+		suite.Equal(recomputationRequestsJSON, output, "Response body mismatch")
+
+	}
+
+}
+
+func (suite *RecomputationsProfileTestSuite) TestListRecomputationsWithPeriodC() {
+	urls := []string{
+		"/api/v2/recomputations?date=2015-01-01",
+		"/api/v2/recomputations?date=2015-01-09",
+		"/api/v2/recomputations?date=2015-02-14",
+		"/api/v2/recomputations?date=2015-02-16",
+		"/api/v2/recomputations?date=2015-04-20",
+		"/api/v2/recomputations?date=2015-04-29",
+		"/api/v2/recomputations?date=2015-05-30",
+		"/api/v2/recomputations?date=2015-01-30&report=Foo",
+		"/api/v2/recomputations?date=2015-03-15&report=Bar",
+	}
+
+	recomputationRequestsJSON := `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": []
+}`
+
+	for _, url := range urls {
+		request, _ := http.NewRequest("GET", url, strings.NewReader(""))
+		request.Header.Set("x-api-key", suite.clientkey)
+		request.Header.Set("Accept", "application/json")
+		response := httptest.NewRecorder()
+
+		suite.router.ServeHTTP(response, request)
+
+		code := response.Code
+		output := response.Body.String()
+
+		// Check that we must have a 200 ok code
+		suite.Equal(200, code, "Internal Server Error")
+		// Compare the expected and actual xml response
+		suite.Equal(recomputationRequestsJSON, output, "Response body mismatch")
+
+	}
+
+}
+
+func (suite *RecomputationsProfileTestSuite) TestListRecomputationsWithPeriodError() {
+	request, _ := http.NewRequest("GET", "/api/v2/recomputations?date=2020-03-303", strings.NewReader(""))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code := response.Code
+	output := response.Body.String()
+	recomputationRequestsJSON := `{
+ "status": {
+  "message": "Bad Request",
+  "code": "400"
+ },
+ "errors": [
+  {
+   "message": "Bad Request",
+   "code": "400",
+   "details": "date argument should be in the YYYY-MM-DD format"
+  }
+ ]
+}`
+	// Check that we must have a 200 ok code
+	suite.Equal(400, code, "Internal Server Error")
+	// Compare the expected and actual xml response
+	suite.Equal(recomputationRequestsJSON, output, "Response body mismatch")
+
+}
+
 func (suite *RecomputationsProfileTestSuite) TestSubmitRecomputations() {
 	submission := IncomingRecomputation{
 		StartTime:      "2015-01-10T12:00:00Z",

--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -3538,6 +3538,16 @@ paths:
         - "application/xml"
       parameters:
         - $ref: "#/parameters/apiKey"
+        - name: "date"
+          in: "query"
+          type: string
+          description: "specific date in YYYY-MM-DD format to retrieve relevant recomputations that cover this date"
+          required: false
+        - name: "report"
+          in: "query"
+          type: string
+          description: "filter recomputation requests by report name"
+          required: false
       responses:
         200:
           description: "Successful retrieval of recomputations"

--- a/respond/validators.go
+++ b/respond/validators.go
@@ -41,6 +41,16 @@ func validateDate(dateStr string) error {
 	return nil
 }
 
+// ValidateDateOnly validates an input date if its in the "YYYY-MM-DD" format
+func ValidateDateOnly(dateStr string) error {
+	_, err := time.Parse("2006-01-02", dateStr)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// ValidateMetricParams validates the parameters required for the metric call
 func ValidateMetricParams(queries url.Values) []ErrorResponse {
 
 	var errs []ErrorResponse
@@ -67,6 +77,7 @@ func ValidateMetricParams(queries url.Values) []ErrorResponse {
 
 }
 
+// ValidateResultsParams validates the input parameters required for the result related calls
 func ValidateResultsParams(queries url.Values) []ErrorResponse {
 
 	var errs []ErrorResponse
@@ -129,6 +140,7 @@ func ValidateResultsParams(queries url.Values) []ErrorResponse {
 
 }
 
+// ValidateStatusParams validates the input parameters required for the status related calls
 func ValidateStatusParams(queries url.Values) []ErrorResponse {
 
 	var errs []ErrorResponse

--- a/website/docs/recomputations.md
+++ b/website/docs/recomputations.md
@@ -8,10 +8,11 @@ title: Recomputation Requests
 Name                                     | Description                                                                            | Shortcut
 ---------------------------------------- | -------------------------------------------------------------------------------------- | ------------------
 GET: List Recomputation Requests         | This method can be used to retrieve a list of current Recomputation requests.          | [ Description](#1)
-POST: Create a new recomputation request | This method can be used to insert a new recomputation request onto the Compute Engine. | [ Description](#2)
-DELETE: Delete a specific recomputation  | This method can be used to delete a specific recomputation. | [ Description](#3)
-POST: change status  | This method can be used to change status of a specific recomputation. | [ Description](#4)
-DELETE: Reset status of recomputation  | This method can be used to reset status of a specific recomputation. | [ Description](#5)
+GET: Get a specific recomputatiomn by id | This method can be used to retrieve a specific recomputation by id                     | [ Description](#2)
+POST: Create a new recomputation request | This method can be used to insert a new recomputation request onto the Compute Engine. | [ Description](#3)
+DELETE: Delete a specific recomputation  | This method can be used to delete a specific recomputation. | [ Description](#4)
+POST: change status  | This method can be used to change status of a specific recomputation. | [ Description](#5)
+DELETE: Reset status of recomputation  | This method can be used to reset status of a specific recomputation. | [ Description](#6)
 
 
 <a id='1'></a>
@@ -25,6 +26,14 @@ This method can be used to retrieve a list of current Recomputation requests.
 GET /recomputations
 ```
 
+#### Optional Query Parameters
+
+| Type     | Description                                                                                                                             | Required |
+| -------- | --------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| `report` | Filter recomputations by report name                                                                                                    | NO       |
+| `date`   | Specific date to retrieve all relevant recomputations that their period include this date                                               | NO       |
+
+
 
 #### Request headers
 
@@ -33,7 +42,7 @@ x-api-key: shared_key_value
 Accept: application/json
 ```
 
-### Response
+#### Response
 Headers: `Status: 200 OK`
 
 #### Response body
@@ -43,12 +52,196 @@ Json Response
 {
 "root": [
      {
-          "requester_name": "Arya Stark",
-          "requester_email": "astark@shadowguild.com",
+          "id": "56db43ee-f331-46ca-b0fd-4555b4aa1cfc",
+          "requester_name": "John Doe",
+          "requester_email": "JohnDoe@foo.com",
           "reason": "power cuts",
           "start_time": "2015-01-10T12:00:00Z",
           "end_time": "2015-01-30T23:00:00Z",
-          "report": "EGI_Critical",
+          "report": "Critical",
+          "exclude": [
+           "Gluster"
+          ],
+          "status": "running",
+          "timestamp": "2015-02-01T14:58:40",
+          "history": [
+              { 
+                  "status": "pending", 
+                  "timestamp" : "2015-02-01T14:58:40"
+              },
+              { 
+                  "status": "approved", 
+                  "timestamp" : "2015-02-02T08:58:40"
+              },
+              { 
+                  "status": "running", 
+                  "timestamp" : "2015-02-02T09:10:40"
+              },
+
+          ]
+     },
+     {
+          "id": "f68b43ee-f331-46ca-b0fd-4555b4aa1cfc",
+          "requester_name": "John Doe",
+          "requester_email": "JohnDoe@foo.com",
+          "reason": "power cuts",
+          "start_time": "2015-03-10T12:00:00Z",
+          "end_time": "2015-03-30T23:00:00Z",
+          "report": "OPS-Critical",
+          "exclude": [
+           "Gluster"
+          ],
+          "status": "running",
+          "timestamp": "2015-02-01T14:58:40",
+          "history": [
+              { 
+                  "status": "pending", 
+                  "timestamp" : "2015-04-01T14:58:40"
+              },
+              { 
+                  "status": "approved", 
+                  "timestamp" : "2015-04-02T08:58:40"
+              },
+              { 
+                  "status": "running", 
+                  "timestamp" : "2015-04-02T09:10:40"
+              },
+
+          ]
+     }
+ ]
+}
+```
+
+### Example Request #2 
+```
+GET /recomputations?date=2015-03-15
+```
+
+#### Response
+Headers: `Status: 200 OK`
+
+#### Response body
+Json Response
+
+```json
+{
+"root": [
+     {
+          "id": "f68b43ee-f331-46ca-b0fd-4555b4aa1cfc",
+          "requester_name": "John Doe",
+          "requester_email": "JohnDoe@foo.com",
+          "reason": "power cuts",
+          "start_time": "2015-03-10T12:00:00Z",
+          "end_time": "2015-03-30T23:00:00Z",
+          "report": "OPS-Critical",
+          "exclude": [
+           "Gluster"
+          ],
+          "status": "running",
+          "timestamp": "2015-02-01T14:58:40",
+          "history": [
+              { 
+                  "status": "pending", 
+                  "timestamp" : "2015-04-01T14:58:40"
+              },
+              { 
+                  "status": "approved", 
+                  "timestamp" : "2015-04-02T08:58:40"
+              },
+              { 
+                  "status": "running", 
+                  "timestamp" : "2015-04-02T09:10:40"
+              },
+
+          ]
+     }
+ ]
+}
+```
+
+### Example Request #3 
+```
+GET /recomputations?report=OPS-Critical
+```
+
+#### Response
+Headers: `Status: 200 OK`
+
+#### Response body
+Json Response
+
+```json
+{
+"root": [
+     {
+          "id": "f68b43ee-f331-46ca-b0fd-4555b4aa1cfc",
+          "requester_name": "John Doe",
+          "requester_email": "JohnDoe@foo.com",
+          "reason": "power cuts",
+          "start_time": "2015-03-10T12:00:00Z",
+          "end_time": "2015-03-30T23:00:00Z",
+          "report": "OPS-Critical",
+          "exclude": [
+           "Gluster"
+          ],
+          "status": "running",
+          "timestamp": "2015-02-01T14:58:40",
+          "history": [
+              { 
+                  "status": "pending", 
+                  "timestamp" : "2015-04-01T14:58:40"
+              },
+              { 
+                  "status": "approved", 
+                  "timestamp" : "2015-04-02T08:58:40"
+              },
+              { 
+                  "status": "running", 
+                  "timestamp" : "2015-04-02T09:10:40"
+              },
+
+          ]
+     }
+ ]
+}
+```
+
+<a id='2'></a>
+
+## [GET]: Get specific recomputation request by id
+This method can be used to retrieve a specific recomputation request by its id
+
+### Input
+
+```
+GET /recomputations/{ID}
+```
+
+#### Request headers
+
+```
+x-api-key: shared_key_value
+Accept: application/json
+```
+
+#### Response
+Headers: `Status: 200 OK`
+
+#### Response body
+Json Response
+
+```json
+{
+"root": [
+     {
+          "id": "56db43ee-f331-46ca-b0fd-4555b4aa1cfc",
+          "requester_name": "John Doe",
+          "requester_email": "JohnDoe@foo.com",
+          "reason": "power cuts",
+          "start_time": "2015-01-10T12:00:00Z",
+          "end_time": "2015-01-30T23:00:00Z",
+          "report": "Critical",
           "exclude": [
            "Gluster"
           ],
@@ -70,12 +263,10 @@ Json Response
 
           ]
      }
- ]
-}
 ```
 
 
-<a id='2'></a>
+<a id='3'></a>
 
 ## [POST]: Create a new recomputation request
 This method can be used to insert a new recomputation request onto the Compute Engine.
@@ -108,7 +299,7 @@ Type         | Description                                                      
 ### Response
 Headers: `Status: 201 Created`
 
-<a id='3'></a>
+<a id='4'></a>
 
 ## [DELETE]: Delete a specific recomputation
 
@@ -126,7 +317,7 @@ Accept: application/json
 ### Response
 `Status 200 OK`
 
-<a id='4'></a>
+<a id='5'></a>
 
 ## [POST]: Change status of recomputation
 
@@ -174,7 +365,7 @@ Json Response
 ```
 
 
-<a id='5'></a>
+<a id='6'></a>
 
 ## [DELETE]: Reset status of a specific recomputation
 


### PR DESCRIPTION
# Goal
Give the ability to filter recomputation by affected date and report name. This will be helpfull in daily computation jobs to be able to retrieve all relevant recomputations for that day and report directly from the api it self

# Implementation
Provide two optional filters by using query parameters in the api call:
`HTTP GET /api/v2/recomputations?report={report_name}&date={YYYY-MM-DD}`

- [x] Update list recomputations handler to accept the new optional filters as url params and update accordingly the mongo queries
- [x] Update documentation
- [x] Update unit tests
- [x] Update swagger
