### PR TITLE
ARGO-2880 Connect specific weight datasets to each report

### DIFF
--- a/app/reports/reportsModel.go
+++ b/app/reports/reportsModel.go
@@ -157,6 +157,7 @@ var validators = map[string]string{
 	"aggregation": "aggregation_profiles",
 	"operations":  "operations_profiles",
 	"thresholds":  "thresholds_profiles",
+	"weights":     "weights",
 }
 
 // ValidateProfiles ensures that the profiles in a report actually exist in the database and
@@ -178,6 +179,14 @@ func (report *MongoInterface) ValidateProfiles(db *mgo.Database) []respond.Error
 				continue
 			}
 			report.Profiles[idx].Name = result.(bson.M)["name"].(string)
+		} else {
+			errs = append(errs,
+				respond.ErrorResponse{
+					Message: "Profile type invalid",
+					Code:    "422",
+					Details: fmt.Sprintf("Profile type %s is invalid", element.Type),
+				})
+			continue
 		}
 	}
 	return errs

--- a/website/docs/reports.md
+++ b/website/docs/reports.md
@@ -352,3 +352,110 @@ There are special argo contextes that are automatically picked up to filter grou
 -   _context:_ `argo.group.filter.tags` - Used to apply filter on tags of group topology. Under this context the `name` targets the group tag name and the `value` holds the actual field pattern
 -   _context:_ `argo.endpoint.filter.fields` - Used to apply filter on basic fields of endpoint topology. Under this context the `name` targets the endpoint field name and the `value` holds the actual field pattern
 -   _context:_ `argo.endpoint.filter.tags` - Used to apply filter on tags of endpoint topology. Under this context the `name` targets the endpoint tag name and the `value` holds the actual field pattern
+
+<a id='6'></a>
+
+## Notes on Optional profile references
+
+In the report's `profiles` list of references, along with the mandatory `metric`, `operations` and `aggregation` profiles, the user can declare references to the optinally used `thresholds` and `weights` profiles. User of the report must ensure that the declared reference `ids` are legit for each corresponding profile type. 
+
+Example of report with all profile type references declared:
+
+```json
+{
+    "status": {
+        "message": "Success",
+        "code": "200"
+    },
+    "data": [
+        {
+            "id": "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+            "tenant": "TenantA",
+            "disabled": false,
+            "info": {
+                "name": "Report_A",
+                "description": "report aaaaa",
+                "created": "2015-9-10 13:43:00",
+                "updated": "2015-10-11 13:43:00"
+            },
+            "topology_schema": {
+                "group": {
+                    "type": "NGI",
+                    "group": {
+                        "type": "SITE"
+                    }
+                }
+            },
+            "thresholds": {
+                "availability": 80.0,
+                "reliability": 85.0,
+                "uptime": 80.0,
+                "unknown": 10.0,
+                "downtime": 10.0
+            },
+            "profiles": [
+                {
+                    "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50b",
+                    "name": "profile1",
+                    "type": "metric"
+                },
+                {
+                    "id": "6ac7d684-1f8e-4a02-a502-720e8f11e523",
+                    "name": "profile2",
+                    "type": "operations"
+                },
+                {
+                    "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50q",
+                    "name": "profile3",
+                    "type": "aggregation"
+                },
+                {
+                    "id": "vac7d684-1f8e-4a02-a502-720e8f11e555",
+                    "name": "profile_38393",
+                    "type": "thresholds"
+                },
+                {
+                    "id": "rac65684-ff8e-5a02-6502-720e8f11e50q",
+                    "name": "profile_393",
+                    "type": "weights"
+                }
+            ],
+            "filter_tags": [
+                {
+                    "name": "name1",
+                    "value": "value1",
+                    "context": ""
+                },
+                {
+                    "name": "name2",
+                    "value": "value2",
+                    "context": ""
+                }
+            ]
+        }
+    ]
+}
+```
+
+During report creation, in case of wrong profile type reference defined or wrong profile uuid the following type of error will occur as a response:
+
+```json
+{
+    "status": {
+        "message": "Unprocessable Entity",
+        "code": "422"
+    },
+    "errors": [
+        {
+            "message": "Profile id not found",
+            "code": "422",
+            "details": "No profile in operations_profiles was found with id 93930-wrong-id"
+        },
+        {
+            "message": "Profile type invalid",
+            "code": "422",
+            "details": "Profile type whatever_profile is invalid"
+        }
+    ]
+}
+```


### PR DESCRIPTION
# Goal
Till now weight datasets were not directly referenced by a report. Instead per report the connector generated an appropriate weight dataset carrying the same name as the report intended to be used. On most tenant cases the same weight dataset was generated multiple times for each report which is inefficient. Instead it would be more robust for each report to optionally reference a weight dataset to be used. So for example for a tenant with 6 reports all of which use the same weights dataset we need 6 references to a single item and the weights dataset stored only once per day in the database.

# Implemetation
Reports already have a convenient list of profiles reference to reference profiles to be used along with the report computation such as metrics, operations, aggreagation and thresholds ones. We can add a new type of reference to the report's profile reference list with the name `weights`. We need to extend the validator to check if a corresponding weight id reference already exists in the database. 

- [x] Extend report model and validator to accomodate a new profile type reference: **weights**
- [x] Extend validator to warn againg incorrect profile type usages (apart from standar ones such as `metric`, `operations`, `aggregation`, `thresholds` & `weights`
- [x] Update unit tests
- [x] Update documentation with new feature explanation and possible api error reponses