### PR TITLE
ARGO-3281 create status trends for endpoint groups

### DIFF
--- a/app/trends/controller.go
+++ b/app/trends/controller.go
@@ -473,7 +473,11 @@ func ListStatusServices(r *http.Request, cfg config.Config) (int, http.Header, [
 					"group":   "$group",
 					"service": "$service",
 					"status":  "$status"},
+<<<<<<< HEAD
 				"duration": bson.M{"$sum": "$duration"},
+=======
+				"duration": bson.M{"$sum": "$trends"},
+>>>>>>> e07cc78 (ARGO-3280 create status trends view for services)
 			}},
 			{"$sort": bson.D{{"_id.month", 1}, {"_id.status", 1}, {"duration", -1}}},
 			{
@@ -520,7 +524,11 @@ func ListStatusServices(r *http.Request, cfg config.Config) (int, http.Header, [
 				"group":   "$group",
 				"service": "$service",
 				"status":  "$status"},
+<<<<<<< HEAD
 			"duration": bson.M{"$sum": "$duration"},
+=======
+			"duration": bson.M{"$sum": "$trends"},
+>>>>>>> e07cc78 (ARGO-3280 create status trends view for services)
 		}},
 		{"$sort": bson.D{{"_id.status", 1}, {"duration", -1}}},
 		{

--- a/app/trends/controller.go
+++ b/app/trends/controller.go
@@ -43,6 +43,7 @@ const flapEndpoints = "flipflop_trends_endpoints"
 const flapServices = "flipflop_trends_services"
 const flapMetrics = "flipflop_trends_metrics"
 const statusMetrics = "status_trends_metrics"
+const statusEndpoints = "status_trends_endpoints"
 
 type list []interface{}
 
@@ -236,6 +237,162 @@ func ListStatusMetrics(r *http.Request, cfg config.Config) (int, http.Header, []
 	}
 
 	output, err = createStatusMetricListView(results, "Success", 200)
+
+	return code, h, output, err
+}
+
+// ListStatusEndpoints returns a list of top status endpoints (in duration) for the day
+func ListStatusEndpoints(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
+
+	//STANDARD DECLARATIONS START
+
+	code := http.StatusOK
+	h := http.Header{}
+	output := []byte("List Flapping Metrics")
+	err := error(nil)
+	charset := "utf-8"
+
+	//STANDARD DECLARATIONS END
+
+	// Set Content-Type response Header value
+	contentType := r.Header.Get("Accept")
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+
+	// Parse the request into the input
+	urlValues := r.URL.Query()
+	vars := mux.Vars(r)
+
+	// Grab Tenant DB configuration from context
+	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
+
+	session, err := mongo.OpenSession(tenantDbConfig)
+	defer mongo.CloseSession(session)
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	endpointCollection := session.DB(tenantDbConfig.Db).C(statusEndpoints)
+
+	// Query the detailed status endpoints trend results
+	reportID, err := mongo.GetReportID(session, tenantDbConfig.Db, vars["report_name"])
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	startDate, endDate, err := getDateRange(urlValues)
+	if err != nil {
+		code = http.StatusBadRequest
+		output, _ = respond.MarshalContent(respond.ErrBadRequestDetails(err.Error()), contentType, "", " ")
+		return code, h, output, err
+	}
+
+	limit := -1
+	limStr := urlValues.Get("top")
+	if limStr != "" {
+		limit, err = strconv.Atoi(limStr)
+		if err != nil {
+			code = http.StatusInternalServerError
+			return code, h, output, err
+		}
+	}
+
+	granularity := urlValues.Get("granularity")
+
+	// query for endpoints
+	filter := bson.M{"report": reportID, "date": bson.M{"$gte": startDate, "$lte": endDate}}
+
+	// apply query for bucketed monthly results if granularity is set to monthly
+	if granularity == "monthly" {
+
+		results := []StatusMonthEndpointData{}
+
+		query := []bson.M{
+			{"$match": filter},
+			{"$group": bson.M{
+				"_id": bson.M{
+					"month":    bson.M{"$substr": list{"$date", 0, 6}},
+					"group":    "$group",
+					"service":  "$service",
+					"endpoint": "$endpoint",
+					"status":   "$status"},
+				"duration": bson.M{"$sum": "$duration"},
+			}},
+			{"$sort": bson.D{{"_id.month", 1}, {"_id.status", 1}, {"duration", -1}}},
+			{
+				"$group": bson.M{
+					"_id": bson.M{"month": "$_id.month", "status": "$_id.status"},
+					"top": bson.M{"$push": bson.M{"group": "$_id.group", "service": "$_id.service", "endpoint": "$_id.endpoint", "status": "$_id.status", "duration": "$duration"}}}},
+		}
+
+		// trim down the list in each month-bucket according to the limit parameter
+		if limit > 0 {
+			query = append(query, bson.M{"$project": bson.M{"date": bson.M{"$concat": list{bson.M{"$substr": list{"$_id.month", 0, 4}},
+				"-", bson.M{"$substr": list{"$_id.month", 4, 6}}}},
+				"status": "$_id.status",
+				"top":    bson.M{"$slice": list{"$top", limit}}}})
+		} else {
+			query = append(query, bson.M{"$project": bson.M{"date": bson.M{"$concat": list{bson.M{"$substr": list{"$_id.month", 0, 4}},
+				"-", bson.M{"$substr": list{"$_id.month", 4, 6}}}},
+				"status": "$_id.status",
+				"top":    "$top"}})
+		}
+
+		// sort end results by month bucket ascending
+		query = append(query, bson.M{"$sort": bson.D{{"date", 1}, {"status", 1}}})
+
+		err = endpointCollection.Pipe(query).All(&results)
+		if err != nil {
+			code = http.StatusInternalServerError
+			return code, h, output, err
+		}
+
+		output, err = createStatusMonthEndpointListView(results, "Success", 200)
+
+		return code, h, output, err
+
+	}
+
+	// continue by calculating non monthly bucketed results
+	results := []StatusGroupEndpointData{}
+
+	query := []bson.M{
+		{"$match": filter},
+		{"$group": bson.M{
+			"_id": bson.M{
+				"group":    "$group",
+				"service":  "$service",
+				"endpoint": "$endpoint",
+				"status":   "$status"},
+			"duration": bson.M{"$sum": "$duration"},
+		}},
+		{"$sort": bson.D{{"_id.status", 1}, {"duration", -1}}},
+		{
+			"$group": bson.M{
+				"_id": bson.M{"status": "$_id.status"},
+				"top": bson.M{"$push": bson.M{"group": "$_id.group", "service": "$_id.service", "endpoint": "$_id.endpoint", "status": "$_id.status", "duration": "$duration"}}}},
+	}
+
+	// trim down the list in each month-bucket according to the limit parameter
+	if limit > 0 {
+		query = append(query, bson.M{"$project": bson.M{"status": "$_id.status",
+			"top": bson.M{"$slice": list{"$top", limit}}}})
+	} else {
+		query = append(query, bson.M{"$project": bson.M{"status": "$_id.status",
+			"top": "$top"}})
+	}
+
+	// sort end results by month bucket ascending
+	query = append(query, bson.M{"$sort": bson.D{{"status", 1}}})
+
+	err = endpointCollection.Pipe(query).All(&results)
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	output, err = createStatusEndpointListView(results, "Success", 200)
 
 	return code, h, output, err
 }

--- a/app/trends/controller.go
+++ b/app/trends/controller.go
@@ -44,6 +44,7 @@ const flapServices = "flipflop_trends_services"
 const flapMetrics = "flipflop_trends_metrics"
 const statusMetrics = "status_trends_metrics"
 const statusEndpoints = "status_trends_endpoints"
+const statusServices = "status_trends_services"
 
 type list []interface{}
 
@@ -393,6 +394,160 @@ func ListStatusEndpoints(r *http.Request, cfg config.Config) (int, http.Header, 
 	}
 
 	output, err = createStatusEndpointListView(results, "Success", 200)
+
+	return code, h, output, err
+}
+
+// ListStatusServices returns a list of top status services (in duration) for the day
+func ListStatusServices(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
+
+	//STANDARD DECLARATIONS START
+
+	code := http.StatusOK
+	h := http.Header{}
+	output := []byte("List Flapping Metrics")
+	err := error(nil)
+	charset := "utf-8"
+
+	//STANDARD DECLARATIONS END
+
+	// Set Content-Type response Header value
+	contentType := r.Header.Get("Accept")
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+
+	// Parse the request into the input
+	urlValues := r.URL.Query()
+	vars := mux.Vars(r)
+
+	// Grab Tenant DB configuration from context
+	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
+
+	session, err := mongo.OpenSession(tenantDbConfig)
+	defer mongo.CloseSession(session)
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	serviceCollection := session.DB(tenantDbConfig.Db).C(statusServices)
+
+	// Query the detailed status services trend results
+	reportID, err := mongo.GetReportID(session, tenantDbConfig.Db, vars["report_name"])
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	startDate, endDate, err := getDateRange(urlValues)
+	if err != nil {
+		code = http.StatusBadRequest
+		output, _ = respond.MarshalContent(respond.ErrBadRequestDetails(err.Error()), contentType, "", " ")
+		return code, h, output, err
+	}
+
+	limit := -1
+	limStr := urlValues.Get("top")
+	if limStr != "" {
+		limit, err = strconv.Atoi(limStr)
+		if err != nil {
+			code = http.StatusInternalServerError
+			return code, h, output, err
+		}
+	}
+
+	granularity := urlValues.Get("granularity")
+
+	// query for services
+	filter := bson.M{"report": reportID, "date": bson.M{"$gte": startDate, "$lte": endDate}}
+
+	// apply query for bucketed monthly results if granularity is set to monthly
+	if granularity == "monthly" {
+
+		results := []StatusMonthServiceData{}
+
+		query := []bson.M{
+			{"$match": filter},
+			{"$group": bson.M{
+				"_id": bson.M{
+					"month":   bson.M{"$substr": list{"$date", 0, 6}},
+					"group":   "$group",
+					"service": "$service",
+					"status":  "$status"},
+				"duration": bson.M{"$sum": "$duration"},
+			}},
+			{"$sort": bson.D{{"_id.month", 1}, {"_id.status", 1}, {"duration", -1}}},
+			{
+				"$group": bson.M{
+					"_id": bson.M{"month": "$_id.month", "status": "$_id.status"},
+					"top": bson.M{"$push": bson.M{"group": "$_id.group", "service": "$_id.service", "status": "$_id.status", "duration": "$duration"}}}},
+		}
+
+		// trim down the list in each month-bucket according to the limit parameter
+		if limit > 0 {
+			query = append(query, bson.M{"$project": bson.M{"date": bson.M{"$concat": list{bson.M{"$substr": list{"$_id.month", 0, 4}},
+				"-", bson.M{"$substr": list{"$_id.month", 4, 6}}}},
+				"status": "$_id.status",
+				"top":    bson.M{"$slice": list{"$top", limit}}}})
+		} else {
+			query = append(query, bson.M{"$project": bson.M{"date": bson.M{"$concat": list{bson.M{"$substr": list{"$_id.month", 0, 4}},
+				"-", bson.M{"$substr": list{"$_id.month", 4, 6}}}},
+				"status": "$_id.status",
+				"top":    "$top"}})
+		}
+
+		// sort end results by month bucket ascending
+		query = append(query, bson.M{"$sort": bson.D{{"date", 1}, {"status", 1}}})
+
+		err = serviceCollection.Pipe(query).All(&results)
+		if err != nil {
+			code = http.StatusInternalServerError
+			return code, h, output, err
+		}
+
+		output, err = createStatusMonthServiceListView(results, "Success", 200)
+
+		return code, h, output, err
+
+	}
+
+	// continue by calculating non monthly bucketed results
+	results := []StatusGroupServiceData{}
+
+	query := []bson.M{
+		{"$match": filter},
+		{"$group": bson.M{
+			"_id": bson.M{
+				"group":   "$group",
+				"service": "$service",
+				"status":  "$status"},
+			"duration": bson.M{"$sum": "$duration"},
+		}},
+		{"$sort": bson.D{{"_id.status", 1}, {"duration", -1}}},
+		{
+			"$group": bson.M{
+				"_id": bson.M{"status": "$_id.status"},
+				"top": bson.M{"$push": bson.M{"group": "$_id.group", "service": "$_id.service", "status": "$_id.status", "duration": "$duration"}}}},
+	}
+
+	// trim down the list in each month-bucket according to the limit parameter
+	if limit > 0 {
+		query = append(query, bson.M{"$project": bson.M{"status": "$_id.status",
+			"top": bson.M{"$slice": list{"$top", limit}}}})
+	} else {
+		query = append(query, bson.M{"$project": bson.M{"status": "$_id.status",
+			"top": "$top"}})
+	}
+
+	// sort end results by month bucket ascending
+	query = append(query, bson.M{"$sort": bson.D{{"status", 1}}})
+
+	err = serviceCollection.Pipe(query).All(&results)
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	output, err = createStatusServiceListView(results, "Success", 200)
 
 	return code, h, output, err
 }

