### PR TITLE
ARGO-3193 Add monthly granularity option over flapping trends

### DIFF
--- a/app/trends/model.go
+++ b/app/trends/model.go
@@ -27,6 +27,27 @@ import "encoding/xml"
 const zuluForm = "2006-01-02T15:04:05Z"
 const ymdForm = "2006-01-02"
 
+//MonthMetricData holds flapping information about monthly metrics
+type MonthMetricData struct {
+	Date string       `bson:"date" json:"date"`
+	Top  []MetricData `bson:"top" json:"top"`
+}
+
+type MonthEndpointData struct {
+	Date string         `bson:"date" json:"date"`
+	Top  []EndpointData `bson:"top" json:"top"`
+}
+
+type MonthServiceData struct {
+	Date string        `bson:"date" json:"date"`
+	Top  []ServiceData `bson:"top" json:"top"`
+}
+
+type MonthEndpointGroupData struct {
+	Date string              `bson:"date" json:"date"`
+	Top  []EndpointGroupData `bson:"top" json:"top"`
+}
+
 // MetricData holds flapping information about metrics
 type MetricData struct {
 	EndpointGroup string `bson:"group" json:"endpoint_group"`

--- a/app/trends/trends_test.go
+++ b/app/trends/trends_test.go
@@ -195,7 +195,7 @@ func (suite *TrendsTestSuite) SetupTest() {
 	c = session.DB(suite.tenantDbConf.Db).C("flipflop_trends_metrics")
 	c.Insert(bson.M{
 		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
-		"date":     "2015-05-01",
+		"date":     20150501,
 		"group":    "SITE-A",
 		"service":  "service-A",
 		"endpoint": "hosta.example.foo",
@@ -204,7 +204,7 @@ func (suite *TrendsTestSuite) SetupTest() {
 	})
 	c.Insert(bson.M{
 		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
-		"date":     "2015-05-01",
+		"date":     20150501,
 		"group":    "SITE-A",
 		"service":  "service-A",
 		"endpoint": "hosta.example.foo",
@@ -213,7 +213,7 @@ func (suite *TrendsTestSuite) SetupTest() {
 	})
 	c.Insert(bson.M{
 		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
-		"date":     "2015-05-01",
+		"date":     20150501,
 		"group":    "SITE-A",
 		"service":  "service-B",
 		"endpoint": "hostb.example.foo",
@@ -222,19 +222,55 @@ func (suite *TrendsTestSuite) SetupTest() {
 	})
 	c.Insert(bson.M{
 		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
-		"date":     "2015-05-01",
+		"date":     20150501,
 		"group":    "SITE-B",
 		"service":  "service-A",
 		"endpoint": "hosta.example2.foo",
 		"metric":   "web-check",
 		"flipflop": 5,
 	})
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     20150502,
+		"group":    "SITE-A",
+		"service":  "service-A",
+		"endpoint": "hosta.example.foo",
+		"metric":   "check-1",
+		"flipflop": 45,
+	})
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     20150502,
+		"group":    "SITE-A",
+		"service":  "service-A",
+		"endpoint": "hosta.example.foo",
+		"metric":   "check-2",
+		"flipflop": 32,
+	})
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     20150502,
+		"group":    "SITE-A",
+		"service":  "service-B",
+		"endpoint": "hostb.example.foo",
+		"metric":   "web-check",
+		"flipflop": 8,
+	})
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     20150502,
+		"group":    "SITE-B",
+		"service":  "service-A",
+		"endpoint": "hosta.example2.foo",
+		"metric":   "web-check",
+		"flipflop": 7,
+	})
 
 	// seed the status detailed trends endpoint data
 	c = session.DB(suite.tenantDbConf.Db).C("flipflop_trends_endpoints")
 	c.Insert(bson.M{
 		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
-		"date":     "2015-05-01",
+		"date":     20150501,
 		"group":    "SITE-A",
 		"service":  "service-A",
 		"endpoint": "hosta.example.foo",
@@ -242,7 +278,7 @@ func (suite *TrendsTestSuite) SetupTest() {
 	})
 	c.Insert(bson.M{
 		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
-		"date":     "2015-05-01",
+		"date":     20150501,
 		"group":    "SITE-A",
 		"service":  "service-B",
 		"endpoint": "hostb.example.foo",
@@ -250,50 +286,108 @@ func (suite *TrendsTestSuite) SetupTest() {
 	})
 	c.Insert(bson.M{
 		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
-		"date":     "2015-05-01",
+		"date":     20150501,
 		"group":    "SITE-B",
 		"service":  "service-A",
 		"endpoint": "hosta.example2.foo",
 		"flipflop": 5,
+	})
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     20150502,
+		"group":    "SITE-A",
+		"service":  "service-A",
+		"endpoint": "hosta.example.foo",
+		"flipflop": 48,
+	})
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     20150502,
+		"group":    "SITE-A",
+		"service":  "service-B",
+		"endpoint": "hostb.example.foo",
+		"flipflop": 7,
+	})
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     20150502,
+		"group":    "SITE-B",
+		"service":  "service-A",
+		"endpoint": "hosta.example2.foo",
+		"flipflop": 3,
 	})
 
 	// seed the status detailed trends service data
 	c = session.DB(suite.tenantDbConf.Db).C("flipflop_trends_services")
 	c.Insert(bson.M{
 		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
-		"date":     "2015-05-01",
+		"date":     20150501,
 		"group":    "SITE-A",
 		"service":  "service-A",
 		"flipflop": 55,
 	})
 	c.Insert(bson.M{
 		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
-		"date":     "2015-05-01",
+		"date":     20150501,
 		"group":    "SITE-A",
 		"service":  "service-B",
 		"flipflop": 12,
 	})
 	c.Insert(bson.M{
 		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
-		"date":     "2015-05-01",
+		"date":     20150501,
 		"group":    "SITE-B",
 		"service":  "service-A",
 		"flipflop": 5,
+	})
+
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     20150502,
+		"group":    "SITE-A",
+		"service":  "service-A",
+		"flipflop": 43,
+	})
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     20150502,
+		"group":    "SITE-A",
+		"service":  "service-B",
+		"flipflop": 11,
+	})
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     20150502,
+		"group":    "SITE-B",
+		"service":  "service-A",
+		"flipflop": 4,
 	})
 
 	// seed the status detailed trends group data
 	c = session.DB(suite.tenantDbConf.Db).C("flipflop_trends_endpoint_groups")
 	c.Insert(bson.M{
 		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
-		"date":     "2015-05-01",
+		"date":     20150501,
 		"group":    "SITE-A",
 		"flipflop": 55,
 	})
 	c.Insert(bson.M{
 		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
-		"date":     "2015-05-01",
+		"date":     20150501,
 		"group":    "SITE-B",
 		"flipflop": 5,
+	})
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     20150502,
+		"group":    "SITE-A",
+		"flipflop": 11,
+	})
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     20150502,
+		"group":    "SITE-B",
+		"flipflop": 4,
 	})
 
 }
