### PR TITLE
ARGO-3197 Display status trend results for metrics

### DIFF
--- a/app/trends/controller.go
+++ b/app/trends/controller.go
@@ -42,6 +42,7 @@ const flapEndpointGroups = "flipflop_trends_endpoint_groups"
 const flapEndpoints = "flipflop_trends_endpoints"
 const flapServices = "flipflop_trends_services"
 const flapMetrics = "flipflop_trends_metrics"
+const statusMetrics = "status_trends_metrics"
 
 type list []interface{}
 
@@ -79,6 +80,164 @@ func getDateRange(urlValues url.Values) (int, int, error) {
 	date, _, err := utils.ParseZuluDate(dateStr)
 	return date, date, err
 
+}
+
+// ListStatusMetrics returns a list of top status metrics for the day
+func ListStatusMetrics(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
+
+	//STANDARD DECLARATIONS START
+
+	code := http.StatusOK
+	h := http.Header{}
+	output := []byte("List Flapping Metrics")
+	err := error(nil)
+	charset := "utf-8"
+
+	//STANDARD DECLARATIONS END
+
+	// Set Content-Type response Header value
+	contentType := r.Header.Get("Accept")
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+
+	// Parse the request into the input
+	urlValues := r.URL.Query()
+	vars := mux.Vars(r)
+
+	// Grab Tenant DB configuration from context
+	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
+
+	session, err := mongo.OpenSession(tenantDbConfig)
+	defer mongo.CloseSession(session)
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	metricCollection := session.DB(tenantDbConfig.Db).C(statusMetrics)
+
+	// Query the detailed metric results
+	reportID, err := mongo.GetReportID(session, tenantDbConfig.Db, vars["report_name"])
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	startDate, endDate, err := getDateRange(urlValues)
+	if err != nil {
+		code = http.StatusBadRequest
+		output, _ = respond.MarshalContent(respond.ErrBadRequestDetails(err.Error()), contentType, "", " ")
+		return code, h, output, err
+	}
+
+	limit := -1
+	limStr := urlValues.Get("top")
+	if limStr != "" {
+		limit, err = strconv.Atoi(limStr)
+		if err != nil {
+			code = http.StatusInternalServerError
+			return code, h, output, err
+		}
+	}
+
+	granularity := urlValues.Get("granularity")
+
+	// query for metrics
+	filter := bson.M{"report": reportID, "date": bson.M{"$gte": startDate, "$lte": endDate}}
+
+	// apply query for bucketed monthly results if granularity is set to monthly
+	if granularity == "monthly" {
+
+		results := []StatusMonthMetricData{}
+
+		query := []bson.M{
+			{"$match": filter},
+			{"$group": bson.M{
+				"_id": bson.M{
+					"month":    bson.M{"$substr": list{"$date", 0, 6}},
+					"group":    "$group",
+					"service":  "$service",
+					"endpoint": "$endpoint",
+					"metric":   "$metric",
+					"status":   "$status"},
+				"events": bson.M{"$sum": "$trends"},
+			}},
+			{"$sort": bson.D{{"_id.month", 1}, {"_id.status", 1}, {"events", -1}}},
+			{
+				"$group": bson.M{
+					"_id": bson.M{"month": "$_id.month", "status": "$_id.status"},
+					"top": bson.M{"$push": bson.M{"group": "$_id.group", "service": "$_id.service", "endpoint": "$_id.endpoint", "metric": "$_id.metric", "status": "$_id.status", "events": "$events"}}}},
+		}
+
+		// trim down the list in each month-bucket according to the limit parameter
+		if limit > 0 {
+			query = append(query, bson.M{"$project": bson.M{"date": bson.M{"$concat": list{bson.M{"$substr": list{"$_id.month", 0, 4}},
+				"-", bson.M{"$substr": list{"$_id.month", 4, 6}}}},
+				"status": "$_id.status",
+				"top":    bson.M{"$slice": list{"$top", limit}}}})
+		} else {
+			query = append(query, bson.M{"$project": bson.M{"date": bson.M{"$concat": list{bson.M{"$substr": list{"$_id.month", 0, 4}},
+				"-", bson.M{"$substr": list{"$_id.month", 4, 6}}}},
+				"status": "$_id.status",
+				"top":    "$top"}})
+		}
+
+		// sort end results by month bucket ascending
+		query = append(query, bson.M{"$sort": bson.D{{"date", 1}, {"status", 1}}})
+
+		err = metricCollection.Pipe(query).All(&results)
+		if err != nil {
+			code = http.StatusInternalServerError
+			return code, h, output, err
+		}
+
+		output, err = createStatusMonthMetricListView(results, "Success", 200)
+
+		return code, h, output, err
+
+	}
+
+	// continue by calculating non monthly bucketed results
+	results := []StatusGroupMetricData{}
+
+	query := []bson.M{
+		{"$match": filter},
+		{"$group": bson.M{
+			"_id": bson.M{
+				"group":    "$group",
+				"service":  "$service",
+				"endpoint": "$endpoint",
+				"metric":   "$metric",
+				"status":   "$status"},
+			"events": bson.M{"$sum": "$trends"},
+		}},
+		{"$sort": bson.D{{"_id.status", 1}, {"events", -1}}},
+		{
+			"$group": bson.M{
+				"_id": bson.M{"status": "$_id.status"},
+				"top": bson.M{"$push": bson.M{"group": "$_id.group", "service": "$_id.service", "endpoint": "$_id.endpoint", "metric": "$_id.metric", "status": "$_id.status", "events": "$events"}}}},
+	}
+
+	// trim down the list in each month-bucket according to the limit parameter
+	if limit > 0 {
+		query = append(query, bson.M{"$project": bson.M{"status": "$_id.status",
+			"top": bson.M{"$slice": list{"$top", limit}}}})
+	} else {
+		query = append(query, bson.M{"$project": bson.M{"status": "$_id.status",
+			"top": "$top"}})
+	}
+
+	// sort end results by month bucket ascending
+	query = append(query, bson.M{"$sort": bson.D{{"status", 1}}})
+
+	err = metricCollection.Pipe(query).All(&results)
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	output, err = createStatusMetricListView(results, "Success", 200)
+
+	return code, h, output, err
 }
 
 // FlatFlappingMetrics returns a list of top flapping metrics for the day

--- a/app/trends/model.go
+++ b/app/trends/model.go
@@ -27,6 +27,27 @@ import "encoding/xml"
 const zuluForm = "2006-01-02T15:04:05Z"
 const ymdForm = "2006-01-02"
 