--- a/app/trends/controller.go
+++ b/app/trends/controller.go
@@ -45,6 +45,7 @@ const flapMetrics = "flipflop_trends_metrics"
 const statusMetrics = "status_trends_metrics"
 const statusEndpoints = "status_trends_endpoints"
 const statusServices = "status_trends_services"
+const statusEgroups = "status_trends_groups"
 
 type list []interface{}
 
@@ -473,11 +474,7 @@ func ListStatusServices(r *http.Request, cfg config.Config) (int, http.Header, [
 					"group":   "$group",
 					"service": "$service",
 					"status":  "$status"},
-<<<<<<< HEAD
 				"duration": bson.M{"$sum": "$duration"},
-=======
-				"duration": bson.M{"$sum": "$trends"},
->>>>>>> e07cc78 (ARGO-3280 create status trends view for services)
 			}},
 			{"$sort": bson.D{{"_id.month", 1}, {"_id.status", 1}, {"duration", -1}}},
 			{
@@ -524,11 +521,7 @@ func ListStatusServices(r *http.Request, cfg config.Config) (int, http.Header, [
 				"group":   "$group",
 				"service": "$service",
 				"status":  "$status"},
-<<<<<<< HEAD
 			"duration": bson.M{"$sum": "$duration"},
-=======
-			"duration": bson.M{"$sum": "$trends"},
->>>>>>> e07cc78 (ARGO-3280 create status trends view for services)
 		}},
 		{"$sort": bson.D{{"_id.status", 1}, {"duration", -1}}},
 		{
@@ -556,6 +549,158 @@ func ListStatusServices(r *http.Request, cfg config.Config) (int, http.Header, [
 	}
 
 	output, err = createStatusServiceListView(results, "Success", 200)
+
+	return code, h, output, err
+}
+
+// ListStatusEgroups returns a list of top status endpoint groups (in duration) for the day
+func ListStatusEgroups(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
+
+	//STANDARD DECLARATIONS START
+
+	code := http.StatusOK
+	h := http.Header{}
+	output := []byte("List Flapping Metrics")
+	err := error(nil)
+	charset := "utf-8"
+
+	//STANDARD DECLARATIONS END
+
+	// Set Content-Type response Header value
+	contentType := r.Header.Get("Accept")
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+
+	// Parse the request into the input
+	urlValues := r.URL.Query()
+	vars := mux.Vars(r)
+
+	// Grab Tenant DB configuration from context
+	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
+
+	session, err := mongo.OpenSession(tenantDbConfig)
+	defer mongo.CloseSession(session)
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	egroupCollection := session.DB(tenantDbConfig.Db).C(statusEgroups)
+
+	// Query the detailed status services trend results
+	reportID, err := mongo.GetReportID(session, tenantDbConfig.Db, vars["report_name"])
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	startDate, endDate, err := getDateRange(urlValues)
+	if err != nil {
+		code = http.StatusBadRequest
+		output, _ = respond.MarshalContent(respond.ErrBadRequestDetails(err.Error()), contentType, "", " ")
+		return code, h, output, err
+	}
+
+	limit := -1
+	limStr := urlValues.Get("top")
+	if limStr != "" {
+		limit, err = strconv.Atoi(limStr)
+		if err != nil {
+			code = http.StatusInternalServerError
+			return code, h, output, err
+		}
+	}
+
+	granularity := urlValues.Get("granularity")
+
+	// query for endpoint groups
+	filter := bson.M{"report": reportID, "date": bson.M{"$gte": startDate, "$lte": endDate}}
+
+	// apply query for bucketed monthly results if granularity is set to monthly
+	if granularity == "monthly" {
+
+		results := []StatusMonthEgroupData{}
+
+		query := []bson.M{
+			{"$match": filter},
+			{"$group": bson.M{
+				"_id": bson.M{
+					"month":  bson.M{"$substr": list{"$date", 0, 6}},
+					"group":  "$group",
+					"status": "$status"},
+				"duration": bson.M{"$sum": "$duration"},
+			}},
+			{"$sort": bson.D{{"_id.month", 1}, {"_id.status", 1}, {"duration", -1}}},
+			{
+				"$group": bson.M{
+					"_id": bson.M{"month": "$_id.month", "status": "$_id.status"},
+					"top": bson.M{"$push": bson.M{"group": "$_id.group", "status": "$_id.status", "duration": "$duration"}}}},
+		}
+
+		// trim down the list in each month-bucket according to the limit parameter
+		if limit > 0 {
+			query = append(query, bson.M{"$project": bson.M{"date": bson.M{"$concat": list{bson.M{"$substr": list{"$_id.month", 0, 4}},
+				"-", bson.M{"$substr": list{"$_id.month", 4, 6}}}},
+				"status": "$_id.status",
+				"top":    bson.M{"$slice": list{"$top", limit}}}})
+		} else {
+			query = append(query, bson.M{"$project": bson.M{"date": bson.M{"$concat": list{bson.M{"$substr": list{"$_id.month", 0, 4}},
+				"-", bson.M{"$substr": list{"$_id.month", 4, 6}}}},
+				"status": "$_id.status",
+				"top":    "$top"}})
+		}
+
+		// sort end results by month bucket ascending
+		query = append(query, bson.M{"$sort": bson.D{{"date", 1}, {"status", 1}}})
+
+		err = egroupCollection.Pipe(query).All(&results)
+		if err != nil {
+			code = http.StatusInternalServerError
+			return code, h, output, err
+		}
+
+		output, err = createStatusMonthEgroupListView(results, "Success", 200)
+
+		return code, h, output, err
+
+	}
+
+	// continue by calculating non monthly bucketed results
+	results := []StatusGroupEgroupData{}
+
+	query := []bson.M{
+		{"$match": filter},
+		{"$group": bson.M{
+			"_id": bson.M{
+				"group":  "$group",
+				"status": "$status"},
+			"duration": bson.M{"$sum": "$duration"},
+		}},
+		{"$sort": bson.D{{"_id.status", 1}, {"duration", -1}}},
+		{
+			"$group": bson.M{
+				"_id": bson.M{"status": "$_id.status"},
+				"top": bson.M{"$push": bson.M{"group": "$_id.group", "status": "$_id.status", "duration": "$duration"}}}},
+	}
+
+	// trim down the list in each month-bucket according to the limit parameter
+	if limit > 0 {
+		query = append(query, bson.M{"$project": bson.M{"status": "$_id.status",
+			"top": bson.M{"$slice": list{"$top", limit}}}})
+	} else {
+		query = append(query, bson.M{"$project": bson.M{"status": "$_id.status",
+			"top": "$top"}})
+	}
+
+	// sort end results by month bucket ascending
+	query = append(query, bson.M{"$sort": bson.D{{"status", 1}}})
+
+	err = egroupCollection.Pipe(query).All(&results)
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	output, err = createStatusEgroupListView(results, "Success", 200)
 
 	return code, h, output, err
 }

--- a/app/trends/model.go
+++ b/app/trends/model.go
@@ -27,48 +27,64 @@ import "encoding/xml"
 const zuluForm = "2006-01-02T15:04:05Z"
 const ymdForm = "2006-01-02"
 
-//StatusMonthMetricData holds status information about monthly metrics
+//StatusMonthMetricData holds monthly status trends information about metrics
 type StatusMonthMetricData struct {
 	Date   string             `bson:"date" json:"date"`
 	Status string             `bson:"status" json:"status"`
 	Top    []StatusMetricData `bson:"top" json:"top"`
 }
 
-//StatusMonthEndpointData holds status information about monthly endpoints
+//StatusMonthEndpointData holds monthly status trends information about endpoints
 type StatusMonthEndpointData struct {
 	Date   string               `bson:"date" json:"date"`
 	Status string               `bson:"status" json:"status"`
 	Top    []StatusEndpointData `bson:"top" json:"top"`
 }
 
-//StatusGroupMetricData holds status information about monthly metrics
+//StatusMonthServiceData holds monthly status trends information about services
+type StatusMonthServiceData struct {
+	Date   string              `bson:"date" json:"date"`
+	Status string              `bson:"status" json:"status"`
+	Top    []StatusServiceData `bson:"top" json:"top"`
+}
+
+//StatusGroupMetricData holds grouped monthly status trends information about metrics
 type StatusGroupMetricData struct {
 	Status string             `bson:"status" json:"status"`
 	Top    []StatusMetricData `bson:"top" json:"top"`
 }
 
-//StatusGroupEndpointData holds status information about monthly endpoints
+//StatusGroupEndpointData holds grouped monthly status trends information about endpoints
 type StatusGroupEndpointData struct {
 	Status string               `bson:"status" json:"status"`
 	Top    []StatusEndpointData `bson:"top" json:"top"`
 }
 
-//MonthMetricData holds flapping information about monthly metrics
+//StatusGroupServiceData holds grouped monthly status trends information about services
+type StatusGroupServiceData struct {
+	Status string              `bson:"status" json:"status"`
+	Top    []StatusServiceData `bson:"top" json:"top"`
+}
+
+//MonthMetricData holds monthly information about flapping metric trends
 type MonthMetricData struct {
 	Date string       `bson:"date" json:"date"`
 	Top  []MetricData `bson:"top" json:"top"`
 }
 
+// MonthEndpointData holds monthly information about flapping endpoint trends
 type MonthEndpointData struct {
 	Date string         `bson:"date" json:"date"`
 	Top  []EndpointData `bson:"top" json:"top"`
 }
 
+// MonthServiceData holds monthly information about flapping service trends
 type MonthServiceData struct {
 	Date string        `bson:"date" json:"date"`
 	Top  []ServiceData `bson:"top" json:"top"`
 }
 
+// MonthEndpointGroupData holds monthly information about flapping endpoint group trends
 type MonthEndpointGroupData struct {
 	Date string              `bson:"date" json:"date"`
 	Top  []EndpointGroupData `bson:"top" json:"top"`
@@ -83,7 +99,7 @@ type MetricData struct {
 	Flapping      int    `bson:"flipflop" json:"flapping"`
 }
 
-// StatusMetricData holds status information about metrics
+// StatusMetricData holds status trend information about metrics
 type StatusMetricData struct {
 	EndpointGroup string `bson:"group" json:"endpoint_group"`
 	Service       string `bson:"service" json:"service"`
@@ -93,10 +109,19 @@ type StatusMetricData struct {
 	Events        int    `bson:"events" json:"events"`
 }
 
+// StatusMetricData holds status trend information about endpoints
 type StatusEndpointData struct {
 	EndpointGroup string `bson:"group" json:"endpoint_group"`
 	Service       string `bson:"service" json:"service"`
 	Endpoint      string `bson:"endpoint" json:"endpoint"`
+	Status        string `bson:"status" json:"status"`
+	Duration      int    `bson:"duration" json:"duration_in_minutes"`
+}
+
+// StatusServiceData holds status trend information about services
+type StatusServiceData struct {
+	EndpointGroup string `bson:"group" json:"endpoint_group"`
+	Service       string `bson:"service" json:"service"`
 	Status        string `bson:"status" json:"status"`
 	Duration      int    `bson:"duration" json:"duration_in_minutes"`
 }

--- a/app/trends/model.go
+++ b/app/trends/model.go
@@ -109,7 +109,7 @@ type StatusMetricData struct {
 	Events        int    `bson:"events" json:"events"`
 }
 
-// StatusMetricData holds status trend information about endpoints
+// StatusEndpointData holds status trend information about endpoints
 type StatusEndpointData struct {
 	EndpointGroup string `bson:"group" json:"endpoint_group"`
 	Service       string `bson:"service" json:"service"`

--- a/app/trends/model.go
+++ b/app/trends/model.go
@@ -34,10 +34,23 @@ type StatusMonthMetricData struct {
 	Top    []StatusMetricData `bson:"top" json:"top"`
 }
 
+//StatusMonthEndpointData holds status information about monthly endpoints
+type StatusMonthEndpointData struct {
+	Date   string               `bson:"date" json:"date"`
+	Status string               `bson:"status" json:"status"`
+	Top    []StatusEndpointData `bson:"top" json:"top"`
+}
+
 //StatusGroupMetricData holds status information about monthly metrics
 type StatusGroupMetricData struct {
 	Status string             `bson:"status" json:"status"`
 	Top    []StatusMetricData `bson:"top" json:"top"`
+}
+
+//StatusGroupEndpointData holds status information about monthly endpoints
+type StatusGroupEndpointData struct {
+	Status string               `bson:"status" json:"status"`
+	Top    []StatusEndpointData `bson:"top" json:"top"`
 }
 
 //MonthMetricData holds flapping information about monthly metrics
@@ -78,6 +91,14 @@ type StatusMetricData struct {
 	Metric        string `bson:"metric" json:"metric"`
 	Status        string `bson:"status" json:"status"`
 	Events        int    `bson:"events" json:"events"`
+}
+
+type StatusEndpointData struct {
+	EndpointGroup string `bson:"group" json:"endpoint_group"`
+	Service       string `bson:"service" json:"service"`
+	Endpoint      string `bson:"endpoint" json:"endpoint"`
+	Status        string `bson:"status" json:"status"`
+	Duration      int    `bson:"duration" json:"duration_in_minutes"`
 }
 
 // EndpointData holds flapping information about endpoints

--- a/app/trends/model.go
+++ b/app/trends/model.go
@@ -109,7 +109,11 @@ type StatusMetricData struct {
 	Events        int    `bson:"events" json:"events"`
 }
 
+<<<<<<< HEAD
 // StatusEndpointData holds status trend information about endpoints
+=======
+// StatusMetricData holds status trend information about endpoints
+>>>>>>> e07cc78 (ARGO-3280 create status trends view for services)
 type StatusEndpointData struct {
 	EndpointGroup string `bson:"group" json:"endpoint_group"`
 	Service       string `bson:"service" json:"service"`

--- a/app/trends/model.go
+++ b/app/trends/model.go
@@ -48,6 +48,13 @@ type StatusMonthServiceData struct {
 	Top    []StatusServiceData `bson:"top" json:"top"`
 }
 
+//StatusMonthEgroupData holds monthly status trends information about endpoint groups
+type StatusMonthEgroupData struct {
+	Date   string             `bson:"date" json:"date"`
+	Status string             `bson:"status" json:"status"`
+	Top    []StatusEgroupData `bson:"top" json:"top"`
+}
+
 //StatusGroupMetricData holds grouped monthly status trends information about metrics
 type StatusGroupMetricData struct {
 	Status string             `bson:"status" json:"status"`
@@ -58,6 +65,12 @@ type StatusGroupMetricData struct {
 type StatusGroupEndpointData struct {
 	Status string               `bson:"status" json:"status"`
 	Top    []StatusEndpointData `bson:"top" json:"top"`
+}
+
+//StatusGroupEgroupData holds grouped monthly status trends information about endpoint groups
+type StatusGroupEgroupData struct {
+	Status string             `bson:"status" json:"status"`
+	Top    []StatusEgroupData `bson:"top" json:"top"`
 }
 
 //StatusGroupServiceData holds grouped monthly status trends information about services
@@ -109,11 +122,7 @@ type StatusMetricData struct {
 	Events        int    `bson:"events" json:"events"`
 }
 
-<<<<<<< HEAD
 // StatusEndpointData holds status trend information about endpoints
-=======
-// StatusMetricData holds status trend information about endpoints
->>>>>>> e07cc78 (ARGO-3280 create status trends view for services)
 type StatusEndpointData struct {
 	EndpointGroup string `bson:"group" json:"endpoint_group"`
 	Service       string `bson:"service" json:"service"`
@@ -126,6 +135,13 @@ type StatusEndpointData struct {
 type StatusServiceData struct {
 	EndpointGroup string `bson:"group" json:"endpoint_group"`
 	Service       string `bson:"service" json:"service"`
+	Status        string `bson:"status" json:"status"`
+	Duration      int    `bson:"duration" json:"duration_in_minutes"`
+}
+
+// StatusEgroupData holds status trend information about endpoint groups
+type StatusEgroupData struct {
+	EndpointGroup string `bson:"group" json:"endpoint_group"`
 	Status        string `bson:"status" json:"status"`
 	Duration      int    `bson:"duration" json:"duration_in_minutes"`
 }

--- a/app/trends/routing.go
+++ b/app/trends/routing.go
@@ -40,9 +40,11 @@ var appRoutesV2 = []respond.AppRoutes{
 	{"trends.flapping_services", "GET", "/{report_name}/flapping/services", ListFlappingServices},
 	{"trends.flapping_endpoint_groups", "GET", "/{report_name}/flapping/groups", ListFlappingEndpointGroups},
 	{"trends.status_metrics", "GET", "/{report_name}/status/metrics", ListStatusMetrics},
+	{"trends.status_endpoints", "GET", "/{report_name}/status/endpoints", ListStatusEndpoints},
 	{"trends.options", "OPTIONS", "/{report_name}/flapping/metrics", Options},
 	{"trends.options", "OPTIONS", "/{report_name}/flapping/endpoints", Options},
 	{"trends.options", "OPTIONS", "/{report_name}/flapping/services", Options},
 	{"trends.options", "OPTIONS", "/{report_name}/flapping/groups", Options},
 	{"trends.options", "OPTIONS", "/{report_name}/status/metrics", Options},
+	{"trends.options", "OPTIONS", "/{report_name}/status/endpoints", Options},
 }

--- a/app/trends/routing.go
+++ b/app/trends/routing.go
@@ -42,6 +42,7 @@ var appRoutesV2 = []respond.AppRoutes{
 	{"trends.status_metrics", "GET", "/{report_name}/status/metrics", ListStatusMetrics},
 	{"trends.status_endpoints", "GET", "/{report_name}/status/endpoints", ListStatusEndpoints},
 	{"trends.status_services", "GET", "/{report_name}/status/services", ListStatusServices},
+	{"trends.status_endpoint_groups", "GET", "/{report_name}/status/groups", ListStatusEgroups},
 	{"trends.options", "OPTIONS", "/{report_name}/flapping/metrics", Options},
 	{"trends.options", "OPTIONS", "/{report_name}/flapping/endpoints", Options},
 	{"trends.options", "OPTIONS", "/{report_name}/flapping/services", Options},
@@ -49,4 +50,5 @@ var appRoutesV2 = []respond.AppRoutes{
 	{"trends.options", "OPTIONS", "/{report_name}/status/metrics", Options},
 	{"trends.options", "OPTIONS", "/{report_name}/status/endpoints", Options},
 	{"trends.options", "OPTIONS", "/{report_name}/status/services", Options},
+	{"trends.options", "OPTIONS", "/{report_name}/status/groups", Options},
 }

--- a/app/trends/routing.go
+++ b/app/trends/routing.go
@@ -41,10 +41,12 @@ var appRoutesV2 = []respond.AppRoutes{
 	{"trends.flapping_endpoint_groups", "GET", "/{report_name}/flapping/groups", ListFlappingEndpointGroups},
 	{"trends.status_metrics", "GET", "/{report_name}/status/metrics", ListStatusMetrics},
 	{"trends.status_endpoints", "GET", "/{report_name}/status/endpoints", ListStatusEndpoints},
+	{"trends.status_services", "GET", "/{report_name}/status/services", ListStatusServices},
 	{"trends.options", "OPTIONS", "/{report_name}/flapping/metrics", Options},
 	{"trends.options", "OPTIONS", "/{report_name}/flapping/endpoints", Options},
 	{"trends.options", "OPTIONS", "/{report_name}/flapping/services", Options},
 	{"trends.options", "OPTIONS", "/{report_name}/flapping/groups", Options},
 	{"trends.options", "OPTIONS", "/{report_name}/status/metrics", Options},
 	{"trends.options", "OPTIONS", "/{report_name}/status/endpoints", Options},
+	{"trends.options", "OPTIONS", "/{report_name}/status/services", Options},
 }

--- a/app/trends/trends_test.go
+++ b/app/trends/trends_test.go
@@ -151,6 +151,10 @@ func (suite *TrendsTestSuite) SetupTest() {
 		bson.M{
 			"resource": "trends.status_services",
 			"roles":    []string{"editor", "viewer"},
+		},
+		bson.M{
+			"resource": "trends.status_endpoint_groups",
+			"roles":    []string{"editor", "viewer"},
 		})
 
 	// get dbconfiguration based on the tenant
@@ -203,6 +207,75 @@ func (suite *TrendsTestSuite) SetupTest() {
 				"name":  "name2",
 				"value": "value2"},
 		}})
+
+	// seed the status detailed trends for endpoint group data
+	c = session.DB(suite.tenantDbConf.Db).C("status_trends_groups")
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     20150401,
+		"group":    "SITE-A",
+		"status":   "CRITICAL",
+		"duration": 55,
+	})
+
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     20150401,
+		"group":    "SITE-B",
+		"status":   "UNKNOWN",
+		"duration": 12,
+	})
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     20150401,
+		"group":    "SITE-XB",
+		"status":   "CRITICAL",
+		"duration": 25,
+	})
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     20150501,
+		"group":    "SITE-A",
+		"status":   "WARNING",
+		"duration": 55,
+	})
+
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     20150501,
+		"group":    "SITE-C",
+		"status":   "WARNING",
+		"duration": 12,
+	})
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     20150501,
+		"group":    "SITE-B",
+		"status":   "UNKNOWN",
+		"duration": 5,
+	})
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     20150502,
+		"group":    "SITE-A",
+		"status":   "UNKNOWN",
+		"duration": 45,
+	})
+
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     20150502,
+		"group":    "SITE-C",
+		"status":   "WARNING",
+		"duration": 8,
+	})
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     20150502,
+		"group":    "SITE-B",
+		"status":   "CRITICAL",
+		"duration": 7,
+	})
 
 	// seed the status detailed trends service data
 	c = session.DB(suite.tenantDbConf.Db).C("status_trends_services")
