### PR TITLE
ARGO-2885 Add notification information to topology items

### DIFF
--- a/app/topology/model.go
+++ b/app/topology/model.go
@@ -67,21 +67,29 @@ type fltrGroup struct {
 
 // Endpoint includes information on endpoint group topology
 type Endpoint struct {
-	Date      string            `bson:"date" json:"date"`
-	DateInt   int               `bson:"date_integer" json:"-"`
-	Group     string            `bson:"group" json:"group"`
-	GroupType string            `bson:"type" json:"type"`
-	Service   string            `bson:"service" json:"service"`
-	Hostname  string            `bson:"hostname" json:"hostname"`
-	Tags      map[string]string `bson:"tags" json:"tags"`
+	Date          string            `bson:"date" json:"date"`
+	DateInt       int               `bson:"date_integer" json:"-"`
+	Group         string            `bson:"group" json:"group"`
+	GroupType     string            `bson:"type" json:"type"`
+	Service       string            `bson:"service" json:"service"`
+	Hostname      string            `bson:"hostname" json:"hostname"`
+	Notifications *Notifications    `bson:"notifications" json:"notifications,omitempty"`
+	Tags          map[string]string `bson:"tags" json:"tags"`
 }
 
 // Group includes information on  of group group topology
 type Group struct {
-	Date      string            `bson:"date" json:"date"`
-	DateInt   int               `bson:"date_integer" json:"-"`
-	Group     string            `bson:"group" json:"group"`
-	GroupType string            `bson:"type" json:"type"`
-	Subgroup  string            `bson:"subgroup" json:"subgroup"`
-	Tags      map[string]string `bson:"tags" json:"tags"`
+	Date          string            `bson:"date" json:"date"`
+	DateInt       int               `bson:"date_integer" json:"-"`
+	Group         string            `bson:"group" json:"group"`
+	GroupType     string            `bson:"type" json:"type"`
+	Subgroup      string            `bson:"subgroup" json:"subgroup"`
+	Notifications *Notifications    `bson:"notifications" json:"notifications,omitempty"`
+	Tags          map[string]string `bson:"tags" json:"tags"`
+}
+
+// Notifications holds notification information about topology items
+type Notifications struct {
+	Contacts []string `bson:"contacts" json:"contacts,omitempty"`
+	Enabled  bool     `bson:"enabled" json:"enabled,omitempty"`
 }

--- a/app/topology/topology_test.go
+++ b/app/topology/topology_test.go
@@ -874,13 +874,14 @@ func (suite *topologyTestSuite) SetupTest() {
 			"tags":         bson.M{"production": "0", "monitored": "0"},
 		},
 		bson.M{
-			"date":         "2015-08-10",
-			"date_integer": 20150810,
-			"group":        "SITEB",
-			"type":         "SITES",
-			"hostname":     "host0.site_b.foo",
-			"service":      "service_x",
-			"tags":         bson.M{"production": "0", "monitored": "0"},
+			"date":          "2015-08-10",
+			"date_integer":  20150810,
+			"group":         "SITEB",
+			"type":          "SITES",
+			"hostname":      "host0.site_b.foo",
+			"service":       "service_x",
+			"tags":          bson.M{"production": "0", "monitored": "0"},
+			"notifications": bson.M{"contacts": []string{"contact01@email.example.foo", "contact02@email.example.foo"}, "enabled": true},
 		})
 	// Seed database with group topology
 	c = session.DB(suite.tenantDbConf.Db).C(groupColName)
@@ -1016,12 +1017,13 @@ func (suite *topologyTestSuite) SetupTest() {
 			"tags":         bson.M{"infrastructure": "Production", "certification": "Uncertified"},
 		},
 		bson.M{
-			"date":         "2012-01-11",
-			"date_integer": 20200111,
-			"group":        "PR01",
-			"type":         "PROJECT",
-			"subgroup":     "SITEPROJECT",
-			"tags":         bson.M{"infrastructure": "Devel", "certification": "Certified"},
+			"date":          "2012-01-11",
+			"date_integer":  20200111,
+			"group":         "PR01",
+			"type":          "PROJECT",
+			"subgroup":      "SITEPROJECT",
+			"tags":          bson.M{"infrastructure": "Devel", "certification": "Certified"},
+			"notifications": bson.M{"contacts": []string{"contact01@email.example.foo", "contact02@email.example.foo"}, "enabled": true},
 		})
 
 }