+//MonthMetricData holds flapping information about monthly metrics
+type MonthMetricData struct {
+	Date string       `bson:"date" json:"date"`
+	Top  []MetricData `bson:"top" json:"top"`
+}
+
+type MonthEndpointData struct {
+	Date string         `bson:"date" json:"date"`
+	Top  []EndpointData `bson:"top" json:"top"`
+}
+
+type MonthServiceData struct {
+	Date string        `bson:"date" json:"date"`
+	Top  []ServiceData `bson:"top" json:"top"`
+}
+
+type MonthEndpointGroupData struct {
+	Date string              `bson:"date" json:"date"`
+	Top  []EndpointGroupData `bson:"top" json:"top"`
+}
+
 // MetricData holds flapping information about metrics
 type MetricData struct {
 	EndpointGroup string `bson:"group" json:"endpoint_group"`

--- a/app/trends/model.go
+++ b/app/trends/model.go
@@ -27,6 +27,19 @@ import "encoding/xml"
 const zuluForm = "2006-01-02T15:04:05Z"
 const ymdForm = "2006-01-02"
 
+//StatusMonthMetricData holds status information about monthly metrics
+type StatusMonthMetricData struct {
+	Date   string             `bson:"date" json:"date"`
+	Status string             `bson:"status" json:"status"`
+	Top    []StatusMetricData `bson:"top" json:"top"`
+}
+
+//StatusGroupMetricData holds status information about monthly metrics
+type StatusGroupMetricData struct {
+	Status string             `bson:"status" json:"status"`
+	Top    []StatusMetricData `bson:"top" json:"top"`
+}
+
 //MonthMetricData holds flapping information about monthly metrics
 type MonthMetricData struct {
 	Date string       `bson:"date" json:"date"`
@@ -55,6 +68,16 @@ type MetricData struct {
 	Endpoint      string `bson:"endpoint" json:"endpoint"`
 	Metric        string `bson:"metric" json:"metric"`
 	Flapping      int    `bson:"flipflop" json:"flapping"`
+}
+
+// StatusMetricData holds status information about metrics
+type StatusMetricData struct {
+	EndpointGroup string `bson:"group" json:"endpoint_group"`
+	Service       string `bson:"service" json:"service"`
+	Endpoint      string `bson:"endpoint" json:"endpoint"`
+	Metric        string `bson:"metric" json:"metric"`
+	Status        string `bson:"status" json:"status"`
+	Events        int    `bson:"events" json:"events"`
 }
 
 // EndpointData holds flapping information about endpoints

--- a/app/trends/routing.go
+++ b/app/trends/routing.go
@@ -39,8 +39,10 @@ var appRoutesV2 = []respond.AppRoutes{
 	{"trends.flapping_endpoints", "GET", "/{report_name}/flapping/endpoints", ListFlappingEndpoints},
 	{"trends.flapping_services", "GET", "/{report_name}/flapping/services", ListFlappingServices},
 	{"trends.flapping_endpoint_groups", "GET", "/{report_name}/flapping/groups", ListFlappingEndpointGroups},
+	{"trends.status_metrics", "GET", "/{report_name}/status/metrics", ListStatusMetrics},
 	{"trends.options", "OPTIONS", "/{report_name}/flapping/metrics", Options},
 	{"trends.options", "OPTIONS", "/{report_name}/flapping/endpoints", Options},
 	{"trends.options", "OPTIONS", "/{report_name}/flapping/services", Options},
 	{"trends.options", "OPTIONS", "/{report_name}/flapping/groups", Options},
+	{"trends.options", "OPTIONS", "/{report_name}/status/metrics", Options},
 }

--- a/app/trends/trends_test.go
+++ b/app/trends/trends_test.go
@@ -195,7 +195,7 @@ func (suite *TrendsTestSuite) SetupTest() {
 	c = session.DB(suite.tenantDbConf.Db).C("flipflop_trends_metrics")
 	c.Insert(bson.M{
 		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
-		"date":     "2015-05-01",
+		"date":     20150501,
 		"group":    "SITE-A",
 		"service":  "service-A",
 		"endpoint": "hosta.example.foo",
@@ -204,7 +204,7 @@ func (suite *TrendsTestSuite) SetupTest() {
 	})
 	c.Insert(bson.M{
 		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
-		"date":     "2015-05-01",
+		"date":     20150501,
 		"group":    "SITE-A",
 		"service":  "service-A",
 		"endpoint": "hosta.example.foo",
@@ -213,7 +213,7 @@ func (suite *TrendsTestSuite) SetupTest() {
 	})
 	c.Insert(bson.M{
 		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
-		"date":     "2015-05-01",
+		"date":     20150501,
 		"group":    "SITE-A",
 		"service":  "service-B",
 		"endpoint": "hostb.example.foo",
@@ -222,19 +222,55 @@ func (suite *TrendsTestSuite) SetupTest() {
 	})
 	c.Insert(bson.M{
 		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
-		"date":     "2015-05-01",
+		"date":     20150501,
 		"group":    "SITE-B",
 		"service":  "service-A",
 		"endpoint": "hosta.example2.foo",
 		"metric":   "web-check",
 		"flipflop": 5,
 	})
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     20150502,
+		"group":    "SITE-A",
+		"service":  "service-A",
+		"endpoint": "hosta.example.foo",
+		"metric":   "check-1",
+		"flipflop": 45,
+	})
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     20150502,
+		"group":    "SITE-A",
+		"service":  "service-A",
+		"endpoint": "hosta.example.foo",
+		"metric":   "check-2",
+		"flipflop": 32,
+	})
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     20150502,
+		"group":    "SITE-A",
+		"service":  "service-B",
+		"endpoint": "hostb.example.foo",
+		"metric":   "web-check",
+		"flipflop": 8,
+	})
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     20150502,
+		"group":    "SITE-B",
+		"service":  "service-A",
+		"endpoint": "hosta.example2.foo",
+		"metric":   "web-check",
+		"flipflop": 7,
+	})
 
 	// seed the status detailed trends endpoint data
 	c = session.DB(suite.tenantDbConf.Db).C("flipflop_trends_endpoints")
 	c.Insert(bson.M{
 		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
-		"date":     "2015-05-01",
+		"date":     20150501,
 		"group":    "SITE-A",
 		"service":  "service-A",
 		"endpoint": "hosta.example.foo",
@@ -242,7 +278,7 @@ func (suite *TrendsTestSuite) SetupTest() {
 	})
 	c.Insert(bson.M{
 		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
-		"date":     "2015-05-01",
+		"date":     20150501,
 		"group":    "SITE-A",
 		"service":  "service-B",
 		"endpoint": "hostb.example.foo",
@@ -250,50 +286,108 @@ func (suite *TrendsTestSuite) SetupTest() {
 	})
 	c.Insert(bson.M{
 		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
-		"date":     "2015-05-01",
+		"date":     20150501,
 		"group":    "SITE-B",
 		"service":  "service-A",
 		"endpoint": "hosta.example2.foo",
 		"flipflop": 5,
+	})
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     20150502,
+		"group":    "SITE-A",
+		"service":  "service-A",
+		"endpoint": "hosta.example.foo",
+		"flipflop": 48,
+	})
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     20150502,
+		"group":    "SITE-A",
+		"service":  "service-B",
+		"endpoint": "hostb.example.foo",
+		"flipflop": 7,
+	})
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     20150502,
+		"group":    "SITE-B",
+		"service":  "service-A",
+		"endpoint": "hosta.example2.foo",
+		"flipflop": 3,
 	})
 
 	// seed the status detailed trends service data
 	c = session.DB(suite.tenantDbConf.Db).C("flipflop_trends_services")
 	c.Insert(bson.M{
 		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
-		"date":     "2015-05-01",
+		"date":     20150501,
 		"group":    "SITE-A",
 		"service":  "service-A",
 		"flipflop": 55,
 	})
 	c.Insert(bson.M{
 		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
-		"date":     "2015-05-01",
+		"date":     20150501,
 		"group":    "SITE-A",
 		"service":  "service-B",
 		"flipflop": 12,
 	})
 	c.Insert(bson.M{
 		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
-		"date":     "2015-05-01",
+		"date":     20150501,
 		"group":    "SITE-B",
 		"service":  "service-A",
 		"flipflop": 5,
+	})
+
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     20150502,
+		"group":    "SITE-A",
+		"service":  "service-A",
+		"flipflop": 43,
+	})
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     20150502,
+		"group":    "SITE-A",
+		"service":  "service-B",
+		"flipflop": 11,
+	})
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     20150502,
+		"group":    "SITE-B",
+		"service":  "service-A",
+		"flipflop": 4,
 	})
 
 	// seed the status detailed trends group data
 	c = session.DB(suite.tenantDbConf.Db).C("flipflop_trends_endpoint_groups")
 	c.Insert(bson.M{
 		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
-		"date":     "2015-05-01",
+		"date":     20150501,
 		"group":    "SITE-A",
 		"flipflop": 55,
 	})
 	c.Insert(bson.M{
 		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
-		"date":     "2015-05-01",
+		"date":     20150501,
 		"group":    "SITE-B",
 		"flipflop": 5,
+	})
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     20150502,
+		"group":    "SITE-A",
+		"flipflop": 11,
+	})
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     20150502,
+		"group":    "SITE-B",
+		"flipflop": 4,
 	})
 
 }
