### PR TITLE
ARGO-3074 Display metric flapping trends

### DIFF
--- a/app/trends/controller.go
+++ b/app/trends/controller.go
@@ -1,0 +1,277 @@
+/*
+ * Copyright (c) 2015 GRNET S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS
+ * IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ *
+ * The views and conclusions contained in the software and
+ * documentation are those of the authors and should not be
+ * interpreted as representing official policies, either expressed
+ * or implied, of GRNET S.A.
+ *
+ */
+
+package trends
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/ARGOeu/argo-web-api/respond"
+	"github.com/ARGOeu/argo-web-api/utils"
+	"github.com/ARGOeu/argo-web-api/utils/config"
+	"github.com/ARGOeu/argo-web-api/utils/mongo"
+	"github.com/gorilla/context"
+	"github.com/gorilla/mux"
+	"gopkg.in/mgo.v2/bson"
+)
+
+const flapEndpointGroups = "flipflop_trends_endpoint_groups"
+const flapEndpoints = "flipflop_trends_endpoints"
+const flapServices = "flipflop_trends_services"
+const flapMetrics = "flipflop_trends_metrics"
+
+// FlatFlappingMetrics returns a list of top flapping metrics for the day
+func ListFlappingMetrics(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
+
+	//STANDARD DECLARATIONS START
+
+	code := http.StatusOK
+	h := http.Header{}
+	output := []byte("List Flapping Metrics")
+	err := error(nil)
+	charset := "utf-8"
+
+	//STANDARD DECLARATIONS END
+
+	// Set Content-Type response Header value
+	contentType := r.Header.Get("Accept")
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+
+	// Parse the request into the input
+	urlValues := r.URL.Query()
+	vars := mux.Vars(r)
+
+	// Grab Tenant DB configuration from context
+	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
+
+	// Mongo Session
+	results := []MetricData{}
+
+	session, err := mongo.OpenSession(tenantDbConfig)
+	defer mongo.CloseSession(session)
+
+	metricCollection := session.DB(tenantDbConfig.Db).C(flapMetrics)
+
+	// Query the detailed metric results
+	reportID, err := mongo.GetReportID(session, tenantDbConfig.Db, vars["report_name"])
+
+	_, dateStr, err := utils.ParseZuluDate(urlValues.Get("date"))
+
+	if err != nil {
+		code = http.StatusBadRequest
+		output, _ = respond.MarshalContent(respond.ErrBadRequestDetails(err.Error()), contentType, "", " ")
+		return code, h, output, err
+	}
+
+	err = metricCollection.Find(bson.M{"report": reportID, "date": dateStr}).All(&results)
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	output, err = createMetricListView(results, "Success", 200)
+
+	return code, h, output, err
+}
+
+// FlatFlappingEndpoints returns a list of top flapping endpoints for the day
+func ListFlappingEndpoints(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
+
+	//STANDARD DECLARATIONS START
+
+	code := http.StatusOK
+	h := http.Header{}
+	output := []byte("List Flapping Endpoints")
+	err := error(nil)
+	charset := "utf-8"
+
+	//STANDARD DECLARATIONS END
+
+	// Set Content-Type response Header value
+	contentType := r.Header.Get("Accept")
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+
+	// Parse the request into the input
+	urlValues := r.URL.Query()
+	vars := mux.Vars(r)
+
+	// Grab Tenant DB configuration from context
+	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
+
+	// Mongo Session
+	results := []EndpointData{}
+
+	session, err := mongo.OpenSession(tenantDbConfig)
+	defer mongo.CloseSession(session)
+
+	endpointCollection := session.DB(tenantDbConfig.Db).C(flapEndpoints)
+
+	// Query the detailed endpoint results
+	reportID, err := mongo.GetReportID(session, tenantDbConfig.Db, vars["report_name"])
+
+	_, dateStr, err := utils.ParseZuluDate(urlValues.Get("date"))
+
+	if err != nil {
+		code = http.StatusBadRequest
+		output, _ = respond.MarshalContent(respond.ErrBadRequestDetails(err.Error()), contentType, "", " ")
+		return code, h, output, err
+	}
+
+	err = endpointCollection.Find(bson.M{"report": reportID, "date": dateStr}).All(&results)
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	output, err = createEndpointListView(results, "Success", 200)
+
+	return code, h, output, err
+}
+
+// FlatFlappingServices returns a list of top flapping services for the day
+func ListFlappingServices(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
+
+	//STANDARD DECLARATIONS START
+
+	code := http.StatusOK
+	h := http.Header{}
+	output := []byte("List Flapping Services")
+	err := error(nil)
+	charset := "utf-8"
+
+	//STANDARD DECLARATIONS END
+
+	// Set Content-Type response Header value
+	contentType := r.Header.Get("Accept")
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+
+	// Parse the request into the input
+	urlValues := r.URL.Query()
+	vars := mux.Vars(r)
+
+	// Grab Tenant DB configuration from context
+	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
+
+	// Mongo Session
+	results := []ServiceData{}
+
+	session, err := mongo.OpenSession(tenantDbConfig)
+	defer mongo.CloseSession(session)
+
+	servicesCollection := session.DB(tenantDbConfig.Db).C(flapServices)
+
+	// Query the detailed service results
+	reportID, err := mongo.GetReportID(session, tenantDbConfig.Db, vars["report_name"])
+
+	_, dateStr, err := utils.ParseZuluDate(urlValues.Get("date"))
+
+	if err != nil {
+		code = http.StatusBadRequest
+		output, _ = respond.MarshalContent(respond.ErrBadRequestDetails(err.Error()), contentType, "", " ")
+		return code, h, output, err
+	}
+
+	err = servicesCollection.Find(bson.M{"report": reportID, "date": dateStr}).All(&results)
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	output, err = createServiceListView(results, "Success", 200)
+
+	return code, h, output, err
+}
+
+// FlatFlappingEndpointGroups returns a list of top flapping endpoint groups for the day
+func ListFlappingEndpointGroups(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
+
+	//STANDARD DECLARATIONS START
+
+	code := http.StatusOK
+	h := http.Header{}
+	output := []byte("List Flapping Endpoint Groups")
+	err := error(nil)
+	charset := "utf-8"
+
+	//STANDARD DECLARATIONS END
+
+	// Set Content-Type response Header value
+	contentType := r.Header.Get("Accept")
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+
+	// Parse the request into the input
+	urlValues := r.URL.Query()
+	vars := mux.Vars(r)
+
+	// Grab Tenant DB configuration from context
+	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
+
+	// Mongo Session
+	results := []EndpointGroupData{}
+
+	session, err := mongo.OpenSession(tenantDbConfig)
+	defer mongo.CloseSession(session)
+
+	eGroupsCollection := session.DB(tenantDbConfig.Db).C(flapEndpointGroups)
+
+	// Query the detailed endpoint group results
+	reportID, err := mongo.GetReportID(session, tenantDbConfig.Db, vars["report_name"])
+
+	_, dateStr, err := utils.ParseZuluDate(urlValues.Get("date"))
+
+	if err != nil {
+		code = http.StatusBadRequest
+		output, _ = respond.MarshalContent(respond.ErrBadRequestDetails(err.Error()), contentType, "", " ")
+		return code, h, output, err
+	}
+
+	err = eGroupsCollection.Find(bson.M{"report": reportID, "date": dateStr}).All(&results)
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	output, err = createEndpointGroupListView(results, "Success", 200)
+
+	return code, h, output, err
+}
+
+// Options implements the option request on resource
+func Options(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
+
+	//STANDARD DECLARATIONS START
+
+	code := http.StatusOK
+	h := http.Header{}
+	output := []byte("")
+	err := error(nil)
+	contentType := "text/plain"
+	charset := "utf-8"
+
+	//STANDARD DECLARATIONS END
+
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+	h.Set("Allow", fmt.Sprintf("GET, OPTIONS"))
+	return code, h, output, err
+
+}

