### PR TITLE
ARGO-3161 Fix issue with multiple values filtering in tags

### DIFF
--- a/website/docs/reports.md
+++ b/website/docs/reports.md
@@ -350,8 +350,10 @@ There are special argo contextes that are automatically picked up to filter grou
 
 -   _context:_ `argo.group.filter.fields` - Used to apply filter on basic fields of group topology. Under this context the `name` targets the group field name and the `value` holds the actual field pattern
 -   _context:_ `argo.group.filter.tags` - Used to apply filter on tags of group topology. Under this context the `name` targets the group tag name and the `value` holds the actual field pattern
+-   _context:_ `argo.group.filter.tags.array` - Used to apply filter, containing a list of comma separated values, on tags of group topology. Under this context the `name` targets the group tag name and the `value` holds the actual field pattern
 -   _context:_ `argo.endpoint.filter.fields` - Used to apply filter on basic fields of endpoint topology. Under this context the `name` targets the endpoint field name and the `value` holds the actual field pattern
 -   _context:_ `argo.endpoint.filter.tags` - Used to apply filter on tags of endpoint topology. Under this context the `name` targets the endpoint tag name and the `value` holds the actual field pattern
+-   _context:_ `argo.endpoint.filter.tags.array` - Used to apply filter, containing a list of comma separated values, on tags of endpoint topology. Under this context the `name` targets the endpoint tag name and the `value` holds the actual field pattern
 
 <a id='6'></a>
 


### PR DESCRIPTION
# Goal 
Allow filtering with multiple values when we have tags that represent comma separated lists. Example of one such tag is scope. 

Usually scope tags have the following pattern
```
{
 "scope" : "value1, value2, value3, value4"
}
```

We need to apply a report filter to such tags using a comma separated pattern
For example:
Filter = `{ "scope" : "value4, value3" }` 
show only elements that have value4 or value3 in their scope tags (or both) 

The current report filters:
- `argo.endpoint.filter.tags`
- `argo.group.filter.tags`
Treat endpoint and group tags as single value strings which can be filtered using regular expressions

# Solution
We introduce two new report filters 
- `argo.endpoint.filter.tags.array`
-  `argo.group.filter.tags.array`
Which can accept a comma separated list of possible values and filter by them in an OR fashion

Example:
```
{
                    "name": "scope",
                    "value": "tier1, tier2",
                    "context": "argo.endpoint.filter.tags.array"
}
```
Show endpoints items that contain either tier1 or tier2 (or both) in their scope tags

# Implementation

- [x] Add two new tags array filters for groups and endpoint items
- [x] Update docs
- [x] Add unit tests
