### PR TITLE
ARGO-2724 Introduce topology tags/values method

### DIFF
--- a/app/topology/controller.go
+++ b/app/topology/controller.go
@@ -28,6 +28,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"sort"
 	"strings"
 
 	"github.com/ARGOeu/argo-web-api/app/reports"
@@ -149,6 +150,97 @@ func ListTopoStats(r *http.Request, cfg config.Config) (int, http.Header, []byte
 	}
 
 	return code, h, output, err
+}
+
+// ListTopoTags list statistics the distinct values appearing for each tag in topology items
+func ListTopoTags(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
+
+	//STANDARD DECLARATIONS START
+	code := http.StatusOK
+	h := http.Header{}
+	output := []byte("")
+	err := error(nil)
+	charset := "utf-8"
+	//STANDARD DECLARATIONS END
+
+	//STANDARD DECLARATIONS END
+
+	// Set Content-Type response Header value
+	contentType := r.Header.Get("Accept")
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+
+	urlValues := r.URL.Query()
+	dateStr := urlValues.Get("date")
+
+	// Grab Tenant DB configuration from context
+	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
+
+	// Open session to tenant database
+	session, err := mongo.OpenSession(tenantDbConfig)
+	defer mongo.CloseSession(session)
+
+	colEndpoint := session.DB(tenantDbConfig.Db).C(endpointColName)
+	colGroup := session.DB(tenantDbConfig.Db).C(groupColName)
+
+	dt, dateStr, err := utils.ParseZuluDate(dateStr)
+	if err != nil {
+		code = http.StatusBadRequest
+		output, _ = respond.MarshalContent(respond.ErrBadRequestDetails(err.Error()), contentType, "", " ")
+		return code, h, output, err
+	}
+
+	expDate := getCloseDate(colEndpoint, dt)
+
+	resTagsEndpoint := []TagValues{}
+	resTagsGroup := []TagValues{}
+
+	if expDate < 0 {
+		output, _ = respond.MarshalContent(respond.ErrNotFoundQuery, contentType, "", " ")
+		code = 404
+		return code, h, output, err
+	}
+
+	err = colEndpoint.Pipe(prepTagAggr(expDate)).All(&resTagsEndpoint)
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	expDate = getCloseDate(colGroup, dt)
+
+	if expDate < 0 {
+		output, _ = respond.MarshalContent(respond.ErrNotFoundQuery, contentType, "", " ")
+		code = 404
+		return code, h, output, err
+	}
+
+	err = colGroup.Pipe(prepTagAggr(expDate)).All(&resTagsGroup)
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	// sort unique tag values in each tag occurence
+	for _, tg := range resTagsEndpoint {
+		sort.Strings(tg.Values)
+	}
+
+	for _, tg := range resTagsGroup {
+		sort.Strings(tg.Values)
+	}
+
+	resTags := []TagInfo{{Name: "endpoints", Values: resTagsEndpoint}, {Name: "groups", Values: resTagsGroup}}
+
+	output, err = createListTags(resTags, "Success", code) //Render the results into JSON
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+	return code, h, output, err
+
 }
 
 // ListEndpoints by date
@@ -614,6 +706,23 @@ func prepEndpointQuery(date int, filter fltrEndpoint) bson.M {
 	}
 
 	return query
+}
+
+func prepTagAggr(date int) []bson.M {
+
+	aggr := []bson.M{
+		{"$match": bson.M{"date_integer": date}},
+		{"$project": bson.M{"_id": 0, "tags": bson.M{"$objectToArray": "$tags"}}},
+		{"$unwind": "$tags"},
+		{"$replaceRoot": bson.M{"newRoot": "$tags"}},
+		{"$project": bson.M{"k": "$k", "v": bson.M{"$split": []string{"$v", ", "}}}},
+		{"$unwind": "$v"},
+		{"$group": bson.M{"_id": "$k", "v": bson.M{"$addToSet": "$v"}}},
+		{"$sort": bson.M{"_id": 1}},
+	}
+
+	return aggr
+
 }
 
 func prepGroupEndpointAggr(date int, fgroup fltrGroup, fendpoint fltrEndpoint) []bson.M {

--- a/app/topology/model.go
+++ b/app/topology/model.go
@@ -85,3 +85,15 @@ type Group struct {
 	Subgroup  string            `bson:"subgroup" json:"subgroup"`
 	Tags      map[string]string `bson:"tags" json:"tags"`
 }
+
+// TagInfo groups all tags for a topology type
+type TagInfo struct {
+	Name   string      `json:"name"`
+	Values []TagValues `json:"values"`
+}
+
+// TagValues holds each value appearing for each tag
+type TagValues struct {
+	Name   string   `bson:"_id" json:"name"`
+	Values []string `bson:"v" json:"values"`
+}

--- a/app/topology/routing.go
+++ b/app/topology/routing.go
@@ -54,6 +54,8 @@ var appRoutesV2 = []respond.AppRoutes{
 	{"topology_endpoints.list", "GET", "/endpoints", ListEndpoints},
 	{"topology_endpoints.delete", "DELETE", "/endpoints", DeleteEndpoints},
 	{"topology_endpoints.options", "OPTIONS", "/endpoints", Options},
+	{"topology_tags.list", "GET", "/tags", ListTopoTags},
+	{"topology_tags.options", "OPTIONS", "/tags", Options},
 	{"topology_stats.list", "GET", "/stats/{report_name}", routeCheckGroup},
 	{"topology.options", "OPTIONS", "/stats/{report_name}", Options},
 }
@@ -93,20 +95,20 @@ func routeCheckGroup(r *http.Request, cfg config.Config) (int, http.Header, []by
 		return code, h, output, err
 	}
 	// default generic group names
-	group_type := "group"
-	endpoint_group_type := "endpoint_group"
+	groupType := "group"
+	endpointGroupType := "endpoint_group"
 
 	// if specific group names are available in report use them
 	if result.Topology.Group != nil {
-		group_type = result.Topology.Group.Type
+		groupType = result.Topology.Group.Type
 		if result.Topology.Group.Group != nil {
-			endpoint_group_type = result.Topology.Group.Group.Type
+			endpointGroupType = result.Topology.Group.Group.Type
 		}
 	}
 
 	// set group names as part of the context
-	context.Set(r, "group_type", group_type)
-	context.Set(r, "endpoint_group_type", endpoint_group_type)
+	context.Set(r, "group_type", groupType)
+	context.Set(r, "endpoint_group_type", endpointGroupType)
 	return ListTopoStats(r, cfg)
 
 }