@@ -2817,6 +2890,349 @@ func (suite *TrendsTestSuite) TestStatusServiceTrends() {
 		suite.Equal(expReq.result, response.Body.String(), "Response body mismatch")
 
 	}
+
+}
+
+func (suite *TrendsTestSuite) TestStatusEgroupTrends() {
+
+	type expReq struct {
+		method string
+		url    string
+		code   int
+		result string
+		key    string
+	}
+
+	expReqs := []expReq{
+
+		expReq{
+			method: "GET",
+			url:    "/api/v2/trends/Report_A/status/groups?start_date=2015-05-01&end_date=2015-05-02",
+			code:   200,
+			key:    "KEY1",
+			result: `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "status": "CRITICAL",
+   "top": [
+    {
+     "endpoint_group": "SITE-B",
+     "status": "CRITICAL",
+     "duration_in_minutes": 7
+    }
+   ]
+  },
+  {
+   "status": "UNKNOWN",
+   "top": [
+    {
+     "endpoint_group": "SITE-A",
+     "status": "UNKNOWN",
+     "duration_in_minutes": 45
+    },
+    {
+     "endpoint_group": "SITE-B",
+     "status": "UNKNOWN",
+     "duration_in_minutes": 5
+    }
+   ]
+  },
+  {
+   "status": "WARNING",
+   "top": [
+    {
+     "endpoint_group": "SITE-A",
+     "status": "WARNING",
+     "duration_in_minutes": 55
+    },
+    {
+     "endpoint_group": "SITE-C",
+     "status": "WARNING",
+     "duration_in_minutes": 20
+    }
+   ]
+  }
+ ]
+}`,
+		},
+
+		expReq{
+			method: "GET",
+			url:    "/api/v2/trends/Report_A/status/groups?start_date=2015-05-01&end_date=2015-05-02&top=1",
+			code:   200,
+			key:    "KEY1",
+			result: `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "status": "CRITICAL",
+   "top": [
+    {
+     "endpoint_group": "SITE-B",
+     "status": "CRITICAL",
+     "duration_in_minutes": 7
+    }
+   ]
+  },
+  {
+   "status": "UNKNOWN",
+   "top": [
+    {
+     "endpoint_group": "SITE-A",
+     "status": "UNKNOWN",
+     "duration_in_minutes": 45
+    }
+   ]
+  },
+  {
+   "status": "WARNING",
+   "top": [
+    {
+     "endpoint_group": "SITE-A",
+     "status": "WARNING",
+     "duration_in_minutes": 55
+    }
+   ]
+  }
+ ]
+}`,
+		},
+
+		expReq{
+			method: "GET",
+			url:    "/api/v2/trends/Report_A/status/groups?start_date=2015-04-01&end_date=2015-05-02&granularity=monthly",
+			code:   200,
+			key:    "KEY1",
+			result: `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "date": "2015-04",
+   "status": "CRITICAL",
+   "top": [
+    {
+     "endpoint_group": "SITE-A",
+     "status": "CRITICAL",
+     "duration_in_minutes": 55
+    },
+    {
+     "endpoint_group": "SITE-XB",
+     "status": "CRITICAL",
+     "duration_in_minutes": 25
+    }
+   ]
+  },
+  {
+   "date": "2015-04",
+   "status": "UNKNOWN",
+   "top": [
+    {
+     "endpoint_group": "SITE-B",
+     "status": "UNKNOWN",
+     "duration_in_minutes": 12
+    }
+   ]
+  },
+  {
+   "date": "2015-05",
+   "status": "CRITICAL",
+   "top": [
+    {
+     "endpoint_group": "SITE-B",
+     "status": "CRITICAL",
+     "duration_in_minutes": 7
+    }
+   ]
+  },
+  {
+   "date": "2015-05",
+   "status": "UNKNOWN",
+   "top": [
+    {
+     "endpoint_group": "SITE-A",
+     "status": "UNKNOWN",
+     "duration_in_minutes": 45
+    },
+    {
+     "endpoint_group": "SITE-B",
+     "status": "UNKNOWN",
+     "duration_in_minutes": 5
+    }
+   ]
+  },
+  {
+   "date": "2015-05",
+   "status": "WARNING",
+   "top": [
+    {
+     "endpoint_group": "SITE-A",
+     "status": "WARNING",
+     "duration_in_minutes": 55
+    },
+    {
+     "endpoint_group": "SITE-C",
+     "status": "WARNING",
+     "duration_in_minutes": 20
+    }
+   ]
+  }
+ ]
+}`,
+		},
+
+		expReq{
+			method: "GET",
+			url:    "/api/v2/trends/Report_A/status/groups?start_date=2015-04-01&end_date=2015-05-02&granularity=monthly&top=1",
+			code:   200,
+			key:    "KEY1",
+			result: `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "date": "2015-04",
+   "status": "CRITICAL",
+   "top": [
+    {
+     "endpoint_group": "SITE-A",
+     "status": "CRITICAL",
+     "duration_in_minutes": 55
+    }
+   ]
+  },
+  {
+   "date": "2015-04",
+   "status": "UNKNOWN",
+   "top": [
+    {
+     "endpoint_group": "SITE-B",
+     "status": "UNKNOWN",
+     "duration_in_minutes": 12
+    }
+   ]
+  },
+  {
+   "date": "2015-05",
+   "status": "CRITICAL",
+   "top": [
+    {
+     "endpoint_group": "SITE-B",
+     "status": "CRITICAL",
+     "duration_in_minutes": 7
+    }
+   ]
+  },
+  {
+   "date": "2015-05",
+   "status": "UNKNOWN",
+   "top": [
+    {
+     "endpoint_group": "SITE-A",
+     "status": "UNKNOWN",
+     "duration_in_minutes": 45
+    }
+   ]
+  },
+  {
+   "date": "2015-05",
+   "status": "WARNING",
+   "top": [
+    {
+     "endpoint_group": "SITE-A",
+     "status": "WARNING",
+     "duration_in_minutes": 55
+    }
+   ]
+  }
+ ]
+}`,
+		},
+
+		expReq{
+			method: "GET",
+			url:    "/api/v2/trends/Report_A/status/groups?date=2015-05-01",
+			code:   200,
+			key:    "KEY1",
+			result: `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "status": "UNKNOWN",
+   "top": [
+    {
+     "endpoint_group": "SITE-B",
+     "status": "UNKNOWN",
+     "duration_in_minutes": 5
+    }
+   ]
+  },
+  {
+   "status": "WARNING",
+   "top": [
+    {
+     "endpoint_group": "SITE-A",
+     "status": "WARNING",
+     "duration_in_minutes": 55
+    },
+    {
+     "endpoint_group": "SITE-C",
+     "status": "WARNING",
+     "duration_in_minutes": 12
+    }
+   ]
+  }
+ ]
+}`,
+		},
+	}
+
+	for _, expReq := range expReqs {
+		request, _ := http.NewRequest(expReq.method, expReq.url, strings.NewReader(""))
+		request.Header.Set("x-api-key", expReq.key)
+		request.Header.Set("Accept", "application/json")
+
+		response := httptest.NewRecorder()
+
+		suite.router.ServeHTTP(response, request)
+
+		suite.Equal(expReq.code, response.Code, "Incorrect HTTP response code")
+		// Compare the expected and actual xml response
+		suite.Equal(expReq.result, response.Body.String(), "Response body mismatch")
+
+	}
+
+}
+
+func (suite *TrendsTestSuite) TestOptionsStatusTrendsEgroups() {
+	request, _ := http.NewRequest("OPTIONS", "/api/v2/trends/Report_A/status/groups", strings.NewReader(""))
+
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code := response.Code
+	output := response.Body.String()
+	headers := response.HeaderMap
+
+	suite.Equal(200, code, "Error in response code")
+	suite.Equal("", output, "Expected empty response body")
+	suite.Equal("GET, OPTIONS", headers.Get("Allow"), "Error in Allow header response (supported resource verbs of resource)")
+	suite.Equal("text/plain; charset=utf-8", headers.Get("Content-Type"), "Error in Content-Type header response")
 
 }
 