--- a/app/trends/model.go
+++ b/app/trends/model.go
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2015 GRNET S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS
+ * IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ *
+ * The views and conclusions contained in the software and
+ * documentation are those of the authors and should not be
+ * interpreted as representing official policies, either expressed
+ * or implied, of GRNET S.A.
+ *
+ */
+
+package trends
+
+import "encoding/xml"
+
+const zuluForm = "2006-01-02T15:04:05Z"
+const ymdForm = "2006-01-02"
+
+// MetricData holds flapping information about metrics
+type MetricData struct {
+	EndpointGroup string `bson:"group" json:"endpoint_group"`
+	Service       string `bson:"service" json:"service"`
+	Endpoint      string `bson:"endpoint" json:"endpoint"`
+	Metric        string `bson:"metric" json:"metric"`
+	Flapping      int    `bson:"flipflop" json:"flapping"`
+}
+
+// EndpointData holds flapping information about endpoints
+type EndpointData struct {
+	EndpointGroup string `bson:"group" json:"endpoint_group"`
+	Service       string `bson:"service" json:"service"`
+	Endpoint      string `bson:"endpoint" json:"endpoint"`
+	Flapping      int    `bson:"flipflop" json:"flapping"`
+}
+
+// ServiceData holds flapping information about services
+type ServiceData struct {
+	EndpointGroup string `bson:"group" json:"endpoint_group"`
+	Service       string `bson:"service" json:"service"`
+	Flapping      int    `bson:"flipflop" json:"flapping"`
+}
+
+// EndpointGroupData holds flapping information about endpoint groups
+type EndpointGroupData struct {
+	EndpointGroup string `bson:"group" json:"endpoint_group"`
+	Flapping      int    `bson:"flipflop" json:"flapping"`
+}
+
+// Message struct to hold the json/xml response
+type messageOUT struct {
+	XMLName xml.Name `xml:"root" json:"-"`
+	Message string   `xml:"message" json:"message"`
+	Code    string   `xml:"code,omitempty" json:"code,omitempty"`
+}

--- a/app/trends/routing.go
+++ b/app/trends/routing.go
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2015 GRNET S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS
+ * IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ *
+ * The views and conclusions contained in the software and
+ * documentation are those of the authors and should not be
+ * interpreted as representing official policies, either expressed
+ * or implied, of GRNET S.A.
+ *
+ */
+
+package trends
+
+import (
+	"github.com/ARGOeu/argo-web-api/respond"
+	"github.com/gorilla/mux"
+)
+
+// HandleSubrouter contains the different paths to follow during subrouting
+func HandleSubrouter(s *mux.Router, confhandler *respond.ConfHandler) {
+
+	s = respond.PrepAppRoutes(s, confhandler, appRoutesV2)
+}
+
+var appRoutesV2 = []respond.AppRoutes{
+
+	{"trends.flapping_metrics", "GET", "/{report_name}/flapping/metrics", ListFlappingMetrics},
+	{"trends.flapping_endpoints", "GET", "/{report_name}/flapping/endpoints", ListFlappingEndpoints},
+	{"trends.flapping_services", "GET", "/{report_name}/flapping/services", ListFlappingServices},
+	{"trends.flapping_endpoint_groups", "GET", "/{report_name}/flapping/groups", ListFlappingEndpointGroups},
+	{"trends.options", "OPTIONS", "/{report_name}/flapping/metrics", Options},
+	{"trends.options", "OPTIONS", "/{report_name}/flapping/endpoints", Options},
+	{"trends.options", "OPTIONS", "/{report_name}/flapping/services", Options},
+	{"trends.options", "OPTIONS", "/{report_name}/flapping/groups", Options},
+}