@@ -434,6 +528,282 @@ func (suite *TrendsTestSuite) TestTrends() {
   {
    "endpoint_group": "SITE-B",
    "flapping": 5
+  }
+ ]
+}`,
+		},
+
+		expReq{
+			method: "GET",
+			url:    "/api/v2/trends/Report_A/flapping/metrics?start_date=2015-05-01&end_date=2015-05-02&top=3",
+			code:   200,
+			key:    "KEY1",
+			result: `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "endpoint_group": "SITE-A",
+   "service": "service-A",
+   "endpoint": "hosta.example.foo",
+   "metric": "check-1",
+   "flapping": 100
+  },
+  {
+   "endpoint_group": "SITE-A",
+   "service": "service-A",
+   "endpoint": "hosta.example.foo",
+   "metric": "check-2",
+   "flapping": 72
+  },
+  {
+   "endpoint_group": "SITE-A",
+   "service": "service-B",
+   "endpoint": "hostb.example.foo",
+   "metric": "web-check",
+   "flapping": 20
+  }
+ ]
+}`,
+		},
+
+		expReq{
+			method: "GET",
+			url:    "/api/v2/trends/Report_A/flapping/metrics?start_date=2015-05-01&end_date=2015-05-02",
+			code:   200,
+			key:    "KEY1",
+			result: `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "endpoint_group": "SITE-A",
+   "service": "service-A",
+   "endpoint": "hosta.example.foo",
+   "metric": "check-1",
+   "flapping": 100
+  },
+  {
+   "endpoint_group": "SITE-A",
+   "service": "service-A",
+   "endpoint": "hosta.example.foo",
+   "metric": "check-2",
+   "flapping": 72
+  },
+  {
+   "endpoint_group": "SITE-A",
+   "service": "service-B",
+   "endpoint": "hostb.example.foo",
+   "metric": "web-check",
+   "flapping": 20
+  },
+  {
+   "endpoint_group": "SITE-B",
+   "service": "service-A",
+   "endpoint": "hosta.example2.foo",
+   "metric": "web-check",
+   "flapping": 12
+  }
+ ]
+}`,
+		},
+
+		expReq{
+			method: "GET",
+			url:    "/api/v2/trends/Report_A/flapping/endpoints?start_date=2015-05-01&end_date=2015-05-02",
+			code:   200,
+			key:    "KEY1",
+			result: `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "endpoint_group": "SITE-A",
+   "service": "service-A",
+   "endpoint": "hosta.example.foo",
+   "flapping": 103
+  },
+  {
+   "endpoint_group": "SITE-A",
+   "service": "service-B",
+   "endpoint": "hostb.example.foo",
+   "flapping": 19
+  },
+  {
+   "endpoint_group": "SITE-B",
+   "service": "service-A",
+   "endpoint": "hosta.example2.foo",
+   "flapping": 8
+  }
+ ]
+}`,
+		},
+
+		expReq{
+			method: "GET",
+			url:    "/api/v2/trends/Report_A/flapping/endpoints?start_date=2015-05-01&end_date=2015-05-02&top=2",
+			code:   200,
+			key:    "KEY1",
+			result: `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "endpoint_group": "SITE-A",
+   "service": "service-A",
+   "endpoint": "hosta.example.foo",
+   "flapping": 103
+  },
+  {
+   "endpoint_group": "SITE-A",
+   "service": "service-B",
+   "endpoint": "hostb.example.foo",
+   "flapping": 19
+  }
+ ]
+}`,
+		},
+
+		expReq{
+			method: "GET",
+			url:    "/api/v2/trends/Report_A/flapping/services?start_date=2015-05-01&end_date=2015-05-02",
+			code:   200,
+			key:    "KEY1",
+			result: `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "endpoint_group": "SITE-A",
+   "service": "service-A",
+   "flapping": 98
+  },
+  {
+   "endpoint_group": "SITE-A",
+   "service": "service-B",
+   "flapping": 23
+  },
+  {
+   "endpoint_group": "SITE-B",
+   "service": "service-A",
+   "flapping": 9
+  }
+ ]
+}`,
+		},
+
+		expReq{
+			method: "GET",
+			url:    "/api/v2/trends/Report_A/flapping/services?start_date=2015-05-01&end_date=2015-05-02&top=2",
+			code:   200,
+			key:    "KEY1",
+			result: `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "endpoint_group": "SITE-A",
+   "service": "service-A",
+   "flapping": 98
+  },
+  {
+   "endpoint_group": "SITE-A",
+   "service": "service-B",
+   "flapping": 23
+  }
+ ]
+}`,
+		},
+
+		expReq{
+			method: "GET",
+			url:    "/api/v2/trends/Report_A/flapping/groups?start_date=2015-05-01",
+			code:   400,
+			key:    "KEY1",
+			result: `{
+ "status": {
+  "message": "Bad Request",
+  "code": "400"
+ },
+ "errors": [
+  {
+   "message": "Bad Request",
+   "code": "400",
+   "details": "Please use either a date url parameter or a combination of start_date and end_date parameters to declare range"
+  }
+ ]
+}`,
+		},
+
+		expReq{
+			method: "GET",
+			url:    "/api/v2/trends/Report_A/flapping/groups?end_date=2015-05-01",
+			code:   400,
+			key:    "KEY1",
+			result: `{
+ "status": {
+  "message": "Bad Request",
+  "code": "400"
+ },
+ "errors": [
+  {
+   "message": "Bad Request",
+   "code": "400",
+   "details": "Please use either a date url parameter or a combination of start_date and end_date parameters to declare range"
+  }
+ ]
+}`,
+		},
+
+		expReq{
+			method: "GET",
+			url:    "/api/v2/trends/Report_A/flapping/groups?start_date=2015-05-01&end_date=2015-05-02",
+			code:   200,
+			key:    "KEY1",
+			result: `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "endpoint_group": "SITE-A",
+   "flapping": 66
+  },
+  {
+   "endpoint_group": "SITE-B",
+   "flapping": 9
+  }
+ ]
+}`,
+		},
+
+		expReq{
+			method: "GET",
+			url:    "/api/v2/trends/Report_A/flapping/groups?start_date=2015-05-01&end_date=2015-05-02&top=1",
+			code:   200,
+			key:    "KEY1",
+			result: `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "endpoint_group": "SITE-A",
+   "flapping": 66
   }
  ]
 }`,

--- a/app/trends/trends_test.go
+++ b/app/trends/trends_test.go
@@ -195,6 +195,42 @@ func (suite *TrendsTestSuite) SetupTest() {
 	c = session.DB(suite.tenantDbConf.Db).C("flipflop_trends_metrics")
 	c.Insert(bson.M{
 		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     20150401,
+		"group":    "SITE-A",
+		"service":  "service-A",
+		"endpoint": "hosta.example.foo",
+		"metric":   "check-1",
+		"flipflop": 55,
+	})
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     20150401,
+		"group":    "SITE-A",
+		"service":  "service-A",
+		"endpoint": "hosta.example.foo",
+		"metric":   "check-2",
+		"flipflop": 40,
+	})
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     20150401,
+		"group":    "SITE-A",
+		"service":  "service-B",
+		"endpoint": "hostb.example.foo",
+		"metric":   "web-check",
+		"flipflop": 12,
+	})
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     20150401,
+		"group":    "SITE-XB",
+		"service":  "service-XA",
+		"endpoint": "hosta.examplex2.foo",
+		"metric":   "web-check",
+		"flipflop": 25,
+	})
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
 		"date":     20150501,
 		"group":    "SITE-A",
 		"service":  "service-A",
@@ -270,6 +306,31 @@ func (suite *TrendsTestSuite) SetupTest() {
 	c = session.DB(suite.tenantDbConf.Db).C("flipflop_trends_endpoints")
 	c.Insert(bson.M{
 		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     20150401,
+		"group":    "SITE-A",
+		"service":  "service-A",
+		"endpoint": "hosta.example.foo",
+		"flipflop": 25,
+	})
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     20150401,
+		"group":    "SITE-A",
+		"service":  "service-B",
+		"endpoint": "hostb.example.foo",
+		"flipflop": 2,
+	})
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     20150401,
+		"group":    "SITE-XB",
+		"service":  "service-XA",
+		"endpoint": "hosta.exampleX2.foo",
+		"flipflop": 35,
+	})
+
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
 		"date":     20150501,
 		"group":    "SITE-A",
 		"service":  "service-A",
@@ -321,6 +382,28 @@ func (suite *TrendsTestSuite) SetupTest() {
 	c = session.DB(suite.tenantDbConf.Db).C("flipflop_trends_services")
 	c.Insert(bson.M{
 		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     20150401,
+		"group":    "SITE-A",
+		"service":  "service-A",
+		"flipflop": 25,
+	})
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     20150401,
+		"group":    "SITE-A",
+		"service":  "service-B",
+		"flipflop": 16,
+	})
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     20150401,
+		"group":    "SITE-XB",
+		"service":  "service-XA",
+		"flipflop": 3,
+	})
+
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
 		"date":     20150501,
 		"group":    "SITE-A",
 		"service":  "service-A",
@@ -365,6 +448,18 @@ func (suite *TrendsTestSuite) SetupTest() {
 
 	// seed the status detailed trends group data
 	c = session.DB(suite.tenantDbConf.Db).C("flipflop_trends_endpoint_groups")
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     20150401,
+		"group":    "SITE-A",
+		"flipflop": 35,
+	})
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     20150401,
+		"group":    "SITE-XB",
+		"flipflop": 3,
+	})
 	c.Insert(bson.M{
 		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
 		"date":     20150501,
@@ -535,6 +630,154 @@ func (suite *TrendsTestSuite) TestTrends() {
 
 		expReq{
 			method: "GET",
+			url:    "/api/v2/trends/Report_A/flapping/metrics?start_date=2015-04-01&end_date=2015-05-02&granularity=monthly",
+			code:   200,
+			key:    "KEY1",
+			result: `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "date": "2015-04",
+   "top": [
+    {
+     "endpoint_group": "SITE-A",
+     "service": "service-A",
+     "endpoint": "hosta.example.foo",
+     "metric": "check-1",
+     "flapping": 55
+    },
+    {
+     "endpoint_group": "SITE-A",
+     "service": "service-A",
+     "endpoint": "hosta.example.foo",
+     "metric": "check-2",
+     "flapping": 40
+    },
+    {
+     "endpoint_group": "SITE-XB",
+     "service": "service-XA",
+     "endpoint": "hosta.examplex2.foo",
+     "metric": "web-check",
+     "flapping": 25
+    },
+    {
+     "endpoint_group": "SITE-A",
+     "service": "service-B",
+     "endpoint": "hostb.example.foo",
+     "metric": "web-check",
+     "flapping": 12
+    }
+   ]
+  },
+  {
+   "date": "2015-05",
+   "top": [
+    {
+     "endpoint_group": "SITE-A",
+     "service": "service-A",
+     "endpoint": "hosta.example.foo",
+     "metric": "check-1",
+     "flapping": 100
+    },
+    {
+     "endpoint_group": "SITE-A",
+     "service": "service-A",
+     "endpoint": "hosta.example.foo",
+     "metric": "check-2",
+     "flapping": 72
+    },
+    {
+     "endpoint_group": "SITE-A",
+     "service": "service-B",
+     "endpoint": "hostb.example.foo",
+     "metric": "web-check",
+     "flapping": 20
+    },
+    {
+     "endpoint_group": "SITE-B",
+     "service": "service-A",
+     "endpoint": "hosta.example2.foo",
+     "metric": "web-check",
+     "flapping": 12
+    }
+   ]
+  }
+ ]
+}`,
+		},
+
+		expReq{
+			method: "GET",
+			url:    "/api/v2/trends/Report_A/flapping/metrics?start_date=2015-04-01&end_date=2015-05-02&top=3&granularity=monthly",
+			code:   200,
+			key:    "KEY1",
+			result: `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "date": "2015-04",
+   "top": [
+    {
+     "endpoint_group": "SITE-A",
+     "service": "service-A",
+     "endpoint": "hosta.example.foo",
+     "metric": "check-1",
+     "flapping": 55
+    },
+    {
+     "endpoint_group": "SITE-A",
+     "service": "service-A",
+     "endpoint": "hosta.example.foo",
+     "metric": "check-2",
+     "flapping": 40
+    },
+    {
+     "endpoint_group": "SITE-XB",
+     "service": "service-XA",
+     "endpoint": "hosta.examplex2.foo",
+     "metric": "web-check",
+     "flapping": 25
+    }
+   ]
+  },
+  {
+   "date": "2015-05",
+   "top": [
+    {
+     "endpoint_group": "SITE-A",
+     "service": "service-A",
+     "endpoint": "hosta.example.foo",
+     "metric": "check-1",
+     "flapping": 100
+    },
+    {
+     "endpoint_group": "SITE-A",
+     "service": "service-A",
+     "endpoint": "hosta.example.foo",
+     "metric": "check-2",
+     "flapping": 72
+    },
+    {
+     "endpoint_group": "SITE-A",
+     "service": "service-B",
+     "endpoint": "hostb.example.foo",
+     "metric": "web-check",
+     "flapping": 20
+    }
+   ]
+  }
+ ]
+}`,
+		},
+
+		expReq{
+			method: "GET",
 			url:    "/api/v2/trends/Report_A/flapping/metrics?start_date=2015-05-01&end_date=2015-05-02&top=3",
 			code:   200,
 			key:    "KEY1",
@@ -647,6 +890,116 @@ func (suite *TrendsTestSuite) TestTrends() {
 
 		expReq{
 			method: "GET",
+			url:    "/api/v2/trends/Report_A/flapping/endpoints?start_date=2015-04-01&end_date=2015-05-02&granularity=monthly",
+			code:   200,
+			key:    "KEY1",
+			result: `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "date": "2015-04",
+   "top": [
+    {
+     "endpoint_group": "SITE-XB",
+     "service": "service-XA",
+     "endpoint": "hosta.exampleX2.foo",
+     "flapping": 35
+    },
+    {
+     "endpoint_group": "SITE-A",
+     "service": "service-A",
+     "endpoint": "hosta.example.foo",
+     "flapping": 25
+    },
+    {
+     "endpoint_group": "SITE-A",
+     "service": "service-B",
+     "endpoint": "hostb.example.foo",
+     "flapping": 2
+    }
+   ]
+  },
+  {
+   "date": "2015-05",
+   "top": [
+    {
+     "endpoint_group": "SITE-A",
+     "service": "service-A",
+     "endpoint": "hosta.example.foo",
+     "flapping": 103
+    },
+    {
+     "endpoint_group": "SITE-A",
+     "service": "service-B",
+     "endpoint": "hostb.example.foo",
+     "flapping": 19
+    },
+    {
+     "endpoint_group": "SITE-B",
+     "service": "service-A",
+     "endpoint": "hosta.example2.foo",
+     "flapping": 8
+    }
+   ]
+  }
+ ]
+}`,
+		},
+
+		expReq{
+			method: "GET",
+			url:    "/api/v2/trends/Report_A/flapping/endpoints?start_date=2015-04-01&end_date=2015-05-02&top=2&granularity=monthly",
+			code:   200,
+			key:    "KEY1",
+			result: `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "date": "2015-04",
+   "top": [
+    {
+     "endpoint_group": "SITE-XB",
+     "service": "service-XA",
+     "endpoint": "hosta.exampleX2.foo",
+     "flapping": 35
+    },
+    {
+     "endpoint_group": "SITE-A",
+     "service": "service-A",
+     "endpoint": "hosta.example.foo",
+     "flapping": 25
+    }
+   ]
+  },
+  {
+   "date": "2015-05",
+   "top": [
+    {
+     "endpoint_group": "SITE-A",
+     "service": "service-A",
+     "endpoint": "hosta.example.foo",
+     "flapping": 103
+    },
+    {
+     "endpoint_group": "SITE-A",
+     "service": "service-B",
+     "endpoint": "hostb.example.foo",
+     "flapping": 19
+    }
+   ]
+  }
+ ]
+}`,
+		},
+
+		expReq{
+			method: "GET",
 			url:    "/api/v2/trends/Report_A/flapping/endpoints?start_date=2015-05-01&end_date=2015-05-02&top=2",
 			code:   200,
 			key:    "KEY1",
@@ -697,6 +1050,106 @@ func (suite *TrendsTestSuite) TestTrends() {
    "endpoint_group": "SITE-B",
    "service": "service-A",
    "flapping": 9
+  }
+ ]
+}`,
+		},
+
+		expReq{
+			method: "GET",
+			url:    "/api/v2/trends/Report_A/flapping/services?start_date=2015-04-01&end_date=2015-05-02&granularity=monthly",
+			code:   200,
+			key:    "KEY1",
+			result: `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "date": "2015-04",
+   "top": [
+    {
+     "endpoint_group": "SITE-A",
+     "service": "service-A",
+     "flapping": 25
+    },
+    {
+     "endpoint_group": "SITE-A",
+     "service": "service-B",
+     "flapping": 16
+    },
+    {
+     "endpoint_group": "SITE-XB",
+     "service": "service-XA",
+     "flapping": 3
+    }
+   ]
+  },
+  {
+   "date": "2015-05",
+   "top": [
+    {
+     "endpoint_group": "SITE-A",
+     "service": "service-A",
+     "flapping": 98
+    },
+    {
+     "endpoint_group": "SITE-A",
+     "service": "service-B",
+     "flapping": 23
+    },
+    {
+     "endpoint_group": "SITE-B",
+     "service": "service-A",
+     "flapping": 9
+    }
+   ]
+  }
+ ]
+}`,
+		},
+
+		expReq{
+			method: "GET",
+			url:    "/api/v2/trends/Report_A/flapping/services?start_date=2015-04-01&end_date=2015-05-02&top=2&granularity=monthly",
+			code:   200,
+			key:    "KEY1",
+			result: `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "date": "2015-04",
+   "top": [
+    {
+     "endpoint_group": "SITE-A",
+     "service": "service-A",
+     "flapping": 25
+    },
+    {
+     "endpoint_group": "SITE-A",
+     "service": "service-B",
+     "flapping": 16
+    }
+   ]
+  },
+  {
+   "date": "2015-05",
+   "top": [
+    {
+     "endpoint_group": "SITE-A",
+     "service": "service-A",
+     "flapping": 98
+    },
+    {
+     "endpoint_group": "SITE-A",
+     "service": "service-B",
+     "flapping": 23
+    }
+   ]
   }
  ]
 }`,
@@ -785,6 +1238,80 @@ func (suite *TrendsTestSuite) TestTrends() {
   {
    "endpoint_group": "SITE-B",
    "flapping": 9
+  }
+ ]
+}`,
+		},
+
+		expReq{
+			method: "GET",
+			url:    "/api/v2/trends/Report_A/flapping/groups?start_date=2015-04-01&end_date=2015-05-02&granularity=monthly",
+			code:   200,
+			key:    "KEY1",
+			result: `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "date": "2015-04",
+   "top": [
+    {
+     "endpoint_group": "SITE-A",
+     "flapping": 35
+    },
+    {
+     "endpoint_group": "SITE-XB",
+     "flapping": 3
+    }
+   ]
+  },
+  {
+   "date": "2015-05",
+   "top": [
+    {
+     "endpoint_group": "SITE-A",
+     "flapping": 66
+    },
+    {
+     "endpoint_group": "SITE-B",
+     "flapping": 9
+    }
+   ]
+  }
+ ]
+}`,
+		},
+
+		expReq{
+			method: "GET",
+			url:    "/api/v2/trends/Report_A/flapping/groups?start_date=2015-04-01&end_date=2015-05-02&top=1&granularity=monthly",
+			code:   200,
+			key:    "KEY1",
+			result: `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "date": "2015-04",
+   "top": [
+    {
+     "endpoint_group": "SITE-A",
+     "flapping": 35
+    }
+   ]
+  },
+  {
+   "date": "2015-05",
+   "top": [
+    {
+     "endpoint_group": "SITE-A",
+     "flapping": 66
+    }
+   ]
   }
  ]
 }`,

--- a/app/trends/view.go
+++ b/app/trends/view.go
@@ -93,6 +93,70 @@ func createEndpointGroupListView(results []EndpointGroupData, msg string, code i
 
 }
 
+// createMonthMetricListView constructs the list response template and exports it as json
+func createMonthMetricListView(results []MonthMetricData, msg string, code int) ([]byte, error) {
+
+	docRoot := &respond.ResponseMessage{
+		Status: respond.StatusResponse{
+			Message: msg,
+			Code:    strconv.Itoa(code),
+		},
+	}
+	docRoot.Data = results
+
+	output, err := json.MarshalIndent(docRoot, "", " ")
+	return output, err
+
+}
+
+// createMonthEndpointListView constructs the list response template and exports it as json
+func createMonthEndpointListView(results []MonthEndpointData, msg string, code int) ([]byte, error) {
+
+	docRoot := &respond.ResponseMessage{
+		Status: respond.StatusResponse{
+			Message: msg,
+			Code:    strconv.Itoa(code),
+		},
+	}
+	docRoot.Data = results
+
+	output, err := json.MarshalIndent(docRoot, "", " ")
+	return output, err
+
+}
+
+// createMonthEndpointListView constructs the list response template and exports it as json
+func createMonthServiceListView(results []MonthServiceData, msg string, code int) ([]byte, error) {
+
+	docRoot := &respond.ResponseMessage{
+		Status: respond.StatusResponse{
+			Message: msg,
+			Code:    strconv.Itoa(code),
+		},
+	}
+	docRoot.Data = results
+
+	output, err := json.MarshalIndent(docRoot, "", " ")
+	return output, err
+
+}
+
+// createMonthEndpointGroupListView constructs the list response template and exports it as json
+func createMonthEndpointGroupListView(results []MonthEndpointGroupData, msg string, code int) ([]byte, error) {
+
+	docRoot := &respond.ResponseMessage{
+		Status: respond.StatusResponse{
+			Message: msg,
+			Code:    strconv.Itoa(code),
+		},
+	}
+	docRoot.Data = results
+
+	output, err := json.MarshalIndent(docRoot, "", " ")
+	return output, err
+
+}
+
 func createMessageOUT(message string, code int, format string) ([]byte, error) {
 
 	output := []byte("message placeholder")

--- a/app/trends/view.go
+++ b/app/trends/view.go
@@ -30,6 +30,22 @@ import (
 )
 
 // createMetricListView constructs the list response template and exports it as json
+func createStatusMetricListView(results []StatusGroupMetricData, msg string, code int) ([]byte, error) {
+
+	docRoot := &respond.ResponseMessage{
+		Status: respond.StatusResponse{
+			Message: msg,
+			Code:    strconv.Itoa(code),
+		},
+	}
+	docRoot.Data = results
+
+	output, err := json.MarshalIndent(docRoot, "", " ")
+	return output, err
+
+}
+
+// createMetricListView constructs the list response template and exports it as json
 func createMetricListView(results []MetricData, msg string, code int) ([]byte, error) {
 
 	docRoot := &respond.ResponseMessage{
@@ -79,6 +95,22 @@ func createEndpointListView(results []EndpointData, msg string, code int) ([]byt
 
 // createEndpointGroupListView constructs the list response template and exports it as json
 func createEndpointGroupListView(results []EndpointGroupData, msg string, code int) ([]byte, error) {
+
+	docRoot := &respond.ResponseMessage{
+		Status: respond.StatusResponse{
+			Message: msg,
+			Code:    strconv.Itoa(code),
+		},
+	}
+	docRoot.Data = results
+
+	output, err := json.MarshalIndent(docRoot, "", " ")
+	return output, err
+
+}
+
+// createStatusMonthMetricListView constructs the list response template and exports it as json
+func createStatusMonthMetricListView(results []StatusMonthMetricData, msg string, code int) ([]byte, error) {
 
 	docRoot := &respond.ResponseMessage{
 		Status: respond.StatusResponse{

--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -3417,6 +3417,9 @@ paths:
         - "application/json"
       parameters:
         - $ref: "#/parameters/profDate"
+        - $ref: "#/parameters/trendsStartDate"
+        - $ref: "#/parameters/trendsEndDate"
+        - $ref: "#/parameters/trendsTop"
         - $ref: "#/parameters/apiKey"
         - name: "REPORT_NAME"
           in: "path"
@@ -3456,6 +3459,9 @@ paths:
         - "application/json"
       parameters:
         - $ref: "#/parameters/profDate"
+        - $ref: "#/parameters/trendsStartDate"
+        - $ref: "#/parameters/trendsEndDate"
+        - $ref: "#/parameters/trendsTop"
         - $ref: "#/parameters/apiKey"
         - name: "REPORT_NAME"
           in: "path"
@@ -3495,6 +3501,9 @@ paths:
         - "application/json"
       parameters:
         - $ref: "#/parameters/profDate"
+        - $ref: "#/parameters/trendsStartDate"
+        - $ref: "#/parameters/trendsEndDate"
+        - $ref: "#/parameters/trendsTop"
         - $ref: "#/parameters/apiKey"
         - name: "REPORT_NAME"
           in: "path"
@@ -3534,6 +3543,9 @@ paths:
         - "application/json"
       parameters:
         - $ref: "#/parameters/profDate"
+        - $ref: "#/parameters/trendsStartDate"
+        - $ref: "#/parameters/trendsEndDate"
+        - $ref: "#/parameters/trendsTop"
         - $ref: "#/parameters/apiKey"
         - name: "REPORT_NAME"
           in: "path"
@@ -3962,6 +3974,21 @@ parameters:
     type: string
     description: "target date to retrieve a historic version of the profile"
     default: todays_date in YYYY-MM-DD format
+  trendsStartDate:
+    name: "start_date"
+    in: "query"
+    type: string
+    description: "start date used to define a range of results"
+  trendsEndDate:
+    name: "end_date"
+    in: "query"
+    type: string
+    description: "end date used to define a range of results"
+  trendsTop:
+    name: "top"
+    in: "query"
+    type: string
+    description: "define a number of top results"
   topoDate:
     name: "date"
     in: "query"

--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -3405,6 +3405,51 @@ paths:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Status_error'
+  
+  /trends/{REPORT_NAME}/status/metrics:
+    get:
+      summary: List trends for top status service endpoint metrics
+      operationId: trends.StatusMetrics
+      description: List top status service endpoint metrics by status events
+      tags:
+        - Trends
+      produces:
+        - "application/json"
+      parameters:
+        - $ref: "#/parameters/profDate"
+        - $ref: "#/parameters/trendsStartDate"
+        - $ref: "#/parameters/trendsEndDate"
+        - $ref: "#/parameters/trendsTop"
+        - $ref: "#/parameters/trendsGran"
+        - $ref: "#/parameters/apiKey"
+        - name: "REPORT_NAME"
+          in: "path"
+          description: "name of the report"
+          required: true
+          type: string
+      responses:
+        '200':
+          description: A list with status metrics per status
+          schema:
+            $ref: '#/definitions/Trends_status_metrics_list'
+        '401':
+          description: Unauthorized user
+          schema:
+            $ref: '#/definitions/Status_error'
+        '404':
+          description: Item not found
+          schema:
+            $ref: '#/definitions/Status_error'
+        '406':
+          description: Content Not acceptable
+          schema:
+            $ref: '#/definitions/Status_error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Status_error'  
+  
+  
             
   /trends/{REPORT_NAME}/flapping/metrics:
     get:
@@ -4839,6 +4884,23 @@ definitions:
             details:
               type: string
               
+
+  Trends_status_metrics:
+    type: object
+    properties:
+      endpoint_group:
+        type: string
+      service:
+        type: string
+      endpoint:
+        type: string
+      metric:
+        type: string
+      status:
+        type: string
+      events:
+        type: integer
+
               
   Trends_metrics:
     type: object
@@ -4884,6 +4946,28 @@ definitions:
       flapping:
         type: integer 
         
+  
+  
+  Trends_status_metrics_group:
+    type: object
+    properties:
+      status:
+        type: string
+      top:
+        type: array
+        items:
+          $ref: '#/definitions/Trends_status_metrics'
+          
+  Trends_status_metrics_list:
+    type: object
+    properties:
+      status:
+       $ref: '#/definitions/Status'
+      data:
+        type: array
+        items:
+          $ref: '#/definitions/Trends_status_metrics_group'
+  
   
   Trends_metrics_list:
     type: object

--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -3420,6 +3420,7 @@ paths:
         - $ref: "#/parameters/trendsStartDate"
         - $ref: "#/parameters/trendsEndDate"
         - $ref: "#/parameters/trendsTop"
+        - $ref: "#/parameters/trendsGran"
         - $ref: "#/parameters/apiKey"
         - name: "REPORT_NAME"
           in: "path"
@@ -3462,6 +3463,7 @@ paths:
         - $ref: "#/parameters/trendsStartDate"
         - $ref: "#/parameters/trendsEndDate"
         - $ref: "#/parameters/trendsTop"
+        - $ref: "#/parameters/trendsGran"
         - $ref: "#/parameters/apiKey"
         - name: "REPORT_NAME"
           in: "path"
@@ -3504,6 +3506,7 @@ paths:
         - $ref: "#/parameters/trendsStartDate"
         - $ref: "#/parameters/trendsEndDate"
         - $ref: "#/parameters/trendsTop"
+        - $ref: "#/parameters/trendsGran"
         - $ref: "#/parameters/apiKey"
         - name: "REPORT_NAME"
           in: "path"
@@ -3546,6 +3549,7 @@ paths:
         - $ref: "#/parameters/trendsStartDate"
         - $ref: "#/parameters/trendsEndDate"
         - $ref: "#/parameters/trendsTop"
+        - $ref: "#/parameters/trendsGran"
         - $ref: "#/parameters/apiKey"
         - name: "REPORT_NAME"
           in: "path"
@@ -3968,6 +3972,12 @@ paths:
 
 
 parameters:
+  trendsGran:
+    name: "granularity"
+    in: "query"
+    type: string
+    description: "use granularity=monthly to get a monthly view of the results"
+    default: empty
   profDate:
     name: "date"
     in: "query"

--- a/website/docs/trends.md
+++ b/website/docs/trends.md
@@ -3,6 +3,304 @@ id:  trends
 title: trends
 ---
 
+## API calls to find status trends among metrics
+
+This API call displays the top metrics by state (e.g. CRITICAL, WARNING etc) over a period of dates - optionally by monthly aggregation - for a specific report
+
+### [GET]: Daily Status trends in service endpoint metrics
+This method may be used to retrieve a list of top status service endpoint metrics. 
+
+### Input
+
+```
+/trends/{report_name}/status/metrics?date=2020-05-01
+```
+
+#### Path Parameters
+| Type | Description | Required | Default value |
+|------|-------------|----------|---------------|
+|`report_name`| name of the report| YES |  |
+
+#### Url Parameters
+
+| Type | Description | Required | Default value |
+|------|-------------|----------|---------------|
+|`date`| Date to view problematic endpoints of | NO |  |
+|`start_date`| define start date to view problematic endpoints over range | NO |  |
+|`end_date`| define end date to view problematic endpoints over range | NO |  |
+|`top`| integer to define a top number of results displayed | NO |  |
+|`granularity`| string value to define if you want monthly granularity in the results - e.g `?granularity=monthly` | NO |  |
+
+
+#### Headers
+```
+x-api-key: shared_key_value
+Accept: application/json or application/xml
+```
+
+#### Response Code
+```
+Status: 200 OK
+```
+
+
+###### Example Request:
+URL:
+```
+/trends/{report_name}/status/metrics?date=2020-05-01
+```
+Headers:
+```
+x-api-key: shared_key_value
+Accept: application/json or application/xml
+
+```
+###### Example Response:
+
+Code:
+```
+Status: 200 OK
+```
+Reponse body:
+```
+{
+  "status": {
+    "message": "Success",
+    "code": "200"
+  },
+  "data": [
+    {
+      "status": "CRITICAL",
+      "top": [
+        {
+          "endpoint_group": "SITE-A",
+          "service": "service-A",
+          "endpoint": "hosta.example.foo",
+          "metric": "check-2",
+          "status": "CRITICAL",
+          "events": 40
+        }
+      ]
+    },
+    {
+      "status": "UNKNOWN",
+      "top": [
+        {
+          "endpoint_group": "SITE-B",
+          "service": "service-A",
+          "endpoint": "hosta.example2.foo",
+          "metric": "web-check",
+          "status": "UNKNOWN",
+          "events": 5
+        }
+      ]
+    },
+    {
+      "status": "WARNING",
+      "top": [
+        {
+          "endpoint_group": "SITE-A",
+          "service": "service-A",
+          "endpoint": "hosta.example.foo",
+          "metric": "check-1",
+          "status": "WARNING",
+          "events": 55
+        },
+        {
+          "endpoint_group": "SITE-A",
+          "service": "service-B",
+          "endpoint": "hostb.example.foo",
+          "metric": "web-check",
+          "status": "WARNING",
+          "events": 12
+        }
+      ]
+    }
+  ]
+}
+```
+
+###### Example Request with Range and top number of results:
+URL:
+```
+/trends/{report_name}/flapping/metrics?start_date=2020-05-01&end_date=2021-06-15&top=1
+```
+Headers:
+```
+x-api-key: shared_key_value
+Accept: application/json or application/xml
+
+```
+###### Example Response:
+
+Code:
+```
+Status: 200 OK
+```
+Reponse body:
+```
+{
+  "status": {
+    "message": "Success",
+    "code": "200"
+  },
+  "data": [
+    {
+      "status": "CRITICAL",
+      "top": [
+        {
+          "endpoint_group": "SITE-A",
+          "service": "service-A",
+          "endpoint": "hosta.example.foo",
+          "metric": "check-2",
+          "status": "CRITICAL",
+          "events": 40
+        }
+      ]
+    },
+    {
+      "status": "UNKNOWN",
+      "top": [
+        {
+          "endpoint_group": "SITE-A",
+          "service": "service-A",
+          "endpoint": "hosta.example.foo",
+          "metric": "check-1",
+          "status": "UNKNOWN",
+          "events": 45
+        }
+      ]
+    },
+    {
+      "status": "WARNING",
+      "top": [
+        {
+          "endpoint_group": "SITE-A",
+          "service": "service-A",
+          "endpoint": "hosta.example.foo",
+          "metric": "check-1",
+          "status": "WARNING",
+          "events": 55
+        }
+      ]
+    }
+  ]
+}
+```
+
+###### Example Request with granularity=monthly option enabled:
+URL:
+```
+/trends/{report_name}/flapping/metrics?start_date=2020-04-01&end_date=2021-05-31&granularity=monthly&top=1
+```
+Headers:
+```
+x-api-key: shared_key_value
+Accept: application/json or application/xml
+
+```
+###### Example Response:
+
+Code:
+```
+Status: 200 OK
+```
+Reponse body:
+```
+{
+  "status": {
+    "message": "Success",
+    "code": "200"
+  },
+  "data": [
+    {
+      "date": "2015-04",
+      "status": "CRITICAL",
+      "top": [
+        {
+          "endpoint_group": "SITE-A",
+          "service": "service-A",
+          "endpoint": "hosta.example.foo",
+          "metric": "check-1",
+          "status": "CRITICAL",
+          "events": 55
+        }
+      ]
+    },
+    {
+      "date": "2015-04",
+      "status": "UNKNOWN",
+      "top": [
+        {
+          "endpoint_group": "SITE-A",
+          "service": "service-B",
+          "endpoint": "hostb.example.foo",
+          "metric": "web-check",
+          "status": "UNKNOWN",
+          "events": 12
+        }
+      ]
+    },
+    {
+      "date": "2015-04",
+      "status": "WARNING",
+      "top": [
+        {
+          "endpoint_group": "SITE-A",
+          "service": "service-A",
+          "endpoint": "hosta.example.foo",
+          "metric": "check-2",
+          "status": "WARNING",
+          "events": 40
+        }
+      ]
+    },
+    {
+      "date": "2015-05",
+      "status": "CRITICAL",
+      "top": [
+        {
+          "endpoint_group": "SITE-A",
+          "service": "service-A",
+          "endpoint": "hosta.example.foo",
+          "metric": "check-2",
+          "status": "CRITICAL",
+          "events": 40
+        }
+      ]
+    },
+    {
+      "date": "2015-05",
+      "status": "UNKNOWN",
+      "top": [
+        {
+          "endpoint_group": "SITE-A",
+          "service": "service-A",
+          "endpoint": "hosta.example.foo",
+          "metric": "check-1",
+          "status": "UNKNOWN",
+          "events": 45
+        }
+      ]
+    },
+    {
+      "date": "2015-05",
+      "status": "WARNING",
+      "top": [
+        {
+          "endpoint_group": "SITE-A",
+          "service": "service-A",
+          "endpoint": "hosta.example.foo",
+          "metric": "check-1",
+          "status": "WARNING",
+          "events": 55
+        }
+      ]
+    }
+  ]
+}
+```
+
 ## API calls to find flapping trends among metrics, endpoints, services and groups by Date
 
 Flapping items are the ones that change state too frequently causing a lot of alarms and notifications. State flapping might be the case of wrong configuration. 

--- a/website/docs/trends.md
+++ b/website/docs/trends.md
@@ -29,6 +29,7 @@ This method may be used to retrieve a list of top flapping service endpoint metr
 |`start_date`| define start date to view problematic endpoints over range | NO |  |
 |`end_date`| define end date to view problematic endpoints over range | NO |  |
 |`top`| integer to define a top number of results displayed | NO |  |
+|`granularity`| string value to define if you want monthly granularity in the results - e.g `?granularity=monthly` | NO |  |
 
 
 #### Headers
@@ -150,6 +151,87 @@ Reponse body:
 }
 ```
 