--- a/app/trends/trends_test.go
+++ b/app/trends/trends_test.go
@@ -147,6 +147,10 @@ func (suite *TrendsTestSuite) SetupTest() {
 		bson.M{
 			"resource": "trends.status_endpoints",
 			"roles":    []string{"editor", "viewer"},
+		},
+		bson.M{
+			"resource": "trends.status_services",
+			"roles":    []string{"editor", "viewer"},
 		})
 
 	// get dbconfiguration based on the tenant
@@ -199,6 +203,84 @@ func (suite *TrendsTestSuite) SetupTest() {
 				"name":  "name2",
 				"value": "value2"},
 		}})
+
+	// seed the status detailed trends service data
+	c = session.DB(suite.tenantDbConf.Db).C("status_trends_services")
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     20150401,
+		"group":    "SITE-A",
+		"service":  "service-A",
+		"status":   "CRITICAL",
+		"duration": 55,
+	})
+
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     20150401,
+		"group":    "SITE-A",
+		"service":  "service-B",
+		"status":   "UNKNOWN",
+		"duration": 12,
+	})
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     20150401,
+		"group":    "SITE-XB",
+		"service":  "service-XA",
+		"status":   "CRITICAL",
+		"duration": 25,
+	})
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     20150501,
+		"group":    "SITE-A",
+		"service":  "service-A",
+		"status":   "WARNING",
+		"duration": 55,
+	})
+
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     20150501,
+		"group":    "SITE-A",
+		"service":  "service-B",
+		"status":   "WARNING",
+		"duration": 12,
+	})
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     20150501,
+		"group":    "SITE-B",
+		"service":  "service-A",
+		"status":   "UNKNOWN",
+		"duration": 5,
+	})
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     20150502,
+		"group":    "SITE-A",
+		"service":  "service-A",
+		"status":   "UNKNOWN",
+		"duration": 45,
+	})
+
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     20150502,
+		"group":    "SITE-A",
+		"service":  "service-B",
+		"status":   "WARNING",
+		"duration": 8,
+	})
+	c.Insert(bson.M{
+		"report":   "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date":     20150502,
+		"group":    "SITE-B",
+		"service":  "service-A",
+		"status":   "CRITICAL",
+		"duration": 7,
+	})
 
 	// seed the status detailed trends endpoint data
 	c = session.DB(suite.tenantDbConf.Db).C("status_trends_endpoints")
@@ -2386,6 +2468,373 @@ func (suite *TrendsTestSuite) TestStatusEndpointTrends() {
 		suite.Equal(expReq.result, response.Body.String(), "Response body mismatch")
 
 	}
