### PR TITLE
Support combined tenant data feeds

### DIFF
--- a/app/feeds/controller.go
+++ b/app/feeds/controller.go
@@ -17,6 +17,120 @@ import (
 //Create a new feeds resource
 const feedsTopoCol = "feeds_topology"
 const feedsWeightsCol = "feeds_weights"
+const feedsDataCol = "feeds_data"
+const tenantsColName = "tenants"
+
+// Update request handler creates a new feed topo resource
+func UpdateData(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
+	//STANDARD DECLARATIONS START
+	code := http.StatusOK
+	h := http.Header{}
+	output := []byte("")
+	err := error(nil)
+	charset := "utf-8"
+	//STANDARD DECLARATIONS END
+
+	// Set Content-Type response Header value
+	contentType := r.Header.Get("Accept")
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+
+	// Grab Tenant DB configuration from context
+	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
+
+	if err != nil {
+		code = http.StatusBadRequest
+		output, _ = respond.MarshalContent(respond.ErrBadRequestDetails(err.Error()), contentType, "", " ")
+		return code, h, output, err
+	}
+
+	// open a master session to the argo core database
+	coreSession, err := mongo.OpenSession(cfg.MongoDB)
+	defer mongo.CloseSession(coreSession)
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	tenantsCol := coreSession.DB(cfg.MongoDB.Db).C(tenantsColName)
+	incoming := Data{}
+
+	// Try ingest request body
+	body, err := ioutil.ReadAll(io.LimitReader(r.Body, cfg.Server.ReqSizeLimit))
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+	if err := r.Body.Close(); err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	// Parse body json
+	if err := json.Unmarshal(body, &incoming); err != nil {
+		output, _ = respond.MarshalContent(respond.BadRequestInvalidJSON, contentType, "", " ")
+		code = 400
+		return code, h, output, err
+	}
+
+	// prep query to find info based on all tenant names given in the incoming list
+	aggr := []bson.M{
+		bson.M{"$match": bson.M{"info.name": bson.M{"$in": incoming.Tenants}}},
+		bson.M{"$project": bson.M{"id": "$id", "name": "$info.name"}},
+	}
+
+	// open a normal session to the specific tenant database
+	session, err := mongo.OpenSession(tenantDbConfig)
+	defer mongo.CloseSession(session)
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	tInfo := []TenantInfo{}
+	err = tenantsCol.Pipe(aggr).All(&tInfo)
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	tenantIDs := Data{}
+
+	// check if incoming tenant names were found
+	for _, name := range incoming.Tenants {
+		found := false
+		for _, tItem := range tInfo {
+
+			if name == tItem.Name {
+				tenantIDs.Tenants = append(tenantIDs.Tenants, tItem.ID)
+				found = true
+			}
+		}
+		if found == false {
+			output, err = createMsgView(fmt.Sprintf("Tenant %s not found", name), 404)
+			code = http.StatusNotFound
+			return code, h, output, err
+		}
+
+	}
+
+	// all incoming tenants were found
+
+	// update the new information
+
+	ftCol := session.DB(tenantDbConfig.Db).C(feedsDataCol)
+	_, err = ftCol.Upsert(bson.M{}, tenantIDs)
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	// Create view of the results
+	output, err = createDataListView([]Data{incoming}, "Feeds resource succesfully updated", 200) //Render the results into JSON
+	code = 200
+	return code, h, output, err
+}
 
 // Update request handler creates a new feed topo resource
 func UpdateTopo(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
@@ -151,6 +265,119 @@ func UpdateWeights(r *http.Request, cfg config.Config) (int, http.Header, []byte
 	// Create view of the results
 	output, err = createWeightsListView([]Weights{incoming}, "Feeds resource succesfully updated", 200) //Render the results into JSON
 	code = 200
+	return code, h, output, err
+}
+
+// ListData lists data feeds Results
+func ListData(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
+
+	//STANDARD DECLARATIONS START
+
+	code := http.StatusOK
+	h := http.Header{}
+	output := []byte("")
+	err := error(nil)
+	charset := "utf-8"
+
+	//STANDARD DECLARATIONS END
+
+	// Set Content-Type response Header value
+	contentType := r.Header.Get("Accept")
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+
+	// Grab Tenant DB configuration from context
+	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
+
+	// Open session to tenant database
+	session, err := mongo.OpenSession(tenantDbConfig)
+	defer mongo.CloseSession(session)
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	// Retrieve Results from database
+	result := Data{}
+
+	if err != nil {
+		code = http.StatusBadRequest
+		output, _ = respond.MarshalContent(respond.ErrBadRequestDetails(err.Error()), contentType, "", " ")
+		return code, h, output, err
+	}
+
+	ftCol := session.DB(tenantDbConfig.Db).C(feedsDataCol)
+	err = ftCol.Find(bson.M{}).One(&result)
+
+	if err != nil {
+		if err.Error() == "not found" {
+
+			output, err = createMsgView("No tenant data feeds were defined. Please specify new ones!", 404)
+			code = http.StatusNotFound
+			return code, h, output, err
+		}
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	tenantNames := Data{}
+
+	if len(result.Tenants) > 0 {
+
+		// open a master session to the argo core database
+		coreSession, err := mongo.OpenSession(cfg.MongoDB)
+		defer mongo.CloseSession(coreSession)
+		if err != nil {
+			code = http.StatusInternalServerError
+			return code, h, output, err
+		}
+
+		tenantsCol := coreSession.DB(cfg.MongoDB.Db).C(tenantsColName)
+
+		// prep query to find info based on all tenant ids given
+		aggr := []bson.M{
+			bson.M{"$match": bson.M{"id": bson.M{"$in": result.Tenants}}},
+			bson.M{"$project": bson.M{"id": "$id", "name": "$info.name"}},
+		}
+
+		tInfo := []TenantInfo{}
+
+		err = tenantsCol.Pipe(aggr).All(&tInfo)
+
+		if err != nil {
+			code = http.StatusInternalServerError
+			return code, h, output, err
+		}
+
+		// check if incoming tenant IDs were found
+		for _, ID := range result.Tenants {
+			found := false
+			for _, tItem := range tInfo {
+				if ID == tItem.ID {
+					tenantNames.Tenants = append(tenantNames.Tenants, tItem.Name)
+					found = true
+				}
+			}
+			if found == false {
+				output, err = createMsgView(fmt.Sprintf("Tenant with ID: %s not found. Please update the feed correctly!", ID), 404)
+				code = http.StatusNotFound
+				return code, h, output, err
+			}
+
+		}
+
+		// all incoming tenants were found
+	}
+
+	// Create view of the results
+	output, err = createDataListView([]Data{tenantNames}, "Success", code) //Render the results into JSON
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
 	return code, h, output, err
 }
 

--- a/app/feeds/model.go
+++ b/app/feeds/model.go
@@ -20,3 +20,14 @@ type Weights struct {
 	// group type that the weight affects
 	GroupType string `bson:"group_type" json:"group_type"`
 }
+
+// Data feeds for combined reports
+type Data struct {
+	Tenants []string `bson:"tenants" json:"tenants"`
+}
+
+// Tenant Info containts quick info of tenant name and id
+type TenantInfo struct {
+	Name string `bson:"name"`
+	ID   string `bson:"id"`
+}

--- a/app/feeds/routing.go
+++ b/app/feeds/routing.go
@@ -20,4 +20,7 @@ var appRoutesV2 = []respond.AppRoutes{
 	{Name: "feeds.weights.update", Verb: "PUT", Path: "/weights", SubrouterHandler: UpdateWeights},
 	{Name: "feeds.weights.get", Verb: "GET", Path: "/weights", SubrouterHandler: ListWeights},
 	{Name: "feeds.weights.options", Verb: "OPTIONS", Path: "/weights", SubrouterHandler: Options},
+	{Name: "feeds.data.update", Verb: "PUT", Path: "/data", SubrouterHandler: UpdateData},
+	{Name: "feeds.data.get", Verb: "GET", Path: "/data", SubrouterHandler: ListData},
+	{Name: "feeds.data.options", Verb: "OPTIONS", Path: "/data", SubrouterHandler: Options},
 }

--- a/app/feeds/view.go
+++ b/app/feeds/view.go
@@ -7,6 +7,22 @@ import (
 	"github.com/ARGOeu/argo-web-api/respond"
 )
 
+// createDataListView constructs the list response template and exports it as json
+func createDataListView(results []Data, msg string, code int) ([]byte, error) {
+
+	docRoot := &respond.ResponseMessage{
+		Status: respond.StatusResponse{
+			Message: msg,
+			Code:    strconv.Itoa(code),
+		},
+	}
+	docRoot.Data = results
+
+	output, err := json.MarshalIndent(docRoot, "", " ")
+	return output, err
+
+}
+
 // createTopoListView constructs the list response template and exports it as json
 func createTopoListView(results []Topo, msg string, code int) ([]byte, error) {
 

--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -3907,8 +3907,84 @@ paths:
           schema:
             $ref: '#/definitions/FeedsTopo'
       responses:
-        '201':
+        '200':
           description: Feeds weights resource Updated
+          schema:
+            $ref: '#/definitions/Status'
+        '400':
+          description: Bad request due to malformed JSON in put body
+          schema:
+            $ref: '#/definitions/Status_error'
+        '401':
+          description: Unauthorized user
+          schema:
+            $ref: '#/definitions/Status_error'
+        '404':
+          description: Item not found
+          schema:
+            $ref: '#/definitions/Status_error'
+        '406':
+          description: Content Not acceptable
+          schema:
+            $ref: '#/definitions/Status_error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Status_error'  
+  
+  /feeds/data:
+    get:
+      summary: List of data feed parameters
+      operationId: feeds.data.list
+      description: list of data feed parameters
+      tags:
+        - Feeds
+      produces:
+        - "application/json"
+      parameters:
+        - $ref: "#/parameters/apiKey"
+      responses:
+        '200':
+          description: A list with data feed parameters
+          schema:
+            $ref: '#/definitions/FeedsData'
+        '401':
+          description: Unauthorized user
+          schema:
+            $ref: '#/definitions/Status_error'
+        '404':
+          description: Item not found
+          schema:
+            $ref: '#/definitions/Status_error'
+        '406':
+          description: Content Not acceptable
+          schema:
+            $ref: '#/definitions/Status_error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Status_error'
+    put:
+      summary: update data feeds parameters
+      operationId: feeds.data.update
+      description: update data feeds parameters
+      tags:
+        - Feeds
+      consumes:
+        - "application/json"
+      produces:
+        - "application/json"
+      parameters:
+        - $ref: "#/parameters/apiKey"
+        - name: "feeds_data_resource"
+          in: "body"
+          description: "Json description of the feeds data resource to be updated"
+          required: true
+          schema:
+            $ref: '#/definitions/FeedsData'
+      responses:
+        '200':
+          description: Feeds data resource Updated
           schema:
             $ref: '#/definitions/Status'
         '400':
@@ -5631,6 +5707,16 @@ definitions:
               type: string
             context:
               type: string
+  
+  FeedsData:
+    type: object
+    properties:
+      tenants:
+        type: array
+        items:
+          type: string
+  
+  
   
   FeedsTopo:
     type: object

--- a/website/docs/feeds.md
+++ b/website/docs/feeds.md
@@ -10,6 +10,8 @@ title: Feeds
 | PUT: Update feed topology info | This method can be used to update feed topology information parameters | [ Description](#2) |
 | GET: Feed Weights information   | This method can be used to retrieve a list of feed weights parameters         | [ Description](#3) |
 | PUT: Update feed weights info | This method can be used to update feed weights information parameters | [ Description](#4) |
+| GET: Feed Data information   | This method can be used to retrieve a list of feed data information parameters         | [ Description](#5) |
+| PUT: Update Data weights info | This method can be used to update feed data  information parameters | [ Description](#6) |
 
 <a id='1'></a>
 
@@ -167,7 +169,7 @@ Json Response
 }
 ```
 
-<a id='2'></a>
+<a id='4'></a>
 
 ## [PUT]: Update topology feed parameters
 This method is used to upadte topology feed parameters
@@ -219,4 +221,91 @@ Json Response
   ]
 }
 ```
+<a id='5'></a>
 
+## [GET]: List Feed Data parameters
+
+This method can be used to retrieve a list of feed data information parameters. Data feeds refer to data coming from other tenants and used in combined reports
+
+### Input
+
+```
+GET /feeds/data
+```
+
+
+### Request headers
+
+```
+x-api-key: shared_key_value
+Accept: application/json
+```
+
+### Response
+
+Headers: `Status: 200 OK`
+
+#### Response body
+
+Json Response
+
+```json
+{
+  "status": {
+    "message": "Success",
+    "code": "200"
+  },
+  "data": [
+    {
+      "tenants": ["TENANT_X", "TENANT_Y"]
+    }
+  ]
+}
+```
+
+<a id='6'></a>
+
+## [PUT]: Update data feed parameters
+This method is used to update data feed parameters
+
+### Input
+
+```
+PUT /feeds/data
+```
+
+#### PUT BODY
+```json
+{
+  "tenants": ["TENANT_Z", "TENANT_W"]
+}
+```
+
+#### Request headers
+
+```
+x-api-key: shared_key_value
+Accept: application/json
+```
+
+### Response
+
+Headers: `Status: 200 OK`
+
+#### Response body
+
+Json Response
+
+```json
+{
+  "status": {
+    "message": "Feeds resource succesfully updated",
+    "code": "200"
+  },
+  "data": [
+    {
+        "tenants": ["TENANT_Z", "TENANT_W"]
+    }
+  ]
+}
+```


### PR DESCRIPTION
We already have a `/feeds` section in web api to declare 
- weight feeds in `/feeds/weights`
- topology feeds in `/feeds/topology`

and now we can accommodate:
- data feeds in `/feeds/data` 
that include data sources from other tenants 