@@ -434,6 +528,282 @@ func (suite *TrendsTestSuite) TestTrends() {
   {
    "endpoint_group": "SITE-B",
    "flapping": 5
+  }
+ ]
+}`,
+		},
+
+		expReq{
+			method: "GET",
+			url:    "/api/v2/trends/Report_A/flapping/metrics?start_date=2015-05-01&end_date=2015-05-02&top=3",
+			code:   200,
+			key:    "KEY1",
+			result: `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "endpoint_group": "SITE-A",
+   "service": "service-A",
+   "endpoint": "hosta.example.foo",
+   "metric": "check-1",
+   "flapping": 100
+  },
+  {
+   "endpoint_group": "SITE-A",
+   "service": "service-A",
+   "endpoint": "hosta.example.foo",
+   "metric": "check-2",
+   "flapping": 72
+  },
+  {
+   "endpoint_group": "SITE-A",
+   "service": "service-B",
+   "endpoint": "hostb.example.foo",
+   "metric": "web-check",
+   "flapping": 20
+  }
+ ]
+}`,
+		},
+
+		expReq{
+			method: "GET",
+			url:    "/api/v2/trends/Report_A/flapping/metrics?start_date=2015-05-01&end_date=2015-05-02",
+			code:   200,
+			key:    "KEY1",
+			result: `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "endpoint_group": "SITE-A",
+   "service": "service-A",
+   "endpoint": "hosta.example.foo",
+   "metric": "check-1",
+   "flapping": 100
+  },
+  {
+   "endpoint_group": "SITE-A",
+   "service": "service-A",
+   "endpoint": "hosta.example.foo",
+   "metric": "check-2",
+   "flapping": 72
+  },
+  {
+   "endpoint_group": "SITE-A",
+   "service": "service-B",
+   "endpoint": "hostb.example.foo",
+   "metric": "web-check",
+   "flapping": 20
+  },
+  {
+   "endpoint_group": "SITE-B",
+   "service": "service-A",
+   "endpoint": "hosta.example2.foo",
+   "metric": "web-check",
+   "flapping": 12
+  }
+ ]
+}`,
+		},
+
+		expReq{
+			method: "GET",
+			url:    "/api/v2/trends/Report_A/flapping/endpoints?start_date=2015-05-01&end_date=2015-05-02",
+			code:   200,
+			key:    "KEY1",
+			result: `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "endpoint_group": "SITE-A",
+   "service": "service-A",
+   "endpoint": "hosta.example.foo",
+   "flapping": 103
+  },
+  {
+   "endpoint_group": "SITE-A",
+   "service": "service-B",
+   "endpoint": "hostb.example.foo",
+   "flapping": 19
+  },
+  {
+   "endpoint_group": "SITE-B",
+   "service": "service-A",
+   "endpoint": "hosta.example2.foo",
+   "flapping": 8
+  }
+ ]
+}`,
+		},
+
+		expReq{
+			method: "GET",
+			url:    "/api/v2/trends/Report_A/flapping/endpoints?start_date=2015-05-01&end_date=2015-05-02&top=2",
+			code:   200,
+			key:    "KEY1",
+			result: `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "endpoint_group": "SITE-A",
+   "service": "service-A",
+   "endpoint": "hosta.example.foo",
+   "flapping": 103
+  },
+  {
+   "endpoint_group": "SITE-A",
+   "service": "service-B",
+   "endpoint": "hostb.example.foo",
+   "flapping": 19
+  }
+ ]
+}`,
+		},
+
+		expReq{
+			method: "GET",
+			url:    "/api/v2/trends/Report_A/flapping/services?start_date=2015-05-01&end_date=2015-05-02",
+			code:   200,
+			key:    "KEY1",
+			result: `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "endpoint_group": "SITE-A",
+   "service": "service-A",
+   "flapping": 98
+  },
+  {
+   "endpoint_group": "SITE-A",
+   "service": "service-B",
+   "flapping": 23
+  },
+  {
+   "endpoint_group": "SITE-B",
+   "service": "service-A",
+   "flapping": 9
+  }
+ ]
+}`,
+		},
+
+		expReq{
+			method: "GET",
+			url:    "/api/v2/trends/Report_A/flapping/services?start_date=2015-05-01&end_date=2015-05-02&top=2",
+			code:   200,
+			key:    "KEY1",
+			result: `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "endpoint_group": "SITE-A",
+   "service": "service-A",
+   "flapping": 98
+  },
+  {
+   "endpoint_group": "SITE-A",
+   "service": "service-B",
+   "flapping": 23
+  }
+ ]
+}`,
+		},
+
+		expReq{
+			method: "GET",
+			url:    "/api/v2/trends/Report_A/flapping/groups?start_date=2015-05-01",
+			code:   400,
+			key:    "KEY1",
+			result: `{
+ "status": {
+  "message": "Bad Request",
+  "code": "400"
+ },
+ "errors": [
+  {
+   "message": "Bad Request",
+   "code": "400",
+   "details": "Please use either a date url parameter or a combination of start_date and end_date parameters to declare range"
+  }
+ ]
+}`,
+		},
+
+		expReq{
+			method: "GET",
+			url:    "/api/v2/trends/Report_A/flapping/groups?end_date=2015-05-01",
+			code:   400,
+			key:    "KEY1",
+			result: `{
+ "status": {
+  "message": "Bad Request",
+  "code": "400"
+ },
+ "errors": [
+  {
+   "message": "Bad Request",
+   "code": "400",
+   "details": "Please use either a date url parameter or a combination of start_date and end_date parameters to declare range"
+  }
+ ]
+}`,
+		},
+
+		expReq{
+			method: "GET",
+			url:    "/api/v2/trends/Report_A/flapping/groups?start_date=2015-05-01&end_date=2015-05-02",
+			code:   200,
+			key:    "KEY1",
+			result: `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "endpoint_group": "SITE-A",
+   "flapping": 66
+  },
+  {
+   "endpoint_group": "SITE-B",
+   "flapping": 9
+  }
+ ]
+}`,
+		},
+
+		expReq{
+			method: "GET",
+			url:    "/api/v2/trends/Report_A/flapping/groups?start_date=2015-05-01&end_date=2015-05-02&top=1",
+			code:   200,
+			key:    "KEY1",
+			result: `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "endpoint_group": "SITE-A",
+   "flapping": 66
   }
  ]
 }`,

--- a/app/trends/trends_test.go
+++ b/app/trends/trends_test.go
@@ -195,6 +195,42 @@ func (suite *TrendsTestSuite) SetupTest() {
 	c = session.DB(suite.tenantDbConf.Db).C("flipflop_trends_metrics")
 	c.Insert(bson.M{
 		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     20150401,
+		"group":    "SITE-A",
+		"service":  "service-A",
+		"endpoint": "hosta.example.foo",
+		"metric":   "check-1",
+		"flipflop": 55,
+	})
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     20150401,
+		"group":    "SITE-A",
+		"service":  "service-A",
+		"endpoint": "hosta.example.foo",
+		"metric":   "check-2",
+		"flipflop": 40,
+	})
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     20150401,
+		"group":    "SITE-A",
+		"service":  "service-B",
+		"endpoint": "hostb.example.foo",
+		"metric":   "web-check",
+		"flipflop": 12,
+	})
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     20150401,
+		"group":    "SITE-XB",
+		"service":  "service-XA",
+		"endpoint": "hosta.examplex2.foo",
+		"metric":   "web-check",
+		"flipflop": 25,
+	})
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
 		"date":     20150501,
 		"group":    "SITE-A",
 		"service":  "service-A",
@@ -270,6 +306,31 @@ func (suite *TrendsTestSuite) SetupTest() {
 	c = session.DB(suite.tenantDbConf.Db).C("flipflop_trends_endpoints")
 	c.Insert(bson.M{
 		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     20150401,
+		"group":    "SITE-A",
+		"service":  "service-A",
+		"endpoint": "hosta.example.foo",
+		"flipflop": 25,
+	})
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     20150401,
+		"group":    "SITE-A",
+		"service":  "service-B",
+		"endpoint": "hostb.example.foo",
+		"flipflop": 2,
+	})
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     20150401,
+		"group":    "SITE-XB",
+		"service":  "service-XA",
+		"endpoint": "hosta.exampleX2.foo",
+		"flipflop": 35,
+	})
+
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
 		"date":     20150501,
 		"group":    "SITE-A",
 		"service":  "service-A",
@@ -321,6 +382,28 @@ func (suite *TrendsTestSuite) SetupTest() {
 	c = session.DB(suite.tenantDbConf.Db).C("flipflop_trends_services")
 	c.Insert(bson.M{
 		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     20150401,
+		"group":    "SITE-A",
+		"service":  "service-A",
+		"flipflop": 25,
+	})
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     20150401,
+		"group":    "SITE-A",
+		"service":  "service-B",
+		"flipflop": 16,
+	})
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     20150401,
+		"group":    "SITE-XB",
+		"service":  "service-XA",
+		"flipflop": 3,
+	})
+
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
 		"date":     20150501,
 		"group":    "SITE-A",
 		"service":  "service-A",
@@ -365,6 +448,18 @@ func (suite *TrendsTestSuite) SetupTest() {
 
 	// seed the status detailed trends group data
 	c = session.DB(suite.tenantDbConf.Db).C("flipflop_trends_endpoint_groups")
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     20150401,
+		"group":    "SITE-A",
+		"flipflop": 35,
+	})
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     20150401,
+		"group":    "SITE-XB",
+		"flipflop": 3,
+	})
 	c.Insert(bson.M{
 		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
 		"date":     20150501,
@@ -535,6 +630,154 @@ func (suite *TrendsTestSuite) TestTrends() {
 
 		expReq{
 			method: "GET",
+			url:    "/api/v2/trends/Report_A/flapping/metrics?start_date=2015-04-01&end_date=2015-05-02&granularity=monthly",
+			code:   200,
+			key:    "KEY1",
+			result: `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "date": "2015-04",
+   "top": [
+    {
+     "endpoint_group": "SITE-A",
+     "service": "service-A",
+     "endpoint": "hosta.example.foo",
+     "metric": "check-1",
+     "flapping": 55
+    },
+    {
+     "endpoint_group": "SITE-A",
+     "service": "service-A",
+     "endpoint": "hosta.example.foo",
+     "metric": "check-2",
+     "flapping": 40
+    },
+    {
+     "endpoint_group": "SITE-XB",
+     "service": "service-XA",
+     "endpoint": "hosta.examplex2.foo",
+     "metric": "web-check",
+     "flapping": 25
+    },
+    {
+     "endpoint_group": "SITE-A",
+     "service": "service-B",
+     "endpoint": "hostb.example.foo",
+     "metric": "web-check",
+     "flapping": 12
+    }
+   ]
+  },
+  {
+   "date": "2015-05",
+   "top": [
+    {
+     "endpoint_group": "SITE-A",
+     "service": "service-A",
+     "endpoint": "hosta.example.foo",
+     "metric": "check-1",
+     "flapping": 100
+    },
+    {
+     "endpoint_group": "SITE-A",
+     "service": "service-A",
+     "endpoint": "hosta.example.foo",
+     "metric": "check-2",
+     "flapping": 72
+    },
+    {
+     "endpoint_group": "SITE-A",
+     "service": "service-B",
+     "endpoint": "hostb.example.foo",
+     "metric": "web-check",
+     "flapping": 20
+    },
+    {
+     "endpoint_group": "SITE-B",
+     "service": "service-A",
+     "endpoint": "hosta.example2.foo",
+     "metric": "web-check",
+     "flapping": 12
+    }
+   ]
+  }
+ ]
+}`,
+		},
+
+		expReq{
+			method: "GET",
+			url:    "/api/v2/trends/Report_A/flapping/metrics?start_date=2015-04-01&end_date=2015-05-02&top=3&granularity=monthly",
+			code:   200,
+			key:    "KEY1",
+			result: `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "date": "2015-04",
+   "top": [
+    {
+     "endpoint_group": "SITE-A",
+     "service": "service-A",
+     "endpoint": "hosta.example.foo",
+     "metric": "check-1",
+     "flapping": 55
+    },
+    {
+     "endpoint_group": "SITE-A",
+     "service": "service-A",
+     "endpoint": "hosta.example.foo",
+     "metric": "check-2",
+     "flapping": 40
+    },
+    {
+     "endpoint_group": "SITE-XB",
+     "service": "service-XA",
+     "endpoint": "hosta.examplex2.foo",
+     "metric": "web-check",
+     "flapping": 25
+    }
+   ]
+  },
+  {
+   "date": "2015-05",
+   "top": [
+    {
+     "endpoint_group": "SITE-A",
+     "service": "service-A",
+     "endpoint": "hosta.example.foo",
+     "metric": "check-1",
+     "flapping": 100
+    },
+    {
+     "endpoint_group": "SITE-A",
+     "service": "service-A",
+     "endpoint": "hosta.example.foo",
+     "metric": "check-2",
+     "flapping": 72
+    },
+    {
+     "endpoint_group": "SITE-A",
+     "service": "service-B",
+     "endpoint": "hostb.example.foo",
+     "metric": "web-check",
+     "flapping": 20
+    }
+   ]
+  }
+ ]
+}`,
+		},
+
+		expReq{
+			method: "GET",
 			url:    "/api/v2/trends/Report_A/flapping/metrics?start_date=2015-05-01&end_date=2015-05-02&top=3",
 			code:   200,
 			key:    "KEY1",
@@ -647,6 +890,116 @@ func (suite *TrendsTestSuite) TestTrends() {
 
 		expReq{
 			method: "GET",
+			url:    "/api/v2/trends/Report_A/flapping/endpoints?start_date=2015-04-01&end_date=2015-05-02&granularity=monthly",
+			code:   200,
+			key:    "KEY1",
+			result: `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "date": "2015-04",
+   "top": [
+    {
+     "endpoint_group": "SITE-XB",
+     "service": "service-XA",
+     "endpoint": "hosta.exampleX2.foo",
+     "flapping": 35
+    },
+    {
+     "endpoint_group": "SITE-A",
+     "service": "service-A",
+     "endpoint": "hosta.example.foo",
+     "flapping": 25
+    },
+    {
+     "endpoint_group": "SITE-A",
+     "service": "service-B",
+     "endpoint": "hostb.example.foo",
+     "flapping": 2
+    }
+   ]
+  },
+  {
+   "date": "2015-05",
+   "top": [
+    {
+     "endpoint_group": "SITE-A",
+     "service": "service-A",
+     "endpoint": "hosta.example.foo",
+     "flapping": 103
+    },
+    {
+     "endpoint_group": "SITE-A",
+     "service": "service-B",
+     "endpoint": "hostb.example.foo",
+     "flapping": 19
+    },
+    {
+     "endpoint_group": "SITE-B",
+     "service": "service-A",
+     "endpoint": "hosta.example2.foo",
+     "flapping": 8
+    }
+   ]
+  }
+ ]
+}`,
+		},
+
+		expReq{
+			method: "GET",
+			url:    "/api/v2/trends/Report_A/flapping/endpoints?start_date=2015-04-01&end_date=2015-05-02&top=2&granularity=monthly",
+			code:   200,
+			key:    "KEY1",
+			result: `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "date": "2015-04",
+   "top": [
+    {
+     "endpoint_group": "SITE-XB",
+     "service": "service-XA",
+     "endpoint": "hosta.exampleX2.foo",
+     "flapping": 35
+    },
+    {
+     "endpoint_group": "SITE-A",
+     "service": "service-A",
+     "endpoint": "hosta.example.foo",
+     "flapping": 25
+    }
+   ]
+  },
+  {
+   "date": "2015-05",
+   "top": [
+    {
+     "endpoint_group": "SITE-A",
+     "service": "service-A",
+     "endpoint": "hosta.example.foo",
+     "flapping": 103
+    },
+    {
+     "endpoint_group": "SITE-A",
+     "service": "service-B",
+     "endpoint": "hostb.example.foo",
+     "flapping": 19
+    }
+   ]
+  }
+ ]
+}`,
+		},
+
+		expReq{
+			method: "GET",
 			url:    "/api/v2/trends/Report_A/flapping/endpoints?start_date=2015-05-01&end_date=2015-05-02&top=2",
 			code:   200,
 			key:    "KEY1",
@@ -697,6 +1050,106 @@ func (suite *TrendsTestSuite) TestTrends() {
    "endpoint_group": "SITE-B",
    "service": "service-A",
    "flapping": 9
+  }
+ ]
+}`,
+		},
+
+		expReq{
+			method: "GET",
+			url:    "/api/v2/trends/Report_A/flapping/services?start_date=2015-04-01&end_date=2015-05-02&granularity=monthly",
+			code:   200,
+			key:    "KEY1",
+			result: `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "date": "2015-04",
+   "top": [
+    {
+     "endpoint_group": "SITE-A",
+     "service": "service-A",
+     "flapping": 25
+    },
+    {
+     "endpoint_group": "SITE-A",
+     "service": "service-B",
+     "flapping": 16
+    },
+    {
+     "endpoint_group": "SITE-XB",
+     "service": "service-XA",
+     "flapping": 3
+    }
+   ]
+  },
+  {
+   "date": "2015-05",
+   "top": [
+    {
+     "endpoint_group": "SITE-A",
+     "service": "service-A",
+     "flapping": 98
+    },
+    {
+     "endpoint_group": "SITE-A",
+     "service": "service-B",
+     "flapping": 23
+    },
+    {
+     "endpoint_group": "SITE-B",
+     "service": "service-A",
+     "flapping": 9
+    }
+   ]
+  }
+ ]
+}`,
+		},
+
+		expReq{
+			method: "GET",
+			url:    "/api/v2/trends/Report_A/flapping/services?start_date=2015-04-01&end_date=2015-05-02&top=2&granularity=monthly",
+			code:   200,
+			key:    "KEY1",
+			result: `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "date": "2015-04",
+   "top": [
+    {
+     "endpoint_group": "SITE-A",
+     "service": "service-A",
+     "flapping": 25
+    },
+    {
+     "endpoint_group": "SITE-A",
+     "service": "service-B",
+     "flapping": 16
+    }
+   ]
+  },
+  {
+   "date": "2015-05",
+   "top": [
+    {
+     "endpoint_group": "SITE-A",
+     "service": "service-A",
+     "flapping": 98
+    },
+    {
+     "endpoint_group": "SITE-A",
+     "service": "service-B",
+     "flapping": 23
+    }
+   ]
   }
  ]
 }`,
@@ -785,6 +1238,80 @@ func (suite *TrendsTestSuite) TestTrends() {
   {
    "endpoint_group": "SITE-B",
    "flapping": 9
+  }
+ ]
+}`,
+		},
+
+		expReq{
+			method: "GET",
+			url:    "/api/v2/trends/Report_A/flapping/groups?start_date=2015-04-01&end_date=2015-05-02&granularity=monthly",
+			code:   200,
+			key:    "KEY1",
+			result: `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "date": "2015-04",
+   "top": [
+    {
+     "endpoint_group": "SITE-A",
+     "flapping": 35
+    },
+    {
+     "endpoint_group": "SITE-XB",
+     "flapping": 3
+    }
+   ]
+  },
+  {
+   "date": "2015-05",
+   "top": [
+    {
+     "endpoint_group": "SITE-A",
+     "flapping": 66
+    },
+    {
+     "endpoint_group": "SITE-B",
+     "flapping": 9
+    }
+   ]
+  }
+ ]
+}`,
+		},
+
+		expReq{
+			method: "GET",
+			url:    "/api/v2/trends/Report_A/flapping/groups?start_date=2015-04-01&end_date=2015-05-02&top=1&granularity=monthly",
+			code:   200,
+			key:    "KEY1",
+			result: `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "date": "2015-04",
+   "top": [
+    {
+     "endpoint_group": "SITE-A",
+     "flapping": 35
+    }
+   ]
+  },
+  {
+   "date": "2015-05",
+   "top": [
+    {
+     "endpoint_group": "SITE-A",
+     "flapping": 66
+    }
+   ]
   }
  ]
 }`,

--- a/app/trends/view.go
+++ b/app/trends/view.go
@@ -93,6 +93,70 @@ func createEndpointGroupListView(results []EndpointGroupData, msg string, code i
 
 }
 
+// createMonthMetricListView constructs the list response template and exports it as json
+func createMonthMetricListView(results []MonthMetricData, msg string, code int) ([]byte, error) {
+
+	docRoot := &respond.ResponseMessage{
+		Status: respond.StatusResponse{
+			Message: msg,
+			Code:    strconv.Itoa(code),
+		},
+	}
+	docRoot.Data = results
+
+	output, err := json.MarshalIndent(docRoot, "", " ")
+	return output, err
+
+}
+
+// createMonthEndpointListView constructs the list response template and exports it as json
+func createMonthEndpointListView(results []MonthEndpointData, msg string, code int) ([]byte, error) {
+
+	docRoot := &respond.ResponseMessage{
+		Status: respond.StatusResponse{
+			Message: msg,
+			Code:    strconv.Itoa(code),
+		},
+	}
+	docRoot.Data = results
+
+	output, err := json.MarshalIndent(docRoot, "", " ")
+	return output, err
+
+}
+
+// createMonthEndpointListView constructs the list response template and exports it as json
+func createMonthServiceListView(results []MonthServiceData, msg string, code int) ([]byte, error) {
+
+	docRoot := &respond.ResponseMessage{
+		Status: respond.StatusResponse{
+			Message: msg,
+			Code:    strconv.Itoa(code),
+		},
+	}
+	docRoot.Data = results
+
+	output, err := json.MarshalIndent(docRoot, "", " ")
+	return output, err
+
+}
+
+// createMonthEndpointGroupListView constructs the list response template and exports it as json
+func createMonthEndpointGroupListView(results []MonthEndpointGroupData, msg string, code int) ([]byte, error) {
+
+	docRoot := &respond.ResponseMessage{
+		Status: respond.StatusResponse{
+			Message: msg,
+			Code:    strconv.Itoa(code),
+		},
+	}
+	docRoot.Data = results
+
+	output, err := json.MarshalIndent(docRoot, "", " ")
+	return output, err
+
+}
+
 func createMessageOUT(message string, code int, format string) ([]byte, error) {
 
 	output := []byte("message placeholder")

--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -3417,6 +3417,9 @@ paths:
         - "application/json"
       parameters:
         - $ref: "#/parameters/profDate"
+        - $ref: "#/parameters/trendsStartDate"
+        - $ref: "#/parameters/trendsEndDate"
+        - $ref: "#/parameters/trendsTop"
         - $ref: "#/parameters/apiKey"
         - name: "REPORT_NAME"
           in: "path"
@@ -3456,6 +3459,9 @@ paths:
         - "application/json"
       parameters:
         - $ref: "#/parameters/profDate"
+        - $ref: "#/parameters/trendsStartDate"
+        - $ref: "#/parameters/trendsEndDate"
+        - $ref: "#/parameters/trendsTop"
         - $ref: "#/parameters/apiKey"
         - name: "REPORT_NAME"
           in: "path"
@@ -3495,6 +3501,9 @@ paths:
         - "application/json"
       parameters:
         - $ref: "#/parameters/profDate"
+        - $ref: "#/parameters/trendsStartDate"
+        - $ref: "#/parameters/trendsEndDate"
+        - $ref: "#/parameters/trendsTop"
         - $ref: "#/parameters/apiKey"
         - name: "REPORT_NAME"
           in: "path"
@@ -3534,6 +3543,9 @@ paths:
         - "application/json"
       parameters:
         - $ref: "#/parameters/profDate"
+        - $ref: "#/parameters/trendsStartDate"
+        - $ref: "#/parameters/trendsEndDate"
+        - $ref: "#/parameters/trendsTop"
         - $ref: "#/parameters/apiKey"
         - name: "REPORT_NAME"
           in: "path"
@@ -3962,6 +3974,21 @@ parameters:
     type: string
     description: "target date to retrieve a historic version of the profile"
     default: todays_date in YYYY-MM-DD format
+  trendsStartDate:
+    name: "start_date"
+    in: "query"
+    type: string
+    description: "start date used to define a range of results"
+  trendsEndDate:
+    name: "end_date"
+    in: "query"
+    type: string
+    description: "end date used to define a range of results"
+  trendsTop:
+    name: "top"
+    in: "query"
+    type: string
+    description: "define a number of top results"
   topoDate:
     name: "date"
     in: "query"

--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -3420,6 +3420,7 @@ paths:
         - $ref: "#/parameters/trendsStartDate"
         - $ref: "#/parameters/trendsEndDate"
         - $ref: "#/parameters/trendsTop"
+        - $ref: "#/parameters/trendsGran"
         - $ref: "#/parameters/apiKey"
         - name: "REPORT_NAME"
           in: "path"
@@ -3462,6 +3463,7 @@ paths:
         - $ref: "#/parameters/trendsStartDate"
         - $ref: "#/parameters/trendsEndDate"
         - $ref: "#/parameters/trendsTop"
+        - $ref: "#/parameters/trendsGran"
         - $ref: "#/parameters/apiKey"
         - name: "REPORT_NAME"
           in: "path"
@@ -3504,6 +3506,7 @@ paths:
         - $ref: "#/parameters/trendsStartDate"
         - $ref: "#/parameters/trendsEndDate"
         - $ref: "#/parameters/trendsTop"
+        - $ref: "#/parameters/trendsGran"
         - $ref: "#/parameters/apiKey"
         - name: "REPORT_NAME"
           in: "path"
@@ -3546,6 +3549,7 @@ paths:
         - $ref: "#/parameters/trendsStartDate"
         - $ref: "#/parameters/trendsEndDate"
         - $ref: "#/parameters/trendsTop"
+        - $ref: "#/parameters/trendsGran"
         - $ref: "#/parameters/apiKey"
         - name: "REPORT_NAME"
           in: "path"
@@ -3968,6 +3972,12 @@ paths:
 
 
 parameters:
+  trendsGran:
+    name: "granularity"
+    in: "query"
+    type: string
+    description: "use granularity=monthly to get a monthly view of the results"
+    default: empty
   profDate:
     name: "date"
     in: "query"

--- a/website/docs/trends.md
+++ b/website/docs/trends.md
@@ -29,6 +29,7 @@ This method may be used to retrieve a list of top flapping service endpoint metr
 |`start_date`| define start date to view problematic endpoints over range | NO |  |
 |`end_date`| define end date to view problematic endpoints over range | NO |  |
 |`top`| integer to define a top number of results displayed | NO |  |
+|`granularity`| string value to define if you want monthly granularity in the results - e.g `?granularity=monthly` | NO |  |
 
 
 #### Headers
@@ -150,6 +151,87 @@ Reponse body:
 }
 ```
 