+
+}
+
+func (suite *TrendsTestSuite) TestStatusServiceTrends() {
+
+	type expReq struct {
+		method string
+		url    string
+		code   int
+		result string
+		key    string
+	}
+
+	expReqs := []expReq{
+
+		expReq{
+			method: "GET",
+			url:    "/api/v2/trends/Report_A/status/services?start_date=2015-05-01&end_date=2015-05-02",
+			code:   200,
+			key:    "KEY1",
+			result: `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "status": "CRITICAL",
+   "top": [
+    {
+     "endpoint_group": "SITE-B",
+     "service": "service-A",
+     "status": "CRITICAL",
+     "duration_in_minutes": 7
+    }
+   ]
+  },
+  {
+   "status": "UNKNOWN",
+   "top": [
+    {
+     "endpoint_group": "SITE-A",
+     "service": "service-A",
+     "status": "UNKNOWN",
+     "duration_in_minutes": 45
+    },
+    {
+     "endpoint_group": "SITE-B",
+     "service": "service-A",
+     "status": "UNKNOWN",
+     "duration_in_minutes": 5
+    }
+   ]
+  },
+  {
+   "status": "WARNING",
+   "top": [
+    {
+     "endpoint_group": "SITE-A",
+     "service": "service-A",
+     "status": "WARNING",
+     "duration_in_minutes": 55
+    },
+    {
+     "endpoint_group": "SITE-A",
+     "service": "service-B",
+     "status": "WARNING",
+     "duration_in_minutes": 20
+    }
+   ]
+  }
+ ]
+}`,
+		},
+
+		expReq{
+			method: "GET",
+			url:    "/api/v2/trends/Report_A/status/services?start_date=2015-05-01&end_date=2015-05-02&top=1",
+			code:   200,
+			key:    "KEY1",
+			result: `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "status": "CRITICAL",
+   "top": [
+    {
+     "endpoint_group": "SITE-B",
+     "service": "service-A",
+     "status": "CRITICAL",
+     "duration_in_minutes": 7
+    }
+   ]
+  },
+  {
+   "status": "UNKNOWN",
+   "top": [
+    {
+     "endpoint_group": "SITE-A",
+     "service": "service-A",
+     "status": "UNKNOWN",
+     "duration_in_minutes": 45
+    }
+   ]
+  },
+  {
+   "status": "WARNING",
+   "top": [
+    {
+     "endpoint_group": "SITE-A",
+     "service": "service-A",
+     "status": "WARNING",
+     "duration_in_minutes": 55
+    }
+   ]
+  }
+ ]
+}`,
+		},
+
+		expReq{
+			method: "GET",
+			url:    "/api/v2/trends/Report_A/status/services?start_date=2015-04-01&end_date=2015-05-02&granularity=monthly",
+			code:   200,
+			key:    "KEY1",
+			result: `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "date": "2015-04",
+   "status": "CRITICAL",
+   "top": [
+    {
+     "endpoint_group": "SITE-A",
+     "service": "service-A",
+     "status": "CRITICAL",
+     "duration_in_minutes": 55
+    },
+    {
+     "endpoint_group": "SITE-XB",
+     "service": "service-XA",
+     "status": "CRITICAL",
+     "duration_in_minutes": 25
+    }
+   ]
+  },
+  {
+   "date": "2015-04",
+   "status": "UNKNOWN",
+   "top": [
+    {
+     "endpoint_group": "SITE-A",
+     "service": "service-B",
+     "status": "UNKNOWN",
+     "duration_in_minutes": 12
+    }
+   ]
+  },
+  {
+   "date": "2015-05",
+   "status": "CRITICAL",
+   "top": [
+    {
+     "endpoint_group": "SITE-B",
+     "service": "service-A",
+     "status": "CRITICAL",
+     "duration_in_minutes": 7
+    }
+   ]
+  },
+  {
+   "date": "2015-05",
+   "status": "UNKNOWN",
+   "top": [
+    {
+     "endpoint_group": "SITE-A",
+     "service": "service-A",
+     "status": "UNKNOWN",
+     "duration_in_minutes": 45
+    },
+    {
+     "endpoint_group": "SITE-B",
+     "service": "service-A",
+     "status": "UNKNOWN",
+     "duration_in_minutes": 5
+    }
+   ]
+  },
+  {
+   "date": "2015-05",
+   "status": "WARNING",
+   "top": [
+    {
+     "endpoint_group": "SITE-A",
+     "service": "service-A",
+     "status": "WARNING",
+     "duration_in_minutes": 55
+    },
+    {
+     "endpoint_group": "SITE-A",
+     "service": "service-B",
+     "status": "WARNING",
+     "duration_in_minutes": 20
+    }
+   ]
+  }
+ ]
+}`,
+		},
+
+		expReq{
+			method: "GET",
+			url:    "/api/v2/trends/Report_A/status/services?start_date=2015-04-01&end_date=2015-05-02&granularity=monthly&top=1",
+			code:   200,
+			key:    "KEY1",
+			result: `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "date": "2015-04",
+   "status": "CRITICAL",
+   "top": [
+    {
+     "endpoint_group": "SITE-A",
+     "service": "service-A",
+     "status": "CRITICAL",
+     "duration_in_minutes": 55
+    }
+   ]
+  },
+  {
+   "date": "2015-04",
+   "status": "UNKNOWN",
+   "top": [
+    {
+     "endpoint_group": "SITE-A",
+     "service": "service-B",
+     "status": "UNKNOWN",
+     "duration_in_minutes": 12
+    }
+   ]
+  },
+  {
+   "date": "2015-05",
+   "status": "CRITICAL",
+   "top": [
+    {
+     "endpoint_group": "SITE-B",
+     "service": "service-A",
+     "status": "CRITICAL",
+     "duration_in_minutes": 7
+    }
+   ]
+  },
+  {
+   "date": "2015-05",
+   "status": "UNKNOWN",
+   "top": [
+    {
+     "endpoint_group": "SITE-A",
+     "service": "service-A",
+     "status": "UNKNOWN",
+     "duration_in_minutes": 45
+    }
+   ]
+  },
+  {
+   "date": "2015-05",
+   "status": "WARNING",
+   "top": [
+    {
+     "endpoint_group": "SITE-A",
+     "service": "service-A",
+     "status": "WARNING",
+     "duration_in_minutes": 55
+    }
+   ]
+  }
+ ]
+}`,
+		},
+
+		expReq{
+			method: "GET",
+			url:    "/api/v2/trends/Report_A/status/services?date=2015-05-01",
+			code:   200,
+			key:    "KEY1",
+			result: `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "status": "UNKNOWN",
+   "top": [
+    {
+     "endpoint_group": "SITE-B",
+     "service": "service-A",
+     "status": "UNKNOWN",
+     "duration_in_minutes": 5
+    }
+   ]
+  },
+  {
+   "status": "WARNING",
+   "top": [
+    {
+     "endpoint_group": "SITE-A",
+     "service": "service-A",
+     "status": "WARNING",
+     "duration_in_minutes": 55
+    },
+    {
+     "endpoint_group": "SITE-A",
+     "service": "service-B",
+     "status": "WARNING",
+     "duration_in_minutes": 12
+    }
+   ]
+  }
+ ]
+}`,
+		},
+	}
+
+	for _, expReq := range expReqs {
+		request, _ := http.NewRequest(expReq.method, expReq.url, strings.NewReader(""))
+		request.Header.Set("x-api-key", expReq.key)
+		request.Header.Set("Accept", "application/json")
+
+		response := httptest.NewRecorder()
+
+		suite.router.ServeHTTP(response, request)
+
+		suite.Equal(expReq.code, response.Code, "Incorrect HTTP response code")
+		// Compare the expected and actual xml response
+		suite.Equal(expReq.result, response.Body.String(), "Response body mismatch")
+
+	}
+
+}
+
+func (suite *TrendsTestSuite) TestOptionsStatusTrendsServices() {
+	request, _ := http.NewRequest("OPTIONS", "/api/v2/trends/Report_A/status/services", strings.NewReader(""))
+
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code := response.Code
+	output := response.Body.String()
+	headers := response.HeaderMap
+
+	suite.Equal(200, code, "Error in response code")
+	suite.Equal("", output, "Expected empty response body")
+	suite.Equal("GET, OPTIONS", headers.Get("Allow"), "Error in Allow header response (supported resource verbs of resource)")
+	suite.Equal("text/plain; charset=utf-8", headers.Get("Content-Type"), "Error in Content-Type header response")
 
 }
 

--- a/app/trends/view.go
+++ b/app/trends/view.go
@@ -29,6 +29,22 @@ import (
 	"github.com/ARGOeu/argo-web-api/respond"
 )
 
