### PR TITLE
ARGO-3279 Create Endpoint status trends view

### DIFF
--- a/app/trends/controller.go
+++ b/app/trends/controller.go
@@ -43,6 +43,7 @@ const flapEndpoints = "flipflop_trends_endpoints"
 const flapServices = "flipflop_trends_services"
 const flapMetrics = "flipflop_trends_metrics"
 const statusMetrics = "status_trends_metrics"
+const statusEndpoints = "status_trends_endpoints"
 
 type list []interface{}
 
@@ -236,6 +237,162 @@ func ListStatusMetrics(r *http.Request, cfg config.Config) (int, http.Header, []
 	}
 
 	output, err = createStatusMetricListView(results, "Success", 200)
+
+	return code, h, output, err
+}
+
+// ListStatusEndpoints returns a list of top status endpoints (in duration) for the day
+func ListStatusEndpoints(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
+
+	//STANDARD DECLARATIONS START
+
+	code := http.StatusOK
+	h := http.Header{}
+	output := []byte("List Flapping Metrics")
+	err := error(nil)
+	charset := "utf-8"
+
+	//STANDARD DECLARATIONS END
+
+	// Set Content-Type response Header value
+	contentType := r.Header.Get("Accept")
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+
+	// Parse the request into the input
+	urlValues := r.URL.Query()
+	vars := mux.Vars(r)
+
+	// Grab Tenant DB configuration from context
+	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
+
+	session, err := mongo.OpenSession(tenantDbConfig)
+	defer mongo.CloseSession(session)
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	endpointCollection := session.DB(tenantDbConfig.Db).C(statusEndpoints)
+
+	// Query the detailed status endpoints trend results
+	reportID, err := mongo.GetReportID(session, tenantDbConfig.Db, vars["report_name"])
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	startDate, endDate, err := getDateRange(urlValues)
+	if err != nil {
+		code = http.StatusBadRequest
+		output, _ = respond.MarshalContent(respond.ErrBadRequestDetails(err.Error()), contentType, "", " ")
+		return code, h, output, err
+	}
+
+	limit := -1
+	limStr := urlValues.Get("top")
+	if limStr != "" {
+		limit, err = strconv.Atoi(limStr)
+		if err != nil {
+			code = http.StatusInternalServerError
+			return code, h, output, err
+		}
+	}
+
+	granularity := urlValues.Get("granularity")
+
+	// query for endpoints
+	filter := bson.M{"report": reportID, "date": bson.M{"$gte": startDate, "$lte": endDate}}
+
+	// apply query for bucketed monthly results if granularity is set to monthly
+	if granularity == "monthly" {
+
+		results := []StatusMonthEndpointData{}
+
+		query := []bson.M{
+			{"$match": filter},
+			{"$group": bson.M{
+				"_id": bson.M{
+					"month":    bson.M{"$substr": list{"$date", 0, 6}},
+					"group":    "$group",
+					"service":  "$service",
+					"endpoint": "$endpoint",
+					"status":   "$status"},
+				"duration": bson.M{"$sum": "$duration"},
+			}},
+			{"$sort": bson.D{{"_id.month", 1}, {"_id.status", 1}, {"duration", -1}}},
+			{
+				"$group": bson.M{
+					"_id": bson.M{"month": "$_id.month", "status": "$_id.status"},
+					"top": bson.M{"$push": bson.M{"group": "$_id.group", "service": "$_id.service", "endpoint": "$_id.endpoint", "status": "$_id.status", "duration": "$duration"}}}},
+		}
+
+		// trim down the list in each month-bucket according to the limit parameter
+		if limit > 0 {
+			query = append(query, bson.M{"$project": bson.M{"date": bson.M{"$concat": list{bson.M{"$substr": list{"$_id.month", 0, 4}},
+				"-", bson.M{"$substr": list{"$_id.month", 4, 6}}}},
+				"status": "$_id.status",
+				"top":    bson.M{"$slice": list{"$top", limit}}}})
+		} else {
+			query = append(query, bson.M{"$project": bson.M{"date": bson.M{"$concat": list{bson.M{"$substr": list{"$_id.month", 0, 4}},
+				"-", bson.M{"$substr": list{"$_id.month", 4, 6}}}},
+				"status": "$_id.status",
+				"top":    "$top"}})
+		}
+
+		// sort end results by month bucket ascending
+		query = append(query, bson.M{"$sort": bson.D{{"date", 1}, {"status", 1}}})
+
+		err = endpointCollection.Pipe(query).All(&results)
+		if err != nil {
+			code = http.StatusInternalServerError
+			return code, h, output, err
+		}
+
+		output, err = createStatusMonthEndpointListView(results, "Success", 200)
+
+		return code, h, output, err
+
+	}
+
+	// continue by calculating non monthly bucketed results
+	results := []StatusGroupEndpointData{}
+
+	query := []bson.M{
+		{"$match": filter},
+		{"$group": bson.M{
+			"_id": bson.M{
+				"group":    "$group",
+				"service":  "$service",
+				"endpoint": "$endpoint",
+				"status":   "$status"},
+			"duration": bson.M{"$sum": "$duration"},
+		}},
+		{"$sort": bson.D{{"_id.status", 1}, {"duration", -1}}},
+		{
+			"$group": bson.M{
+				"_id": bson.M{"status": "$_id.status"},
+				"top": bson.M{"$push": bson.M{"group": "$_id.group", "service": "$_id.service", "endpoint": "$_id.endpoint", "status": "$_id.status", "duration": "$duration"}}}},
+	}
+
+	// trim down the list in each month-bucket according to the limit parameter
+	if limit > 0 {
+		query = append(query, bson.M{"$project": bson.M{"status": "$_id.status",
+			"top": bson.M{"$slice": list{"$top", limit}}}})
+	} else {
+		query = append(query, bson.M{"$project": bson.M{"status": "$_id.status",
+			"top": "$top"}})
+	}
+
+	// sort end results by month bucket ascending
+	query = append(query, bson.M{"$sort": bson.D{{"status", 1}}})
+
+	err = endpointCollection.Pipe(query).All(&results)
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	output, err = createStatusEndpointListView(results, "Success", 200)
 
 	return code, h, output, err
 }