+###### Example Request with granularity=monthly option enabled:
+URL:
+```
+/trends/{report_name}/flapping/metrics?start_date=2020-04-01&end_date=2021-05-31&granularity=monthly&top=3
+```
+Headers:
+```
+x-api-key: shared_key_value
+Accept: application/json or application/xml
+
+```
+###### Example Response:
+
+Code:
+```
+Status: 200 OK
+```
+Reponse body:
+```
+{
+  "status": {
+    "message": "Success",
+    "code": "200"
+  },
+  "data": [
+    {
+      "date": "2015-04",
+      "top": [
+        {
+          "endpoint_group": "SITE-A",
+          "service": "service-A",
+          "endpoint": "hosta.example.foo",
+          "metric": "check-1",
+          "flapping": 55
+        },
+        {
+          "endpoint_group": "SITE-A",
+          "service": "service-A",
+          "endpoint": "hosta.example.foo",
+          "metric": "check-2",
+          "flapping": 40
+        },
+        {
+          "endpoint_group": "SITE-XB",
+          "service": "service-XA",
+          "endpoint": "hosta.examplex2.foo",
+          "metric": "web-check",
+          "flapping": 25
+        }
+      ]
+    },
+    {
+      "date": "2015-05",
+      "top": [
+        {
+          "endpoint_group": "SITE-A",
+          "service": "service-A",
+          "endpoint": "hosta.example.foo",
+          "metric": "check-1",
+          "flapping": 100
+        },
+        {
+          "endpoint_group": "SITE-A",
+          "service": "service-A",
+          "endpoint": "hosta.example.foo",
+          "metric": "check-2",
+          "flapping": 72
+        },
+        {
+          "endpoint_group": "SITE-A",
+          "service": "service-B",
+          "endpoint": "hostb.example.foo",
+          "metric": "web-check",
+          "flapping": 20
+        }
+      ]
+    }
+  ]
+}
+```
+
 
 ### [GET]: Daily Flapping trends in service endpoints 
 This method may be used to retrieve a list of top flapping service endpoints