--- a/app/trends/trends_test.go
+++ b/app/trends/trends_test.go
@@ -1,0 +1,546 @@
+/*
+ * Copyright (c) 2015 GRNET S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS
+ * IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ *
+ * The views and conclusions contained in the software and
+ * documentation are those of the authors and should not be
+ * interpreted as representing official policies, either expressed
+ * or implied, of GRNET S.A.
+ *
+ */
+
+package trends
+
+import (
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/ARGOeu/argo-web-api/respond"
+	"github.com/ARGOeu/argo-web-api/utils/authentication"
+	"github.com/ARGOeu/argo-web-api/utils/config"
+	"github.com/ARGOeu/argo-web-api/utils/mongo"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/suite"
+	"gopkg.in/gcfg.v1"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+)
+
+// This is a util. suite struct used in tests (see pkg "testify")
+type TrendsTestSuite struct {
+	suite.Suite
+	cfg          config.Config
+	router       *mux.Router
+	confHandler  respond.ConfHandler
+	tenantDbConf config.MongoConfig
+}
+
+// Setup the Test Environment
+// This function runs before any test and setups the environment
+// A test configuration object is instantiated using a reference
+// to testdb: argo_test_details. Also here is are instantiated some expected
+// xml response validation messages (authorization,crud responses).
+// Also the testdb is seeded with tenants,reports,metric_profiles and status_metrics
+func (suite *TrendsTestSuite) SetupTest() {
+
+	log.SetOutput(ioutil.Discard)
+
+	const testConfig = `
+    [server]
+    bindip = ""
+    port = 8080
+    maxprocs = 4
+    cache = false
+    lrucache = 700000000
+    gzip = true
+    [mongodb]
+    host = "127.0.0.1"
+    port = 27017
+    db = "argotest_trends"
+`
+
+	_ = gcfg.ReadStringInto(&suite.cfg, testConfig)
+
+	// Create router and confhandler for test
+	suite.confHandler = respond.ConfHandler{suite.cfg}
+	suite.router = mux.NewRouter().StrictSlash(true).PathPrefix("/api/v2/trends").Subrouter()
+	HandleSubrouter(suite.router, &suite.confHandler)
+
+	// Connect to mongo testdb
+	session, _ := mongo.OpenSession(suite.cfg.MongoDB)
+
+	// Add authentication token to mongo testdb
+	seedAuth := bson.M{"api_key": "S3CR3T"}
+	_ = mongo.Insert(session, suite.cfg.MongoDB.Db, "authentication", seedAuth)
+
+	// seed mongo
+	session, err := mgo.Dial(suite.cfg.MongoDB.Host)
+	if err != nil {
+		panic(err)
+	}
+	defer session.Close()
+
+	// seed a tenant to use
+	c := session.DB(suite.cfg.MongoDB.Db).C("tenants")
+	c.Insert(bson.M{
+		"id": "6ac7d684-1f8e-4a02-a502-720e8f11e50c",
+		"info": bson.M{
+			"name":    "GUARDIANS",
+			"email":   "email@something2",
+			"website": "www.gotg.com",
+			"created": "2015-10-20 02:08:04",
+			"updated": "2015-10-20 02:08:04"},
+		"db_conf": []bson.M{
+			bson.M{
+				"store":    "main",
+				"server":   "localhost",
+				"port":     27017,
+				"database": "argotest_trends_tenant",
+				"username": "",
+				"password": ""},
+		},
+		"users": []bson.M{
+			bson.M{
+				"name":    "tenant_user",
+				"email":   "tenant_user@email.com",
+				"roles":   []string{"viewer"},
+				"api_key": "KEY1"},
+		}})
+
+	c = session.DB(suite.cfg.MongoDB.Db).C("roles")
+	c.Insert(
+		bson.M{
+			"resource": "trends.flapping_metrics",
+			"roles":    []string{"editor", "viewer"},
+		},
+		bson.M{
+			"resource": "trends.flapping_endpoints",
+			"roles":    []string{"editor", "viewer"},
+		},
+		bson.M{
+			"resource": "trends.flapping_services",
+			"roles":    []string{"editor", "viewer"},
+		},
+		bson.M{
+			"resource": "trends.flapping_endpoint_groups",
+			"roles":    []string{"editor", "viewer"},
+		})
+
+	// get dbconfiguration based on the tenant
+	// Prepare the request object
+	request, _ := http.NewRequest("GET", "", strings.NewReader(""))
+	// add the content-type header to application/json
+	request.Header.Set("Content-Type", "application/json")
+	// add the authentication token which is seeded in testdb
+	request.Header.Set("x-api-key", "KEY1")
+	// authenticate user's api key and find corresponding tenant
+	suite.tenantDbConf, _, err = authentication.AuthenticateTenant(request.Header, suite.cfg)
+
+	// Now seed the report DEFINITIONS
+	c = session.DB(suite.tenantDbConf.Db).C("reports")
+	c.Insert(bson.M{
+		"id": "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"info": bson.M{
+			"name":        "Report_A",
+			"description": "report aaaaa",
+			"created":     "2015-9-10 13:43:00",
+			"updated":     "2015-10-11 13:43:00",
+		},
+		"topology_schema": bson.M{
+			"group": bson.M{
+				"type": "NGI",
+				"group": bson.M{
+					"type": "SITES",
+				},
+			},
+		},
+		"profiles": []bson.M{
+			bson.M{
+				"id":   "6ac7d684-1f8e-4a02-a502-720e8f11e50b",
+				"type": "metric",
+				"name": "profile1"},
+			bson.M{
+				"id":   "6ac7d684-1f8e-4a02-a502-720e8f11e523",
+				"type": "operations",
+				"name": "profile2"},
+			bson.M{
+				"id":   "6ac7d684-1f8e-4a02-a502-720e8f11e50q",
+				"type": "aggregation",
+				"name": "profile3"},
+		},
+		"filter_tags": []bson.M{
+			bson.M{
+				"name":  "name1",
+				"value": "value1"},
+			bson.M{
+				"name":  "name2",
+				"value": "value2"},
+		}})
+	// seed the status detailed trends metric data
+	c = session.DB(suite.tenantDbConf.Db).C("flipflop_trends_metrics")
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     "2015-05-01",
+		"group":    "SITE-A",
+		"service":  "service-A",
+		"endpoint": "hosta.example.foo",
+		"metric":   "check-1",
+		"flipflop": 55,
+	})
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     "2015-05-01",
+		"group":    "SITE-A",
+		"service":  "service-A",
+		"endpoint": "hosta.example.foo",
+		"metric":   "check-2",
+		"flipflop": 40,
+	})
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     "2015-05-01",
+		"group":    "SITE-A",
+		"service":  "service-B",
+		"endpoint": "hostb.example.foo",
+		"metric":   "web-check",
+		"flipflop": 12,
+	})
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     "2015-05-01",
+		"group":    "SITE-B",
+		"service":  "service-A",
+		"endpoint": "hosta.example2.foo",
+		"metric":   "web-check",
+		"flipflop": 5,
+	})
+
+	// seed the status detailed trends endpoint data
+	c = session.DB(suite.tenantDbConf.Db).C("flipflop_trends_endpoints")
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     "2015-05-01",
+		"group":    "SITE-A",
+		"service":  "service-A",
+		"endpoint": "hosta.example.foo",
+		"flipflop": 55,
+	})
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     "2015-05-01",
+		"group":    "SITE-A",
+		"service":  "service-B",
+		"endpoint": "hostb.example.foo",
+		"flipflop": 12,
+	})
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     "2015-05-01",
+		"group":    "SITE-B",
+		"service":  "service-A",
+		"endpoint": "hosta.example2.foo",
+		"flipflop": 5,
+	})
+
+	// seed the status detailed trends service data
+	c = session.DB(suite.tenantDbConf.Db).C("flipflop_trends_services")
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     "2015-05-01",
+		"group":    "SITE-A",
+		"service":  "service-A",
+		"flipflop": 55,
+	})
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     "2015-05-01",
+		"group":    "SITE-A",
+		"service":  "service-B",
+		"flipflop": 12,
+	})
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     "2015-05-01",
+		"group":    "SITE-B",
+		"service":  "service-A",
+		"flipflop": 5,
+	})
+
+	// seed the status detailed trends group data
+	c = session.DB(suite.tenantDbConf.Db).C("flipflop_trends_endpoint_groups")
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     "2015-05-01",
+		"group":    "SITE-A",
+		"flipflop": 55,
+	})
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     "2015-05-01",
+		"group":    "SITE-B",
+		"flipflop": 5,
+	})
+
+}
+
+func (suite *TrendsTestSuite) TestTrends() {
+
+	type expReq struct {
+		method string
+		url    string
+		code   int
+		result string
+		key    string
+	}
+
+	expReqs := []expReq{
+
+		expReq{
+			method: "GET",
+			url:    "/api/v2/trends/Report_A/flapping/metrics?date=2015-05-01",
+			code:   200,
+			key:    "KEY1",
+			result: `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "endpoint_group": "SITE-A",
+   "service": "service-A",
+   "endpoint": "hosta.example.foo",
+   "metric": "check-1",
+   "flapping": 55
+  },
+  {
+   "endpoint_group": "SITE-A",
+   "service": "service-A",
+   "endpoint": "hosta.example.foo",
+   "metric": "check-2",
+   "flapping": 40
+  },
+  {
+   "endpoint_group": "SITE-A",
+   "service": "service-B",
+   "endpoint": "hostb.example.foo",
+   "metric": "web-check",
+   "flapping": 12
+  },
+  {
+   "endpoint_group": "SITE-B",
+   "service": "service-A",
+   "endpoint": "hosta.example2.foo",
+   "metric": "web-check",
+   "flapping": 5
+  }
+ ]
+}`,
+		},
+
+		expReq{
+			method: "GET",
+			url:    "/api/v2/trends/Report_A/flapping/endpoints?date=2015-05-01",
+			code:   200,
+			key:    "KEY1",
+			result: `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "endpoint_group": "SITE-A",
+   "service": "service-A",
+   "endpoint": "hosta.example.foo",
+   "flapping": 55
+  },
+  {
+   "endpoint_group": "SITE-A",
+   "service": "service-B",
+   "endpoint": "hostb.example.foo",
+   "flapping": 12
+  },
+  {
+   "endpoint_group": "SITE-B",
+   "service": "service-A",
+   "endpoint": "hosta.example2.foo",
+   "flapping": 5
+  }
+ ]
+}`,
+		},
+
+		expReq{
+			method: "GET",
+			url:    "/api/v2/trends/Report_A/flapping/services?date=2015-05-01",
+			code:   200,
+			key:    "KEY1",
+			result: `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "endpoint_group": "SITE-A",
+   "service": "service-A",
+   "flapping": 55
+  },
+  {
+   "endpoint_group": "SITE-A",
+   "service": "service-B",
+   "flapping": 12
+  },
+  {
+   "endpoint_group": "SITE-B",
+   "service": "service-A",
+   "flapping": 5
+  }
+ ]
+}`,
+		},
+
+		expReq{
+			method: "GET",
+			url:    "/api/v2/trends/Report_A/flapping/groups?date=2015-05-01",
+			code:   200,
+			key:    "KEY1",
+			result: `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "endpoint_group": "SITE-A",
+   "flapping": 55
+  },
+  {
+   "endpoint_group": "SITE-B",
+   "flapping": 5
+  }
+ ]
+}`,
+		},
+	}
+
+	for _, expReq := range expReqs {
+		request, _ := http.NewRequest(expReq.method, expReq.url, strings.NewReader(""))
+		request.Header.Set("x-api-key", expReq.key)
+		request.Header.Set("Accept", "application/json")
+
+		response := httptest.NewRecorder()
+
+		suite.router.ServeHTTP(response, request)
+
+		suite.Equal(expReq.code, response.Code, "Incorrect HTTP response code")
+		// Compare the expected and actual xml response
+		suite.Equal(expReq.result, response.Body.String(), "Response body mismatch")
+
+	}
+
+}
+
+func (suite *TrendsTestSuite) TestOptionsTrendsMetrics() {
+	request, _ := http.NewRequest("OPTIONS", "/api/v2/trends/Report_A/flapping/metrics", strings.NewReader(""))
+
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code := response.Code
+	output := response.Body.String()
+	headers := response.HeaderMap
+
+	suite.Equal(200, code, "Error in response code")
+	suite.Equal("", output, "Expected empty response body")
+	suite.Equal("GET, OPTIONS", headers.Get("Allow"), "Error in Allow header response (supported resource verbs of resource)")
+	suite.Equal("text/plain; charset=utf-8", headers.Get("Content-Type"), "Error in Content-Type header response")
+
+}
+
+func (suite *TrendsTestSuite) TestOptionsTrendsEndpoints() {
+	request, _ := http.NewRequest("OPTIONS", "/api/v2/trends/Report_A/flapping/endpoints", strings.NewReader(""))
+
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code := response.Code
+	output := response.Body.String()
+	headers := response.HeaderMap
+
+	suite.Equal(200, code, "Error in response code")
+	suite.Equal("", output, "Expected empty response body")
+	suite.Equal("GET, OPTIONS", headers.Get("Allow"), "Error in Allow header response (supported resource verbs of resource)")
+	suite.Equal("text/plain; charset=utf-8", headers.Get("Content-Type"), "Error in Content-Type header response")
+
+}
+
+func (suite *TrendsTestSuite) TestOptionsTrendsServices() {
+	request, _ := http.NewRequest("OPTIONS", "/api/v2/trends/Report_A/flapping/services", strings.NewReader(""))
+
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code := response.Code
+	output := response.Body.String()
+	headers := response.HeaderMap
+
+	suite.Equal(200, code, "Error in response code")
+	suite.Equal("", output, "Expected empty response body")
+	suite.Equal("GET, OPTIONS", headers.Get("Allow"), "Error in Allow header response (supported resource verbs of resource)")
+	suite.Equal("text/plain; charset=utf-8", headers.Get("Content-Type"), "Error in Content-Type header response")
+
+}
+
+func (suite *TrendsTestSuite) TestOptionsTrendsEndpointGroups() {
+	request, _ := http.NewRequest("OPTIONS", "/api/v2/trends/Report_A/flapping/groups", strings.NewReader(""))
+
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code := response.Code
+	output := response.Body.String()
+	headers := response.HeaderMap
+
+	suite.Equal(200, code, "Error in response code")
+	suite.Equal("", output, "Expected empty response body")
+	suite.Equal("GET, OPTIONS", headers.Get("Allow"), "Error in Allow header response (supported resource verbs of resource)")
+	suite.Equal("text/plain; charset=utf-8", headers.Get("Content-Type"), "Error in Content-Type header response")
+
+}
+
+// This function is actually called in the end of all tests
+// and clears the test environment.
+// Mainly it's purpose is to drop the testdb
+func (suite *TrendsTestSuite) TearDownTest() {
+
+	session, _ := mongo.OpenSession(suite.cfg.MongoDB)
+
+	session.DB("argotest_trends").DropDatabase()
+	session.DB("argotest_trends_tenant").DropDatabase()
+}
+
+// This is the first function called when go test is issued
+func TestTrends(t *testing.T) {
+	suite.Run(t, new(TrendsTestSuite))
+}

