### PR TITLE
ARGO-3269 Fix empty downtime response

### DIFF
--- a/app/downtimes/controller.go
+++ b/app/downtimes/controller.go
@@ -199,6 +199,11 @@ func List(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) 
 		return code, h, output, err
 	}
 
+	if !(len(results) > 0) {
+		downtimes := Downtimes{Date: dateStr, Endpoints: []Downtime{}}
+		results = append(results, downtimes)
+	}
+
 	// Create view of the results
 	output, err = createListView(results, "Success", code) //Render the results into JSON
 

--- a/app/downtimes/downtimes_test.go
+++ b/app/downtimes/downtimes_test.go
@@ -386,9 +386,9 @@ func (suite *DowntimesTestSuite) TestCreate() {
 
 }
 
-func (suite *DowntimesTestSuite) TestList() {
+func (suite *DowntimesTestSuite) TestListNotFound() {
 
-	request, _ := http.NewRequest("GET", "/api/v2/downtimes", strings.NewReader(""))
+	request, _ := http.NewRequest("GET", "/api/v2/downtimes?date=2020-05-05", strings.NewReader(""))
 	request.Header.Set("x-api-key", suite.clientkey)
 	request.Header.Set("Accept", "application/json")
 	response := httptest.NewRecorder()
@@ -403,7 +403,12 @@ func (suite *DowntimesTestSuite) TestList() {
   "message": "Success",
   "code": "200"
  },
- "data": []
+ "data": [
+  {
+   "date": "2020-05-05",
+   "endpoints": []
+  }
+ ]
 }`
 	// Check that we must have a 200 ok code
 	suite.Equal(200, code, "Internal Server Error")


### PR DESCRIPTION
Fix downtime response consistency when no declared downtimes are found... 

Instead of returning just
```
{
  "data" : [ ] 
}

```
We need to return 
```
{
  "data" : [ 
      {
          "date": "YYYY-MM-DD"
          "endpoints": [ ]
       }
     ]
}
```