@@ -173,6 +255,7 @@ This method may be used to retrieve a list of top flapping service endpoints
 |`start_date`| define start date to view problematic endpoints over range | NO |  |
 |`end_date`| define end date to view problematic endpoints over range | NO |  |
 |`top`| integer to define a top number of results displayed | NO |  |
+|`granularity`| string value to define if you want monthly granularity in the results - e.g `?granularity=monthly` | NO |  |
 
 
 #### Headers
@@ -275,6 +358,69 @@ Reponse body:
 }
 ```
 
+###### Example Request with granularity=monthly option enabled
+URL:
+```
+/trends/{report_name}/flapping/endpoints?start_date=2020-04-01&end_date=2020-05-31&top=2&granularity=monthly
+```
+Headers:
+```
+x-api-key: shared_key_value
+Accept: application/json or application/xml
+
+```
+###### Example Response:
+
+Code:
+```
+Status: 200 OK
+```
+Reponse body:
+```
+{
+  "status": {
+    "message": "Success",
+    "code": "200"
+  },
+  "data": [
+    {
+      "date": "2015-04",
+      "top": [
+        {
+          "endpoint_group": "SITE-XB",
+          "service": "service-XA",
+          "endpoint": "hosta.exampleX2.foo",
+          "flapping": 35
+        },
+        {
+          "endpoint_group": "SITE-A",
+          "service": "service-A",
+          "endpoint": "hosta.example.foo",
+          "flapping": 25
+        }
+      ]
+    },
+    {
+      "date": "2015-05",
+      "top": [
+        {
+          "endpoint_group": "SITE-A",
+          "service": "service-A",
+          "endpoint": "hosta.example.foo",
+          "flapping": 103
+        },
+        {
+          "endpoint_group": "SITE-A",
+          "service": "service-B",
+          "endpoint": "hostb.example.foo",
+          "flapping": 19
+        }
+      ]
+    }
+  ]
+}
+```
+
 
 ### [GET]: Daily Flapping trends in services
 This method may be used to retrieve a list of top flapping services
@@ -298,6 +444,7 @@ This method may be used to retrieve a list of top flapping services
 |`start_date`| define start date to view problematic endpoints over range | NO |  |
 |`end_date`| define end date to view problematic endpoints over range | NO |  |
 |`top`| integer to define a top number of results displayed | NO |  |
+|`granularity`| string value to define if you want monthly granularity in the results - e.g `?granularity=monthly` | NO |  |
 
 
 #### Headers
@@ -390,6 +537,55 @@ Reponse body:
 }
 ```
 