+###### Example Request with granularity=monthly option enabled:
+URL:
+```
+/trends/{report_name}/flapping/metrics?start_date=2020-04-01&end_date=2021-05-31&granularity=monthly&top=3
+```
+Headers:
+```
+x-api-key: shared_key_value
+Accept: application/json or application/xml
+
+```
+###### Example Response:
+
+Code:
+```
+Status: 200 OK
+```
+Reponse body:
+```
+{
+  "status": {
+    "message": "Success",
+    "code": "200"
+  },
+  "data": [
+    {
+      "date": "2015-04",
+      "top": [
+        {
+          "endpoint_group": "SITE-A",
+          "service": "service-A",
+          "endpoint": "hosta.example.foo",
+          "metric": "check-1",
+          "flapping": 55
+        },
+        {
+          "endpoint_group": "SITE-A",
+          "service": "service-A",
+          "endpoint": "hosta.example.foo",
+          "metric": "check-2",
+          "flapping": 40
+        },
+        {
+          "endpoint_group": "SITE-XB",
+          "service": "service-XA",
+          "endpoint": "hosta.examplex2.foo",
+          "metric": "web-check",
+          "flapping": 25
+        }
+      ]
+    },
+    {
+      "date": "2015-05",
+      "top": [
+        {
+          "endpoint_group": "SITE-A",
+          "service": "service-A",
+          "endpoint": "hosta.example.foo",
+          "metric": "check-1",
+          "flapping": 100
+        },
+        {
+          "endpoint_group": "SITE-A",
+          "service": "service-A",
+          "endpoint": "hosta.example.foo",
+          "metric": "check-2",
+          "flapping": 72
+        },
+        {
+          "endpoint_group": "SITE-A",
+          "service": "service-B",
+          "endpoint": "hostb.example.foo",
+          "metric": "web-check",
+          "flapping": 20
+        }
+      ]
+    }
+  ]
+}
+```
+
 
 ### [GET]: Daily Flapping trends in service endpoints 
 This method may be used to retrieve a list of top flapping service endpoints