--- a/app/trends/view.go
+++ b/app/trends/view.go
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2015 GRNET S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS
+ * IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ *
+ * The views and conclusions contained in the software and
+ * documentation are those of the authors and should not be
+ * interpreted as representing official policies, either expressed
+ * or implied, of GRNET S.A.
+ *
+ */
+
+package trends
+
+import (
+	"encoding/json"
+	"strconv"
+
+	"github.com/ARGOeu/argo-web-api/respond"
+)
+
+// createMetricListView constructs the list response template and exports it as json
+func createMetricListView(results []MetricData, msg string, code int) ([]byte, error) {
+
+	docRoot := &respond.ResponseMessage{
+		Status: respond.StatusResponse{
+			Message: msg,
+			Code:    strconv.Itoa(code),
+		},
+	}
+	docRoot.Data = results
+
+	output, err := json.MarshalIndent(docRoot, "", " ")
+	return output, err
+
+}
+
+// createServiceListView constructs the list response template and exports it as json
+func createServiceListView(results []ServiceData, msg string, code int) ([]byte, error) {
+
+	docRoot := &respond.ResponseMessage{
+		Status: respond.StatusResponse{
+			Message: msg,
+			Code:    strconv.Itoa(code),
+		},
+	}
+	docRoot.Data = results
+
+	output, err := json.MarshalIndent(docRoot, "", " ")
+	return output, err
+
+}
+
+// createEndpointListView constructs the list response template and exports it as json
+func createEndpointListView(results []EndpointData, msg string, code int) ([]byte, error) {
+
+	docRoot := &respond.ResponseMessage{
+		Status: respond.StatusResponse{
+			Message: msg,
+			Code:    strconv.Itoa(code),
+		},
+	}
+	docRoot.Data = results
+
+	output, err := json.MarshalIndent(docRoot, "", " ")
+	return output, err
+
+}
+
+// createEndpointGroupListView constructs the list response template and exports it as json
+func createEndpointGroupListView(results []EndpointGroupData, msg string, code int) ([]byte, error) {
+
+	docRoot := &respond.ResponseMessage{
+		Status: respond.StatusResponse{
+			Message: msg,
+			Code:    strconv.Itoa(code),
+		},
+	}
+	docRoot.Data = results
+
+	output, err := json.MarshalIndent(docRoot, "", " ")
+	return output, err
+
+}
+
+func createMessageOUT(message string, code int, format string) ([]byte, error) {
+
+	output := []byte("message placeholder")
+	err := error(nil)
+	docRoot := &messageOUT{}
+
+	docRoot.Message = message
+	docRoot.Code = strconv.Itoa(code)
+	output, err = respond.MarshalContent(docRoot, format, "", " ")
+	return output, err
+}