+###### Example Request with granularity=monthly option enabled:
+URL:
+```
+/trends/{report_name}/flapping/services?start_date=2020-04-01&end_date=2020-05-31&top=1&granularity=monthly
+```
+Headers:
+```
+x-api-key: shared_key_value
+Accept: application/json or application/xml
+
+```
+###### Example Response:
+
+Code:
+```
+Status: 200 OK
+```
+Reponse body:
+```
+{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "date": "2015-04",
+   "top": [
+    {
+     "endpoint_group": "SITE-A",
+     "service": "service-A",
+     "flapping": 25
+    }
+   ]
+  },
+  {
+   "date": "2015-05",
+   "top": [
+    {
+     "endpoint_group": "SITE-A",
+     "service": "service-A",
+     "flapping": 98
+    }
+   ]
+  }
+ ]
+}
+```
+
 ### [GET]: Daily Flapping trends in endpoint groups
 This method may be used to retrieve a list of top endpoint groups
 
@@ -412,6 +608,7 @@ This method may be used to retrieve a list of top endpoint groups
 |`start_date`| define start date to view problematic endpoints over range | NO |  |
 |`end_date`| define end date to view problematic endpoints over range | NO |  |
 |`top`| integer to define a top number of results displayed | NO |  |
+|`granularity`| string value to define if you want monthly granularity in the results - e.g `?granularity=monthly` | NO |  |
 
 
 #### Headers