@@ -173,6 +255,7 @@ This method may be used to retrieve a list of top flapping service endpoints
 |`start_date`| define start date to view problematic endpoints over range | NO |  |
 |`end_date`| define end date to view problematic endpoints over range | NO |  |
 |`top`| integer to define a top number of results displayed | NO |  |
+|`granularity`| string value to define if you want monthly granularity in the results - e.g `?granularity=monthly` | NO |  |
 
 
 #### Headers
@@ -275,6 +358,69 @@ Reponse body:
 }
 ```
 
+###### Example Request with granularity=monthly option enabled
+URL:
+```
+/trends/{report_name}/flapping/endpoints?start_date=2020-04-01&end_date=2020-05-31&top=2&granularity=monthly
+```
+Headers:
+```
+x-api-key: shared_key_value
+Accept: application/json or application/xml
+
+```
+###### Example Response:
+
+Code:
+```
+Status: 200 OK
+```
+Reponse body:
+```
+{
+  "status": {
+    "message": "Success",
+    "code": "200"
+  },
+  "data": [
+    {
+      "date": "2015-04",
+      "top": [
+        {
+          "endpoint_group": "SITE-XB",
+          "service": "service-XA",
+          "endpoint": "hosta.exampleX2.foo",
+          "flapping": 35
+        },
+        {
+          "endpoint_group": "SITE-A",
+          "service": "service-A",
+          "endpoint": "hosta.example.foo",
+          "flapping": 25
+        }
+      ]
+    },
+    {
+      "date": "2015-05",
+      "top": [
+        {
+          "endpoint_group": "SITE-A",
+          "service": "service-A",
+          "endpoint": "hosta.example.foo",
+          "flapping": 103
+        },
+        {
+          "endpoint_group": "SITE-A",
+          "service": "service-B",
+          "endpoint": "hostb.example.foo",
+          "flapping": 19
+        }
+      ]
+    }
+  ]
+}
+```
+
 
 ### [GET]: Daily Flapping trends in services
 This method may be used to retrieve a list of top flapping services
@@ -298,6 +444,7 @@ This method may be used to retrieve a list of top flapping services
 |`start_date`| define start date to view problematic endpoints over range | NO |  |
 |`end_date`| define end date to view problematic endpoints over range | NO |  |
 |`top`| integer to define a top number of results displayed | NO |  |
+|`granularity`| string value to define if you want monthly granularity in the results - e.g `?granularity=monthly` | NO |  |
 
 
 #### Headers
@@ -390,6 +537,55 @@ Reponse body:
 }
 ```
 