@@ -1571,6 +1573,13 @@ func (suite *topologyTestSuite) TestListFilterGroupsByReport() {
    "group": "PR01",
    "type": "PROJECT",
    "subgroup": "SITEPROJECT",
+   "notifications": {
+    "contacts": [
+     "contact01@email.example.foo",
+     "contact02@email.example.foo"
+    ],
+    "enabled": true
+   },
    "tags": {
     "certification": "Certified",
     "infrastructure": "Devel"
@@ -1593,6 +1602,13 @@ func (suite *topologyTestSuite) TestListFilterGroupsByReport() {
    "group": "PR01",
    "type": "PROJECT",
    "subgroup": "SITEPROJECT",
+   "notifications": {
+    "contacts": [
+     "contact01@email.example.foo",
+     "contact02@email.example.foo"
+    ],
+    "enabled": true
+   },
    "tags": {
     "certification": "Certified",
     "infrastructure": "Devel"
@@ -1615,6 +1631,13 @@ func (suite *topologyTestSuite) TestListFilterGroupsByReport() {
    "group": "PR01",
    "type": "PROJECT",
    "subgroup": "SITEPROJECT",
+   "notifications": {
+    "contacts": [
+     "contact01@email.example.foo",
+     "contact02@email.example.foo"
+    ],
+    "enabled": true
+   },
    "tags": {
     "certification": "Certified",
     "infrastructure": "Devel"
@@ -2084,6 +2107,13 @@ func (suite *topologyTestSuite) TestListFilterEndpoints() {
    "type": "SITES",
    "service": "service_x",
    "hostname": "host0.site_b.foo",
+   "notifications": {
+    "contacts": [
+     "contact01@email.example.foo",
+     "contact02@email.example.foo"
+    ],
+    "enabled": true
+   },
    "tags": {
     "monitored": "0",
     "production": "0"
@@ -2106,6 +2136,13 @@ func (suite *topologyTestSuite) TestListFilterEndpoints() {
    "type": "SITES",
    "service": "service_x",
    "hostname": "host0.site_b.foo",
+   "notifications": {
+    "contacts": [
+     "contact01@email.example.foo",
+     "contact02@email.example.foo"
+    ],
+    "enabled": true
+   },
    "tags": {
     "monitored": "0",
     "production": "0"
@@ -2139,6 +2176,13 @@ func (suite *topologyTestSuite) TestListFilterEndpoints() {
    "type": "SITES",
    "service": "service_x",
    "hostname": "host0.site_b.foo",
+   "notifications": {
+    "contacts": [
+     "contact01@email.example.foo",
+     "contact02@email.example.foo"
+    ],
+    "enabled": true
+   },
    "tags": {
     "monitored": "0",
     "production": "0"
@@ -2161,6 +2205,13 @@ func (suite *topologyTestSuite) TestListFilterEndpoints() {
    "type": "SITES",
    "service": "service_x",
    "hostname": "host0.site_b.foo",
+   "notifications": {
+    "contacts": [
+     "contact01@email.example.foo",
+     "contact02@email.example.foo"
+    ],
+    "enabled": true
+   },
    "tags": {
     "monitored": "0",
     "production": "0"
@@ -2183,6 +2234,13 @@ func (suite *topologyTestSuite) TestListFilterEndpoints() {
    "type": "SITES",
    "service": "service_x",
    "hostname": "host0.site_b.foo",
+   "notifications": {
+    "contacts": [
+     "contact01@email.example.foo",
+     "contact02@email.example.foo"
+    ],
+    "enabled": true
+   },
    "tags": {
     "monitored": "0",
     "production": "0"
@@ -2227,6 +2285,13 @@ func (suite *topologyTestSuite) TestListFilterEndpoints() {
    "type": "SITES",
    "service": "service_x",
    "hostname": "host0.site_b.foo",
+   "notifications": {
+    "contacts": [
+     "contact01@email.example.foo",
+     "contact02@email.example.foo"
+    ],
+    "enabled": true
+   },
    "tags": {
     "monitored": "0",
     "production": "0"
@@ -2290,6 +2355,13 @@ func (suite *topologyTestSuite) TestListEndpoints() {
    "type": "SITES",
    "service": "service_x",
    "hostname": "host0.site_b.foo",
+   "notifications": {
+    "contacts": [
+     "contact01@email.example.foo",
+     "contact02@email.example.foo"
+    ],
+    "enabled": true
+   },
    "tags": {
     "monitored": "0",
     "production": "0"
@@ -2510,6 +2582,13 @@ func (suite *topologyTestSuite) TestListEndpoints4() {
    "type": "SITES",
    "service": "service_x",
    "hostname": "host0.site_b.foo",
+   "notifications": {
+    "contacts": [
+     "contact01@email.example.foo",
+     "contact02@email.example.foo"
+    ],
+    "enabled": true
+   },
    "tags": {
     "monitored": "0",
     "production": "0"
@@ -2618,6 +2697,13 @@ func (suite *topologyTestSuite) TestListGroups() {
    "group": "PR01",
    "type": "PROJECT",
    "subgroup": "SITEPROJECT",
+   "notifications": {
+    "contacts": [
+     "contact01@email.example.foo",
+     "contact02@email.example.foo"
+    ],
+    "enabled": true
+   },
    "tags": {
     "certification": "Certified",
     "infrastructure": "Devel"

--- a/website/docs/topology_endpoints.md
+++ b/website/docs/topology_endpoints.md
@@ -60,7 +60,8 @@ Accept: application/json
         "hostname": "host1.site-a.foo",
         "type": "SITES",
         "service": "c.service.foo",
-        "tags": { "scope": "TENANT", "production": "1", "monitored": "1" }
+        "tags": { "scope": "TENANT", "production": "1", "monitored": "1" },
+        "notifications": {"contacts": ["email01@example.com"], "enabled": true}
     }
 ]
 ```
@@ -185,6 +186,10 @@ Status: 200 OK
                 "scope": "TENANT",
                 "production": "1",
                 "monitored": "1"
+            },
+            "notifications": {
+                "contacts": ["email01@example.com"],
+                "enabled": true
             }
         }
     ]
@@ -307,6 +312,10 @@ Status: 200 OK
                 "scope": "TENANT",
                 "production": "1",
                 "monitored": "1"
+            },
+            "notifications": {
+                "contacts": ["email01@example.com"],
+                "enabled": true
             }
         }
     ]

--- a/website/docs/topology_groups.md
+++ b/website/docs/topology_groups.md
@@ -59,6 +59,10 @@ Accept: application/json
             "scope": "FEDERATION",
             "infrastructure": "Production",
             "certification": "Certified"
+        },
+        "notifications": {
+                "contacts": ["email01@example.com"],
+                "enabled": true
         }
     },
     {
@@ -183,6 +187,10 @@ Status: 200 OK
             "tags": {
                 "certification": "Certified",
                 "infrastructure": "Production"
+            },
+            "notifications": {
+                "contacts": ["email01@example.com"],
+                "enabled": true
             }
         }
     ]
@@ -289,6 +297,10 @@ Status: 200 OK
             "tags": {
                 "certification": "Certified",
                 "infrastructure": "Production"
+            },
+            "notifications": {
+                "contacts": ["email01@example.com"],
+                "enabled": true
             }
         },
         {


### PR DESCRIPTION
# Goal
Add notification information (contacts and notifications enabled/disabled) per topology item: groups and endpoints

# Implementation
- [x] Extend the models of TopologyGroups and TopologyEndpoints to include information about notifications 
- [x] Update unit tests
- [x] Update documentation
- [x] Update swagger   