@@ -492,5 +689,52 @@ Reponse body:
       "flapping": 75
     }
   ]
+}
+```
+
+###### Example Request with granularity=monthly option enabled
+URL:
+```
+/trends/{report_name}/flapping/groups?start_date=2020-04-01&end_date=2020-05-31&top=1&granularity=monthly
+```
+Headers:
+```
+x-api-key: shared_key_value
+Accept: application/json or application/xml
+
+```
+###### Example Response:
+
+Code:
+```
+Status: 200 OK
+```
+Reponse body:
+```
+{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "date": "2015-04",
+   "top": [
+    {
+     "endpoint_group": "SITE-A",
+     "flapping": 35
+    }
+   ]
+  },
+  {
+   "date": "2015-05",
+   "top": [
+    {
+     "endpoint_group": "SITE-A",
+     "flapping": 66
+    }
+   ]
+  }
+ ]
 }
 ```

--- a/website/docs/trends.md
+++ b/website/docs/trends.md
@@ -26,6 +26,9 @@ This method may be used to retrieve a list of top flapping service endpoint metr
 | Type | Description | Required | Default value |
 |------|-------------|----------|---------------|
 |`date`| Date to view problematic endpoints of | NO |  |
+|`start_date`| define start date to view problematic endpoints over range | NO |  |
+|`end_date`| define end date to view problematic endpoints over range | NO |  |
+|`top`| integer to define a top number of results displayed | NO |  |
 
 
 #### Headers
@@ -39,7 +42,6 @@ Accept: application/json or application/xml
 Status: 200 OK
 ```
 