--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -3405,6 +3405,162 @@ paths:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Status_error'
+            
+  /trends/{REPORT_NAME}/flapping/metrics:
+    get:
+      summary: List trends for top flapping service endpoint metrics
+      operationId: trends.FlappingMetrics
+      description: List top flapping service endpoint metrics (that change status frequently)
+      tags:
+        - Trends
+      produces:
+        - "application/json"
+      parameters:
+        - $ref: "#/parameters/profDate"
+        - $ref: "#/parameters/apiKey"
+        - name: "REPORT_NAME"
+          in: "path"
+          description: "name of the report"
+          required: true
+          type: string
+      responses:
+        '200':
+          description: A list with flapping metrics
+          schema:
+            $ref: '#/definitions/Trends_metrics_list'
+        '401':
+          description: Unauthorized user
+          schema:
+            $ref: '#/definitions/Status_error'
+        '404':
+          description: Item not found
+          schema:
+            $ref: '#/definitions/Status_error'
+        '406':
+          description: Content Not acceptable
+          schema:
+            $ref: '#/definitions/Status_error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Status_error'
+
+  /trends/{REPORT_NAME}/flapping/endpoints:
+    get:
+      summary: List trends for top flapping service endpoints
+      operationId: trends.FlappingEdpoints
+      description: List top flapping service endpoints (that change status frequently)
+      tags:
+        - Trends
+      produces:
+        - "application/json"
+      parameters:
+        - $ref: "#/parameters/profDate"
+        - $ref: "#/parameters/apiKey"
+        - name: "REPORT_NAME"
+          in: "path"
+          description: "name of the report"
+          required: true
+          type: string
+      responses:
+        '200':
+          description: A list with flapping endpoints
+          schema:
+            $ref: '#/definitions/Trends_endpoints_list'
+        '401':
+          description: Unauthorized user
+          schema:
+            $ref: '#/definitions/Status_error'
+        '404':
+          description: Item not found
+          schema:
+            $ref: '#/definitions/Status_error'
+        '406':
+          description: Content Not acceptable
+          schema:
+            $ref: '#/definitions/Status_error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Status_error'
+            
+  /trends/{REPORT_NAME}/flapping/services:
+    get:
+      summary: List trends for top flapping services
+      operationId: trends.FlappingServices
+      description: List top flapping services (that change status frequently)
+      tags:
+        - Trends
+      produces:
+        - "application/json"
+      parameters:
+        - $ref: "#/parameters/profDate"
+        - $ref: "#/parameters/apiKey"
+        - name: "REPORT_NAME"
+          in: "path"
+          description: "name of the report"
+          required: true
+          type: string
+      responses:
+        '200':
+          description: A list with flapping services
+          schema:
+            $ref: '#/definitions/Trends_services_list'
+        '401':
+          description: Unauthorized user
+          schema:
+            $ref: '#/definitions/Status_error'
+        '404':
+          description: Item not found
+          schema:
+            $ref: '#/definitions/Status_error'
+        '406':
+          description: Content Not acceptable
+          schema:
+            $ref: '#/definitions/Status_error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Status_error'
+
+  /trends/{REPORT_NAME}/flapping/groups:
+    get:
+      summary: List trends for top flapping endpoint groups
+      operationId: trends.FlappingGroups
+      description: List top flapping endpoint groups (that change status frequently)
+      tags:
+        - Trends
+      produces:
+        - "application/json"
+      parameters:
+        - $ref: "#/parameters/profDate"
+        - $ref: "#/parameters/apiKey"
+        - name: "REPORT_NAME"
+          in: "path"
+          description: "name of the report"
+          required: true
+          type: string
+      responses:
+        '200':
+          description: A list with flapping endpoint groups
+          schema:
+            $ref: '#/definitions/Trends_groups_list'
+        '401':
+          description: Unauthorized user
+          schema:
+            $ref: '#/definitions/Status_error'
+        '404':
+          description: Item not found
+          schema:
+            $ref: '#/definitions/Status_error'
+        '406':
+          description: Content Not acceptable
+          schema:
+            $ref: '#/definitions/Status_error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Status_error'
 
   /factors:
     get:
@@ -4646,6 +4802,92 @@ definitions:
             details:
               type: string
               
+              
+  Trends_metrics:
+    type: object
+    properties:
+      endpoint_group:
+        type: string
+      service:
+        type: string
+      endpoint:
+        type: string
+      metric:
+        type: string
+      flapping:
+        type: integer
+        
+  Trends_endpoints:
+    type: object
+    properties:
+      endpoint_group:
+        type: string
+      service:
+        type: string
+      endpoint:
+        type: string
+      flapping:
+        type: integer
+        
+  Trends_services:
+    type: object
+    properties:
+      endpoint_group:
+        type: string
+      service:
+        type: string
+      flapping:
+        type: integer 
+
+  Trends_groups:
+    type: object
+    properties:
+      endpoint_group:
+        type: string
+      flapping:
+        type: integer 
+        
+  
+  Trends_metrics_list:
+    type: object
+    properties:
+      status:
+       $ref: '#/definitions/Status'
+      data:
+        type: array
+        items:
+          $ref: '#/definitions/Trends_metrics'
+          
+  Trends_endpoints_list:
+    type: object
+    properties:
+      status:
+       $ref: '#/definitions/Status'
+      data:
+        type: array
+        items:
+          $ref: '#/definitions/Trends_endpoints'
+          
+          
+  Trends_services_list:
+    type: object
+    properties:
+      status:
+       $ref: '#/definitions/Status'
+      data:
+        type: array
+        items:
+          $ref: '#/definitions/Trends_services'
+          
+  Trends_groups_list:
+    type: object
+    properties:
+      status:
+       $ref: '#/definitions/Status'
+      data:
+        type: array
+        items:
+          $ref: '#/definitions/Trends_groups'
 
   Downtimes_list:
     type: object

--- a/routing/routes.go
+++ b/routing/routes.go
@@ -44,6 +44,7 @@ import (
 	"github.com/ARGOeu/argo-web-api/app/tenants"
 	"github.com/ARGOeu/argo-web-api/app/thresholdsProfiles"
 	"github.com/ARGOeu/argo-web-api/app/topology"
+	"github.com/ARGOeu/argo-web-api/app/trends"
 	"github.com/ARGOeu/argo-web-api/app/weights"
 	"github.com/ARGOeu/argo-web-api/version"
 )
