### PR TITLE
ARGO-3186 Show flapping trends over range of time

### DIFF
--- a/app/trends/trends_test.go
+++ b/app/trends/trends_test.go
@@ -195,7 +195,7 @@ func (suite *TrendsTestSuite) SetupTest() {
 	c = session.DB(suite.tenantDbConf.Db).C("flipflop_trends_metrics")
 	c.Insert(bson.M{
 		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
-		"date":     "2015-05-01",
+		"date":     20150501,
 		"group":    "SITE-A",
 		"service":  "service-A",
 		"endpoint": "hosta.example.foo",
@@ -204,7 +204,7 @@ func (suite *TrendsTestSuite) SetupTest() {
 	})
 	c.Insert(bson.M{
 		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
-		"date":     "2015-05-01",
+		"date":     20150501,
 		"group":    "SITE-A",
 		"service":  "service-A",
 		"endpoint": "hosta.example.foo",
@@ -213,7 +213,7 @@ func (suite *TrendsTestSuite) SetupTest() {
 	})
 	c.Insert(bson.M{
 		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
-		"date":     "2015-05-01",
+		"date":     20150501,
 		"group":    "SITE-A",
 		"service":  "service-B",
 		"endpoint": "hostb.example.foo",
@@ -222,19 +222,55 @@ func (suite *TrendsTestSuite) SetupTest() {
 	})
 	c.Insert(bson.M{
 		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
-		"date":     "2015-05-01",
+		"date":     20150501,
 		"group":    "SITE-B",
 		"service":  "service-A",
 		"endpoint": "hosta.example2.foo",
 		"metric":   "web-check",
 		"flipflop": 5,
 	})
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     20150502,
+		"group":    "SITE-A",
+		"service":  "service-A",
+		"endpoint": "hosta.example.foo",
+		"metric":   "check-1",
+		"flipflop": 45,
+	})
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     20150502,
+		"group":    "SITE-A",
+		"service":  "service-A",
+		"endpoint": "hosta.example.foo",
+		"metric":   "check-2",
+		"flipflop": 32,
+	})
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     20150502,
+		"group":    "SITE-A",
+		"service":  "service-B",
+		"endpoint": "hostb.example.foo",
+		"metric":   "web-check",
+		"flipflop": 8,
+	})
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     20150502,
+		"group":    "SITE-B",
+		"service":  "service-A",
+		"endpoint": "hosta.example2.foo",
+		"metric":   "web-check",
+		"flipflop": 7,
+	})
 
 	// seed the status detailed trends endpoint data
 	c = session.DB(suite.tenantDbConf.Db).C("flipflop_trends_endpoints")
 	c.Insert(bson.M{
 		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
-		"date":     "2015-05-01",
+		"date":     20150501,
 		"group":    "SITE-A",
 		"service":  "service-A",
 		"endpoint": "hosta.example.foo",
@@ -242,7 +278,7 @@ func (suite *TrendsTestSuite) SetupTest() {
 	})
 	c.Insert(bson.M{
 		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
-		"date":     "2015-05-01",
+		"date":     20150501,
 		"group":    "SITE-A",
 		"service":  "service-B",
 		"endpoint": "hostb.example.foo",
@@ -250,50 +286,108 @@ func (suite *TrendsTestSuite) SetupTest() {
 	})
 	c.Insert(bson.M{
 		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
-		"date":     "2015-05-01",
+		"date":     20150501,
 		"group":    "SITE-B",
 		"service":  "service-A",
 		"endpoint": "hosta.example2.foo",
 		"flipflop": 5,
+	})
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     20150502,
+		"group":    "SITE-A",
+		"service":  "service-A",
+		"endpoint": "hosta.example.foo",
+		"flipflop": 48,
+	})
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     20150502,
+		"group":    "SITE-A",
+		"service":  "service-B",
+		"endpoint": "hostb.example.foo",
+		"flipflop": 7,
+	})
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     20150502,
+		"group":    "SITE-B",
+		"service":  "service-A",
+		"endpoint": "hosta.example2.foo",
+		"flipflop": 3,
 	})
 
 	// seed the status detailed trends service data
 	c = session.DB(suite.tenantDbConf.Db).C("flipflop_trends_services")
 	c.Insert(bson.M{
 		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
-		"date":     "2015-05-01",
+		"date":     20150501,
 		"group":    "SITE-A",
 		"service":  "service-A",
 		"flipflop": 55,
 	})
 	c.Insert(bson.M{
 		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
-		"date":     "2015-05-01",
+		"date":     20150501,
 		"group":    "SITE-A",
 		"service":  "service-B",
 		"flipflop": 12,
 	})
 	c.Insert(bson.M{
 		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
-		"date":     "2015-05-01",
+		"date":     20150501,
 		"group":    "SITE-B",
 		"service":  "service-A",
 		"flipflop": 5,
+	})
+
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     20150502,
+		"group":    "SITE-A",
+		"service":  "service-A",
+		"flipflop": 43,
+	})
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     20150502,
+		"group":    "SITE-A",
+		"service":  "service-B",
+		"flipflop": 11,
+	})
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     20150502,
+		"group":    "SITE-B",
+		"service":  "service-A",
+		"flipflop": 4,
 	})
 
 	// seed the status detailed trends group data
 	c = session.DB(suite.tenantDbConf.Db).C("flipflop_trends_endpoint_groups")
 	c.Insert(bson.M{
 		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
-		"date":     "2015-05-01",
+		"date":     20150501,
 		"group":    "SITE-A",
 		"flipflop": 55,
 	})
 	c.Insert(bson.M{
 		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
-		"date":     "2015-05-01",
+		"date":     20150501,
 		"group":    "SITE-B",
 		"flipflop": 5,
+	})
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     20150502,
+		"group":    "SITE-A",
+		"flipflop": 11,
+	})
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     20150502,
+		"group":    "SITE-B",
+		"flipflop": 4,
 	})
 
 }