--- a/app/topology/topology_test.go
+++ b/app/topology/topology_test.go
@@ -78,7 +78,7 @@ func (suite *topologyTestSuite) SetupSuite() {
 	suite.clientkey = "secretkey"
 
 	// Create router and confhandler for test
-	suite.confHandler = respond.ConfHandler{suite.cfg}
+	suite.confHandler = respond.ConfHandler{Config: suite.cfg}
 	suite.router = mux.NewRouter().StrictSlash(false).PathPrefix("/api/v2/topology").Subrouter()
 	HandleSubrouter(suite.router, &suite.confHandler)
 }
@@ -102,12 +102,12 @@ func (suite *topologyTestSuite) SetupTest() {
 		bson.M{"name": "Westeros",
 			"db_conf": []bson.M{
 
-				bson.M{
+				{
 					"server":   "localhost",
 					"port":     27017,
 					"database": "argo_Westeros1",
 				},
-				bson.M{
+				{
 					"server":   "localhost",
 					"port":     27017,
 					"database": "argo_Westeros2",
@@ -115,13 +115,13 @@ func (suite *topologyTestSuite) SetupTest() {
 			},
 			"users": []bson.M{
 
-				bson.M{
+				{
 					"name":    "John Snow",
 					"email":   "J.Snow@brothers.wall",
 					"api_key": "wh1t3_w@lk3rs",
 					"roles":   []string{"viewer"},
 				},
-				bson.M{
+				{
 					"name":    "King Joffrey",
 					"email":   "g0dk1ng@kingslanding.gov",
 					"api_key": "sansa <3",
@@ -132,14 +132,14 @@ func (suite *topologyTestSuite) SetupTest() {
 		bson.M{"name": "EGI",
 			"db_conf": []bson.M{
 
-				bson.M{
+				{
 					"server":   "localhost",
 					"port":     27017,
 					"database": suite.tenantDbConf.Db,
 					"username": suite.tenantDbConf.Username,
 					"password": suite.tenantDbConf.Password,
 				},
-				bson.M{
+				{
 					"server":   "localhost",
 					"port":     27017,
 					"database": "argo_wrong_db_serviceflavoravailability",
@@ -147,13 +147,13 @@ func (suite *topologyTestSuite) SetupTest() {
 			},
 			"users": []bson.M{
 
-				bson.M{
+				{
 					"name":    "Joe Complex",
 					"email":   "C.Joe@egi.eu",
 					"api_key": suite.clientkey,
 					"roles":   []string{"viewer"},
 				},
-				bson.M{
+				{
 					"name":    "Josh Plain",
 					"email":   "P.Josh@egi.eu",
 					"api_key": "itsamysterytoyou",
@@ -209,6 +209,11 @@ func (suite *topologyTestSuite) SetupTest() {
 		})
 	c.Insert(
 		bson.M{
+			"resource": "topology_tags.list",
+			"roles":    []string{"editor", "viewer"},
+		})
+	c.Insert(
+		bson.M{
 			"resource": "results.get",
 			"roles":    []string{"editor", "viewer"},
 		})
@@ -228,7 +233,7 @@ func (suite *topologyTestSuite) SetupTest() {
 			"availability": 98.26389,
 			"reliability":  98.26389,
 			"tags": []bson.M{
-				bson.M{
+				{
 					"name":  "production",
 					"value": "Y",
 				},
@@ -245,7 +250,7 @@ func (suite *topologyTestSuite) SetupTest() {
 			"availability": 96.875,
 			"reliability":  96.875,
 			"tags": []bson.M{
-				bson.M{
+				{
 					"name":  "production",
 					"value": "Y",
 				},
@@ -262,7 +267,7 @@ func (suite *topologyTestSuite) SetupTest() {
 			"availability": 96.875,
 			"reliability":  96.875,
 			"tags": []bson.M{
-				bson.M{
+				{
 					"name":  "production",
 					"value": "Y",
 				},
@@ -279,7 +284,7 @@ func (suite *topologyTestSuite) SetupTest() {
 			"availability": 54.03509,
 			"reliability":  81.48148,
 			"tags": []bson.M{
-				bson.M{
+				{
 					"name":  "production",
 					"value": "Y",
 				},
@@ -296,7 +301,7 @@ func (suite *topologyTestSuite) SetupTest() {
 			"availability": 100,
 			"reliability":  100,
 			"tags": []bson.M{
-				bson.M{
+				{
 					"name":  "production",
 					"value": "Y",
 				},
@@ -320,7 +325,7 @@ func (suite *topologyTestSuite) SetupTest() {
 			"reliability":  54.6,
 			"weight":       5634,
 			"tags": []bson.M{
-				bson.M{
+				{
 					"name":  "",
 					"value": "",
 				},
@@ -338,7 +343,7 @@ func (suite *topologyTestSuite) SetupTest() {
 			"reliability":  45,
 			"weight":       4356,
 			"tags": []bson.M{
-				bson.M{
+				{
 					"name":  "",
 					"value": "",
 				},
@@ -356,7 +361,7 @@ func (suite *topologyTestSuite) SetupTest() {
 			"reliability":  100,
 			"weight":       5634,
 			"tags": []bson.M{
-				bson.M{
+				{
 					"name":  "",
 					"value": "",
 				},
@@ -374,7 +379,7 @@ func (suite *topologyTestSuite) SetupTest() {
 			"reliability":  100,
 			"weight":       5344,
 			"tags": []bson.M{
-				bson.M{
+				{
 					"name":  "",
 					"value": "",
 				},
@@ -392,7 +397,7 @@ func (suite *topologyTestSuite) SetupTest() {
 			"reliability":  100,
 			"weight":       5634,
 			"tags": []bson.M{
-				bson.M{
+				{
 					"name":  "",
 					"value": "",
 				},
@@ -410,7 +415,7 @@ func (suite *topologyTestSuite) SetupTest() {
 			"reliability":  70,
 			"weight":       5634,
 			"tags": []bson.M{
-				bson.M{
+				{
 					"name":  "",
 					"value": "",
 				},
@@ -428,7 +433,7 @@ func (suite *topologyTestSuite) SetupTest() {
 			"reliability":  70,
 			"weight":       5634,
 			"tags": []bson.M{
-				bson.M{
+				{
 					"name":  "",
 					"value": "",
 				},
@@ -446,7 +451,7 @@ func (suite *topologyTestSuite) SetupTest() {
 			"reliability":  56,
 			"weight":       4356,
 			"tags": []bson.M{
-				bson.M{
+				{
 					"name":  "",
 					"value": "",
 				},
@@ -469,15 +474,15 @@ func (suite *topologyTestSuite) SetupTest() {
 			},
 		},
 		"profiles": []bson.M{
-			bson.M{
+			{
 				"type": "metric",
 				"name": "ch.cern.SAM.ROC_CRITICAL"},
 		},
 		"filter_tags": []bson.M{
-			bson.M{
+			{
 				"name":  "name1",
 				"value": "value1"},
-			bson.M{
+			{
 				"name":  "name2",
 				"value": "value2"},
 		}})
@@ -497,15 +502,15 @@ func (suite *topologyTestSuite) SetupTest() {
 			},
 		},
 		"profiles": []bson.M{
-			bson.M{
+			{
 				"type": "metric",
 				"name": "ch.cern.SAM.ROC_CRITICAL"},
 		},
 		"filter_tags": []bson.M{
-			bson.M{
+			{
 				"name":  "name1",
 				"value": "value1"},
-			bson.M{
+			{
 				"name":  "name2",
 				"value": "value2"},
 		}})
@@ -525,15 +530,15 @@ func (suite *topologyTestSuite) SetupTest() {
 			},
 		},
 		"profiles": []bson.M{
-			bson.M{
+			{
 				"type": "metric",
 				"name": "ch.cern.SAM.ROC_CRITICAL"},
 		},
 		"filter_tags": []bson.M{
-			bson.M{
+			{
 				"name":  "name1",
 				"value": "value1"},
-			bson.M{
+			{
 				"name":  "name2",
 				"value": "value2"},
 		}})
@@ -553,15 +558,15 @@ func (suite *topologyTestSuite) SetupTest() {
 			},
 		},
 		"profiles": []bson.M{
-			bson.M{
+			{
 				"type": "metric",
 				"name": "ch.cern.SAM.ROC_CRITICAL"},
 		},
 		"filter_tags": []bson.M{
-			bson.M{
+			{
 				"name":  "name1",
 				"value": "value1"},
-			bson.M{
+			{
 				"name":  "name2",
 				"value": "value2"},
 		}})
@@ -580,12 +585,12 @@ func (suite *topologyTestSuite) SetupTest() {
 			},
 		},
 		"profiles": []bson.M{
-			bson.M{
+			{
 				"type": "metric",
 				"name": "ch.cern.SAM.ROC_CRITICAL"},
 		},
 		"filter_tags": []bson.M{
-			bson.M{
+			{
 				"context": "argo.group.filter.tags",
 				"name":    "infrastructure",
 				"value":   "Devel"},
@@ -606,12 +611,12 @@ func (suite *topologyTestSuite) SetupTest() {
 			},
 		},
 		"profiles": []bson.M{
-			bson.M{
+			{
 				"type": "metric",
 				"name": "ch.cern.SAM.ROC_CRITICAL"},
 		},
 		"filter_tags": []bson.M{
-			bson.M{
+			{
 				"context": "argo.group.filter.tags",
 				"name":    "certification",
 				"value":   "Certified"},
@@ -631,12 +636,12 @@ func (suite *topologyTestSuite) SetupTest() {
 			},
 		},
 		"profiles": []bson.M{
-			bson.M{
+			{
 				"type": "metric",
 				"name": "ch.cern.SAM.ROC_CRITICAL"},
 		},
 		"filter_tags": []bson.M{
-			bson.M{
+			{
 				"context": "argo.group.filter.fields",
 				"name":    "group",
 				"value":   "NGI0"},
@@ -656,16 +661,16 @@ func (suite *topologyTestSuite) SetupTest() {
 			},
 		},
 		"profiles": []bson.M{
-			bson.M{
+			{
 				"type": "metric",
 				"name": "ch.cern.SAM.ROC_CRITICAL"},
 		},
 		"filter_tags": []bson.M{
-			bson.M{
+			{
 				"context": "argo.group.filter.fields",
 				"name":    "group",
 				"value":   "NGI0"},
-			bson.M{
+			{
 				"context": "argo.endpoint.filter.fields",
 				"name":    "service",
 				"value":   "service_1"},
@@ -686,20 +691,20 @@ func (suite *topologyTestSuite) SetupTest() {
 			},
 		},
 		"profiles": []bson.M{
-			bson.M{
+			{
 				"type": "metric",
 				"name": "ch.cern.SAM.ROC_CRITICAL"},
 		},
 		"filter_tags": []bson.M{
-			bson.M{
+			{
 				"context": "argo.group.filter.fields",
 				"name":    "group",
 				"value":   "NGI0"},
-			bson.M{
+			{
 				"context": "argo.endpoint.filter.fields",
 				"name":    "service",
 				"value":   "service_1"},
-			bson.M{
+			{
 				"context": "argo.endpoint.filter.tags",
 				"name":    "monitored",
 				"value":   "YesNo"},
@@ -719,24 +724,24 @@ func (suite *topologyTestSuite) SetupTest() {
 			},
 		},
 		"profiles": []bson.M{
-			bson.M{
+			{
 				"type": "metric",
 				"name": "ch.cern.SAM.ROC_CRITICAL"},
 		},
 		"filter_tags": []bson.M{
-			bson.M{
+			{
 				"context": "argo.group.filter.fields",
 				"name":    "group",
 				"value":   "NGI0"},
-			bson.M{
+			{
 				"context": "argo.group.filter.fields",
 				"name":    "group",
 				"value":   "NGI0"},
-			bson.M{
+			{
 				"context": "argo.endpoint.filter.fields",
 				"name":    "hostname",
 				"value":   "host1.site_a.foo"},
-			bson.M{
+			{
 				"context": "argo.endpoint.filter.fields",
 				"name":    "hostname",
 				"value":   "host2.site_a.foo"},
@@ -799,7 +804,7 @@ func (suite *topologyTestSuite) SetupTest() {
 			"type":         "SITES",
 			"hostname":     "host2.site_a.foo",
 			"service":      "service_2",
-			"tags":         bson.M{"production": "0", "monitored": "Y"},
+			"tags":         bson.M{"production": "0", "monitored": "Y", "scope": "GROUPC, GROUPD, GROUPE"},
 		},
 		bson.M{
 			"date":         "2015-06-11",
@@ -808,7 +813,7 @@ func (suite *topologyTestSuite) SetupTest() {
 			"type":         "SITES",
 			"hostname":     "host1.site_b.foo",
 			"service":      "service_1",
-			"tags":         bson.M{"production": "1Prod", "monitored": "YesNo"},
+			"tags":         bson.M{"production": "Prod", "monitored": "YesNo", "scope": "GROUPA, GROUPB"},
 		},
 		bson.M{
 			"date":         "2015-06-22",
@@ -1049,15 +1054,15 @@ func (suite *topologyTestSuite) TestBadDate() {
 	}
 
 	requests := []reqHeader{
-		reqHeader{Method: "GET", Path: "/api/v2/topology/endpoints?date=2020-02", Data: ""},
-		reqHeader{Method: "GET", Path: "/api/v2/topology/endpoints/by_report/Critical?date=2020-02", Data: ""},
-		reqHeader{Method: "POST", Path: "/api/v2/topology/endpoints?date=2020-02", Data: ""},
-		reqHeader{Method: "DELETE", Path: "/api/v2/topology/endpoints?date=2020-02", Data: ""},
-		reqHeader{Method: "GET", Path: "/api/v2/topology/groups?date=2020-02", Data: ""},
-		reqHeader{Method: "GET", Path: "/api/v2/topology/groups/by_report/Critical?date=2020-02", Data: ""},
-		reqHeader{Method: "POST", Path: "/api/v2/topology/groups?date=2020-02", Data: ""},
-		reqHeader{Method: "DELETE", Path: "/api/v2/topology/groups?date=2020-02", Data: ""},
-		reqHeader{Method: "GET", Path: "/api/v2/topology/stats/Critical?date=2020-02", Data: ""},
+		{Method: "GET", Path: "/api/v2/topology/endpoints?date=2020-02", Data: ""},
+		{Method: "GET", Path: "/api/v2/topology/endpoints/by_report/Critical?date=2020-02", Data: ""},
+		{Method: "POST", Path: "/api/v2/topology/endpoints?date=2020-02", Data: ""},
+		{Method: "DELETE", Path: "/api/v2/topology/endpoints?date=2020-02", Data: ""},
+		{Method: "GET", Path: "/api/v2/topology/groups?date=2020-02", Data: ""},
+		{Method: "GET", Path: "/api/v2/topology/groups/by_report/Critical?date=2020-02", Data: ""},
+		{Method: "POST", Path: "/api/v2/topology/groups?date=2020-02", Data: ""},
+		{Method: "DELETE", Path: "/api/v2/topology/groups?date=2020-02", Data: ""},
+		{Method: "GET", Path: "/api/v2/topology/stats/Critical?date=2020-02", Data: ""},
 	}
 
 	for _, r := range requests {
@@ -1187,7 +1192,7 @@ func (suite *topologyTestSuite) TestListFilterEndpointTags() {
 	}
 
 	expected := []TestReq{
-		TestReq{
+		{
 			Path: "/api/v2/topology/endpoints?date=2015-06-12&tags=monitored:Y*",
 			Code: 200,
 			JSON: `{
@@ -1215,7 +1220,8 @@ func (suite *topologyTestSuite) TestListFilterEndpointTags() {
    "hostname": "host2.site_a.foo",
    "tags": {
     "monitored": "Y",
-    "production": "0"
+    "production": "0",
+    "scope": "GROUPC, GROUPD, GROUPE"
    }
   },
   {
@@ -1226,12 +1232,13 @@ func (suite *topologyTestSuite) TestListFilterEndpointTags() {
    "hostname": "host1.site_b.foo",
    "tags": {
     "monitored": "YesNo",
-    "production": "1Prod"
+    "production": "Prod",
+    "scope": "GROUPA, GROUPB"
    }
   }
  ]
 }`},
-		TestReq{
+		{
 			Path: "/api/v2/topology/endpoints?date=2015-06-12&tags=production:1*",
 			Code: 200,
 			JSON: `{
@@ -1250,22 +1257,11 @@ func (suite *topologyTestSuite) TestListFilterEndpointTags() {
     "monitored": "Yes",
     "production": "1"
    }
-  },
-  {
-   "date": "2015-06-11",
-   "group": "SITEB",
-   "type": "SITES",
-   "service": "service_1",
-   "hostname": "host1.site_b.foo",
-   "tags": {
-    "monitored": "YesNo",
-    "production": "1Prod"
-   }
   }
  ]
 }`},
 
-		TestReq{
+		{
 			Path: "/api/v2/topology/endpoints?date=2015-06-12&tags=monitored:Yes,monitored:Y",
 			Code: 200,
 			JSON: `{
@@ -1293,7 +1289,8 @@ func (suite *topologyTestSuite) TestListFilterEndpointTags() {
    "hostname": "host2.site_a.foo",
    "tags": {
     "monitored": "Y",
-    "production": "0"
+    "production": "0",
+    "scope": "GROUPC, GROUPD, GROUPE"
    }
   }
  ]
@@ -1326,7 +1323,7 @@ func (suite *topologyTestSuite) TestListFilterGroupTags() {
 	}
 
 	expected := []TestReq{
-		TestReq{
+		{
 			Path: "/api/v2/topology/groups?&date=2015-06-12&tags=infrastructure:production",
 			Code: 200,
 			JSON: `{
@@ -1347,7 +1344,7 @@ func (suite *topologyTestSuite) TestListFilterGroupTags() {
   }
  ]
 }`},
-		TestReq{
+		{
 			Path: "/api/v2/topology/groups?&date=2015-06-12&tags=infrastructure:dev*",
 			Code: 200,
 			JSON: `{
@@ -1379,7 +1376,7 @@ func (suite *topologyTestSuite) TestListFilterGroupTags() {
  ]
 }`},
 
-		TestReq{
+		{
 			Path: "/api/v2/topology/groups?&date=2015-06-12&tags=infrastructure:*test",
 			Code: 200,
 			JSON: `{
@@ -1401,7 +1398,7 @@ func (suite *topologyTestSuite) TestListFilterGroupTags() {
  ]
 }`},
 
-		TestReq{
+		{
 			Path: "/api/v2/topology/groups?&date=2015-06-12&tags=certification:Cert*",
 			Code: 200,
 			JSON: `{
@@ -1433,7 +1430,7 @@ func (suite *topologyTestSuite) TestListFilterGroupTags() {
  ]
 }`},
 
-		TestReq{
+		{
 			Path: "/api/v2/topology/groups?&date=2015-06-12&tags=infrastructure:devel,infrastructure:production",
 			Code: 200,
 			JSON: `{
@@ -1485,6 +1482,100 @@ func (suite *topologyTestSuite) TestListFilterGroupTags() {
 	}
 }
 
+func (suite *topologyTestSuite) TestListTopologyTags() {
+
+	type TestReq struct {
+		Path string
+		Code int
+		JSON string
+	}
+
+	expected := []TestReq{
+		{
+			Path: "/api/v2/topology/tags?&date=2015-06-12",
+			Code: 200,
+			JSON: `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "name": "endpoints",
+   "values": [
+    {
+     "name": "monitored",
+     "values": [
+      "Y",
+      "Yes",
+      "YesNo"
+     ]
+    },
+    {
+     "name": "production",
+     "values": [
+      "0",
+      "1",
+      "Prod"
+     ]
+    },
+    {
+     "name": "scope",
+     "values": [
+      "GROUPA",
+      "GROUPB",
+      "GROUPC",
+      "GROUPD",
+      "GROUPE"
+     ]
+    }
+   ]
+  },
+  {
+   "name": "groups",
+   "values": [
+    {
+     "name": "certification",
+     "values": [
+      "CertNot",
+      "Certified",
+      "uncertified"
+     ]
+    },
+    {
+     "name": "infrastructure",
+     "values": [
+      "devel",
+      "devtest",
+      "production"
+     ]
+    }
+   ]
+  }
+ ]
+}`},
+	}
+
+	for _, exp := range expected {
+		request, _ := http.NewRequest("GET", exp.Path, strings.NewReader(""))
+		request.Header.Set("x-api-key", suite.clientkey)
+		request.Header.Set("Accept", "application/json")
+		response := httptest.NewRecorder()
+
+		suite.router.ServeHTTP(response, request)
+
+		code := response.Code
+		output := response.Body.String()
+
+		// Check that we must have a 200 ok code
+		suite.Equal(exp.Code, code, "Response Code Mismatch on call:"+exp.Path)
+		// Compare the expected and actual json response
+
+		suite.Equal(exp.JSON, output, "Response body mismatch on call:"+exp.Path)
+
+	}
+}
+
 func (suite *topologyTestSuite) TestListFilterGroupsByReport() {
 
 	type TestReq struct {
@@ -1494,7 +1585,7 @@ func (suite *topologyTestSuite) TestListFilterGroupsByReport() {
 	}
 
 	expected := []TestReq{
-		TestReq{
+		{
 			Path: "/api/v2/topology/groups/by_report/Critical2",
 			Code: 200,
 			JSON: `{
@@ -1535,7 +1626,7 @@ func (suite *topologyTestSuite) TestListFilterGroupsByReport() {
   }
  ]
 }`},
-		TestReq{
+		{
 			Path: "/api/v2/topology/groups/by_report/Critical3",
 			Code: 200,
 			JSON: `{
@@ -1557,7 +1648,7 @@ func (suite *topologyTestSuite) TestListFilterGroupsByReport() {
  ]
 }`},
 
-		TestReq{
+		{
 			Path: "/api/v2/topology/groups/by_report/Critical4",
 			Code: 200,
 			JSON: `{
@@ -1579,7 +1670,7 @@ func (suite *topologyTestSuite) TestListFilterGroupsByReport() {
  ]
 }`},
 
-		TestReq{
+		{
 			Path: "/api/v2/topology/groups/by_report/Critical5",
 			Code: 200,
 			JSON: `{
@@ -1601,7 +1692,7 @@ func (suite *topologyTestSuite) TestListFilterGroupsByReport() {
  ]
 }`},
 
-		TestReq{
+		{
 			Path: "/api/v2/topology/groups/by_report/Critical6",
 			Code: 200,
 			JSON: `{
@@ -1623,7 +1714,7 @@ func (suite *topologyTestSuite) TestListFilterGroupsByReport() {
  ]
 }`},
 
-		TestReq{
+		{
 			Path: "/api/v2/topology/groups/by_report/Critical7?date=2015-01-11",
 			Code: 200,
 			JSON: `{
@@ -1655,7 +1746,7 @@ func (suite *topologyTestSuite) TestListFilterGroupsByReport() {
  ]
 }`},
 
-		TestReq{
+		{
 			Path: "/api/v2/topology/groups/by_report/CriticalCombine?date=2015-01-11",
 			Code: 200,
 			JSON: `{
@@ -1716,7 +1807,7 @@ func (suite *topologyTestSuite) TestListFilterEndpointsByReport() {
 	}
 
 	expected := []TestReq{
-		TestReq{
+		{
 			Path: "/api/v2/topology/endpoints/by_report/Critical7?date=2015-01-11",
 			Code: 200,
 			JSON: `{
@@ -1761,7 +1852,7 @@ func (suite *topologyTestSuite) TestListFilterEndpointsByReport() {
  ]
 }`},
 
-		TestReq{
+		{
 			Path: "/api/v2/topology/endpoints/by_report/Critical8?date=2015-01-11",
 			Code: 200,
 			JSON: `{
@@ -1795,7 +1886,7 @@ func (suite *topologyTestSuite) TestListFilterEndpointsByReport() {
  ]
 }`},
 
-		TestReq{
+		{
 			Path: "/api/v2/topology/endpoints/by_report/Critical9?date=2015-01-11",
 			Code: 200,
 			JSON: `{
@@ -1818,7 +1909,7 @@ func (suite *topologyTestSuite) TestListFilterEndpointsByReport() {
  ]
 }`},
 
-		TestReq{
+		{
 			Path: "/api/v2/topology/endpoints/by_report/CriticalCombine?date=2015-01-11",
 			Code: 200,
 			JSON: `{
@@ -1881,7 +1972,7 @@ func (suite *topologyTestSuite) TestListFilterGroups() {
 	}
 
 	expected := []TestReq{
-		TestReq{
+		{
 			Path: "/api/v2/topology/groups?date=2015-06-30&group=NGIA",
 			Code: 200,
 			JSON: `{
@@ -1912,7 +2003,7 @@ func (suite *topologyTestSuite) TestListFilterGroups() {
   }
  ]
 }`},
-		TestReq{
+		{
 			Path: "/api/v2/topology/groups?date=2015-06-30&group=NGIA&subgroup=SITEB",
 			Code: 200,
 			JSON: `{
@@ -1933,7 +2024,7 @@ func (suite *topologyTestSuite) TestListFilterGroups() {
   }
  ]
 }`},
-		TestReq{
+		{
 			Path: "/api/v2/topology/groups?date=2015-06-30&subgroup=*A",
 			Code: 200,
 			JSON: `{
@@ -1954,7 +2045,7 @@ func (suite *topologyTestSuite) TestListFilterGroups() {
   }
  ]
 }`},
-		TestReq{
+		{
 			Path: "/api/v2/topology/groups?date=2015-06-30&subgroup=A*",
 			Code: 200,
 			JSON: `{
@@ -1965,7 +2056,7 @@ func (suite *topologyTestSuite) TestListFilterGroups() {
  "data": []
 }`},
 
-		TestReq{
+		{
 			Path: "/api/v2/topology/groups?date=2015-06-30&subgroup=*A&subgroup=*B",
 			Code: 200,
 			JSON: `{
@@ -2026,7 +2117,7 @@ func (suite *topologyTestSuite) TestListFilterEndpoints() {
 	}
 
 	expected := []TestReq{
-		TestReq{
+		{
 			Path: "/api/v2/topology/endpoints?group=SITEA",
 			Code: 200,
 			JSON: `{
@@ -2048,7 +2139,7 @@ func (suite *topologyTestSuite) TestListFilterEndpoints() {
   }
  ]
 }`},
-		TestReq{
+		{
 			Path: "/api/v2/topology/endpoints?group=B*",
 			Code: 200,
 			JSON: `{
@@ -2058,7 +2149,7 @@ func (suite *topologyTestSuite) TestListFilterEndpoints() {
  },
  "data": []
 }`},
-		TestReq{
+		{
 			Path: "/api/v2/topology/endpoints?service=serv*",
 			Code: 200,
 			JSON: `{
@@ -2091,7 +2182,7 @@ func (suite *topologyTestSuite) TestListFilterEndpoints() {
   }
  ]
 }`},
-		TestReq{
+		{
 			Path: "/api/v2/topology/endpoints?service=serv*&hostname=*site_b*",
 			Code: 200,
 			JSON: `{
@@ -2113,7 +2204,7 @@ func (suite *topologyTestSuite) TestListFilterEndpoints() {
   }
  ]
 }`},
-		TestReq{
+		{
 			Path: "/api/v2/topology/endpoints?service=serv*&hostname=*.foo*",
 			Code: 200,
 			JSON: `{
@@ -2146,7 +2237,7 @@ func (suite *topologyTestSuite) TestListFilterEndpoints() {
   }
  ]
 }`},
-		TestReq{
+		{
 			Path: "/api/v2/topology/endpoints?service=serv*&hostname=*.foo*&group=*B",
 			Code: 200,
 			JSON: `{
@@ -2168,7 +2259,7 @@ func (suite *topologyTestSuite) TestListFilterEndpoints() {
   }
  ]
 }`},
-		TestReq{
+		{
 			Path: "/api/v2/topology/endpoints?service=serv*&hostname=*.foo*&group=*B&type=SITES",
 			Code: 200,
 			JSON: `{
@@ -2190,7 +2281,7 @@ func (suite *topologyTestSuite) TestListFilterEndpoints() {
   }
  ]
 }`},
-		TestReq{
+		{
 			Path: "/api/v2/topology/endpoints?service=serv*&hostname=*.foo*&group=*B&type=BITES",
 			Code: 200,
 			JSON: `{
@@ -2201,7 +2292,7 @@ func (suite *topologyTestSuite) TestListFilterEndpoints() {
  "data": []
 }`},
 
-		TestReq{
+		{
 			Path: "/api/v2/topology/endpoints?group=*A&group=*B",
 			Code: 200,
 			JSON: `{

--- a/app/topology/view.go
+++ b/app/topology/view.go
@@ -59,6 +59,21 @@ func createListEndpoint(results []Endpoint, msg string, code int) ([]byte, error
 
 }
 
+func createListTags(results []TagInfo, msg string, code int) ([]byte, error) {
+
+	docRoot := &respond.ResponseMessage{
+		Status: respond.StatusResponse{
+			Message: msg,
+			Code:    strconv.Itoa(code),
+		},
+	}
+	docRoot.Data = results
+
+	output, err := json.MarshalIndent(docRoot, "", " ")
+	return output, err
+
+}
+
 func createListGroup(results []Group, msg string, code int) ([]byte, error) {
 
 	docRoot := &respond.ResponseMessage{

--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -1958,6 +1958,35 @@ paths:
         500:
           $ref: "#/responses/ServerError"
           
+  /topology/tags:
+    get:
+      summary: "List topology tags and values"
+      description: "This request lists the available tags and their distinct values present in the daily topology items"
+      operationId: topology.tags
+      tags:
+        - Topology
+      produces:
+        - "application/json"
+      parameters:
+        - $ref: "#/parameters/apiKey"
+        - $ref: "#/parameters/topoDate"
+
+      responses:
+        200:
+          description: "Successful retrieval of latest metric data"
+          schema:
+            $ref: "#/definitions/TopologyTags_list"
+        400:
+          $ref: "#/responses/404"
+        401:
+          $ref: "#/responses/Unauthorized"
+        406:
+          $ref: "#/responses/406"
+        422:
+          $ref: "#/responses/422"
+        500:
+          $ref: "#/responses/ServerError"
+          
   /topology/groups:
     post:
       summary: Create a new group topology per date
@@ -5084,6 +5113,38 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/User'
+          
+          
+  TopologyTags_list:
+    type: object
+    properties:
+      status:
+       $ref: '#/definitions/Status'
+      data:
+        type: array
+        items:
+          $ref: '#/definitions/TopologyTags'
+    
+  
+  TopologyTags:
+    type: array
+    items:
+      type: object
+      properties:
+        name: 
+          type: string
+        values:
+          type: array
+          items:
+            type: object
+            properties:
+              name: 
+                type: string
+              values:
+                type: array
+                items:
+                  type: string
+              
 
   User:
     type: object

--- a/scripts/mongodb/populate_default_roles.js
+++ b/scripts/mongodb/populate_default_roles.js
@@ -19,6 +19,10 @@ function populate_default_roles() {
     print("INFO\tOpened argo_core db");
     db.roles.insert([
         {
+            resource: "topology_tags.list",
+            roles: ["admin", "editor", "viewer", "admin_ui"]
+        },
+        {
             resource: "topology_stats.list",
             roles: ["admin", "editor", "viewer", "admin_ui"]
         },

--- a/website/docs/topology_tags.md
+++ b/website/docs/topology_tags.md
@@ -1,0 +1,169 @@
+---
+id: topology_tags
+title: Topology Tags & Values
+---
+
+## API calls for all available tags and distinct values present in topology items
+
+| Name                          | Description                                           | Shortcut                     |
+| ----------------------------- | ----------------------------------------------------- | ---------------------------- |
+| GET: List topology tags | List available tags and distinct values present in topology items. | <a href="#1">Description</a> |
+
+<a id="1"></a>
+
+## [GET]: List topology tags
+
+This method may be used to retrieve available topology tags and their distinct values available 
+
+### Input
+
+##### List All topology tag values
+
+```
+/topology/tags?[date]
+```
+
+
+#### Url Parameters
+
+| Type   | Description            | Required | Default value |
+| ------ | ---------------------- | -------- | ------------- |
+| `date` | target a specific data | NO       | today's date  |
+
+#### Headers
+
+```
+x-api-key: secret_key_value
+Accept: application/json
+```
+
+#### Response Code
+
+```
+Status: 200 OK
+```
+
+### Response body
+
+```json
+{
+    "status": {
+        "message": "application/json",
+        "code": "200"
+    },
+    "data": [
+        {
+            "name": "endpoints",
+            "values": [
+                {
+                    "name": "tag1",
+                    "values": ["value1", "value2", "value3"]
+                },
+                {
+                    "name": "tag2",
+                    "values": ["value1", "value2"]
+                }
+            ]
+        },
+        {
+            "name": "groups",
+            "values": [
+                {
+                    "name": "tag3",
+                    "values": ["value1", "value2", "value3"]
+                },
+                {
+                    "name": "tag4",
+                    "values": ["value1"]
+                }
+            ]
+        }
+    ]
+}
+```
+
+###### Example Request:
+
+URL:
+
+```
+/topology/tags?date=2016-01-01
+```
+
+
+Headers:
+
+```
+x-api-key: secret_key_value
+Accept: application/json
+```
+
+###### Example Response:
+
+Code:
+
+```
+Status: 200 OK
+```
+
+Response body:
+
+```json
+{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "name": "endpoints",
+   "values": [
+    {
+     "name": "scope",
+     "values": [
+      "GROUPB",
+      "GROUPA",
+      "GROUPE",
+      "GROUPD",
+      "GROUPC"
+     ]
+    },
+    {
+     "name": "production",
+     "values": [
+      "0",
+      "1"
+     ]
+    },
+    {
+     "name": "monitored",
+     "values": [
+      "0",
+      "1"
+     ]
+    }
+   ]
+  },
+  {
+   "name": "groups",
+   "values": [
+    {
+     "name": "certification",
+     "values": [
+      "Certified",
+      "Uncertified"
+     ]
+    },
+    {
+     "name": "infrastructure",
+     "values": [
+      "production",
+      "devel",
+      "devtest"
+     ]
+    }
+   ]
+  }
+ ]
+}
+```


### PR DESCRIPTION
# Goal 
Add a new topology call to quickly get the available tag/values present in daily topology items. The goal of the call is to present a quick list with all distinct tags and their associated values present in both endpoint and group topology items

The call signature is the following:
`/api/v2/topology/tags`

The sample response is the following:
```
{
    "status": {
        "message": "application/json",
        "code": "200"
    },
    "data": {
        {
            "name": "endpoints",
            "values": [
                {
                    "name": "tag1",
                    "values": ["value1", "value2", "value3"]
                },
                {
                    "name": "tag2",
                    "values": ["value1", "value2"]
                }
            ]
        },
        {
            "name": "groups",
            "values": [
                {
                    "name": "tag3",
                    "values": ["value1", "value2", "value3"]
                },
                {
                    "name": "tag4",
                    "values": ["value1"]
                }
            ]
        },
    }
}
```