+// createStatusEndpointListView constructs the list response template and exports it as json
+func createStatusEndpointListView(results []StatusGroupEndpointData, msg string, code int) ([]byte, error) {
+
+	docRoot := &respond.ResponseMessage{
+		Status: respond.StatusResponse{
+			Message: msg,
+			Code:    strconv.Itoa(code),
+		},
+	}
+	docRoot.Data = results
+
+	output, err := json.MarshalIndent(docRoot, "", " ")
+	return output, err
+
+}
+
 // createMetricListView constructs the list response template and exports it as json
 func createStatusMetricListView(results []StatusGroupMetricData, msg string, code int) ([]byte, error) {
 
@@ -95,6 +111,22 @@ func createEndpointListView(results []EndpointData, msg string, code int) ([]byt
 
 // createEndpointGroupListView constructs the list response template and exports it as json
 func createEndpointGroupListView(results []EndpointGroupData, msg string, code int) ([]byte, error) {
+
+	docRoot := &respond.ResponseMessage{
+		Status: respond.StatusResponse{
+			Message: msg,
+			Code:    strconv.Itoa(code),
+		},
+	}
+	docRoot.Data = results
+
+	output, err := json.MarshalIndent(docRoot, "", " ")
+	return output, err
+
+}
+
+// createStatusMonthEndpointListView constructs the list response template and exports it as json
+func createStatusMonthEndpointListView(results []StatusMonthEndpointData, msg string, code int) ([]byte, error) {
 
 	docRoot := &respond.ResponseMessage{
 		Status: respond.StatusResponse{

--- a/app/trends/view.go
+++ b/app/trends/view.go
@@ -29,6 +29,22 @@ import (
 	"github.com/ARGOeu/argo-web-api/respond"
 )
 
+// createStatusEgroupListView constructs the list response template and exports it as json
+func createStatusEgroupListView(results []StatusGroupEgroupData, msg string, code int) ([]byte, error) {
+
+	docRoot := &respond.ResponseMessage{
+		Status: respond.StatusResponse{
+			Message: msg,
+			Code:    strconv.Itoa(code),
+		},
+	}
+	docRoot.Data = results
+
+	output, err := json.MarshalIndent(docRoot, "", " ")
+	return output, err
+
+}
+
 // createStatusServiceListView constructs the list response template and exports it as json
 func createStatusServiceListView(results []StatusGroupServiceData, msg string, code int) ([]byte, error) {
 
@@ -127,6 +143,22 @@ func createEndpointListView(results []EndpointData, msg string, code int) ([]byt
 
 // createEndpointGroupListView constructs the list response template and exports it as json
 func createEndpointGroupListView(results []EndpointGroupData, msg string, code int) ([]byte, error) {
+
+	docRoot := &respond.ResponseMessage{
+		Status: respond.StatusResponse{
+			Message: msg,
+			Code:    strconv.Itoa(code),
+		},
+	}
+	docRoot.Data = results
+
+	output, err := json.MarshalIndent(docRoot, "", " ")
+	return output, err
+
+}
+
+// createStatusMonthEgroupListView constructs the list response template and exports it as json
+func createStatusMonthEgroupListView(results []StatusMonthEgroupData, msg string, code int) ([]byte, error) {
 
 	docRoot := &respond.ResponseMessage{
 		Status: respond.StatusResponse{

--- a/app/trends/view.go
+++ b/app/trends/view.go
@@ -29,6 +29,22 @@ import (
 	"github.com/ARGOeu/argo-web-api/respond"
 )
 
+// createStatusServiceListView constructs the list response template and exports it as json
+func createStatusServiceListView(results []StatusGroupServiceData, msg string, code int) ([]byte, error) {
+
+	docRoot := &respond.ResponseMessage{
+		Status: respond.StatusResponse{
+			Message: msg,
+			Code:    strconv.Itoa(code),
+		},
+	}
+	docRoot.Data = results
+
+	output, err := json.MarshalIndent(docRoot, "", " ")
+	return output, err
+
+}
+
 // createStatusEndpointListView constructs the list response template and exports it as json
 func createStatusEndpointListView(results []StatusGroupEndpointData, msg string, code int) ([]byte, error) {
 
@@ -111,6 +127,22 @@ func createEndpointListView(results []EndpointData, msg string, code int) ([]byt
 
 // createEndpointGroupListView constructs the list response template and exports it as json
 func createEndpointGroupListView(results []EndpointGroupData, msg string, code int) ([]byte, error) {
+
+	docRoot := &respond.ResponseMessage{
+		Status: respond.StatusResponse{
+			Message: msg,
+			Code:    strconv.Itoa(code),
+		},
+	}
+	docRoot.Data = results
+
+	output, err := json.MarshalIndent(docRoot, "", " ")
+	return output, err
+
+}
+
+// createStatusMonthServiceListView constructs the list response template and exports it as json
+func createStatusMonthServiceListView(results []StatusMonthServiceData, msg string, code int) ([]byte, error) {
 
 	docRoot := &respond.ResponseMessage{
 		Status: respond.StatusResponse{

--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -5014,6 +5014,18 @@ definitions:
 >>>>>>> 0fae46e (ARGO-3279 Create Endpoint status trends view)
       events:
         type: integer
+        
+  Trends_status_services:
+    type: object
+    properties:
+      endpoint_group:
+        type: string
+      service:
+        type: string
+      status:
+        type: string
+      events:
+        type: integer
 
               
   Trends_metrics:

--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -3429,7 +3429,7 @@ paths:
           type: string
       responses:
         '200':
-          description: A list with status metrics per status
+          description: A list with status trends for metrics
           schema:
             $ref: '#/definitions/Trends_status_metrics_list'
         '401':
@@ -3472,7 +3472,7 @@ paths:
           type: string
       responses:
         '200':
-          description: A list with status metrics per status
+          description: A list with status trends for endpoints
           schema:
             $ref: '#/definitions/Trends_status_endpoints_list'
         '401':
@@ -3492,6 +3492,48 @@ paths:
           schema:
             $ref: '#/definitions/Status_error'
   
+  /trends/{REPORT_NAME}/status/services:
+    get:
+      summary: List trends for top status service trends
+      operationId: trends.StatusServices
+      description: List top status services by status events
+      tags:
+        - Trends
+      produces:
+        - "application/json"
+      parameters:
+        - $ref: "#/parameters/profDate"
+        - $ref: "#/parameters/trendsStartDate"
+        - $ref: "#/parameters/trendsEndDate"
+        - $ref: "#/parameters/trendsTop"
+        - $ref: "#/parameters/trendsGran"
+        - $ref: "#/parameters/apiKey"
+        - name: "REPORT_NAME"
+          in: "path"
+          description: "name of the report"
+          required: true
+          type: string
+      responses:
+        '200':
+          description: A list with status trends for services
+          schema:
+            $ref: '#/definitions/Trends_status_services_list'
+        '401':
+          description: Unauthorized user
+          schema:
+            $ref: '#/definitions/Status_error'
+        '404':
+          description: Item not found
+          schema:
+            $ref: '#/definitions/Status_error'
+        '406':
+          description: Content Not acceptable
+          schema:
+            $ref: '#/definitions/Status_error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Status_error'
   
             
   /trends/{REPORT_NAME}/flapping/metrics:
@@ -4957,6 +4999,18 @@ definitions:
         type: string
       events:
         type: integer
+        
+  Trends_status_services:
+    type: object
+    properties:
+      endpoint_group:
+        type: string
+      service:
+        type: string
+      status:
+        type: string
+      events:
+        type: integer
 
               
   Trends_metrics:
@@ -5003,6 +5057,17 @@ definitions:
       flapping:
         type: integer 
         
+        
+  Trends_status_services_group:
+    type: object
+    properties:
+      status:
+        type: string
+      top:
+        type: array
+        items:
+          $ref: '#/definitions/Trends_status_services'
+        
 
   Trends_status_endpoints_group:
     type: object
@@ -5024,6 +5089,16 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/Trends_status_metrics'
+          
+  Trends_status_services_list:
+    type: object
+    properties:
+      status:
+       $ref: '#/definitions/Status'
+      data:
+        type: array
+        items:
+          $ref: '#/definitions/Trends_status_services_group'
           
           
   Trends_status_endpoints_list:

--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -3535,6 +3535,50 @@ paths:
           schema:
             $ref: '#/definitions/Status_error'
   
+  /trends/{REPORT_NAME}/status/groups:
+    get:
+      summary: List trends for top status endpoint group trends
+      operationId: trends.StatusEgroups
+      description: List top endpoint groups by status events
+      tags:
+        - Trends
+      produces:
+        - "application/json"
+      parameters:
+        - $ref: "#/parameters/profDate"
+        - $ref: "#/parameters/trendsStartDate"
+        - $ref: "#/parameters/trendsEndDate"
+        - $ref: "#/parameters/trendsTop"
+        - $ref: "#/parameters/trendsGran"
+        - $ref: "#/parameters/apiKey"
+        - name: "REPORT_NAME"
+          in: "path"
+          description: "name of the report"
+          required: true
+          type: string
+      responses:
+        '200':
+          description: A list with status trends for endpoint groups
+          schema:
+            $ref: '#/definitions/Trends_status_egroups_list'
+        '401':
+          description: Unauthorized user
+          schema:
+            $ref: '#/definitions/Status_error'
+        '404':
+          description: Item not found
+          schema:
+            $ref: '#/definitions/Status_error'
+        '406':
+          description: Content Not acceptable
+          schema:
+            $ref: '#/definitions/Status_error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Status_error'
+  
+  
             
   /trends/{REPORT_NAME}/flapping/metrics:
     get:
@@ -4997,7 +5041,6 @@ definitions:
         type: string
       status:
         type: string
-<<<<<<< HEAD
       events:
         type: integer
         
@@ -5010,17 +5053,13 @@ definitions:
         type: string
       status:
         type: string
-=======
->>>>>>> 0fae46e (ARGO-3279 Create Endpoint status trends view)
       events:
         type: integer
         
-  Trends_status_services:
+  Trends_status_egroups:
     type: object
     properties:
       endpoint_group:
-        type: string
-      service:
         type: string
       status:
         type: string
@@ -5073,6 +5112,17 @@ definitions:
         type: integer 
         
         
+  Trends_status_egroups_group:
+    type: object
+    properties:
+      status:
+        type: string
+      top:
+        type: array
+        items:
+          $ref: '#/definitions/Trends_status_egroups'
+        
+        
   Trends_status_services_group:
     type: object
     properties:
@@ -5104,6 +5154,17 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/Trends_status_metrics'
+          
+          
+  Trends_status_egroups_list:
+    type: object
+    properties:
+      status:
+       $ref: '#/definitions/Status'
+      data:
+        type: array
+        items:
+          $ref: '#/definitions/Trends_status_egroups_group'
           
   Trends_status_services_list:
     type: object

--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -4997,6 +4997,7 @@ definitions:
         type: string
       status:
         type: string
+<<<<<<< HEAD
       events:
         type: integer
         
@@ -5009,6 +5010,8 @@ definitions:
         type: string
       status:
         type: string
+=======
+>>>>>>> 0fae46e (ARGO-3279 Create Endpoint status trends view)
       events:
         type: integer
 

--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -3448,6 +3448,49 @@ paths:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Status_error'  
+            
+  /trends/{REPORT_NAME}/status/endpoints:
+    get:
+      summary: List trends for top status service endpoints
+      operationId: trends.StatusEndpoints
+      description: List top status service endpoints by status events
+      tags:
+        - Trends
+      produces:
+        - "application/json"
+      parameters:
+        - $ref: "#/parameters/profDate"
+        - $ref: "#/parameters/trendsStartDate"
+        - $ref: "#/parameters/trendsEndDate"
+        - $ref: "#/parameters/trendsTop"
+        - $ref: "#/parameters/trendsGran"
+        - $ref: "#/parameters/apiKey"
+        - name: "REPORT_NAME"
+          in: "path"
+          description: "name of the report"
+          required: true
+          type: string
+      responses:
+        '200':
+          description: A list with status metrics per status
+          schema:
+            $ref: '#/definitions/Trends_status_endpoints_list'
+        '401':
+          description: Unauthorized user
+          schema:
+            $ref: '#/definitions/Status_error'
+        '404':
+          description: Item not found
+          schema:
+            $ref: '#/definitions/Status_error'
+        '406':
+          description: Content Not acceptable
+          schema:
+            $ref: '#/definitions/Status_error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Status_error'
   
   
             
@@ -4898,6 +4941,20 @@ definitions:
         type: string
       status:
         type: string
+      duration_in_minutes:
+        type: integer
+        
+  Trends_status_endpoints:
+    type: object
+    properties:
+      endpoint_group:
+        type: string
+      service:
+        type: string
+      endpoint:
+        type: string
+      status:
+        type: string
       events:
         type: integer
 
@@ -4946,6 +5003,16 @@ definitions:
       flapping:
         type: integer 
         
+
+  Trends_status_endpoints_group:
+    type: object
+    properties:
+      status:
+        type: string
+      top:
+        type: array
+        items:
+          $ref: '#/definitions/Trends_status_endpoints'
   
   
   Trends_status_metrics_group:
@@ -4957,6 +5024,17 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/Trends_status_metrics'
+          
+          
+  Trends_status_endpoints_list:
+    type: object
+    properties:
+      status:
+       $ref: '#/definitions/Status'
+      data:
+        type: array
+        items:
+          $ref: '#/definitions/Trends_status_endpoints_group'
           
   Trends_status_metrics_list:
     type: object

--- a/scripts/mongodb/populate_default_roles.js
+++ b/scripts/mongodb/populate_default_roles.js
@@ -217,19 +217,27 @@ function populate_default_roles() {
         },
         {
             resource: "trends.flapping_metrics",
-            roles: ["admin", "editor", "viewer"]
+            roles: ["admin", "editor", "viewer", "admin_ui"]
         },
         {
             resource: "trends.flapping_endpoints",
-            roles: ["admin", "editor", "viewer"]
+            roles: ["admin", "editor", "viewer", "admin_ui"]
         },
         {
             resource: "trends.flapping_services",
-            roles: ["admin", "editor", "viewer"]
+            roles: ["admin", "editor", "viewer", "admin_ui"]
         },
         {
             resource: "trends.flapping_endpoint_groups",
-            roles: ["admin", "editor", "viewer"]
+            roles: ["admin", "editor", "viewer", "admin_ui"]
+        },
+        {
+            resource: "trends.status_metrics",
+            roles: ["admin", "editor", "viewer", "admin_ui"]
+        },
+        {
+            resource: "trends.status_endpoints",
+            roles: ["admin", "editor", "viewer", "admin_ui"]
         }
     ]);
     print("INFO\tPolulated default roles in 'roles' collection");

--- a/scripts/mongodb/populate_default_roles.js
+++ b/scripts/mongodb/populate_default_roles.js
@@ -242,6 +242,10 @@ function populate_default_roles() {
         {
             resource: "trends.status_services",
             roles: ["admin", "editor", "viewer", "admin_ui"]
+        },
+        {
+            resource: "trends.status_endpoint_groups",
+            roles: ["admin", "editor", "viewer", "admin_ui"]
         }
     ]);
     print("INFO\tPolulated default roles in 'roles' collection");

--- a/scripts/mongodb/populate_default_roles.js
+++ b/scripts/mongodb/populate_default_roles.js
@@ -238,6 +238,10 @@ function populate_default_roles() {
         {
             resource: "trends.status_endpoints",
             roles: ["admin", "editor", "viewer", "admin_ui"]
+        },
+        {
+            resource: "trends.status_services",
+            roles: ["admin", "editor", "viewer", "admin_ui"]
         }
     ]);
     print("INFO\tPolulated default roles in 'roles' collection");

--- a/website/docs/trends.md
+++ b/website/docs/trends.md
@@ -858,6 +858,265 @@ Reponse body:
 }
 ```
 
+## API calls to find status trends among endpoint groups
+
+This API call displays the top endpoint groups by state (e.g. CRITICAL, WARNING etc) over a period of dates - optionally by monthly aggregation - for a specific report
+
+### [GET]: Daily Status trends in service endpoint groups
+This method may be used to retrieve a list of top status endpoint groups. 
+
+### Input
+
+```
+/trends/{report_name}/status/groups?date=2020-05-01
+```
+
+#### Path Parameters
+| Type | Description | Required | Default value |
+|------|-------------|----------|---------------|
+|`report_name`| name of the report| YES |  |
+
+#### Url Parameters
+
+| Type | Description | Required | Default value |
+|------|-------------|----------|---------------|
+|`date`| Date to view problematic endpoint groups of | NO |  |
+|`start_date`| define start date to view problematic endpoint groups over range | NO |  |
+|`end_date`| define end date to view problematic endpoint groups over range | NO |  |
+|`top`| integer to define a top number of results displayed | NO |  |
+|`granularity`| string value to define if you want monthly granularity in the results - e.g `?granularity=monthly` | NO |  |
+
+
+#### Headers
+```
+x-api-key: shared_key_value
+Accept: application/json or application/xml
+```
+
+#### Response Code
+```
+Status: 200 OK
+```
+
+
+###### Example Request:
+URL:
+```
+/trends/{report_name}/status/groups?date=2020-05-01
+```
+Headers:
+```
+x-api-key: shared_key_value
+Accept: application/json or application/xml
+
+```
+###### Example Response:
+
+Code:
+```
+Status: 200 OK
+```
+Reponse body:
+```
+{
+  "status": {
+    "message": "Success",
+    "code": "200"
+  },
+  "data": [
+    {
+      "status": "CRITICAL",
+      "top": [
+        {
+          "endpoint_group": "SITE-A",
+          "status": "CRITICAL",
+          "duration_in_minutes": 40
+        }
+      ]
+    },
+    {
+      "status": "UNKNOWN",
+      "top": [
+        {
+          "endpoint_group": "SITE-B",
+          "status": "UNKNOWN",
+          "duration_in_minutes": 5
+        }
+      ]
+    },
+    {
+      "status": "WARNING",
+      "top": [
+        {
+          "endpoint_group": "SITE-C",
+          "status": "WARNING",
+          "duration_in_minutes": 55
+        },
+        {
+          "endpoint_group": "SITE-D",
+          "status": "WARNING",
+          "duration_in_minutes": 12
+        }
+      ]
+    }
+  ]
+}
+```
+
+###### Example Request with Range and top number of results:
+URL:
+```
+/trends/{report_name}/status/groups?start_date=2020-05-01&end_date=2021-06-15&top=1
+```
+Headers:
+```
+x-api-key: shared_key_value
+Accept: application/json or application/xml
+
+```
+###### Example Response:
+
+Code:
+```
+Status: 200 OK
+```
+Reponse body:
+```
+{
+  "status": {
+    "message": "Success",
+    "code": "200"
+  },
+  "data": [
+    {
+      "status": "CRITICAL",
+      "top": [
+        {
+          "endpoint_group": "SITE-A",
+          "status": "CRITICAL",
+          "duration_in_minutes": 40
+        }
+      ]
+    },
+    {
+      "status": "UNKNOWN",
+      "top": [
+        {
+          "endpoint_group": "SITE-B",
+          "status": "UNKNOWN",
+          "duration_in_minutes": 45
+        }
+      ]
+    },
+    {
+      "status": "WARNING",
+      "top": [
+        {
+          "endpoint_group": "SITE-C",
+          "status": "WARNING",
+          "duration_in_minutes": 55
+        }
+      ]
+    }
+  ]
+}
+```
+
+###### Example Request with granularity=monthly option enabled:
+URL:
+```
+/trends/{report_name}/status/groups?start_date=2020-04-01&end_date=2021-05-31&granularity=monthly&top=1
+```
+Headers:
+```
+x-api-key: shared_key_value
+Accept: application/json or application/xml
+
+```
+###### Example Response:
+
+Code:
+```
+Status: 200 OK
+```
+Reponse body:
+```
+{
+  "status": {
+    "message": "Success",
+    "code": "200"
+  },
+  "data": [
+    {
+      "date": "2015-04",
+      "status": "CRITICAL",
+      "top": [
+        {
+          "endpoint_group": "SITE-A",
+          "status": "CRITICAL",
+          "duration_in_minutes": 55
+        }
+      ]
+    },
+    {
+      "date": "2015-04",
+      "status": "UNKNOWN",
+      "top": [
+        {
+          "endpoint_group": "SITE-B",
+          "status": "UNKNOWN",
+          "duration_in_minutes": 12
+        }
+      ]
+    },
+    {
+      "date": "2015-04",
+      "status": "WARNING",
+      "top": [
+        {
+          "endpoint_group": "SITE-C",
+          "status": "WARNING",
+          "duration_in_minutes": 40
+        }
+      ]
+    },
+    {
+      "date": "2015-05",
+      "status": "CRITICAL",
+      "top": [
+        {
+          "endpoint_group": "SITE-A",
+          "status": "CRITICAL",
+          "duration_in_minutes": 40
+        }
+      ]
+    },
+    {
+      "date": "2015-05",
+      "status": "UNKNOWN",
+      "top": [
+        {
+          "endpoint_group": "SITE-B",
+          "status": "UNKNOWN",
+          "duration_in_minutes": 45
+        }
+      ]
+    },
+    {
+      "date": "2015-05",
+      "status": "WARNING",
+      "top": [
+        {
+          "endpoint_group": "SITE-C",
+          "status": "WARNING",
+          "duration_in_minutes": 55
+        }
+      ]
+    }
+  ]
+}
+```
+
 ## API calls to find flapping trends among metrics, endpoints, services and groups by Date
 
 Flapping items are the ones that change state too frequently causing a lot of alarms and notifications. State flapping might be the case of wrong configuration. 

--- a/website/docs/trends.md
+++ b/website/docs/trends.md
@@ -586,6 +586,278 @@ Reponse body:
 }
 ```
 
+## API calls to find status trends among services
+
+This API call displays the top services by state (e.g. CRITICAL, WARNING etc) over a period of dates - optionally by monthly aggregation - for a specific report
+
+### [GET]: Daily Status trends in service endpoint metrics
+This method may be used to retrieve a list of top status service services. 
+
+### Input
+
+```
+/trends/{report_name}/status/services?date=2020-05-01
+```
+
+#### Path Parameters
+| Type | Description | Required | Default value |
+|------|-------------|----------|---------------|
+|`report_name`| name of the report| YES |  |
+
+#### Url Parameters
+
+| Type | Description | Required | Default value |
+|------|-------------|----------|---------------|
+|`date`| Date to view problematic services of | NO |  |
+|`start_date`| define start date to view problematic services over range | NO |  |
+|`end_date`| define end date to view problematic servces over range | NO |  |
+|`top`| integer to define a top number of results displayed | NO |  |
+|`granularity`| string value to define if you want monthly granularity in the results - e.g `?granularity=monthly` | NO |  |
+
+
+#### Headers
+```
+x-api-key: shared_key_value
+Accept: application/json or application/xml
+```
+
+#### Response Code
+```
+Status: 200 OK
+```
+
+
+###### Example Request:
+URL:
+```
+/trends/{report_name}/status/services?date=2020-05-01
+```
+Headers:
+```
+x-api-key: shared_key_value
+Accept: application/json or application/xml
+
+```
+###### Example Response:
+
+Code:
+```
+Status: 200 OK
+```
+Reponse body:
+```
+{
+  "status": {
+    "message": "Success",
+    "code": "200"
+  },
+  "data": [
+    {
+      "status": "CRITICAL",
+      "top": [
+        {
+          "endpoint_group": "SITE-A",
+          "service": "service-A",
+          "status": "CRITICAL",
+          "duration_in_minutes": 40
+        }
+      ]
+    },
+    {
+      "status": "UNKNOWN",
+      "top": [
+        {
+          "endpoint_group": "SITE-B",
+          "service": "service-D",
+          "status": "UNKNOWN",
+          "duration_in_minutes": 5
+        }
+      ]
+    },
+    {
+      "status": "WARNING",
+      "top": [
+        {
+          "endpoint_group": "SITE-A",
+          "service": "service-X",
+          "status": "WARNING",
+          "duration_in_minutes": 55
+        },
+        {
+          "endpoint_group": "SITE-A",
+          "service": "service-B",
+          "status": "WARNING",
+          "duration_in_minutes": 12
+        }
+      ]
+    }
+  ]
+}
+```
+
+###### Example Request with Range and top number of results:
+URL:
+```
+/trends/{report_name}/status/services?start_date=2020-05-01&end_date=2021-06-15&top=1
+```
+Headers:
+```
+x-api-key: shared_key_value
+Accept: application/json or application/xml
+
+```
+###### Example Response:
+
+Code:
+```
+Status: 200 OK
+```
+Reponse body:
+```
+{
+  "status": {
+    "message": "Success",
+    "code": "200"
+  },
+  "data": [
+    {
+      "status": "CRITICAL",
+      "top": [
+        {
+          "endpoint_group": "SITE-A",
+          "service": "service-A",
+          "status": "CRITICAL",
+          "duration_in_minutes": 40
+        }
+      ]
+    },
+    {
+      "status": "UNKNOWN",
+      "top": [
+        {
+          "endpoint_group": "SITE-A",
+          "service": "service-B",
+          "status": "UNKNOWN",
+          "duration_in_minutes": 45
+        }
+      ]
+    },
+    {
+      "status": "WARNING",
+      "top": [
+        {
+          "endpoint_group": "SITE-A",
+          "service": "service-C",
+          "status": "WARNING",
+          "duration_in_minutes": 55
+        }
+      ]
+    }
+  ]
+}
+```
+
+###### Example Request with granularity=monthly option enabled:
+URL:
+```
+/trends/{report_name}/status/services?start_date=2020-04-01&end_date=2021-05-31&granularity=monthly&top=1
+```
+Headers:
+```
+x-api-key: shared_key_value
+Accept: application/json or application/xml
+
+```
+###### Example Response:
+
+Code:
+```
+Status: 200 OK
+```
+Reponse body:
+```
+{
+  "status": {
+    "message": "Success",
+    "code": "200"
+  },
+  "data": [
+    {
+      "date": "2015-04",
+      "status": "CRITICAL",
+      "top": [
+        {
+          "endpoint_group": "SITE-A",
+          "service": "service-A",
+          "status": "CRITICAL",
+          "duration_in_minutes": 55
+        }
+      ]
+    },
+    {
+      "date": "2015-04",
+      "status": "UNKNOWN",
+      "top": [
+        {
+          "endpoint_group": "SITE-A",
+          "service": "service-B",
+          "status": "UNKNOWN",
+          "duration_in_minutes": 12
+        }
+      ]
+    },
+    {
+      "date": "2015-04",
+      "status": "WARNING",
+      "top": [
+        {
+          "endpoint_group": "SITE-A",
+          "service": "service-C",
+          "status": "WARNING",
+          "duration_in_minutes": 40
+        }
+      ]
+    },
+    {
+      "date": "2015-05",
+      "status": "CRITICAL",
+      "top": [
+        {
+          "endpoint_group": "SITE-A",
+          "service": "service-D",
+          "status": "CRITICAL",
+          "duration_in_minutes": 40
+        }
+      ]
+    },
+    {
+      "date": "2015-05",
+      "status": "UNKNOWN",
+      "top": [
+        {
+          "endpoint_group": "SITE-A",
+          "service": "service-A",
+          "status": "UNKNOWN",
+          "duration_in_minutes": 45
+        }
+      ]
+    },
+    {
+      "date": "2015-05",
+      "status": "WARNING",
+      "top": [
+        {
+          "endpoint_group": "SITE-A",
+          "service": "service-B",
+          "status": "WARNING",
+          "duration_in_minutes": 55
+        }
+      ]
+    }
+  ]
+}
+```
+
 ## API calls to find flapping trends among metrics, endpoints, services and groups by Date
 
 Flapping items are the ones that change state too frequently causing a lot of alarms and notifications. State flapping might be the case of wrong configuration. 

--- a/website/docs/trends.md
+++ b/website/docs/trends.md
@@ -123,7 +123,7 @@ Reponse body:
 ###### Example Request with Range and top number of results:
 URL:
 ```
-/trends/{report_name}/flapping/metrics?start_date=2020-05-01&end_date=2021-06-15&top=1
+/trends/{report_name}/status/metrics?start_date=2020-05-01&end_date=2021-06-15&top=1
 ```
 Headers:
 ```
@@ -191,7 +191,7 @@ Reponse body:
 ###### Example Request with granularity=monthly option enabled:
 URL:
 ```
-/trends/{report_name}/flapping/metrics?start_date=2020-04-01&end_date=2021-05-31&granularity=monthly&top=1
+/trends/{report_name}/status/metrics?start_date=2020-04-01&end_date=2021-05-31&granularity=monthly&top=1
 ```
 Headers:
 ```
@@ -294,6 +294,291 @@ Reponse body:
           "metric": "check-1",
           "status": "WARNING",
           "events": 55
+        }
+      ]
+    }
+  ]
+}
+```
+
+## API calls to find status trends among endpoints
+
+This API call displays the top endpoints by state (e.g. CRITICAL, WARNING etc) over a period of dates - optionally by monthly aggregation - for a specific report
+
+### [GET]: Daily Status trends in service endpoint metrics
+This method may be used to retrieve a list of top status service endpoints. 
+
+### Input
+
+```
+/trends/{report_name}/status/endpoints?date=2020-05-01
+```
+
+#### Path Parameters
+| Type | Description | Required | Default value |
+|------|-------------|----------|---------------|
+|`report_name`| name of the report| YES |  |
+
+#### Url Parameters
+
+| Type | Description | Required | Default value |
+|------|-------------|----------|---------------|
+|`date`| Date to view problematic endpoints of | NO |  |
+|`start_date`| define start date to view problematic endpoints over range | NO |  |
+|`end_date`| define end date to view problematic endpoints over range | NO |  |
+|`top`| integer to define a top number of results displayed | NO |  |
+|`granularity`| string value to define if you want monthly granularity in the results - e.g `?granularity=monthly` | NO |  |
+
+
+#### Headers
+```
+x-api-key: shared_key_value
+Accept: application/json or application/xml
+```
+
+#### Response Code
+```
+Status: 200 OK
+```
+
+
+###### Example Request:
+URL:
+```
+/trends/{report_name}/status/endpoints?date=2020-05-01
+```
+Headers:
+```
+x-api-key: shared_key_value
+Accept: application/json or application/xml
+
+```
+###### Example Response:
+
+Code:
+```
+Status: 200 OK
+```
+Reponse body:
+```
+{
+  "status": {
+    "message": "Success",
+    "code": "200"
+  },
+  "data": [
+    {
+      "status": "CRITICAL",
+      "top": [
+        {
+          "endpoint_group": "SITE-A",
+          "service": "service-A",
+          "endpoint": "hosta.example.foo",
+          "status": "CRITICAL",
+          "duration_in_minutes": 40
+        }
+      ]
+    },
+    {
+      "status": "UNKNOWN",
+      "top": [
+        {
+          "endpoint_group": "SITE-B",
+          "service": "service-A",
+          "endpoint": "hosta.example2.foo",
+          "status": "UNKNOWN",
+          "duration_in_minutes": 5
+        }
+      ]
+    },
+    {
+      "status": "WARNING",
+      "top": [
+        {
+          "endpoint_group": "SITE-A",
+          "service": "service-A",
+          "endpoint": "hosta.example.foo",
+          "status": "WARNING",
+          "duration_in_minutes": 55
+        },
+        {
+          "endpoint_group": "SITE-A",
+          "service": "service-B",
+          "endpoint": "hostb.example.foo",
+          "status": "WARNING",
+          "duration_in_minutes": 12
+        }
+      ]
+    }
+  ]
+}
+```
+
+###### Example Request with Range and top number of results:
+URL:
+```
+/trends/{report_name}/status/endpoints?start_date=2020-05-01&end_date=2021-06-15&top=1
+```
+Headers:
+```
+x-api-key: shared_key_value
+Accept: application/json or application/xml
+
+```
+###### Example Response:
+
+Code:
+```
+Status: 200 OK
+```
+Reponse body:
+```
+{
+  "status": {
+    "message": "Success",
+    "code": "200"
+  },
+  "data": [
+    {
+      "status": "CRITICAL",
+      "top": [
+        {
+          "endpoint_group": "SITE-A",
+          "service": "service-A",
+          "endpoint": "hosta.example.foo",
+          "status": "CRITICAL",
+          "duration_in_minutes": 40
+        }
+      ]
+    },
+    {
+      "status": "UNKNOWN",
+      "top": [
+        {
+          "endpoint_group": "SITE-A",
+          "service": "service-A",
+          "endpoint": "hosta.example.foo",
+          "status": "UNKNOWN",
+          "duration_in_minutes": 45
+        }
+      ]
+    },
+    {
+      "status": "WARNING",
+      "top": [
+        {
+          "endpoint_group": "SITE-A",
+          "service": "service-A",
+          "endpoint": "hosta.example.foo",
+          "status": "WARNING",
+          "duration_in_minutes": 55
+        }
+      ]
+    }
+  ]
+}
+```
+
+###### Example Request with granularity=monthly option enabled:
+URL:
+```
+/trends/{report_name}/status/endpoints?start_date=2020-04-01&end_date=2021-05-31&granularity=monthly&top=1
+```
+Headers:
+```
+x-api-key: shared_key_value
+Accept: application/json or application/xml
+
+```
+###### Example Response:
+
+Code:
+```
+Status: 200 OK
+```
+Reponse body:
+```
+{
+  "status": {
+    "message": "Success",
+    "code": "200"
+  },
+  "data": [
+    {
+      "date": "2015-04",
+      "status": "CRITICAL",
+      "top": [
+        {
+          "endpoint_group": "SITE-A",
+          "service": "service-A",
+          "endpoint": "hosta.example.foo",
+          "status": "CRITICAL",
+          "duration_in_minutes": 55
+        }
+      ]
+    },
+    {
+      "date": "2015-04",
+      "status": "UNKNOWN",
+      "top": [
+        {
+          "endpoint_group": "SITE-A",
+          "service": "service-B",
+          "endpoint": "hostb.example.foo",
+          "status": "UNKNOWN",
+          "duration_in_minutes": 12
+        }
+      ]
+    },
+    {
+      "date": "2015-04",
+      "status": "WARNING",
+      "top": [
+        {
+          "endpoint_group": "SITE-A",
+          "service": "service-A",
+          "endpoint": "hosta.example.foo",
+          "status": "WARNING",
+          "duration_in_minutes": 40
+        }
+      ]
+    },
+    {
+      "date": "2015-05",
+      "status": "CRITICAL",
+      "top": [
+        {
+          "endpoint_group": "SITE-A",
+          "service": "service-A",
+          "endpoint": "hosta.example.foo",
+          "status": "CRITICAL",
+          "duration_in_minutes": 40
+        }
+      ]
+    },
+    {
+      "date": "2015-05",
+      "status": "UNKNOWN",
+      "top": [
+        {
+          "endpoint_group": "SITE-A",
+          "service": "service-A",
+          "endpoint": "hosta.example.foo",
+          "status": "UNKNOWN",
+          "duration_in_minutes": 45
+        }
+      ]
+    },
+    {
+      "date": "2015-05",
+      "status": "WARNING",
+      "top": [
+        {
+          "endpoint_group": "SITE-A",
+          "service": "service-A",
+          "endpoint": "hosta.example.foo",
+          "status": "WARNING",
+          "duration_in_minutes": 55
         }
       ]
     }


### PR DESCRIPTION
## Goal
Introduce a new category of trends: status endpoint groups

Status service trends displays top endpoint groups by status type (CRITICAL, WARNING etc)  duration over a range of time

The new api call has the following signature path
`HTTP GET /api/v1/trends{report_name}/status/groups`

and uses the following parameters:
- `?start_date=YYYY-MM-DD` & `end_date=YYYY-MM-DD` for ranges
- `?date=YYYY-MM-DD` for singe day results
- `?granularity=monthly` for monthly aggregation of ranged results
- `?top=N` for limiting results on top N items

Examples and response format 
👉  Get status endpoint groups results for period of 2 months 2021-04-01 ➡️ 2021-05-31 without monthly aggregation:
`HTTP GET /api/v1/trends/{report_name}/status/services?start_date=2021-04-01&end_date=2021-05-31`

Response:
```json
{
 "status": {
  "message": "Success",
  "code": "200"
 },
 "data": [
  {
   "status": "CRITICAL",
   "top": [
    {
     "endpoint_group": "SITE-A",
     "status": "CRITICAL",
     "duration_in_minutes": 40
    },
    {
     "endpoint_group": "SITE-B",
     "status": "CRITICAL",
     "duration_in_minutes": 7
    }
   ]
  },
  {
   "status": "UNKNOWN",
   "top": [
    {
     "endpoint_group": "SITE-C",
     "status": "UNKNOWN",
     "duration_in_minutes": 45
    },
    {
     "endpoint_group": "SITE-D",
     "status": "UNKNOWN",
     "duration_in_minutes": 32
    }
   ]
  },
  {
   "status": "WARNING",
   "top": [
    {
     "endpoint_group": "SITE-X",
     "service": "service-A",
     "status": "WARNING",
     "duration_in_minutes": 55
    }
   ]
  }
 ]
}
```

👉  Get endpoint group results for period of 2 months 2021-04-01 ➡️ 2021-05-31  **with** monthly aggregation:
`HTTP GET /api/v1/trends/{report_name}/status/groups?start_date=2021-04-01&end_date=2021-05-31&granularity=enabled`

```json
{
 "status": {
  "message": "Success",
  "code": "200"
 },
 "data": [
  {
   "date": "2015-04",
   "status": "CRITICAL",
   "top": [
    {
     "endpoint_group": "SITE-A",
     "status": "CRITICAL",
     "duration_in_minutes": 55
    },
    {
     "endpoint_group": "SITE-XB",
     "status": "CRITICAL",
     "duration_in_minutes": 25
    }
   ]
  },
  {
   "date": "2015-04",
   "status": "UNKNOWN",
   "top": [
    {
     "endpoint_group": "SITE-C",
     "status": "UNKNOWN",
     "duration_in_minutes": 12
    }
   ]
  },
  {
   "date": "2015-04",
   "status": "WARNING",
   "top": [
    {
     "endpoint_group": "SITE-D",
     "status": "WARNING",
     "duration_in_minutes": 40
    }
   ]
  },
  {
   "date": "2015-05",
   "status": "CRITICAL",
   "top": [
    {
     "endpoint_group": "SITE-A",
     "status": "CRITICAL",
     "duration_in_minutes": 40
    },
    {
     "endpoint_group": "SITE-B",
     "status": "CRITICAL",
     "duration_in_minutes": 7
    }
   ]
  },
  {
   "date": "2015-05",
   "status": "UNKNOWN",
   "top": [
    {
     "endpoint_group": "SITE-A",
     "status": "UNKNOWN",
     "duration_in_minutes": 32
    },
    {
     "endpoint_group": "SITE-B",
     "status": "UNKNOWN",
     "duration_in_minutes": 5
    }
   ]
  },
  {
   "date": "2015-05",
   "status": "WARNING",
   "top": [
    {
     "endpoint_group": "SITE-C",
     "status": "WARNING",
     "duration_in_minutes": 55
    },
    {
     "endpoint_group": "SITE-D",
     "status": "WARNING",
     "duration_in_minutes": 20
    }
   ]
  }
 ]
}
```
The new results are presented in a data array partitioned by date in the following schema

```json
{
  "data": [
    {
      "date": "YYYY-MM",
      "status": "eg. CRITICAL or WARNING etc...",
      "top": [
        {},
        {},
        {}
      ]
    }
  ]
}
```

## Implementations 
- [x] Add  status endpoint group models for displaying status endpoint group trend data
- [x] Add date-range and monthly aggregation queries for status endpoint group results
- [x] Add new unit tests for status endpoint group results
- [x] Update docusaurus documents
- [x] Update swagger