+###### Example Request with granularity=monthly option enabled:
+URL:
+```
+/trends/{report_name}/flapping/services?start_date=2020-04-01&end_date=2020-05-31&top=1&granularity=monthly
+```
+Headers:
+```
+x-api-key: shared_key_value
+Accept: application/json or application/xml
+
+```
+###### Example Response:
+
+Code:
+```
+Status: 200 OK
+```
+Reponse body:
+```
+{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "date": "2015-04",
+   "top": [
+    {
+     "endpoint_group": "SITE-A",
+     "service": "service-A",
+     "flapping": 25
+    }
+   ]
+  },
+  {
+   "date": "2015-05",
+   "top": [
+    {
+     "endpoint_group": "SITE-A",
+     "service": "service-A",
+     "flapping": 98
+    }
+   ]
+  }
+ ]
+}
+```
+
 ### [GET]: Daily Flapping trends in endpoint groups
 This method may be used to retrieve a list of top endpoint groups
 
@@ -412,6 +608,7 @@ This method may be used to retrieve a list of top endpoint groups
 |`start_date`| define start date to view problematic endpoints over range | NO |  |
 |`end_date`| define end date to view problematic endpoints over range | NO |  |
 |`top`| integer to define a top number of results displayed | NO |  |
+|`granularity`| string value to define if you want monthly granularity in the results - e.g `?granularity=monthly` | NO |  |
 
 
 #### Headers