@@ -51,6 +52,7 @@ import (
 var routesV2 = []RouteV2{
 
 	{"Issues", "/issues", issues.HandleSubrouter},
+	{"Trends", "/trends", trends.HandleSubrouter},
 	{"Feeds", "/feeds", feeds.HandleSubrouter},
 	{"Topology", "/topology", topology.HandleSubrouter},
 	{"Latest", "/latest", latest.HandleSubrouter},

--- a/scripts/mongodb/populate_default_roles.js
+++ b/scripts/mongodb/populate_default_roles.js
@@ -214,6 +214,22 @@ function populate_default_roles() {
         {
             resource: "downtimes.create",
             roles: ["admin", "editor"]
+        },
+        {
+            resource: "trends.flapping_metrics",
+            roles: ["admin", "editor", "viewer"]
+        },
+        {
+            resource: "trends.flapping_endpoints",
+            roles: ["admin", "editor", "viewer"]
+        },
+        {
+            resource: "trends.flapping_services",
+            roles: ["admin", "editor", "viewer"]
+        },
+        {
+            resource: "trends.flapping_endpoint_groups",
+            roles: ["admin", "editor", "viewer"]
         }
     ]);
     print("INFO\tPolulated default roles in 'roles' collection");

--- a/website/docs/trends.md
+++ b/website/docs/trends.md
@@ -1,0 +1,330 @@
+---
+id:  trends
+title: trends
+---
+
+## API calls to find flapping trends among metrics, endpoints, services and groups by Date
+
+Flapping items are the ones that change state too frequently causing a lot of alarms and notifications. State flapping might be the case of wrong configuration. 
+
+### [GET]: Daily Flapping trends in service endpoint metrics
+This method may be used to retrieve a list of top flapping service endpoint metrics. 
+
+### Input
+
+```
+/trends/{report_name}/flapping/metrics?date=2020-05-01
+```
+
+#### Path Parameters
+| Type | Description | Required | Default value |
+|------|-------------|----------|---------------|
+|`report_name`| name of the report| YES |  |
+
+#### Url Parameters
+
+| Type | Description | Required | Default value |
+|------|-------------|----------|---------------|
+|`date`| Date to view problematic endpoints of | NO |  |
+
+
+#### Headers
+```
+x-api-key: shared_key_value
+Accept: application/json or application/xml
+```
+
+#### Response Code
+```
+Status: 200 OK
+```
+
+### Response body
+
+###### Example Request:
+URL:
+```
+/trends/{report_name}/flapping/metrics?date=2020-05-01
+```
+Headers:
+```
+x-api-key: shared_key_value
+Accept: application/json or application/xml
+
+```
+###### Example Response:
+
+Code:
+```
+Status: 200 OK
+```
+Reponse body:
+```
+{
+  "status": {
+    "message": "Success",
+    "code": "200"
+  },
+  "data": [
+    {
+      "endpoint_group": "SITE-A",
+      "service": "service-A",
+      "endpoint": "hosta.example.foo",
+      "metric": "check-1",
+      "flapping": 55
+    },
+    {
+      "endpoint_group": "SITE-A",
+      "service": "service-A",
+      "endpoint": "hosta.example.foo",
+      "metric": "check-2",
+      "flapping": 40
+    },
+    {
+      "endpoint_group": "SITE-A",
+      "service": "service-B",
+      "endpoint": "hostb.example.foo",
+      "metric": "web-check",
+      "flapping": 12
+    },
+    {
+      "endpoint_group": "SITE-B",
+      "service": "service-A",
+      "endpoint": "hosta.example2.foo",
+      "metric": "web-check",
+      "flapping": 5
+    }
+  ]
+}
+```
+
+
+### [GET]: Daily Flapping trends in service endpoints 
+This method may be used to retrieve a list of top flapping service endpoints
+
+### Input
+
+```
+/trends/{report_name}/flapping/endpoints?date=2020-05-01
+```
+
+#### Path Parameters
+| Type | Description | Required | Default value |
+|------|-------------|----------|---------------|
+|`report_name`| name of the report| YES |  |
+
+#### Url Parameters
+
+| Type | Description | Required | Default value |
+|------|-------------|----------|---------------|
+|`date`| Date to view problematic endpoints of | NO |  |
+
+
+#### Headers
+```
+x-api-key: shared_key_value
+Accept: application/json or application/xml
+```
+
+#### Response Code
+```
+Status: 200 OK
+```
+
+### Response body
+
+###### Example Request:
+URL:
+```
+/trends/{report_name}/flapping/endpoints?date=2020-05-01
+```
+Headers:
+```
+x-api-key: shared_key_value
+Accept: application/json or application/xml
+
+```
+###### Example Response:
+
+Code:
+```
+Status: 200 OK
+```
+Reponse body:
+```
+{
+  "status": {
+    "message": "Success",
+    "code": "200"
+  },
+  "data": [
+    {
+      "endpoint_group": "SITE-A",
+      "service": "service-A",
+      "endpoint": "hosta.example.foo",
+      "flapping": 55
+    },
+    {
+      "endpoint_group": "SITE-A",
+      "service": "service-B",
+      "endpoint": "hostb.example.foo",
+      "flapping": 12
+    },
+    {
+      "endpoint_group": "SITE-B",
+      "service": "service-A",
+      "endpoint": "hosta.example2.foo",
+      "flapping": 5
+    }
+  ]
+}
+```
+
+### [GET]: Daily Flapping trends in services
+This method may be used to retrieve a list of top flapping services
+
+### Input
+
+```
+/trends/{report_name}/flapping/services?date=2020-05-01
+```
+
+#### Path Parameters
+| Type | Description | Required | Default value |
+|------|-------------|----------|---------------|
+|`report_name`| name of the report| YES |  |
+
+#### Url Parameters
+
+| Type | Description | Required | Default value |
+|------|-------------|----------|---------------|
+|`date`| Date to view problematic endpoints of | NO |  |
+
+
+#### Headers
+```
+x-api-key: shared_key_value
+Accept: application/json or application/xml
+```
+
+#### Response Code
+```
+Status: 200 OK
+```
+
+### Response body
+
+###### Example Request:
+URL:
+```
+/trends/{report_name}/flapping/services?date=2020-05-01
+```
+Headers:
+```
+x-api-key: shared_key_value
+Accept: application/json or application/xml
+
+```
+###### Example Response:
+
+Code:
+```
+Status: 200 OK
+```
+Reponse body:
+```
+{
+  "status": {
+    "message": "Success",
+    "code": "200"
+  },
+  "data": [
+    {
+      "endpoint_group": "SITE-A",
+      "service": "service-A",
+      "flapping": 55
+    },
+    {
+      "endpoint_group": "SITE-A",
+      "service": "service-B",
+      "flapping": 12
+    },
+    {
+      "endpoint_group": "SITE-B",
+      "service": "service-A",
+      "flapping": 5
+    }
+  ]
+}
+```
+
+### [GET]: Daily Flapping trends in endpoint groups
+This method may be used to retrieve a list of top endpoint groups
+
+### Input
+
+```
+/trends/{report_name}/flapping/groups?date=2020-05-01
+```
+
+#### Path Parameters
+| Type | Description | Required | Default value |
+|------|-------------|----------|---------------|
+|`report_name`| name of the report| YES |  |
+
+#### Url Parameters
+
+| Type | Description | Required | Default value |
+|------|-------------|----------|---------------|
+|`date`| Date to view problematic endpoints of | NO |  |
+
+
+#### Headers
+```
+x-api-key: shared_key_value
+Accept: application/json or application/xml
+```
+
+#### Response Code
+```
+Status: 200 OK
+```
+
+### Response body
+
+###### Example Request:
+URL:
+```
+/trends/{report_name}/flapping/groups?date=2020-05-01
+```
+Headers:
+```
+x-api-key: shared_key_value
+Accept: application/json or application/xml
+
+```
+###### Example Response:
+
+Code:
+```
+Status: 200 OK
+```
+Reponse body:
+```
+{
+  "status": {
+    "message": "Success",
+    "code": "200"
+  },
+  "data": [
+    {
+      "endpoint_group": "SITE-A",
+      "flapping": 55
+    },
+    {
+      "endpoint_group": "SITE-B",
+      "flapping": 5
+    }
+  ]
+}
+```

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -2,7 +2,7 @@ module.exports = {
   someSidebar: {
     'Tenants & Feeds': ['tenants', 'feeds', 'downtimes', 'topology_endpoints', 'topology_groups', 'weights'],
     'Profiles & Reports': ['operations_profiles', 'metric_profiles', 'aggregation_profiles', 'threshold_profiles', 'reports'],
-    'Results' : ['ar_results', 'status_results', 'issues', 'metric_results', 'topology_stats', 'recomputations'],
+    'Results' : ['ar_results', 'status_results', 'issues', 'trends', 'metric_results', 'topology_stats', 'recomputations'],
     'Validations & Errors': ['validations', 'errors']
   },
 };


### PR DESCRIPTION
ARGO-3075 Display endpoint flapping trends
ARGO-3076 Display service flapping trends
ARGO-3077 Display group flapping trends

# Goal 

Provide four calls to display flapping trends for metrics, endpoints, services and endpoint groups

ℹ️ flapping items are the ones that change state too frequently. This causes a lot of alarms and notifications. Flapping usually is the result of wrong configuration. 

### Requests

Argo-web-api provides the following calls to quickly view the top flapping metrics, endpoints, services and groups:
- *metrics*: `/api/v2/trends/{report_name}/flapping/metrics?date={date}`
- *endpoints*: `/api/v2/trends/{report_name}/flapping/endpoints?date={date}`
- *services*: `/api/v2/trends/{report_name}/flapping/services?date={date}`
- *groups*: `/api/v2/trends/{report_name}/flapping/groups?date={date}`

_Results are queried per report and date_

### Responses
For each monitored item asked (metrics, endpoints, services, groups) the api returns a list of top flapping items in json format. For example:

:point_right: *metrics*:
```
json
{
  "status": {
    "message": "Success",
    "code": "200"
  },
  "data": [
    {
      "endpoint_group": "SITE-A",
      "service": "service-A",
      "endpoint": "hosta.example.foo",
      "metric": "check-1",
      "flapping": 55
    },
    {
      "endpoint_group": "SITE-A",
      "service": "service-A",
      "endpoint": "hosta.example.foo",
      "metric": "check-2",
      "flapping": 40
    },
    {
      "endpoint_group": "SITE-A",
      "service": "service-B",
      "endpoint": "hostb.example.foo",
      "metric": "web-check",
      "flapping": 12
    },
    {
      "endpoint_group": "SITE-B",
      "service": "service-A",
      "endpoint": "hosta.example2.foo",
      "metric": "web-check",
      "flapping": 5
    }
  ]
}
```

:point_right: *endpoints*:
```
{
  "status": {
    "message": "Success",
    "code": "200"
  },
  "data": [
    {
      "endpoint_group": "SITE-A",
      "service": "service-A",
      "endpoint": "hosta.example.foo",
      "flapping": 55
    },
    {
      "endpoint_group": "SITE-A",
      "service": "service-B",
      "endpoint": "hostb.example.foo",
      "flapping": 12
    },
    {
      "endpoint_group": "SITE-B",
      "service": "service-A",
      "endpoint": "hosta.example2.foo",
      "flapping": 5
    }
  ]
}
```

:point_right: *services*:
```
{
  "status": {
    "message": "Success",
    "code": "200"
  },
  "data": [
    {
      "endpoint_group": "SITE-A",
      "service": "service-A",
      "flapping": 55
    },
    {
      "endpoint_group": "SITE-A",
      "service": "service-B",
      "flapping": 12
    },
    {
      "endpoint_group": "SITE-B",
      "service": "service-A",
      "flapping": 5
    }
  ]
}
```

:point_right: *groups*:
```
{
  "status": {
    "message": "Success",
    "code": "200"
  },
  "data": [
    {
      "endpoint_group": "SITE-A",
      "flapping": 55
    },
    {
      "endpoint_group": "SITE-B",
      "flapping": 5
    }
  ]
}
```

# Implementations
- [x] Create a new pkg named trends to implement subrouting, models and controllers for trends
- [x] Implement trends models with mongo annotations
- [x] Implement get handlers for all trend requests
- [x] Implement json views for all trend responses
- [x] Implement unit tests
- [x] Add docusaurus documentation
- [x] Update swagger blueprint


