### PR TITLE
version 1.10.0

### DIFF
--- a/argo-web-api.spec
+++ b/argo-web-api.spec
@@ -3,7 +3,7 @@
 
 Name: argo-web-api
 Summary: A/R API
-Version: 1.9.2
+Version: 1.10.0
 Release: 1%{?dist}
 License: ASL 2.0
 Buildroot: %{_tmppath}/%{name}-buildroot
@@ -68,6 +68,8 @@ go clean
 %attr(0644,root,root) /usr/lib/systemd/system/argo-web-api.service
 
 %changelog
+* Wed Sep 1 2021 Konstantinos Kagkelidis <kaggis@gmail.com> 1.10.0-1%{dist}
+- Release of argo-web-api version 1.10.0
 * Wed Dec 16 2020 Konstantinos Kagkelidis <kaggis@gmail.com> 1.9.2-1%{dist}
 - Release of argo-web-api version 1.9.2
 * Wed Jul 08 2020 Konstantinos Kagkelidis <kaggis@gmail.com> 1.9.1-1%{dist}

--- a/version/version.go
+++ b/version/version.go
@@ -6,7 +6,7 @@ import (
 
 var (
 	// Release version of the service. Bump it up during new version release
-	Release = "1.9.2"
+	Release = "1.10.0"
 	// Commit hash provided during build
 	Commit = "Unknown"
 	// BuildTime provided during build


### PR DESCRIPTION
v.1.10.0 - 2021-09-02

**Added**:

- ARGO-3197 Display status trend results for metrics
- ARGO-3193 Add monthly granularity option over flapping trends
- ARGO-3186 Show flapping trends over range of time
- ARGO-3077 Display group flapping trends
- ARGO-3076 Display service flapping trends
- ARGO-3075 Display endpoint flapping trends 
- ARGO-3074 Display metric flapping trends 
- ARGO-2885 Add notification information to topology items
- ARGO-2724 Introduce topology tags/values method 

**Fixed**:

- ARGO-3269 Fix empty downtime response
- ARGO-3241 close mongodb sessions in recomputation handlers
- ARGO-3225 Fix endpoint group type filtering by report
- ARGO-3161 Fix issue with multiple values filtering in tags

**Changed**:

- ARGO-3265 Return exact date downtime instead of close to date
- ARGO-2880 Connect specific weight datasets to each report
- 