@@ -434,6 +528,282 @@ func (suite *TrendsTestSuite) TestTrends() {
   {
    "endpoint_group": "SITE-B",
    "flapping": 5
+  }
+ ]
+}`,
+		},
+
+		expReq{
+			method: "GET",
+			url:    "/api/v2/trends/Report_A/flapping/metrics?start_date=2015-05-01&end_date=2015-05-02&top=3",
+			code:   200,
+			key:    "KEY1",
+			result: `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "endpoint_group": "SITE-A",
+   "service": "service-A",
+   "endpoint": "hosta.example.foo",
+   "metric": "check-1",
+   "flapping": 100
+  },
+  {
+   "endpoint_group": "SITE-A",
+   "service": "service-A",
+   "endpoint": "hosta.example.foo",
+   "metric": "check-2",
+   "flapping": 72
+  },
+  {
+   "endpoint_group": "SITE-A",
+   "service": "service-B",
+   "endpoint": "hostb.example.foo",
+   "metric": "web-check",
+   "flapping": 20
+  }
+ ]
+}`,
+		},
+
+		expReq{
+			method: "GET",
+			url:    "/api/v2/trends/Report_A/flapping/metrics?start_date=2015-05-01&end_date=2015-05-02",
+			code:   200,
+			key:    "KEY1",
+			result: `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "endpoint_group": "SITE-A",
+   "service": "service-A",
+   "endpoint": "hosta.example.foo",
+   "metric": "check-1",
+   "flapping": 100
+  },
+  {
+   "endpoint_group": "SITE-A",
+   "service": "service-A",
+   "endpoint": "hosta.example.foo",
+   "metric": "check-2",
+   "flapping": 72
+  },
+  {
+   "endpoint_group": "SITE-A",
+   "service": "service-B",
+   "endpoint": "hostb.example.foo",
+   "metric": "web-check",
+   "flapping": 20
+  },
+  {
+   "endpoint_group": "SITE-B",
+   "service": "service-A",
+   "endpoint": "hosta.example2.foo",
+   "metric": "web-check",
+   "flapping": 12
+  }
+ ]
+}`,
+		},
+
+		expReq{
+			method: "GET",
+			url:    "/api/v2/trends/Report_A/flapping/endpoints?start_date=2015-05-01&end_date=2015-05-02",
+			code:   200,
+			key:    "KEY1",
+			result: `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "endpoint_group": "SITE-A",
+   "service": "service-A",
+   "endpoint": "hosta.example.foo",
+   "flapping": 103
+  },
+  {
+   "endpoint_group": "SITE-A",
+   "service": "service-B",
+   "endpoint": "hostb.example.foo",
+   "flapping": 19
+  },
+  {
+   "endpoint_group": "SITE-B",
+   "service": "service-A",
+   "endpoint": "hosta.example2.foo",
+   "flapping": 8
+  }
+ ]
+}`,
+		},
+
+		expReq{
+			method: "GET",
+			url:    "/api/v2/trends/Report_A/flapping/endpoints?start_date=2015-05-01&end_date=2015-05-02&top=2",
+			code:   200,
+			key:    "KEY1",
+			result: `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "endpoint_group": "SITE-A",
+   "service": "service-A",
+   "endpoint": "hosta.example.foo",
+   "flapping": 103
+  },
+  {
+   "endpoint_group": "SITE-A",
+   "service": "service-B",
+   "endpoint": "hostb.example.foo",
+   "flapping": 19
+  }
+ ]
+}`,
+		},
+
+		expReq{
+			method: "GET",
+			url:    "/api/v2/trends/Report_A/flapping/services?start_date=2015-05-01&end_date=2015-05-02",
+			code:   200,
+			key:    "KEY1",
+			result: `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "endpoint_group": "SITE-A",
+   "service": "service-A",
+   "flapping": 98
+  },
+  {
+   "endpoint_group": "SITE-A",
+   "service": "service-B",
+   "flapping": 23
+  },
+  {
+   "endpoint_group": "SITE-B",
+   "service": "service-A",
+   "flapping": 9
+  }
+ ]
+}`,
+		},
+
+		expReq{
+			method: "GET",
+			url:    "/api/v2/trends/Report_A/flapping/services?start_date=2015-05-01&end_date=2015-05-02&top=2",
+			code:   200,
+			key:    "KEY1",
+			result: `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "endpoint_group": "SITE-A",
+   "service": "service-A",
+   "flapping": 98
+  },
+  {
+   "endpoint_group": "SITE-A",
+   "service": "service-B",
+   "flapping": 23
+  }
+ ]
+}`,
+		},
+
+		expReq{
+			method: "GET",
+			url:    "/api/v2/trends/Report_A/flapping/groups?start_date=2015-05-01",
+			code:   400,
+			key:    "KEY1",
+			result: `{
+ "status": {
+  "message": "Bad Request",
+  "code": "400"
+ },
+ "errors": [
+  {
+   "message": "Bad Request",
+   "code": "400",
+   "details": "Please use either a date url parameter or a combination of start_date and end_date parameters to declare range"
+  }
+ ]
+}`,
+		},
+
+		expReq{
+			method: "GET",
+			url:    "/api/v2/trends/Report_A/flapping/groups?end_date=2015-05-01",
+			code:   400,
+			key:    "KEY1",
+			result: `{
+ "status": {
+  "message": "Bad Request",
+  "code": "400"
+ },
+ "errors": [
+  {
+   "message": "Bad Request",
+   "code": "400",
+   "details": "Please use either a date url parameter or a combination of start_date and end_date parameters to declare range"
+  }
+ ]
+}`,
+		},
+
+		expReq{
+			method: "GET",
+			url:    "/api/v2/trends/Report_A/flapping/groups?start_date=2015-05-01&end_date=2015-05-02",
+			code:   200,
+			key:    "KEY1",
+			result: `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "endpoint_group": "SITE-A",
+   "flapping": 66
+  },
+  {
+   "endpoint_group": "SITE-B",
+   "flapping": 9
+  }
+ ]
+}`,
+		},
+
+		expReq{
+			method: "GET",
+			url:    "/api/v2/trends/Report_A/flapping/groups?start_date=2015-05-01&end_date=2015-05-02&top=1",
+			code:   200,
+			key:    "KEY1",
+			result: `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "endpoint_group": "SITE-A",
+   "flapping": 66
   }
  ]
 }`,

--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -3417,6 +3417,9 @@ paths:
         - "application/json"
       parameters:
         - $ref: "#/parameters/profDate"
+        - $ref: "#/parameters/trendsStartDate"
+        - $ref: "#/parameters/trendsEndDate"
+        - $ref: "#/parameters/trendsTop"
         - $ref: "#/parameters/apiKey"
         - name: "REPORT_NAME"
           in: "path"
@@ -3456,6 +3459,9 @@ paths:
         - "application/json"
       parameters:
         - $ref: "#/parameters/profDate"
+        - $ref: "#/parameters/trendsStartDate"
+        - $ref: "#/parameters/trendsEndDate"
+        - $ref: "#/parameters/trendsTop"
         - $ref: "#/parameters/apiKey"
         - name: "REPORT_NAME"
           in: "path"
@@ -3495,6 +3501,9 @@ paths:
         - "application/json"
       parameters:
         - $ref: "#/parameters/profDate"
+        - $ref: "#/parameters/trendsStartDate"
+        - $ref: "#/parameters/trendsEndDate"
+        - $ref: "#/parameters/trendsTop"
         - $ref: "#/parameters/apiKey"
         - name: "REPORT_NAME"
           in: "path"
@@ -3534,6 +3543,9 @@ paths:
         - "application/json"
       parameters:
         - $ref: "#/parameters/profDate"
+        - $ref: "#/parameters/trendsStartDate"
+        - $ref: "#/parameters/trendsEndDate"
+        - $ref: "#/parameters/trendsTop"
         - $ref: "#/parameters/apiKey"
         - name: "REPORT_NAME"
           in: "path"
@@ -3962,6 +3974,21 @@ parameters:
     type: string
     description: "target date to retrieve a historic version of the profile"
     default: todays_date in YYYY-MM-DD format
+  trendsStartDate:
+    name: "start_date"
+    in: "query"
+    type: string
+    description: "start date used to define a range of results"
+  trendsEndDate:
+    name: "end_date"
+    in: "query"
+    type: string
+    description: "end date used to define a range of results"
+  trendsTop:
+    name: "top"
+    in: "query"
+    type: string
+    description: "define a number of top results"
   topoDate:
     name: "date"
     in: "query"

--- a/website/docs/trends.md
+++ b/website/docs/trends.md
@@ -26,6 +26,9 @@ This method may be used to retrieve a list of top flapping service endpoint metr
 | Type | Description | Required | Default value |
 |------|-------------|----------|---------------|
 |`date`| Date to view problematic endpoints of | NO |  |
+|`start_date`| define start date to view problematic endpoints over range | NO |  |
+|`end_date`| define end date to view problematic endpoints over range | NO |  |
+|`top`| integer to define a top number of results displayed | NO |  |
 
 
 #### Headers
@@ -39,7 +42,6 @@ Accept: application/json or application/xml
 Status: 200 OK
 ```
 