--- a/app/trends/model.go
+++ b/app/trends/model.go
@@ -34,10 +34,23 @@ type StatusMonthMetricData struct {
 	Top    []StatusMetricData `bson:"top" json:"top"`
 }
 
+//StatusMonthEndpointData holds status information about monthly endpoints
+type StatusMonthEndpointData struct {
+	Date   string               `bson:"date" json:"date"`
+	Status string               `bson:"status" json:"status"`
+	Top    []StatusEndpointData `bson:"top" json:"top"`
+}
+
 //StatusGroupMetricData holds status information about monthly metrics
 type StatusGroupMetricData struct {
 	Status string             `bson:"status" json:"status"`
 	Top    []StatusMetricData `bson:"top" json:"top"`
+}
+
+//StatusGroupEndpointData holds status information about monthly endpoints
+type StatusGroupEndpointData struct {
+	Status string               `bson:"status" json:"status"`
+	Top    []StatusEndpointData `bson:"top" json:"top"`
 }
 
 //MonthMetricData holds flapping information about monthly metrics
@@ -78,6 +91,14 @@ type StatusMetricData struct {
 	Metric        string `bson:"metric" json:"metric"`
 	Status        string `bson:"status" json:"status"`
 	Events        int    `bson:"events" json:"events"`
+}
+
+type StatusEndpointData struct {
+	EndpointGroup string `bson:"group" json:"endpoint_group"`
+	Service       string `bson:"service" json:"service"`
+	Endpoint      string `bson:"endpoint" json:"endpoint"`
+	Status        string `bson:"status" json:"status"`
+	Duration      int    `bson:"duration" json:"duration_in_minutes"`
 }
 
 // EndpointData holds flapping information about endpoints