@@ -492,5 +689,52 @@ Reponse body:
       "flapping": 75
     }
   ]
+}
+```
+
+###### Example Request with granularity=monthly option enabled
+URL:
+```
+/trends/{report_name}/flapping/groups?start_date=2020-04-01&end_date=2020-05-31&top=1&granularity=monthly
+```
+Headers:
+```
+x-api-key: shared_key_value
+Accept: application/json or application/xml
+
+```
+###### Example Response:
+
+Code:
+```
+Status: 200 OK
+```
+Reponse body:
+```
+{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "date": "2015-04",
+   "top": [
+    {
+     "endpoint_group": "SITE-A",
+     "flapping": 35
+    }
+   ]
+  },
+  {
+   "date": "2015-05",
+   "top": [
+    {
+     "endpoint_group": "SITE-A",
+     "flapping": 66
+    }
+   ]
+  }
+ ]
 }
 ```

--- a/website/docs/trends.md
+++ b/website/docs/trends.md
@@ -26,6 +26,9 @@ This method may be used to retrieve a list of top flapping service endpoint metr
 | Type | Description | Required | Default value |
 |------|-------------|----------|---------------|
 |`date`| Date to view problematic endpoints of | NO |  |
+|`start_date`| define start date to view problematic endpoints over range | NO |  |
+|`end_date`| define end date to view problematic endpoints over range | NO |  |
+|`top`| integer to define a top number of results displayed | NO |  |
 
 
 #### Headers
@@ -39,7 +42,6 @@ Accept: application/json or application/xml
 Status: 200 OK
 ```
 
-### Response body
 
 ###### Example Request:
 URL:
@@ -98,6 +100,56 @@ Reponse body:
 }
 ```
 
+###### Example Request with Range and top number of results:
+URL:
+```
+/trends/{report_name}/flapping/metrics?start_date=2020-05-01&end_date=2021-06-15&top=3
+```
+Headers:
+```
+x-api-key: shared_key_value
+Accept: application/json or application/xml
+
+```
+###### Example Response:
+
+Code:
+```
+Status: 200 OK
+```
+Reponse body:
+```
+{
+  "status": {
+    "message": "Success",
+    "code": "200"
+  },
+  "data": [
+    {
+      "endpoint_group": "SITE-A",
+      "service": "service-A",
+      "endpoint": "hosta.example.foo",
+      "metric": "check-1",
+      "flapping": 255
+    },
+    {
+      "endpoint_group": "SITE-A",
+      "service": "service-A",
+      "endpoint": "hosta.example.foo",
+      "metric": "check-2",
+      "flapping": 340
+    },
+    {
+      "endpoint_group": "SITE-A",
+      "service": "service-B",
+      "endpoint": "hostb.example.foo",
+      "metric": "web-check",
+      "flapping": 112
+    }
+  ]
+}
+```
+
 
 ### [GET]: Daily Flapping trends in service endpoints 
 This method may be used to retrieve a list of top flapping service endpoints
@@ -118,6 +170,9 @@ This method may be used to retrieve a list of top flapping service endpoints
 | Type | Description | Required | Default value |
 |------|-------------|----------|---------------|
 |`date`| Date to view problematic endpoints of | NO |  |
+|`start_date`| define start date to view problematic endpoints over range | NO |  |
+|`end_date`| define end date to view problematic endpoints over range | NO |  |
+|`top`| integer to define a top number of results displayed | NO |  |
 
 
 #### Headers
@@ -131,7 +186,6 @@ Accept: application/json or application/xml
 Status: 200 OK
 ```
 
-### Response body
 
 ###### Example Request:
 URL:
@@ -180,6 +234,48 @@ Reponse body:
 }
 ```
 
+###### Example Request with date range and top number of results:
+URL:
+```
+/trends/{report_name}/flapping/endpoints?start_date=2020-05-01&end_date=2020-05-15&top=2
+```
+Headers:
+```
+x-api-key: shared_key_value
+Accept: application/json or application/xml
+
+```
+###### Example Response:
+
+Code:
+```
+Status: 200 OK
+```
+Reponse body:
+```
+{
+  "status": {
+    "message": "Success",
+    "code": "200"
+  },
+  "data": [
+    {
+      "endpoint_group": "SITE-A",
+      "service": "service-A",
+      "endpoint": "hosta.example.foo",
+      "flapping": 83
+    },
+    {
+      "endpoint_group": "SITE-A",
+      "service": "service-B",
+      "endpoint": "hostb.example.foo",
+      "flapping": 53
+    }
+  ]
+}
+```
+
+
 ### [GET]: Daily Flapping trends in services
 This method may be used to retrieve a list of top flapping services
 
@@ -199,6 +295,9 @@ This method may be used to retrieve a list of top flapping services
 | Type | Description | Required | Default value |
 |------|-------------|----------|---------------|
 |`date`| Date to view problematic endpoints of | NO |  |
+|`start_date`| define start date to view problematic endpoints over range | NO |  |
+|`end_date`| define end date to view problematic endpoints over range | NO |  |
+|`top`| integer to define a top number of results displayed | NO |  |
 
 
 #### Headers
@@ -212,7 +311,6 @@ Accept: application/json or application/xml
 Status: 200 OK
 ```
 