-### Response body
 
 ###### Example Request:
 URL:
@@ -98,6 +100,56 @@ Reponse body:
 }
 ```
 
+###### Example Request with Range and top number of results:
+URL:
+```
+/trends/{report_name}/flapping/metrics?start_date=2020-05-01&end_date=2021-06-15&top=3
+```
+Headers:
+```
+x-api-key: shared_key_value
+Accept: application/json or application/xml
+
+```
+###### Example Response:
+
+Code:
+```
+Status: 200 OK
+```
+Reponse body:
+```
+{
+  "status": {
+    "message": "Success",
+    "code": "200"
+  },
+  "data": [
+    {
+      "endpoint_group": "SITE-A",
+      "service": "service-A",
+      "endpoint": "hosta.example.foo",
+      "metric": "check-1",
+      "flapping": 255
+    },
+    {
+      "endpoint_group": "SITE-A",
+      "service": "service-A",
+      "endpoint": "hosta.example.foo",
+      "metric": "check-2",
+      "flapping": 340
+    },
+    {
+      "endpoint_group": "SITE-A",
+      "service": "service-B",
+      "endpoint": "hostb.example.foo",
+      "metric": "web-check",
+      "flapping": 112
+    }
+  ]
+}
+```
+
 
 ### [GET]: Daily Flapping trends in service endpoints 
 This method may be used to retrieve a list of top flapping service endpoints
@@ -118,6 +170,9 @@ This method may be used to retrieve a list of top flapping service endpoints
 | Type | Description | Required | Default value |
 |------|-------------|----------|---------------|
 |`date`| Date to view problematic endpoints of | NO |  |
+|`start_date`| define start date to view problematic endpoints over range | NO |  |
+|`end_date`| define end date to view problematic endpoints over range | NO |  |
+|`top`| integer to define a top number of results displayed | NO |  |
 
 
 #### Headers
@@ -131,7 +186,6 @@ Accept: application/json or application/xml
 Status: 200 OK
 ```
 