--- a/app/trends/routing.go
+++ b/app/trends/routing.go
@@ -40,9 +40,11 @@ var appRoutesV2 = []respond.AppRoutes{
 	{"trends.flapping_services", "GET", "/{report_name}/flapping/services", ListFlappingServices},
 	{"trends.flapping_endpoint_groups", "GET", "/{report_name}/flapping/groups", ListFlappingEndpointGroups},
 	{"trends.status_metrics", "GET", "/{report_name}/status/metrics", ListStatusMetrics},
+	{"trends.status_endpoints", "GET", "/{report_name}/status/endpoints", ListStatusEndpoints},
 	{"trends.options", "OPTIONS", "/{report_name}/flapping/metrics", Options},
 	{"trends.options", "OPTIONS", "/{report_name}/flapping/endpoints", Options},
 	{"trends.options", "OPTIONS", "/{report_name}/flapping/services", Options},
 	{"trends.options", "OPTIONS", "/{report_name}/flapping/groups", Options},
 	{"trends.options", "OPTIONS", "/{report_name}/status/metrics", Options},
+	{"trends.options", "OPTIONS", "/{report_name}/status/endpoints", Options},
 }

--- a/app/trends/view.go
+++ b/app/trends/view.go
@@ -29,6 +29,22 @@ import (
 	"github.com/ARGOeu/argo-web-api/respond"
 )
 