-### Response body
 
 ###### Example Request:
 URL:
@@ -258,6 +356,40 @@ Reponse body:
 }
 ```
 
+###### Example Request with date range and top number of results:
+URL:
+```
+/trends/{report_name}/flapping/services?start_date=2020-05-01&end_date=2020-07-05&top=1
+```
+Headers:
+```
+x-api-key: shared_key_value
+Accept: application/json or application/xml
+
+```
+###### Example Response:
+
+Code:
+```
+Status: 200 OK
+```
+Reponse body:
+```
+{
+  "status": {
+    "message": "Success",
+    "code": "200"
+  },
+  "data": [
+    {
+      "endpoint_group": "SITE-A",
+      "service": "service-A",
+      "flapping": 955
+    }
+  ]
+}
+```
+
 ### [GET]: Daily Flapping trends in endpoint groups
 This method may be used to retrieve a list of top endpoint groups
 
@@ -277,6 +409,9 @@ This method may be used to retrieve a list of top endpoint groups
 | Type | Description | Required | Default value |
 |------|-------------|----------|---------------|
 |`date`| Date to view problematic endpoints of | NO |  |
+|`start_date`| define start date to view problematic endpoints over range | NO |  |
+|`end_date`| define end date to view problematic endpoints over range | NO |  |
+|`top`| integer to define a top number of results displayed | NO |  |
 
 
 #### Headers
@@ -289,8 +424,6 @@ Accept: application/json or application/xml
 ```
 Status: 200 OK
 ```
-
-### Response body
 
 ###### Example Request:
 URL:
@@ -324,6 +457,39 @@ Reponse body:
     {
       "endpoint_group": "SITE-B",
       "flapping": 5
+    }
+  ]
+}
+```
+
+###### Example Request with date range and top number of results:
+URL:
+```
+/trends/{report_name}/flapping/groups?start_date=2020-05-01&end_date=2020-05-03&top=1
+```
+Headers:
+```
+x-api-key: shared_key_value
+Accept: application/json or application/xml
+
+```
+###### Example Response:
+
+Code:
+```
+Status: 200 OK
+```
+Reponse body:
+```
+{
+  "status": {
+    "message": "Success",
+    "code": "200"
+  },
+  "data": [
+    {
+      "endpoint_group": "SITE-A",
+      "flapping": 75
     }
   ]
 }


### PR DESCRIPTION
## Goal
Introduce a new category of trends: status metrics

Status metrics displays top service endpoint metrics by status type (CRITICAL, WARNING etc) over a range of time

The new api call has the following signature path
`HTTP GET /api/v1/trends{report_name}/status/metrics`

and uses the following parameters:
- `?start_date=YYYY-MM-DD` & `end_date=YYYY-MM-DD` for ranges
- `?date=YYYY-MM-DD` for singe day results
- `?granularity=monthly` for monthly aggregation of ranged results
- `?top=N` for limiting results on top N items

Examples and response format 
👉  Get status metrics results for period of 2 months 2021-04-01 ➡️ 2021-05-31 without monthly aggregation:
`HTTP GET /api/v1/trends/{report_name}/status/metrics?start_date=2021-04-01&end_date=2021-05-31`

Response:
```json
{
 "status": {
  "message": "Success",
  "code": "200"
 },
 "data": [
  {
   "status": "CRITICAL",
   "top": [
    {
     "endpoint_group": "SITE-A",
     "service": "service-A",
     "endpoint": "hosta.example.foo",
     "metric": "check-2",
     "status": "CRITICAL",
     "events": 40
    },
    {
     "endpoint_group": "SITE-B",
     "service": "service-A",
     "endpoint": "hosta.example2.foo",
     "metric": "web-check",
     "status": "CRITICAL",
     "events": 7
    }
   ]
  },
  {
   "status": "UNKNOWN",
   "top": [
    {
     "endpoint_group": "SITE-A",
     "service": "service-A",
     "endpoint": "hosta.example.foo",
     "metric": "check-1",
     "status": "UNKNOWN",
     "events": 45
    },
    {
     "endpoint_group": "SITE-A",
     "service": "service-A",
     "endpoint": "hosta.example.foo",
     "metric": "check-2",
     "status": "UNKNOWN",
     "events": 32
    },
    {
     "endpoint_group": "SITE-B",
     "service": "service-A",
     "endpoint": "hosta.example2.foo",
     "metric": "web-check",
     "status": "UNKNOWN",
     "events": 5
    }
   ]
  },
  {
   "status": "WARNING",
   "top": [
    {
     "endpoint_group": "SITE-A",
     "service": "service-A",
     "endpoint": "hosta.example.foo",
     "metric": "check-1",
     "status": "WARNING",
     "events": 55
    },
    {
     "endpoint_group": "SITE-A",
     "service": "service-B",
     "endpoint": "hostb.example.foo",
     "metric": "web-check",
     "status": "WARNING",
     "events": 20
    }
   ]
  }
 ]
}
```

👉  Get service results for period of 2 months 2021-04-01 ➡️ 2021-05-31  **with** monthly aggregation:
`HTTP GET /api/v1/trends/{report_name}/status/metrics?start_date=2021-04-01&end_date=2021-05-31&granularity=enabled`

```json
{
 "status": {
  "message": "Success",
  "code": "200"
 },
 "data": [
  {
   "date": "2015-04",
   "status": "CRITICAL",
   "top": [
    {
     "endpoint_group": "SITE-A",
     "service": "service-A",
     "endpoint": "hosta.example.foo",
     "metric": "check-1",
     "status": "CRITICAL",
     "events": 55
    },
    {
     "endpoint_group": "SITE-XB",
     "service": "service-XA",
     "endpoint": "hosta.examplex2.foo",
     "metric": "web-check",
     "status": "CRITICAL",
     "events": 25
    }
   ]
  },
  {
   "date": "2015-04",
   "status": "UNKNOWN",
   "top": [
    {
     "endpoint_group": "SITE-A",
     "service": "service-B",
     "endpoint": "hostb.example.foo",
     "metric": "web-check",
     "status": "UNKNOWN",
     "events": 12
    }
   ]
  },
  {
   "date": "2015-04",
   "status": "WARNING",
   "top": [
    {
     "endpoint_group": "SITE-A",
     "service": "service-A",
     "endpoint": "hosta.example.foo",
     "metric": "check-2",
     "status": "WARNING",
     "events": 40
    }
   ]
  },
  {
   "date": "2015-05",
   "status": "CRITICAL",
   "top": [
    {
     "endpoint_group": "SITE-A",
     "service": "service-A",
     "endpoint": "hosta.example.foo",
     "metric": "check-2",
     "status": "CRITICAL",
     "events": 40
    },
    {
     "endpoint_group": "SITE-B",
     "service": "service-A",
     "endpoint": "hosta.example2.foo",
     "metric": "web-check",
     "status": "CRITICAL",
     "events": 7
    }
   ]
  },
  {
   "date": "2015-05",
   "status": "UNKNOWN",
   "top": [
    {
     "endpoint_group": "SITE-A",
     "service": "service-A",
     "endpoint": "hosta.example.foo",
     "metric": "check-1",
     "status": "UNKNOWN",
     "events": 45
    },
    {
     "endpoint_group": "SITE-A",
     "service": "service-A",
     "endpoint": "hosta.example.foo",
     "metric": "check-2",
     "status": "UNKNOWN",
     "events": 32
    },
    {
     "endpoint_group": "SITE-B",
     "service": "service-A",
     "endpoint": "hosta.example2.foo",
     "metric": "web-check",
     "status": "UNKNOWN",
     "events": 5
    }
   ]
  },
  {
   "date": "2015-05",
   "status": "WARNING",
   "top": [
    {
     "endpoint_group": "SITE-A",
     "service": "service-A",
     "endpoint": "hosta.example.foo",
     "metric": "check-1",
     "status": "WARNING",
     "events": 55
    },
    {
     "endpoint_group": "SITE-A",
     "service": "service-B",
     "endpoint": "hostb.example.foo",
     "metric": "web-check",
     "status": "WARNING",
     "events": 20
    }
   ]
  }
 ]
}
```
The new results are presented in a data array partitioned by date in the following schema

```json
{
  "data": [
    {
      "date": "YYYY-MM",
      "status": "eg. CRITICAL or WARNING etc...",
      "top": [
        {},
        {},
        {}
      ]
    }
  ]
}
```

## Implementations 
- [x] Add  status metric models for displaying status metric trend data
- [x] Add date-range and monthly aggregation queries for status metric results
- [x] Add new unit tests for status metric results
- [x] Update docusaurus documents
- [x] Update swagger