-### Response body
 
 ###### Example Request:
 URL:
@@ -180,6 +234,48 @@ Reponse body:
 }
 ```
 
+###### Example Request with date range and top number of results:
+URL:
+```
+/trends/{report_name}/flapping/endpoints?start_date=2020-05-01&end_date=2020-05-15&top=2
+```
+Headers:
+```
+x-api-key: shared_key_value
+Accept: application/json or application/xml
+
+```
+###### Example Response:
+
+Code:
+```
+Status: 200 OK
+```
+Reponse body:
+```
+{
+  "status": {
+    "message": "Success",
+    "code": "200"
+  },
+  "data": [
+    {
+      "endpoint_group": "SITE-A",
+      "service": "service-A",
+      "endpoint": "hosta.example.foo",
+      "flapping": 83
+    },
+    {
+      "endpoint_group": "SITE-A",
+      "service": "service-B",
+      "endpoint": "hostb.example.foo",
+      "flapping": 53
+    }
+  ]
+}
+```
+
+
 ### [GET]: Daily Flapping trends in services
 This method may be used to retrieve a list of top flapping services
 
@@ -199,6 +295,9 @@ This method may be used to retrieve a list of top flapping services
 | Type | Description | Required | Default value |
 |------|-------------|----------|---------------|
 |`date`| Date to view problematic endpoints of | NO |  |
+|`start_date`| define start date to view problematic endpoints over range | NO |  |
+|`end_date`| define end date to view problematic endpoints over range | NO |  |
+|`top`| integer to define a top number of results displayed | NO |  |
 
 
 #### Headers
@@ -212,7 +311,6 @@ Accept: application/json or application/xml
 Status: 200 OK
 ```
 