-### Response body
 
 ###### Example Request:
 URL:
@@ -98,6 +100,56 @@ Reponse body:
 }
 ```
 
+###### Example Request with Range and top number of results:
+URL:
+```
+/trends/{report_name}/flapping/metrics?start_date=2020-05-01&end_date=2021-06-15&top=3
+```
+Headers:
+```
+x-api-key: shared_key_value
+Accept: application/json or application/xml
+
+```
+###### Example Response:
+
+Code:
+```
+Status: 200 OK
+```
+Reponse body:
+```
+{
+  "status": {
+    "message": "Success",
+    "code": "200"
+  },
+  "data": [
+    {
+      "endpoint_group": "SITE-A",
+      "service": "service-A",
+      "endpoint": "hosta.example.foo",
+      "metric": "check-1",
+      "flapping": 255
+    },
+    {
+      "endpoint_group": "SITE-A",
+      "service": "service-A",
+      "endpoint": "hosta.example.foo",
+      "metric": "check-2",
+      "flapping": 340
+    },
+    {
+      "endpoint_group": "SITE-A",
+      "service": "service-B",
+      "endpoint": "hostb.example.foo",
+      "metric": "web-check",
+      "flapping": 112
+    }
+  ]
+}
+```
+
 
 ### [GET]: Daily Flapping trends in service endpoints 
 This method may be used to retrieve a list of top flapping service endpoints
@@ -118,6 +170,9 @@ This method may be used to retrieve a list of top flapping service endpoints
 | Type | Description | Required | Default value |
 |------|-------------|----------|---------------|
 |`date`| Date to view problematic endpoints of | NO |  |
+|`start_date`| define start date to view problematic endpoints over range | NO |  |
+|`end_date`| define end date to view problematic endpoints over range | NO |  |
+|`top`| integer to define a top number of results displayed | NO |  |
 
 
 #### Headers
@@ -131,7 +186,6 @@ Accept: application/json or application/xml
 Status: 200 OK
 ```
 
-### Response body
 
 ###### Example Request:
 URL:
@@ -180,6 +234,48 @@ Reponse body:
 }
 ```
 
+###### Example Request with date range and top number of results:
+URL:
+```
+/trends/{report_name}/flapping/endpoints?start_date=2020-05-01&end_date=2020-05-15&top=2
+```
+Headers:
+```
+x-api-key: shared_key_value
+Accept: application/json or application/xml
+
+```
+###### Example Response:
+
+Code:
+```
+Status: 200 OK
+```
+Reponse body:
+```
+{
+  "status": {
+    "message": "Success",
+    "code": "200"
+  },
+  "data": [
+    {
+      "endpoint_group": "SITE-A",
+      "service": "service-A",
+      "endpoint": "hosta.example.foo",
+      "flapping": 83
+    },
+    {
+      "endpoint_group": "SITE-A",
+      "service": "service-B",
+      "endpoint": "hostb.example.foo",
+      "flapping": 53
+    }
+  ]
+}
+```
+
+
 ### [GET]: Daily Flapping trends in services
 This method may be used to retrieve a list of top flapping services
 
@@ -199,6 +295,9 @@ This method may be used to retrieve a list of top flapping services
 | Type | Description | Required | Default value |
 |------|-------------|----------|---------------|
 |`date`| Date to view problematic endpoints of | NO |  |
+|`start_date`| define start date to view problematic endpoints over range | NO |  |
+|`end_date`| define end date to view problematic endpoints over range | NO |  |
+|`top`| integer to define a top number of results displayed | NO |  |
 
 
 #### Headers
@@ -212,7 +311,6 @@ Accept: application/json or application/xml
 Status: 200 OK
 ```
 
-### Response body
 
 ###### Example Request:
 URL:
@@ -258,6 +356,40 @@ Reponse body:
 }
 ```
 
+###### Example Request with date range and top number of results:
+URL:
+```
+/trends/{report_name}/flapping/services?start_date=2020-05-01&end_date=2020-07-05&top=1
+```
+Headers:
+```
+x-api-key: shared_key_value
+Accept: application/json or application/xml
+
+```
+###### Example Response:
+
+Code:
+```
+Status: 200 OK
+```
+Reponse body:
+```
+{
+  "status": {
+    "message": "Success",
+    "code": "200"
+  },
+  "data": [
+    {
+      "endpoint_group": "SITE-A",
+      "service": "service-A",
+      "flapping": 955
+    }
+  ]
+}
+```
+
 ### [GET]: Daily Flapping trends in endpoint groups
 This method may be used to retrieve a list of top endpoint groups
 
@@ -277,6 +409,9 @@ This method may be used to retrieve a list of top endpoint groups
 | Type | Description | Required | Default value |
 |------|-------------|----------|---------------|
 |`date`| Date to view problematic endpoints of | NO |  |
+|`start_date`| define start date to view problematic endpoints over range | NO |  |
+|`end_date`| define end date to view problematic endpoints over range | NO |  |
+|`top`| integer to define a top number of results displayed | NO |  |
 
 
 #### Headers
@@ -289,8 +424,6 @@ Accept: application/json or application/xml
 ```
 Status: 200 OK
 ```
-
-### Response body
 
 ###### Example Request:
 URL:
@@ -324,6 +457,39 @@ Reponse body:
     {
       "endpoint_group": "SITE-B",
       "flapping": 5
+    }
+  ]
+}
+```
+
+###### Example Request with date range and top number of results:
+URL:
+```
+/trends/{report_name}/flapping/groups?start_date=2020-05-01&end_date=2020-05-03&top=1
+```
+Headers:
+```
+x-api-key: shared_key_value
+Accept: application/json or application/xml
+
+```
+###### Example Response:
+
+Code:
+```
+Status: 200 OK
+```
+Reponse body:
+```
+{
+  "status": {
+    "message": "Success",
+    "code": "200"
+  },
+  "data": [
+    {
+      "endpoint_group": "SITE-A",
+      "flapping": 75
     }
   ]
 }


### PR DESCRIPTION
## Goal
When exploring flapping trends:
 - `/api/v1/trends/{report_name}/flapping/metrics`
 - `/api/v1/trends/{report_name}/flapping/endpoints`
 - `/api/v1/trends/{report_name}/flapping/services`
 - `/api/v1/trends/{report_name}/flapping/groups`

and the start_date & end_date range is used ... Give the ability to aggregate results per month 

### Solution 
Introduce `?granularity=monthly` parameter which is optional but when used aggregates results per month. Lets see it in example:

👉  Get service results for period of 2 months 2021-04-01 ➡️ 2021-05-31 without monthly aggregation:
`HTTP GET /api/v1/trends/{report_name}/flapping/services?start_date=2021-04-01&end_date=2021-05-31`

Response:
```json

  "status": {
    "message": "Success",
    "code": "200"
  },
  "data": [
    {
      "endpoint_group": "SITE-A",
      "service": "service-A",
      "endpoint": "hosta.example.foo",
      "flapping": 55
    },
    {
      "endpoint_group": "SITE-A",
      "service": "service-B",
      "endpoint": "hostb.example.foo",
      "flapping": 12
    }
  ]
}
```

*NEW* 🌟 Same example with monthly aggregation enabled:
👉  Get service results for period of 2 months 2021-04-01 ➡️ 2021-05-31  **with** monthly aggregation:
`HTTP GET /api/v1/trends/{report_name}/flapping/services?start_date=2021-04-01&end_date=2021-05-31&granularity=enabled`

```json
{
  "status": {
    "message": "Success",
    "code": "200"
  },
  "data": [
    {
      "date": "201504",
      "top": [
        {
          "endpoint_group": "SITE-XB",
          "service": "service-XA",
          "endpoint": "hosta.exampleX2.foo",
          "flapping": 35
        },
        {
          "endpoint_group": "SITE-A",
          "service": "service-A",
          "endpoint": "hosta.example.foo",
          "flapping": 25
        }
      ]
    },
    {
      "date": "201505",
      "top": [
        {
          "endpoint_group": "SITE-A",
          "service": "service-A",
          "endpoint": "hosta.example.foo",
          "flapping": 103
        },
        {
          "endpoint_group": "SITE-A",
          "service": "service-B",
          "endpoint": "hostb.example.foo",
          "flapping": 19
        }
      ]
    }
  ]
}
```
The new results are presented in a data array partitioned by date in the following schema

```json
{
  "data": [
    {
      "date": "YYYY-MM",
      "top": [
        {},
        {},
        {}
      ]
    }
  ]
}
```

## Implementations 
- [x] Add monthly models for displaying monthly aggregated data
- [x] Add monthly aggregation queries to flapping trends handlers for metrics, endpoints, services, groups
- [x] Add new unit tests for monthly aggregation
- [x] Update docusaurus documents
- [x] Update swagger