+// createStatusEndpointListView constructs the list response template and exports it as json
+func createStatusEndpointListView(results []StatusGroupEndpointData, msg string, code int) ([]byte, error) {
+
+	docRoot := &respond.ResponseMessage{
+		Status: respond.StatusResponse{
+			Message: msg,
+			Code:    strconv.Itoa(code),
+		},
+	}
+	docRoot.Data = results
+
+	output, err := json.MarshalIndent(docRoot, "", " ")
+	return output, err
+
+}
+
 // createMetricListView constructs the list response template and exports it as json
 func createStatusMetricListView(results []StatusGroupMetricData, msg string, code int) ([]byte, error) {
 
@@ -95,6 +111,22 @@ func createEndpointListView(results []EndpointData, msg string, code int) ([]byt
 
 // createEndpointGroupListView constructs the list response template and exports it as json
 func createEndpointGroupListView(results []EndpointGroupData, msg string, code int) ([]byte, error) {
+
+	docRoot := &respond.ResponseMessage{
+		Status: respond.StatusResponse{
+			Message: msg,
+			Code:    strconv.Itoa(code),
+		},
+	}
+	docRoot.Data = results
+
+	output, err := json.MarshalIndent(docRoot, "", " ")
+	return output, err
+
+}
+
+// createStatusMonthEndpointListView constructs the list response template and exports it as json
+func createStatusMonthEndpointListView(results []StatusMonthEndpointData, msg string, code int) ([]byte, error) {
 
 	docRoot := &respond.ResponseMessage{
 		Status: respond.StatusResponse{

--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -3448,6 +3448,49 @@ paths:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Status_error'  
+            
+  /trends/{REPORT_NAME}/status/endpoints:
+    get:
+      summary: List trends for top status service endpoints
+      operationId: trends.StatusEndpoints
+      description: List top status service endpoints by status events
+      tags:
+        - Trends
+      produces:
+        - "application/json"
+      parameters:
+        - $ref: "#/parameters/profDate"
+        - $ref: "#/parameters/trendsStartDate"
+        - $ref: "#/parameters/trendsEndDate"
+        - $ref: "#/parameters/trendsTop"
+        - $ref: "#/parameters/trendsGran"
+        - $ref: "#/parameters/apiKey"
+        - name: "REPORT_NAME"
+          in: "path"
+          description: "name of the report"
+          required: true
+          type: string
+      responses:
+        '200':
+          description: A list with status metrics per status
+          schema:
+            $ref: '#/definitions/Trends_status_endpoints_list'
+        '401':
+          description: Unauthorized user
+          schema:
+            $ref: '#/definitions/Status_error'
+        '404':
+          description: Item not found
+          schema:
+            $ref: '#/definitions/Status_error'
+        '406':
+          description: Content Not acceptable
+          schema:
+            $ref: '#/definitions/Status_error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Status_error'
   
   
             
@@ -4898,6 +4941,20 @@ definitions:
         type: string
       status:
         type: string
+      duration_in_minutes:
+        type: integer
+        
+  Trends_status_endpoints:
+    type: object
+    properties:
+      endpoint_group:
+        type: string
+      service:
+        type: string
+      endpoint:
+        type: string
+      status:
+        type: string
       events:
         type: integer
 
@@ -4946,6 +5003,16 @@ definitions:
       flapping:
         type: integer 
         
+
+  Trends_status_endpoints_group:
+    type: object
+    properties:
+      status:
+        type: string
+      top:
+        type: array
+        items:
+          $ref: '#/definitions/Trends_status_endpoints'
   
   
   Trends_status_metrics_group:
@@ -4957,6 +5024,17 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/Trends_status_metrics'
+          
+          
+  Trends_status_endpoints_list:
+    type: object
+    properties:
+      status:
+       $ref: '#/definitions/Status'
+      data:
+        type: array
+        items:
+          $ref: '#/definitions/Trends_status_endpoints_group'
           
   Trends_status_metrics_list:
     type: object

--- a/scripts/mongodb/populate_default_roles.js
+++ b/scripts/mongodb/populate_default_roles.js
@@ -217,19 +217,27 @@ function populate_default_roles() {
         },
         {
             resource: "trends.flapping_metrics",
-            roles: ["admin", "editor", "viewer"]
+            roles: ["admin", "editor", "viewer", "admin_ui"]
         },
         {
             resource: "trends.flapping_endpoints",
-            roles: ["admin", "editor", "viewer"]
+            roles: ["admin", "editor", "viewer", "admin_ui"]
         },
         {
             resource: "trends.flapping_services",
-            roles: ["admin", "editor", "viewer"]
+            roles: ["admin", "editor", "viewer", "admin_ui"]
         },
         {
             resource: "trends.flapping_endpoint_groups",
-            roles: ["admin", "editor", "viewer"]
+            roles: ["admin", "editor", "viewer", "admin_ui"]
+        },
+        {
+            resource: "trends.status_metrics",
+            roles: ["admin", "editor", "viewer", "admin_ui"]
+        },
+        {
+            resource: "trends.status_endpoints",
+            roles: ["admin", "editor", "viewer", "admin_ui"]
         }
     ]);
     print("INFO\tPolulated default roles in 'roles' collection");

--- a/website/docs/trends.md
+++ b/website/docs/trends.md
@@ -123,7 +123,7 @@ Reponse body:
 ###### Example Request with Range and top number of results:
 URL:
 ```
-/trends/{report_name}/flapping/metrics?start_date=2020-05-01&end_date=2021-06-15&top=1
+/trends/{report_name}/status/metrics?start_date=2020-05-01&end_date=2021-06-15&top=1
 ```
 Headers:
 ```
@@ -191,7 +191,7 @@ Reponse body:
 ###### Example Request with granularity=monthly option enabled:
 URL:
 ```
-/trends/{report_name}/flapping/metrics?start_date=2020-04-01&end_date=2021-05-31&granularity=monthly&top=1
+/trends/{report_name}/status/metrics?start_date=2020-04-01&end_date=2021-05-31&granularity=monthly&top=1
 ```
 Headers:
 ```
@@ -294,6 +294,291 @@ Reponse body:
           "metric": "check-1",
           "status": "WARNING",
           "events": 55
+        }
+      ]
+    }
+  ]
+}
+```
+
+## API calls to find status trends among endpoints
+
+This API call displays the top endpoints by state (e.g. CRITICAL, WARNING etc) over a period of dates - optionally by monthly aggregation - for a specific report
+
+### [GET]: Daily Status trends in service endpoint metrics
+This method may be used to retrieve a list of top status service endpoints. 
+
+### Input
+
+```
+/trends/{report_name}/status/endpoints?date=2020-05-01
+```
+
+#### Path Parameters
+| Type | Description | Required | Default value |
+|------|-------------|----------|---------------|
+|`report_name`| name of the report| YES |  |
+
+#### Url Parameters
+
+| Type | Description | Required | Default value |
+|------|-------------|----------|---------------|
+|`date`| Date to view problematic endpoints of | NO |  |
+|`start_date`| define start date to view problematic endpoints over range | NO |  |
+|`end_date`| define end date to view problematic endpoints over range | NO |  |
+|`top`| integer to define a top number of results displayed | NO |  |
+|`granularity`| string value to define if you want monthly granularity in the results - e.g `?granularity=monthly` | NO |  |
+
+
+#### Headers
+```
+x-api-key: shared_key_value
+Accept: application/json or application/xml
+```
+
+#### Response Code
+```
+Status: 200 OK
+```
+
+
+###### Example Request:
+URL:
+```
+/trends/{report_name}/status/endpoints?date=2020-05-01
+```
+Headers:
+```
+x-api-key: shared_key_value
+Accept: application/json or application/xml
+
+```
+###### Example Response:
+
+Code:
+```
+Status: 200 OK
+```
+Reponse body:
+```
+{
+  "status": {
+    "message": "Success",
+    "code": "200"
+  },
+  "data": [
+    {
+      "status": "CRITICAL",
+      "top": [
+        {
+          "endpoint_group": "SITE-A",
+          "service": "service-A",
+          "endpoint": "hosta.example.foo",
+          "status": "CRITICAL",
+          "duration_in_minutes": 40
+        }
+      ]
+    },
+    {
+      "status": "UNKNOWN",
+      "top": [
+        {
+          "endpoint_group": "SITE-B",
+          "service": "service-A",
+          "endpoint": "hosta.example2.foo",
+          "status": "UNKNOWN",
+          "duration_in_minutes": 5
+        }
+      ]
+    },
+    {
+      "status": "WARNING",
+      "top": [
+        {
+          "endpoint_group": "SITE-A",
+          "service": "service-A",
+          "endpoint": "hosta.example.foo",
+          "status": "WARNING",
+          "duration_in_minutes": 55
+        },
+        {
+          "endpoint_group": "SITE-A",
+          "service": "service-B",
+          "endpoint": "hostb.example.foo",
+          "status": "WARNING",
+          "duration_in_minutes": 12
+        }
+      ]
+    }
+  ]
+}
+```
+
+###### Example Request with Range and top number of results:
+URL:
+```
+/trends/{report_name}/status/endpoints?start_date=2020-05-01&end_date=2021-06-15&top=1
+```
+Headers:
+```
+x-api-key: shared_key_value
+Accept: application/json or application/xml
+
+```
+###### Example Response:
+
+Code:
+```
+Status: 200 OK
+```
+Reponse body:
+```
+{
+  "status": {
+    "message": "Success",
+    "code": "200"
+  },
+  "data": [
+    {
+      "status": "CRITICAL",
+      "top": [
+        {
+          "endpoint_group": "SITE-A",
+          "service": "service-A",
+          "endpoint": "hosta.example.foo",
+          "status": "CRITICAL",
+          "duration_in_minutes": 40
+        }
+      ]
+    },
+    {
+      "status": "UNKNOWN",
+      "top": [
+        {
+          "endpoint_group": "SITE-A",
+          "service": "service-A",
+          "endpoint": "hosta.example.foo",
+          "status": "UNKNOWN",
+          "duration_in_minutes": 45
+        }
+      ]
+    },
+    {
+      "status": "WARNING",
+      "top": [
+        {
+          "endpoint_group": "SITE-A",
+          "service": "service-A",
+          "endpoint": "hosta.example.foo",
+          "status": "WARNING",
+          "duration_in_minutes": 55
+        }
+      ]
+    }
+  ]
+}
+```
+
+###### Example Request with granularity=monthly option enabled:
+URL:
+```
+/trends/{report_name}/status/endpoints?start_date=2020-04-01&end_date=2021-05-31&granularity=monthly&top=1
+```
+Headers:
+```
+x-api-key: shared_key_value
+Accept: application/json or application/xml
+
+```
+###### Example Response:
+
+Code:
+```
+Status: 200 OK
+```
+Reponse body:
+```
+{
+  "status": {
+    "message": "Success",
+    "code": "200"
+  },
+  "data": [
+    {
+      "date": "2015-04",
+      "status": "CRITICAL",
+      "top": [
+        {
+          "endpoint_group": "SITE-A",
+          "service": "service-A",
+          "endpoint": "hosta.example.foo",
+          "status": "CRITICAL",
+          "duration_in_minutes": 55
+        }
+      ]
+    },
+    {
+      "date": "2015-04",
+      "status": "UNKNOWN",
+      "top": [
+        {
+          "endpoint_group": "SITE-A",
+          "service": "service-B",
+          "endpoint": "hostb.example.foo",
+          "status": "UNKNOWN",
+          "duration_in_minutes": 12
+        }
+      ]
+    },
+    {
+      "date": "2015-04",
+      "status": "WARNING",
+      "top": [
+        {
+          "endpoint_group": "SITE-A",
+          "service": "service-A",
+          "endpoint": "hosta.example.foo",
+          "status": "WARNING",
+          "duration_in_minutes": 40
+        }
+      ]
+    },
+    {
+      "date": "2015-05",
+      "status": "CRITICAL",
+      "top": [
+        {
+          "endpoint_group": "SITE-A",
+          "service": "service-A",
+          "endpoint": "hosta.example.foo",
+          "status": "CRITICAL",
+          "duration_in_minutes": 40
+        }
+      ]
+    },
+    {
+      "date": "2015-05",
+      "status": "UNKNOWN",
+      "top": [
+        {
+          "endpoint_group": "SITE-A",
+          "service": "service-A",
+          "endpoint": "hosta.example.foo",
+          "status": "UNKNOWN",
+          "duration_in_minutes": 45
+        }
+      ]
+    },
+    {
+      "date": "2015-05",
+      "status": "WARNING",
+      "top": [
+        {
+          "endpoint_group": "SITE-A",
+          "service": "service-A",
+          "endpoint": "hosta.example.foo",
+          "status": "WARNING",
+          "duration_in_minutes": 55
         }
       ]
     }


### PR DESCRIPTION
## Goal
Introduce a new category of trends: status metrics

Status endpoint trends displays top service endpoints by status type (CRITICAL, WARNING etc)  duration over a range of time

The new api call has the following signature path
`HTTP GET /api/v1/trends{report_name}/status/endpoints`

and uses the following parameters:
- `?start_date=YYYY-MM-DD` & `end_date=YYYY-MM-DD` for ranges
- `?date=YYYY-MM-DD` for singe day results
- `?granularity=monthly` for monthly aggregation of ranged results
- `?top=N` for limiting results on top N items

Examples and response format 
👉  Get status endpoint results for period of 2 months 2021-04-01 ➡️ 2021-05-31 without monthly aggregation:
`HTTP GET /api/v1/trends/{report_name}/status/endpoints?start_date=2021-04-01&end_date=2021-05-31`

Response:
```json
{
 "status": {
  "message": "Success",
  "code": "200"
 },
 "data": [
  {
   "status": "CRITICAL",
   "top": [
    {
     "endpoint_group": "SITE-A",
     "service": "service-A",
     "endpoint": "hosta.example.foo",
     "status": "CRITICAL",
     "duration_in_minutes": 40
    },
    {
     "endpoint_group": "SITE-B",
     "service": "service-A",
     "endpoint": "hosta.example2.foo",
     "status": "CRITICAL",
     "duration_in_minutes": 7
    }
   ]
  },
  {
   "status": "UNKNOWN",
   "top": [
    {
     "endpoint_group": "SITE-A",
     "service": "service-A",
     "endpoint": "hosta.example.foo",
     "status": "UNKNOWN",
     "duration_in_minutes": 45
    },
    {
     "endpoint_group": "SITE-A",
     "service": "service-A",
     "endpoint": "hosta.example.foo",
     "status": "UNKNOWN",
     "duration_in_minutes": 32
    },
    {
     "endpoint_group": "SITE-B",
     "service": "service-A",
     "endpoint": "hosta.example2.foo",
     "status": "UNKNOWN",
     "duration_in_minutes": 5
    }
   ]
  },
  {
   "status": "WARNING",
   "top": [
    {
     "endpoint_group": "SITE-A",
     "service": "service-A",
     "endpoint": "hosta.example.foo",
     "status": "WARNING",
     "duration_in_minutes": 55
    },
    {
     "endpoint_group": "SITE-A",
     "service": "service-B",
     "endpoint": "hostb.example.foo",
     "status": "WARNING",
     "duration_in_minutes": 20
    }
   ]
  }
 ]
}
```

👉  Get service results for period of 2 months 2021-04-01 ➡️ 2021-05-31  **with** monthly aggregation:
`HTTP GET /api/v1/trends/{report_name}/status/endpoints?start_date=2021-04-01&end_date=2021-05-31&granularity=enabled`

```json
{
 "status": {
  "message": "Success",
  "code": "200"
 },
 "data": [
  {
   "date": "2015-04",
   "status": "CRITICAL",
   "top": [
    {
     "endpoint_group": "SITE-A",
     "service": "service-A",
     "endpoint": "hosta.example.foo",
     "status": "CRITICAL",
     "duration_in_minutes": 55
    },
    {
     "endpoint_group": "SITE-XB",
     "service": "service-XA",
     "endpoint": "hosta.examplex2.foo",
     "status": "CRITICAL",
     "duration_in_minutes": 25
    }
   ]
  },
  {
   "date": "2015-04",
   "status": "UNKNOWN",
   "top": [
    {
     "endpoint_group": "SITE-A",
     "service": "service-B",
     "endpoint": "hostb.example.foo",
     "status": "UNKNOWN",
     "duration_in_minutes": 12
    }
   ]
  },
  {
   "date": "2015-04",
   "status": "WARNING",
   "top": [
    {
     "endpoint_group": "SITE-A",
     "service": "service-A",
     "endpoint": "hosta.example.foo",
     "status": "WARNING",
     "duration_in_minutes": 40
    }
   ]
  },
  {
   "date": "2015-05",
   "status": "CRITICAL",
   "top": [
    {
     "endpoint_group": "SITE-A",
     "service": "service-A",
     "endpoint": "hosta.example.foo",
     "status": "CRITICAL",
     "duration_in_minutes": 40
    },
    {
     "endpoint_group": "SITE-B",
     "service": "service-A",
     "endpoint": "hosta.example2.foo",
     "status": "CRITICAL",
     "duration_in_minutes": 7
    }
   ]
  },
  {
   "date": "2015-05",
   "status": "UNKNOWN",
   "top": [
    {
     "endpoint_group": "SITE-A",
     "service": "service-A",
     "endpoint": "hosta.example.foo",
     "status": "UNKNOWN",
     "duration_in_minutes": 32
    },
    {
     "endpoint_group": "SITE-B",
     "service": "service-A",
     "endpoint": "hosta.example2.foo",
     "status": "UNKNOWN",
     "duration_in_minutes": 5
    }
   ]
  },
  {
   "date": "2015-05",
   "status": "WARNING",
   "top": [
    {
     "endpoint_group": "SITE-A",
     "service": "service-A",
     "endpoint": "hosta.example.foo",
     "status": "WARNING",
     "duration_in_minutes": 55
    },
    {
     "endpoint_group": "SITE-A",
     "service": "service-B",
     "endpoint": "hostb.example.foo",
     "status": "WARNING",
     "duration_in_minutes": 20
    }
   ]
  }
 ]
}
```
The new results are presented in a data array partitioned by date in the following schema

```json
{
  "data": [
    {
      "date": "YYYY-MM",
      "status": "eg. CRITICAL or WARNING etc...",
      "top": [
        {},
        {},
        {}
      ]
    }
  ]
}
```

## Implementations 
- [x] Add  status endpoints models for displaying status endpoint trend data
- [x] Add date-range and monthly aggregation queries for status endpoint results
- [x] Add new unit tests for status endpoint results
- [x] Update docusaurus documents
- [x] Update swagger