-### Response body
 
 ###### Example Request:
 URL:
@@ -258,6 +356,40 @@ Reponse body:
 }
 ```
 
+###### Example Request with date range and top number of results:
+URL:
+```
+/trends/{report_name}/flapping/services?start_date=2020-05-01&end_date=2020-07-05&top=1
+```
+Headers:
+```
+x-api-key: shared_key_value
+Accept: application/json or application/xml
+
+```
+###### Example Response:
+
+Code:
+```
+Status: 200 OK
+```
+Reponse body:
+```
+{
+  "status": {
+    "message": "Success",
+    "code": "200"
+  },
+  "data": [
+    {
+      "endpoint_group": "SITE-A",
+      "service": "service-A",
+      "flapping": 955
+    }
+  ]
+}
+```
+
 ### [GET]: Daily Flapping trends in endpoint groups
 This method may be used to retrieve a list of top endpoint groups
 
@@ -277,6 +409,9 @@ This method may be used to retrieve a list of top endpoint groups
 | Type | Description | Required | Default value |
 |------|-------------|----------|---------------|
 |`date`| Date to view problematic endpoints of | NO |  |
+|`start_date`| define start date to view problematic endpoints over range | NO |  |
+|`end_date`| define end date to view problematic endpoints over range | NO |  |
+|`top`| integer to define a top number of results displayed | NO |  |
 
 
 #### Headers
@@ -289,8 +424,6 @@ Accept: application/json or application/xml
 ```
 Status: 200 OK
 ```
-
-### Response body
 
 ###### Example Request:
 URL:
@@ -324,6 +457,39 @@ Reponse body:
     {
       "endpoint_group": "SITE-B",
       "flapping": 5
+    }
+  ]
+}
+```
+
+###### Example Request with date range and top number of results:
+URL:
+```
+/trends/{report_name}/flapping/groups?start_date=2020-05-01&end_date=2020-05-03&top=1
+```
+Headers:
+```
+x-api-key: shared_key_value
+Accept: application/json or application/xml
+
+```
+###### Example Response:
+
+Code:
+```
+Status: 200 OK
+```
+Reponse body:
+```
+{
+  "status": {
+    "message": "Success",
+    "code": "200"
+  },
+  "data": [
+    {
+      "endpoint_group": "SITE-A",
+      "flapping": 75
     }
   ]
 }


### PR DESCRIPTION
Goal:
====
Till now we served trends flapping results per specific date by using the url Query parameter `?date=YYYY-MM-DD`.
We need to be able to also show top flapping results over a range of dates (start --> end)

Implementation:
============
Introduce two additional optional url Parameters: `start_date=YYYY-MM-DD` and `end_date=YYYY-MM-DD`. If `?date=YYYY-MM-DD` is defined as previously then we serve results for the range of a single day (e.g. 2021-06-25 --> 2021-06-25). If date is omitted and instead start_date and end_date are used we display aggregated results over the defined period. 

*Extras:* We also added a `?top=INTEGER` query parameter to be able to display a limit of top results.

Mongodb queries were modified to complex aggregations that match over a range of dates and then group by the monitoring level attributes and calculate the sum of each encountered daily item. 

- [x] Add new query paramaters
- [x] Create mongo aggregations
- [x] Update unit tests
- [x] Update docusaurus
- [x] Update swagger