### PR TITLE
ARGO-3423 Add list of metric to tags mappings

### DIFF
--- a/app/metrics/controller.go
+++ b/app/metrics/controller.go
@@ -1,0 +1,324 @@
+package metrics
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/ARGOeu/argo-web-api/app/metricProfiles"
+	"github.com/ARGOeu/argo-web-api/app/reports"
+	"github.com/ARGOeu/argo-web-api/respond"
+	"github.com/ARGOeu/argo-web-api/utils"
+	"github.com/ARGOeu/argo-web-api/utils/config"
+	"github.com/ARGOeu/argo-web-api/utils/mongo"
+	"github.com/gorilla/context"
+	"github.com/gorilla/mux"
+	"gopkg.in/mgo.v2/bson"
+)
+
+//Create a new metrics resource
+const metricsColName = "monitoring_metrics"
+const reportsColName = "reports"
+const mprofilesColName = "metric_profiles"
+
+// gets a report result and retuns the metric profile ID
+func getReportMetricProfileID(r reports.MongoInterface) string {
+	for _, item := range r.Profiles {
+		if item.Type == "metric" {
+			return item.ID
+		}
+	}
+	return ""
+}
+
+// gets a list with metric names from a metric profile
+func getMetricsFromProfile(mp metricProfiles.MetricProfile) []string {
+	set := make(map[string]bool)
+	result := []string{}
+
+	for _, service := range mp.Services {
+		for _, metric := range service.Metrics {
+			set[metric] = true
+		}
+	}
+
+	for key := range set {
+		result = append(result, key)
+	}
+
+	return result
+}
+
+func prepQueryMprofile(dt int, id string) interface{} {
+
+	return bson.M{"date_integer": bson.M{"$lte": dt}, "id": id}
+
+}
+
+// Update request handler creates a new list of metrics
+func UpdateMetrics(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
+	//STANDARD DECLARATIONS START
+	code := http.StatusOK
+	h := http.Header{}
+	output := []byte("")
+	err := error(nil)
+	charset := "utf-8"
+	//STANDARD DECLARATIONS END
+
+	// Set Content-Type response Header value
+	contentType := r.Header.Get("Accept")
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+
+	if err != nil {
+		code = http.StatusBadRequest
+		output, _ = respond.MarshalContent(respond.ErrBadRequestDetails(err.Error()), contentType, "", " ")
+		return code, h, output, err
+	}
+
+	// open a master session to the argo core database
+	coreSession, err := mongo.OpenSession(cfg.MongoDB)
+	defer mongo.CloseSession(coreSession)
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	incoming := []Metric{}
+
+	// Try ingest request body
+	body, err := ioutil.ReadAll(io.LimitReader(r.Body, cfg.Server.ReqSizeLimit))
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+	if err := r.Body.Close(); err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	// Parse body json
+	if err := json.Unmarshal(body, &incoming); err != nil {
+		output, _ = respond.MarshalContent(respond.BadRequestInvalidJSON, contentType, "", " ")
+		code = 400
+		return code, h, output, err
+	}
+
+	_, err = mongo.Remove(coreSession, cfg.MongoDB.Db, metricsColName, bson.M{})
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	err = mongo.MultiInsert(coreSession, cfg.MongoDB.Db, metricsColName, incoming)
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	// Create view of the results
+	output, err = createMetricsListView(incoming, "Metrics resource succesfully updated", 200) //Render the results into JSON
+	code = 200
+	return code, h, output, err
+}
+
+// ListMetrics actually list monitoring metrics
+func ListMetrics(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
+
+	//STANDARD DECLARATIONS START
+
+	code := http.StatusOK
+	h := http.Header{}
+	output := []byte("")
+	err := error(nil)
+	charset := "utf-8"
+
+	//STANDARD DECLARATIONS END
+
+	// Set Content-Type response Header value
+	contentType := r.Header.Get("Accept")
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+
+	// open a master session to the argo core database
+	coreSession, err := mongo.OpenSession(cfg.MongoDB)
+	defer mongo.CloseSession(coreSession)
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	// Retrieve Results from database
+	result := []Metric{}
+
+	if err != nil {
+		code = http.StatusBadRequest
+		output, _ = respond.MarshalContent(respond.ErrBadRequestDetails(err.Error()), contentType, "", " ")
+		return code, h, output, err
+	}
+
+	mCol := coreSession.DB(cfg.MongoDB.Db).C(metricsColName)
+	err = mCol.Find(bson.M{}).All(&result)
+	if err != nil {
+		if err.Error() == "not found" {
+			output, _ = respond.MarshalContent(respond.ErrNotFound, contentType, "", " ")
+			code = 404
+			return code, h, output, err
+		}
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	// Create view of the results
+	output, err = createMetricsListView(result, "Success", code) //Render the results into JSON
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+	return code, h, output, err
+}
+
+//ListMetricsByReport list all metrics available in the metric profile used by a report
+func ListMetricsByReport(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
+
+	//STANDARD DECLARATIONS START
+
+	code := http.StatusOK
+	h := http.Header{}
+	output := []byte("")
+	err := error(nil)
+	charset := "utf-8"
+
+	//STANDARD DECLARATIONS END
+
+	// Set Content-Type response Header value
+	contentType := r.Header.Get("Accept")
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+
+	vars := mux.Vars(r)
+	urlValues := r.URL.Query()
+	dateStr := urlValues.Get("date")
+
+	reportName := vars["report"]
+
+	// Grab Tenant DB configuration from context
+	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
+
+	// Open session to tenant database
+	session, err := mongo.OpenSession(tenantDbConfig)
+	defer mongo.CloseSession(session)
+
+	colReports := session.DB(tenantDbConfig.Db).C(reportsColName)
+	//get the report
+	report := reports.MongoInterface{}
+	err = colReports.Find(bson.M{"info.name": reportName}).One(&report)
+
+	if err != nil {
+		if err.Error() == "not found" {
+			output, err = createMessageOUT(fmt.Sprintf("No report with name: %s exists!", reportName), 404, "json")
+			code = 404
+			return code, h, output, err
+		}
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	mprofileID := getReportMetricProfileID(report)
+
+	if mprofileID == "" {
+		output, err = createMessageOUT("Report doesn't contain a metric profile", 404, "json")
+		code = 404
+		return code, h, output, err
+	}
+
+	dt, dateStr, err := utils.ParseZuluDate(dateStr)
+	if err != nil {
+		code = http.StatusBadRequest
+		output, _ = respond.MarshalContent(respond.ErrBadRequestDetails(err.Error()), contentType, "", " ")
+		return code, h, output, err
+	}
+
+	mpQuery := prepQueryMprofile(dt, mprofileID)
+
+	colMProfiles := session.DB(tenantDbConfig.Db).C(mprofilesColName)
+	//get the report
+	mprofile := metricProfiles.MetricProfile{}
+	err = colMProfiles.Find(mpQuery).One(&mprofile)
+
+	if err != nil {
+		if err.Error() == "not found" {
+			output, err = createMessageOUT(fmt.Sprintf("No metric profiles with ID: %s exists!", mprofileID), 404, "json")
+			code = 404
+			return code, h, output, err
+		}
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	metrics := getMetricsFromProfile(mprofile)
+
+	// open a master session to the argo core database
+	coreSession, err := mongo.OpenSession(cfg.MongoDB)
+	defer mongo.CloseSession(coreSession)
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	// Retrieve Results from database
+	result := []Metric{}
+
+	if err != nil {
+		code = http.StatusBadRequest
+		output, _ = respond.MarshalContent(respond.ErrBadRequestDetails(err.Error()), contentType, "", " ")
+		return code, h, output, err
+	}
+
+	mCol := coreSession.DB(cfg.MongoDB.Db).C(metricsColName)
+	err = mCol.Find(bson.M{"name": bson.M{"$in": metrics}}).All(&result)
+
+	if err != nil {
+		if err.Error() == "not found" {
+			output, _ = respond.MarshalContent(respond.ErrNotFound, contentType, "", " ")
+			code = 404
+			return code, h, output, err
+		}
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	// Create view of the results
+	output, err = createMetricsListView(result, "Success", code) //Render the results into JSON
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+	return code, h, output, err
+}
+
+// Options request handler
+func Options(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
+
+	//STANDARD DECLARATIONS START
+
+	code := http.StatusOK
+	h := http.Header{}
+	output := []byte("")
+	err := error(nil)
+	contentType := "text/plain"
+	charset := "utf-8"
+
+	//STANDARD DECLARATIONS END
+
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+	h.Set("Allow", fmt.Sprintf("GET, POST, DELETE, PUT, OPTIONS"))
+	return code, h, output, err
+
+}

--- a/app/metrics/metrics__admin_test.go
+++ b/app/metrics/metrics__admin_test.go
@@ -1,0 +1,312 @@
+package metrics
+
+import (
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/ARGOeu/argo-web-api/respond"
+	"github.com/ARGOeu/argo-web-api/utils/config"
+	"github.com/ARGOeu/argo-web-api/utils/mongo"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/suite"
+	"gopkg.in/gcfg.v1"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+)
+
+// This is a util. suite struct used in tests (see pkg "testify")
+type MetricsAdminTestSuite struct {
+	suite.Suite
+	cfg                       config.Config
+	router                    *mux.Router
+	confHandler               respond.ConfHandler
+	tenantDbConf              config.MongoConfig
+	clientkey                 string
+	respRecomputationsCreated string
+	respUnauthorized          string
+}
+
+// Setup the Test Environment
+func (suite *MetricsAdminTestSuite) SetupSuite() {
+	const testConfig = `
+	 [server]
+	 bindip = ""
+	 port = 8080
+	 maxprocs = 4
+	 cache = false
+	 lrucache = 700000000
+	 gzip = true
+	 reqsizelimit = 1073741824
+ 
+	 [mongodb]
+	 host = "127.0.0.1"
+	 port = 27017
+	 db = "AR_test_metrics"
+	 `
+
+	_ = gcfg.ReadStringInto(&suite.cfg, testConfig)
+
+	suite.respUnauthorized = "Unauthorized"
+	suite.tenantDbConf = config.MongoConfig{
+		Host:     "localhost",
+		Port:     27017,
+		Db:       "AR_test_metrics_tenant",
+		Password: "pass",
+		Username: "dbuser",
+		Store:    "ar",
+	}
+	suite.clientkey = "SUPERADMINTOKEN"
+
+	suite.confHandler = respond.ConfHandler{Config: suite.cfg}
+	suite.router = mux.NewRouter().StrictSlash(false).PathPrefix("/api/v2/admin").Subrouter()
+	HandleAdminSubrouter(suite.router, &suite.confHandler)
+}
+
+// This function runs before any test and setups the environment
+func (suite *MetricsAdminTestSuite) SetupTest() {
+
+	log.SetOutput(ioutil.Discard)
+
+	// seed mongo
+	session, err := mgo.Dial(suite.cfg.MongoDB.Host)
+	if err != nil {
+		panic(err)
+	}
+	defer session.Close()
+
+	seedSuperAdmin := bson.M{"api_key": suite.clientkey}
+	seedAuth := bson.M{"api_key": "S3CR3T"}
+	seedResAuth := bson.M{"api_key": "R3STRICT3D", "restricted": true}
+	seedResAdminUI := bson.M{"api_key": "ADM1NU1", "super_admin_ui": true}
+	_ = mongo.Insert(session, suite.cfg.MongoDB.Db, "authentication", seedSuperAdmin)
+	_ = mongo.Insert(session, suite.cfg.MongoDB.Db, "authentication", seedAuth)
+	_ = mongo.Insert(session, suite.cfg.MongoDB.Db, "authentication", seedResAuth)
+	_ = mongo.Insert(session, suite.cfg.MongoDB.Db, "authentication", seedResAdminUI)
+
+	// Seed database with tenants
+	c := session.DB(suite.cfg.MongoDB.Db).C("tenants")
+	c.Insert(
+		bson.M{"id": "6ac7d684-1f8e-4a02-a502-720e8f11e50c",
+			"info": bson.M{
+				"name":    "TENANT_A",
+				"email":   "email@something2",
+				"website": "tenant-b.example.com",
+				"created": "2015-10-20 02:08:04",
+				"updated": "2015-10-20 02:08:04"},
+			"db_conf": []bson.M{
+
+				bson.M{
+					"server":   "localhost",
+					"port":     27017,
+					"database": "argo_FOO",
+				},
+				bson.M{
+					"server":   "localhost",
+					"port":     27017,
+					"database": "argo_FOO",
+				},
+			},
+			"users": []bson.M{
+
+				bson.M{
+					"name":    "user1",
+					"email":   "user1@email.com",
+					"api_key": "USER1KEY",
+					"roles":   []string{"editor"},
+				},
+				bson.M{
+					"name":    "user2",
+					"email":   "user2@email.com",
+					"api_key": "USER2KEY",
+					"roles":   []string{"editor"},
+				},
+			}})
+	c.Insert(
+		bson.M{"id": "6ac7d684-1f8e-4a02-a502-720e8f11e50d",
+			"info": bson.M{
+				"name":    "TENANT_B",
+				"email":   "email@something2",
+				"website": "tenanta.example.com",
+				"created": "2015-10-20 02:08:04",
+				"updated": "2015-10-20 02:08:04"},
+			"db_conf": []bson.M{
+
+				bson.M{
+					// "store":    "ar",
+					"server":   suite.tenantDbConf.Host,
+					"port":     suite.tenantDbConf.Port,
+					"database": suite.tenantDbConf.Db,
+					"username": suite.tenantDbConf.Username,
+					"password": suite.tenantDbConf.Password,
+				},
+				bson.M{
+					"server":   suite.tenantDbConf.Host,
+					"port":     suite.tenantDbConf.Port,
+					"database": suite.tenantDbConf.Db,
+				},
+			},
+			"users": []bson.M{
+
+				bson.M{
+					"name":    "user3",
+					"email":   "user3@email.com",
+					"api_key": "TESTKEY",
+					"roles":   []string{"editor"},
+				},
+				bson.M{
+					"name":    "user4",
+					"email":   "user4@email.com",
+					"api_key": "VIEWERKEY",
+					"roles":   []string{"viewer"},
+				},
+			}})
+
+	c = session.DB(suite.cfg.MongoDB.Db).C("roles")
+	c.Insert(
+		bson.M{
+			"resource": "metrics_admin.get",
+			"roles":    []string{"super_admin"},
+		})
+	c.Insert(
+		bson.M{
+			"resource": "metrics_admin.update",
+			"roles":    []string{"super_admin"},
+		})
+
+	// Seed database with metrics
+	c = session.DB(suite.cfg.MongoDB.Db).C("monitoring_metrics")
+	c.Insert(
+		bson.M{
+			"name": "test_metric_1",
+			"tags": []string{"network", "internal"},
+		})
+
+	c.Insert(
+		bson.M{
+			"name": "test_metric_2",
+			"tags": []string{"disk", "agent"},
+		})
+
+	c.Insert(
+		bson.M{
+			"name": "test_metric_3",
+			"tags": []string{"aai"},
+		})
+
+}
+
+func (suite *MetricsAdminTestSuite) TestAdminUpdateMetricData() {
+
+	jsonInput := `
+  [{"name":"metric1","tags":["tag1", "tag2"]}]
+`
+
+	jsonOutput := `{
+ "status": {
+  "message": "Metrics resource succesfully updated",
+  "code": "200"
+ },
+ "data": [
+  {
+   "name": "metric1",
+   "tags": [
+    "tag1",
+    "tag2"
+   ]
+  }
+ ]
+}`
+
+	request, _ := http.NewRequest("PUT", "/api/v2/admin/metrics", strings.NewReader(jsonInput))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code := response.Code
+	output := response.Body.String()
+
+	// Check that we must have a 200 ok code
+	suite.Equal(200, code, "Internal Server Error")
+	// Compare the expected and actual json response
+	suite.Equal(jsonOutput, output, "Response body mismatch")
+
+}
+
+func (suite *MetricsAdminTestSuite) TestAdminListMetrics() {
+
+	request, _ := http.NewRequest("GET", "/api/v2/admin/metrics", strings.NewReader(""))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code := response.Code
+	output := response.Body.String()
+
+	metricsJSON := `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "name": "test_metric_1",
+   "tags": [
+    "network",
+    "internal"
+   ]
+  },
+  {
+   "name": "test_metric_2",
+   "tags": [
+    "disk",
+    "agent"
+   ]
+  },
+  {
+   "name": "test_metric_3",
+   "tags": [
+    "aai"
+   ]
+  }
+ ]
+}`
+	// Check that we must have a 200 ok code
+	suite.Equal(200, code, "Internal Server Error")
+	// Compare the expected and actual json response
+	suite.Equal(metricsJSON, output, "Response body mismatch")
+
+}
+
+//TearDownTest to tear down every test
+func (suite *MetricsAdminTestSuite) TearDownTest() {
+
+	session, err := mgo.Dial(suite.cfg.MongoDB.Host)
+	if err != nil {
+		panic(err)
+	}
+	session.DB(suite.tenantDbConf.Db).DropDatabase()
+	session.DB(suite.cfg.MongoDB.Db).DropDatabase()
+}
+
+//TearDownTest to tear down every test
+func (suite *MetricsAdminTestSuite) TearDownSuite() {
+
+	session, err := mgo.Dial(suite.cfg.MongoDB.Host)
+	if err != nil {
+		panic(err)
+	}
+	session.DB(suite.tenantDbConf.Db).DropDatabase()
+	session.DB(suite.cfg.MongoDB.Db).DropDatabase()
+}
+
+func TestMetricsAdminTestSuite(t *testing.T) {
+	suite.Run(t, new(MetricsAdminTestSuite))
+}

--- a/app/metrics/metrics_test.go
+++ b/app/metrics/metrics_test.go
@@ -1,0 +1,376 @@
+package metrics
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/ARGOeu/argo-web-api/respond"
+	"github.com/ARGOeu/argo-web-api/utils/config"
+	"github.com/ARGOeu/argo-web-api/utils/mongo"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/suite"
+	"gopkg.in/gcfg.v1"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+)
+
+// This is a util. suite struct used in tests (see pkg "testify")
+type MetricsTestSuite struct {
+	suite.Suite
+	cfg                       config.Config
+	router                    *mux.Router
+	confHandler               respond.ConfHandler
+	tenantDbConf              config.MongoConfig
+	clientkey                 string
+	respRecomputationsCreated string
+	respUnauthorized          string
+}
+
+// Setup the Test Environment
+func (suite *MetricsTestSuite) SetupSuite() {
+	const testConfig = `
+	 [server]
+	 bindip = ""
+	 port = 8080
+	 maxprocs = 4
+	 cache = false
+	 lrucache = 700000000
+	 gzip = true
+	 reqsizelimit = 1073741824
+ 
+	 [mongodb]
+	 host = "127.0.0.1"
+	 port = 27017
+	 db = "AR_test_metrics"
+	 `
+
+	_ = gcfg.ReadStringInto(&suite.cfg, testConfig)
+
+	suite.respUnauthorized = "Unauthorized"
+	suite.tenantDbConf = config.MongoConfig{
+		Host:     "localhost",
+		Port:     27017,
+		Db:       "AR_test_metrics_tenant",
+		Password: "pass",
+		Username: "dbuser",
+		Store:    "ar",
+	}
+	suite.clientkey = "123456"
+
+	suite.confHandler = respond.ConfHandler{Config: suite.cfg}
+	suite.router = mux.NewRouter().StrictSlash(false).PathPrefix("/api/v2").Subrouter()
+	HandleSubrouter(suite.router, &suite.confHandler)
+}
+
+// This function runs before any test and setups the environment
+func (suite *MetricsTestSuite) SetupTest() {
+
+	log.SetOutput(ioutil.Discard)
+
+	// seed mongo
+	session, err := mgo.Dial(suite.cfg.MongoDB.Host)
+	if err != nil {
+		panic(err)
+	}
+	defer session.Close()
+
+	seedAuth := bson.M{"api_key": "S3CR3T"}
+	seedResAuth := bson.M{"api_key": "R3STRICT3D", "restricted": true}
+	seedResAdminUI := bson.M{"api_key": "ADM1NU1", "super_admin_ui": true}
+	_ = mongo.Insert(session, suite.cfg.MongoDB.Db, "authentication", seedAuth)
+	_ = mongo.Insert(session, suite.cfg.MongoDB.Db, "authentication", seedResAuth)
+	_ = mongo.Insert(session, suite.cfg.MongoDB.Db, "authentication", seedResAdminUI)
+
+	// Seed database with tenants
+	c := session.DB(suite.cfg.MongoDB.Db).C("tenants")
+	c.Insert(
+		bson.M{"id": "6ac7d684-1f8e-4a02-a502-720e8f11e50c",
+			"info": bson.M{
+				"name":    "TENANT_A",
+				"email":   "email@something2",
+				"website": "tenant-b.example.com",
+				"created": "2015-10-20 02:08:04",
+				"updated": "2015-10-20 02:08:04"},
+			"db_conf": []bson.M{
+
+				bson.M{
+					"server":   "localhost",
+					"port":     27017,
+					"database": "argo_FOO",
+				},
+				bson.M{
+					"server":   "localhost",
+					"port":     27017,
+					"database": "argo_FOO",
+				},
+			},
+			"users": []bson.M{
+
+				bson.M{
+					"name":    "user1",
+					"email":   "user1@email.com",
+					"api_key": "USER1KEY",
+					"roles":   []string{"editor"},
+				},
+				bson.M{
+					"name":    "user2",
+					"email":   "user2@email.com",
+					"api_key": "USER2KEY",
+					"roles":   []string{"editor"},
+				},
+			}})
+	c.Insert(
+		bson.M{"id": "6ac7d684-1f8e-4a02-a502-720e8f11e50d",
+			"info": bson.M{
+				"name":    "TENANT_B",
+				"email":   "email@something2",
+				"website": "tenanta.example.com",
+				"created": "2015-10-20 02:08:04",
+				"updated": "2015-10-20 02:08:04"},
+			"db_conf": []bson.M{
+
+				bson.M{
+					// "store":    "ar",
+					"server":   suite.tenantDbConf.Host,
+					"port":     suite.tenantDbConf.Port,
+					"database": suite.tenantDbConf.Db,
+					"username": suite.tenantDbConf.Username,
+					"password": suite.tenantDbConf.Password,
+				},
+				bson.M{
+					"server":   suite.tenantDbConf.Host,
+					"port":     suite.tenantDbConf.Port,
+					"database": suite.tenantDbConf.Db,
+				},
+			},
+			"users": []bson.M{
+
+				bson.M{
+					"name":    "user3",
+					"email":   "user3@email.com",
+					"api_key": suite.clientkey,
+					"roles":   []string{"editor"},
+				},
+				bson.M{
+					"name":    "user4",
+					"email":   "user4@email.com",
+					"api_key": "VIEWERKEY",
+					"roles":   []string{"viewer"},
+				},
+			}})
+
+	c = session.DB(suite.cfg.MongoDB.Db).C("roles")
+	c.Insert(
+		bson.M{
+			"resource": "metrics.get",
+			"roles":    []string{"admin", "editor", "viewer"},
+		})
+	c.Insert(
+		bson.M{
+			"resource": "metrics_report.get",
+			"roles":    []string{"admin", "editor", "viewer"},
+		})
+
+	// Seed database with metrics
+	c = session.DB(suite.cfg.MongoDB.Db).C("monitoring_metrics")
+	c.Insert(
+		bson.M{
+			"name": "test_metric_1",
+			"tags": []string{"network", "internal"},
+		})
+
+	c.Insert(
+		bson.M{
+			"name": "test_metric_2",
+			"tags": []string{"disk", "agent"},
+		})
+
+	c.Insert(
+		bson.M{
+			"name": "test_metric_3",
+			"tags": []string{"aai"},
+		})
+
+	c = session.DB(suite.tenantDbConf.Db).C("reports")
+
+	c.Insert(bson.M{
+		"id": "eba61a9e-22e9-4521-9e47-ecaa4a49436",
+		"info": bson.M{
+			"name":        "Critical",
+			"description": "lalalallala",
+		},
+		"topology_schema": bson.M{
+			"group": bson.M{
+				"type": "GROUP",
+				"group": bson.M{
+					"type": "SITE",
+				},
+			},
+		},
+		"profiles": []bson.M{
+			{
+				"type": "metric",
+				"id":   "6ac7d684-1f8e-4a02-a502-720e8f11e50b",
+				"name": "ch.cern.SAM.ROC_CRITICAL"},
+		},
+		"filter_tags": []bson.M{
+			{
+				"name":  "name1",
+				"value": "value1"},
+			{
+				"name":  "name2",
+				"value": "value2"},
+		}})
+
+	c = session.DB(suite.tenantDbConf.Db).C("metric_profiles")
+
+	c.EnsureIndexKey("-date_integer", "id")
+	c.Insert(
+		bson.M{
+			"id":           "6ac7d684-1f8e-4a02-a502-720e8f11e50b",
+			"name":         "ch.cern.SAM.ROC_CRITICAL",
+			"date_integer": 20191004,
+			"date":         "2019-10-04",
+			"description":  "critical profile",
+			"services": []bson.M{
+				bson.M{"service": "CREAM-CE",
+					"metrics": []string{
+						"emi.cream.CREAMCE-JobSubmit",
+						"test_metric_2",
+						"emi.wn.WN-Csh",
+						"emi.wn.WN-SoftVer"},
+				},
+				bson.M{"service": "SRMv2",
+					"metrics": []string{"hr.srce.SRM2-CertLifetime",
+						"org.sam.SRM-Del",
+						"test_metric_3",
+						"org.sam.SRM-GetSURLs",
+						"org.sam.SRM-GetTURLs",
+						"org.sam.SRM-Ls",
+						"org.sam.SRM-LsDir",
+						"org.sam.SRM-Put"},
+				},
+			},
+		})
+
+}
+
+func (suite *MetricsTestSuite) TestListMetrics() {
+
+	request, _ := http.NewRequest("GET", "/api/v2/metrics", strings.NewReader(""))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code := response.Code
+	output := response.Body.String()
+
+	metricsJSON := `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "name": "test_metric_1",
+   "tags": [
+    "network",
+    "internal"
+   ]
+  },
+  {
+   "name": "test_metric_2",
+   "tags": [
+    "disk",
+    "agent"
+   ]
+  },
+  {
+   "name": "test_metric_3",
+   "tags": [
+    "aai"
+   ]
+  }
+ ]
+}`
+	// Check that we must have a 200 ok code
+	suite.Equal(200, code, "Internal Server Error")
+	// Compare the expected and actual json response
+	suite.Equal(metricsJSON, output, "Response body mismatch")
+
+}
+
+func (suite *MetricsTestSuite) TestListMetricsByReport() {
+
+	request, _ := http.NewRequest("GET", "/api/v2/metrics/by_report/Critical", strings.NewReader(""))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code := response.Code
+	output := response.Body.String()
+
+	metricsJSON := `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "name": "test_metric_2",
+   "tags": [
+    "disk",
+    "agent"
+   ]
+  },
+  {
+   "name": "test_metric_3",
+   "tags": [
+    "aai"
+   ]
+  }
+ ]
+}`
+	// Check that we must have a 200 ok code
+	suite.Equal(200, code, "Internal Server Error")
+	// Compare the expected and actual json response
+	suite.Equal(metricsJSON, output, "Response body mismatch")
+	fmt.Println(output)
+
+}
+
+//TearDownTest to tear down every test
+func (suite *MetricsTestSuite) TearDownTest() {
+
+	session, err := mgo.Dial(suite.cfg.MongoDB.Host)
+	if err != nil {
+		panic(err)
+	}
+	session.DB(suite.tenantDbConf.Db).DropDatabase()
+	session.DB(suite.cfg.MongoDB.Db).DropDatabase()
+}
+
+//TearDownTest to tear down every test
+func (suite *MetricsTestSuite) TearDownSuite() {
+
+	session, err := mgo.Dial(suite.cfg.MongoDB.Host)
+	if err != nil {
+		panic(err)
+	}
+	session.DB(suite.tenantDbConf.Db).DropDatabase()
+	session.DB(suite.cfg.MongoDB.Db).DropDatabase()
+
+}
+
+func TestMetricsTestSuite(t *testing.T) {
+	suite.Run(t, new(MetricsTestSuite))
+}

--- a/app/metrics/model.go
+++ b/app/metrics/model.go
@@ -1,0 +1,16 @@
+package metrics
+
+import "encoding/xml"
+
+//Metric holds basic information about a metric profile and it's tags
+type Metric struct {
+	Name string   `bson:"name" json:"name"`
+	Tags []string `bson:"tags" json:"tags"`
+}
+
+// Message struct to hold the json/xml response
+type messageOUT struct {
+	XMLName xml.Name `xml:"root" json:"-"`
+	Message string   `xml:"message" json:"message"`
+	Code    string   `xml:"code,omitempty" json:"code,omitempty"`
+}

--- a/app/metrics/routing.go
+++ b/app/metrics/routing.go
@@ -1,0 +1,32 @@
+package metrics
+
+import (
+	"github.com/ARGOeu/argo-web-api/respond"
+	"github.com/gorilla/mux"
+)
+
+// HandleAdminSubrouter includes the admin specific calls (put/get)
+func HandleAdminSubrouter(s *mux.Router, confhandler *respond.ConfHandler) {
+
+	s = respond.PrepAppRoutes(s, confhandler, appAdminRoutesV2)
+
+}
+
+// HandleSubrouter includes the tenant only specific calls (get only)
+func HandleSubrouter(s *mux.Router, confhandler *respond.ConfHandler) {
+
+	s = respond.PrepAppRoutes(s, confhandler, appRoutesV2)
+
+}
+
+var appAdminRoutesV2 = []respond.AppRoutes{
+	{Name: "metrics_admin.update", Verb: "PUT", Path: "/metrics", SubrouterHandler: UpdateMetrics},
+	{Name: "metrics_admin.get", Verb: "GET", Path: "/metrics", SubrouterHandler: ListMetrics},
+	{Name: "metrics_admin.options", Verb: "OPTIONS", Path: "/metrics", SubrouterHandler: Options},
+}
+
+var appRoutesV2 = []respond.AppRoutes{
+	{Name: "metrics_report.get", Verb: "GET", Path: "/metrics/by_report/{report}", SubrouterHandler: ListMetricsByReport},
+	{Name: "metrics.get", Verb: "GET", Path: "/metrics", SubrouterHandler: ListMetrics},
+	{Name: "metrics.options", Verb: "OPTIONS", Path: "/metrics", SubrouterHandler: Options},
+}

--- a/app/metrics/view.go
+++ b/app/metrics/view.go
@@ -1,0 +1,49 @@
+package metrics
+
+import (
+	"encoding/json"
+	"strconv"
+
+	"github.com/ARGOeu/argo-web-api/respond"
+)
+
+// createMetricsListView constructs the list response template and exports it as json
+func createMetricsListView(results []Metric, msg string, code int) ([]byte, error) {
+
+	docRoot := &respond.ResponseMessage{
+		Status: respond.StatusResponse{
+			Message: msg,
+			Code:    strconv.Itoa(code),
+		},
+	}
+	docRoot.Data = results
+
+	output, err := json.MarshalIndent(docRoot, "", " ")
+	return output, err
+
+}
+
+// createMsgView constructs a simple message response without data
+func createMsgView(msg string, code int) ([]byte, error) {
+	docRoot := &respond.ResponseMessage{
+		Status: respond.StatusResponse{
+			Message: msg,
+			Code:    strconv.Itoa(code),
+		},
+	}
+
+	output, err := json.MarshalIndent(docRoot, "", " ")
+	return output, err
+}
+
+func createMessageOUT(message string, code int, format string) ([]byte, error) {
+
+	output := []byte("message placeholder")
+	err := error(nil)
+	docRoot := &messageOUT{}
+
+	docRoot.Message = message
+	docRoot.Code = strconv.Itoa(code)
+	output, err = respond.MarshalContent(docRoot, format, "", " ")
+	return output, err
+}

--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -2310,6 +2310,143 @@ paths:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Status_error'
+            
+  /metrics:
+    get:
+      summary: List of metrics
+      operationId: metrics.list
+      description: List of metrics
+      tags:
+        - Metrics
+      consumes:
+        - "application/json"
+      produces:
+        - "application/json"
+      parameters:
+        - $ref: "#/parameters/apiKey"
+    
+      responses:
+        '200':
+          description: list of metrics
+          schema:
+            $ref: '#/definitions/Self_reference'
+        '401':
+          description: Unauthorized user
+          schema:
+            $ref: '#/definitions/Status_error'
+        '406':
+          description: Content Not acceptable
+          schema:
+            $ref: '#/definitions/Status_error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Status_error'
+            
+  /metrics/by_report/{report_name}:
+    get:
+      summary: List metrics per date and filter by report
+      operationId: metrics_report.list
+      description: List metrics per date and filter by report
+      tags:
+        - Metrics
+      consumes:
+        - "application/json"
+      produces:
+        - "application/json"
+      parameters:
+        - in: path
+          name: report_name
+          type: string
+          description: filter results based on selected report
+          required: true
+        - $ref: "#/parameters/apiKey"
+        - $ref: "#/parameters/profDate"
+      responses:
+        '200':
+          description: filtered metric list based on the metric profile attached to the report
+          schema:
+            $ref: '#/definitions/Self_reference'
+        '401':
+          description: Unauthorized user
+          schema:
+            $ref: '#/definitions/Status_error'
+        '406':
+          description: Content Not acceptable
+          schema:
+            $ref: '#/definitions/Status_error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Status_error'
+            
+  /admin/metrics:
+    get:
+      summary: List of metrics (administrative)
+      operationId: metrics_admin.list
+      description: List of metrics from an admin point of view
+      tags:
+        - Metrics
+      consumes:
+        - "application/json"
+      produces:
+        - "application/json"
+      parameters:
+        - $ref: "#/parameters/apiKey"
+    
+      responses:
+        '200':
+          description: list of metrics
+          schema:
+            $ref: '#/definitions/Self_reference'
+        '401':
+          description: Unauthorized user
+          schema:
+            $ref: '#/definitions/Status_error'
+        '406':
+          description: Content Not acceptable
+          schema:
+            $ref: '#/definitions/Status_error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Status_error'
+    put:
+      summary: Update list of metrics (administrative)
+      operationId: metrics_admin.update
+      description: Update the list of metrics
+      tags:
+        - Metrics
+      consumes:
+        - "application/json"
+      produces:
+        - "application/json"
+      parameters:
+        - name: "endpoint_resource"
+          in: "body"
+          description: "Json description of endpoint topology items to be created"
+          required: true
+          schema:
+            $ref: '#/definitions/MetricList'
+        - $ref: "#/parameters/apiKey"
+        - $ref: "#/parameters/profDate"
+      responses:
+        '200':
+          description: Topology resource Created
+          schema:
+            $ref: '#/definitions/Self_reference'
+        '401':
+          description: Unauthorized user
+          schema:
+            $ref: '#/definitions/Status_error'
+        '406':
+          description: Content Not acceptable
+          schema:
+            $ref: '#/definitions/Status_error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Status_error'
 
   /latest/{report_name}/{lgroup_type}:
     get:
@@ -4480,6 +4617,23 @@ definitions:
       tags:
         type: object
         description: "key value tags"
+        
+  MetricList:
+    type: array
+    items:
+      $ref: '#/definitions/Metric'
+        
+  Metric:
+    type: object
+    properties:
+      name:
+        type: string
+        description: "the name of the metric"
+      tags:
+        type: array
+        description: "a list of tags attached to the metric"
+        items:
+           type: string
       
 
   FactorsResponse:

--- a/respond/wrappers.go
+++ b/respond/wrappers.go
@@ -21,7 +21,9 @@ import (
 // }
 
 func needsAPIAdmin(routeName string) bool {
-	if strings.Split(routeName, ".")[0] == "tenants" {
+
+	routePart := strings.Split(routeName, ".")[0]
+	if routePart == "tenants" || routePart == "metrics_admin" {
 		return true
 	}
 

--- a/routing/routes.go
+++ b/routing/routes.go
@@ -31,6 +31,7 @@ import (
 	"github.com/ARGOeu/argo-web-api/app/latest"
 	"github.com/ARGOeu/argo-web-api/app/metricProfiles"
 	"github.com/ARGOeu/argo-web-api/app/metricResult"
+	"github.com/ARGOeu/argo-web-api/app/metrics"
 	"github.com/ARGOeu/argo-web-api/app/operationsProfiles"
 	"github.com/ARGOeu/argo-web-api/app/recomputations2"
 	"github.com/ARGOeu/argo-web-api/app/reports"
@@ -70,7 +71,9 @@ var routesV2 = []RouteV2{
 	{"Aggregation Profiles", "", aggregationProfiles.HandleSubrouter},
 	{"Operations Profiles", "", operationsProfiles.HandleSubrouter},
 	{"Thresholds Profiles", "", thresholdsProfiles.HandleSubrouter},
+	{"Metrics", "", metrics.HandleSubrouter},
 	{"Tenants", "/admin", tenants.HandleSubrouter},
+	{"Metrics_Admin", "/admin", metrics.HandleAdminSubrouter},
 	{"Factors", "", factors.HandleSubrouter},
 	{"Version", "", version.HandleSubrouter},
 	{"Downtimes", "", downtimes.HandleSubrouter},

--- a/scripts/mongodb/populate_default_roles.js
+++ b/scripts/mongodb/populate_default_roles.js
@@ -246,7 +246,23 @@ function populate_default_roles() {
         {
             resource: "trends.status_endpoint_groups",
             roles: ["admin", "editor", "viewer", "admin_ui"]
-        }
+        },
+        {
+            resource: "metrics.get",
+            roles: ["admin", "editor", "viewer", "admin_ui"]
+        },
+        {
+            resource: "metrics_report.get",
+            roles: ["admin", "editor", "viewer", "admin_ui"]
+        },
+        {
+            resource: "metrics_admin.get",
+            roles: ["super_admin"]
+        },
+        {
+            resource: "metrics_admin.update",
+            roles: ["super_admin"]
+        },
     ]);
     print("INFO\tPolulated default roles in 'roles' collection");
 }

--- a/website/docs/metric_results.md
+++ b/website/docs/metric_results.md
@@ -1,0 +1,380 @@
+---
+id: metric_results
+title: Metric Results
+---
+
+## API call for retrieving detailed metric result.
+
+### [GET]: Metric Result
+
+This method may be used to retrieve a specific service metric result.
+
+### Input
+
+```
+/metric_result/{hostname}/{metric_name}?[exec_time]
+```
+
+#### Path Parameters
+| Type | Description | Required | Default value |
+|------|-------------|----------|---------------|
+|`hostname`| hostname of service endpoint| YES |  |
+|`metric_name`| name of the metric| YES |  |
+
+#### Url Parameters
+
+| Type | Description | Required | Default value |
+|------|-------------|----------|---------------|
+|`exec_time`| The execution date of query in zulu format| YES |  |
+
+___Notes___:
+`exec_time` : The execution date of query in zulu format. In order to get the correct execution time get status results for all metrics (under a given endpoint, service and endpoint group). ( GET /status/{report_name}/{lgroup_type}/{lgroup_name}/services/{service_name}/endpoints/{endpoint_name}/metrics List)
+
+#### Headers
+```
+x-api-key: shared_key_value
+Accept: application/json or application/xml
+```
+
+#### Response Code
+```
+Status: 200 OK
+```
+
+### Response body
+
+###### Example Request:
+URL:
+```
+/api/v2/metric_result/www.example.com/httpd_check?exec_time=2015-06-20T12:00:00Z
+```
+Headers:
+```
+x-api-key: shared_key_value
+Accept: application/json or application/xml
+
+```
+###### Example Response:
+
+Code:
+```
+Status: 200 OK
+```
+Reponse body:
+```
+ {
+   "root": [
+     {
+       "Name": "www.example.com",
+       "Metrics": [
+         {
+           "Name": "httpd_check",
+           "Service": "httpd",
+           "Details": [
+             {
+               "Timestamp": "2015-06-20T12:00:00Z",
+               "Value": "OK",
+               "Summary": "httpd is ok",
+               "Message": "all checks ok"
+             }
+           ]
+         }
+       ]
+     }
+   ]
+ }
+ 
+```
+
+## [GET]: Multiple Metric Results for a specific host, on a specific day
+
+This method may be used to retrieve multiple service metric results for a specific host on a specific day
+
+### Input
+
+```
+/metric_result/{hostname}?[exec_time]
+```
+
+#### Path Parameters
+| Type | Description | Required | Default value |
+|------|-------------|----------|---------------|
+|`hostname`| hostname of service endpoint| YES |  |
+
+#### Url Parameters
+
+| Type | Description | Required | Default value |
+|------|-------------|----------|---------------|
+|`exec_time`| The execution date of query in zulu format - timepart is irrelevant (can be 00:00:00Z) | YES |  |
+|`filter`| Filter metric results by statuses: non-ok, ok, critical, warning | NO |  |
+
+___Notes___:
+`exec_time` : The specific date of query in zulu format. The time part of the date is irrelevant because all metrics of that day are returned. ( GET /status/{report_name}/{lgroup_type}/{lgroup_name}/services/{service_name}/endpoints/{endpoint_name}/metrics List)
+
+#### Headers
+```
+x-api-key: shared_key_value
+Accept: application/json or application/xml
+```
+
+#### Response Code
+```
+Status: 200 OK
+```
+
+### Response body
+
+###### Example Request:
+URL:
+```
+/api/v2/metric_result/www.example.com?exec_time=2015-06-20T00:00:00Z
+```
+Headers:
+```
+x-api-key: shared_key_value
+Accept: application/json or application/xml
+
+```
+###### Example Response:
+
+Code:
+```
+Status: 200 OK
+```
+Reponse body:
+```
+{
+   "root": [
+     {
+       "Name": "www.example.com",
+       "Metrics": [
+         {
+           "Name": "httpd_check",
+           "Service": "httpd",
+           "Details": [
+             {
+               "Timestamp": "2015-06-20T12:00:00Z",
+               "Value": "OK",
+               "Summary": "httpd is ok",
+               "Message": "all checks ok"
+             },
+              {
+               "Timestamp": "2015-06-20T18:00:00Z",
+               "Value": "CRITICAL",
+               "Summary": "httpd is critical",
+               "Message": "some checks failed"
+             },
+              {
+               "Timestamp": "2015-06-20T23:00:00Z",
+               "Value": "OK",
+               "Summary": "httpd is ok",
+               "Message": "all checks ok"
+             }
+           ]
+         },
+         {
+           "Name": "httpd_memory",
+           "Service": "httpd",
+           "Details": [
+             {
+               "Timestamp": "2015-06-20T06:00:00Z",
+               "Value": "OK",
+               "Summary": "memcheck ok",
+               "Message": "memory under 20%"
+             },
+             {
+               "Timestamp": "2015-06-20T09:00:00Z",
+               "Value": "OK",
+               "Summary": "memcheck ok",
+               "Message": "memory under 20%"
+             },
+             {
+               "Timestamp": "2015-06-20T18:00:00Z",
+               "Value": "OK",
+               "Summary": "memcheck ok",
+               "Message": "memory under 20%"
+             },
+           ]
+         }
+       ]
+     }
+   ]
+ }
+```
+
+###### Example Request with filter parameter set to `non-ok`:
+URL:
+```
+/api/v2/metric_result/www.example.com?exec_time=2015-06-20T00:00:00Z&filter=non-ok
+```
+Headers:
+```
+x-api-key: shared_key_value
+Accept: application/json or application/xml
+
+```
+###### Example Response using fitler parameter set to `non-ok`:
+
+Code:
+```
+Status: 200 OK
+```
+Reponse body:
+```
+{
+   "root": [
+     {
+       "Name": "www.example.com",
+       "Metrics": [
+         {
+           "Name": "httpd_check",
+           "Service": "httpd",
+           "Details": [
+              {
+               "Timestamp": "2015-06-20T18:00:00Z",
+               "Value": "CRITICAL",
+               "Summary": "httpd is critical",
+               "Message": "some checks failed"
+              }
+           ]
+         }
+       ]
+     }
+   ]
+ }
+```
+
+###### Example Request with filter parameter set to `ok`:
+URL:
+```
+/api/v2/metric_result/www.example.com?exec_time=2015-06-20T00:00:00Z&filter=ok
+```
+Headers:
+```
+x-api-key: shared_key_value
+Accept: application/json or application/xml
+
+```
+###### Example Response using fitler parameter set to `ok`:
+
+Code:
+```
+Status: 200 OK
+```
+Reponse body:
+```
+{
+   "root": [
+     {
+       "Name": "www.example.com",
+       "Metrics": [
+         {
+           "Name": "httpd_check",
+           "Service": "httpd",
+           "Details": [
+             {
+               "Timestamp": "2015-06-20T12:00:00Z",
+               "Value": "OK",
+               "Summary": "httpd is ok",
+               "Message": "all checks ok"
+             },
+             {
+               "Timestamp": "2015-06-20T23:00:00Z",
+               "Value": "OK",
+               "Summary": "httpd is ok",
+               "Message": "all checks ok"
+             }
+           ]
+         },
+         {
+           "Name": "httpd_memory",
+           "Service": "httpd",
+           "Details": [
+             {
+               "Timestamp": "2015-06-20T06:00:00Z",
+               "Value": "OK",
+               "Summary": "memcheck ok",
+               "Message": "memory under 20%"
+             },
+             {
+               "Timestamp": "2015-06-20T09:00:00Z",
+               "Value": "OK",
+               "Summary": "memcheck ok",
+               "Message": "memory under 20%"
+             },
+             {
+               "Timestamp": "2015-06-20T18:00:00Z",
+               "Value": "OK",
+               "Summary": "memcheck ok",
+               "Message": "memory under 20%"
+             },
+           ]
+         }
+       ]
+     }
+   ]
+ }
+```
+
+### Extra endpoint information on metric results
+
+Some metric results have additional information regarding the specific service endpoint such as it's Url, certificat DN etc... If this information is available it will be displayed under each service endpoint along with status results. For example:
+
+
+
+```
+{
+   "root": [
+     {
+       "Name": "www.example.com",
+       "info": {
+                  "Url": "https://example.com/path/to/service/check"
+               },
+       "Metrics": [
+         {
+           "Name": "httpd_check",
+           "Service": "httpd",
+           "Details": [
+             {
+               "Timestamp": "2015-06-20T12:00:00Z",
+               "Value": "OK",
+               "Summary": "httpd is ok",
+               "Message": "all checks ok"
+             },
+             {
+               "Timestamp": "2015-06-20T23:00:00Z",
+               "Value": "OK",
+               "Summary": "httpd is ok",
+               "Message": "all checks ok"
+             }
+           ]
+         },
+         {
+           "Name": "httpd_memory",
+           "Service": "httpd",
+           "Details": [
+             {
+               "Timestamp": "2015-06-20T06:00:00Z",
+               "Value": "OK",
+               "Summary": "memcheck ok",
+               "Message": "memory under 20%"
+             },
+             {
+               "Timestamp": "2015-06-20T09:00:00Z",
+               "Value": "OK",
+               "Summary": "memcheck ok",
+               "Message": "memory under 20%"
+             },
+             {
+               "Timestamp": "2015-06-20T18:00:00Z",
+               "Value": "OK",
+               "Summary": "memcheck ok",
+               "Message": "memory under 20%"
+             },
+           ]
+         }
+       ]
+     }
+   ]
+ }
+```

--- a/website/docs/metrics.md
+++ b/website/docs/metrics.md
@@ -1,380 +1,243 @@
 ---
-id: metric_results
-title: Metric Resulst
+id: metrics
+title: Metrics
 ---
+## API Calls
 
-## API call for retrieving detailed metric result.
+| Name                                  | Description                                                                     | Shortcut           |
+| ------------------------------------- | ------------------------------------------------------------------------------- | ------------------ |
+| GET: List Metrics (Admin)   | This method can be used to retrieve a list of all metrics         | [ Description](#1) |
+| PUT: Update Metrics (Admin) | This method can be used to update the list of metrics | [ Description](#2) |
+| GET: List Metrics  | This method can be used to retrieve a list of metrics (as a tenant user)        | [ Description](#3) |
+| PUT: List Metrics by report | This method can be used to retrieve a list of metrics included in a report (as a tenant user) | [ Description](#4) |
 
-### [GET]: Metric Result
 
-This method may be used to retrieve a specific service metric result.
+<a id='1'></a>
 
-### Input
+## [GET]: List Metrics (Admin)
 
-```
-/metric_result/{hostname}/{metric_name}?[exec_time]
-```
-
-#### Path Parameters
-| Type | Description | Required | Default value |
-|------|-------------|----------|---------------|
-|`hostname`| hostname of service endpoint| YES |  |
-|`metric_name`| name of the metric| YES |  |
-
-#### Url Parameters
-
-| Type | Description | Required | Default value |
-|------|-------------|----------|---------------|
-|`exec_time`| The execution date of query in zulu format| YES |  |
-
-___Notes___:
-`exec_time` : The execution date of query in zulu format. In order to get the correct execution time get status results for all metrics (under a given endpoint, service and endpoint group). ( GET /status/{report_name}/{lgroup_type}/{lgroup_name}/services/{service_name}/endpoints/{endpoint_name}/metrics List)
-
-#### Headers
-```
-x-api-key: shared_key_value
-Accept: application/json or application/xml
-```
-
-#### Response Code
-```
-Status: 200 OK
-```
-
-### Response body
-
-###### Example Request:
-URL:
-```
-/api/v2/metric_result/www.example.com/httpd_check?exec_time=2015-06-20T12:00:00Z
-```
-Headers:
-```
-x-api-key: shared_key_value
-Accept: application/json or application/xml
-
-```
-###### Example Response:
-
-Code:
-```
-Status: 200 OK
-```
-Reponse body:
-```
- {
-   "root": [
-     {
-       "Name": "www.example.com",
-       "Metrics": [
-         {
-           "Name": "httpd_check",
-           "Service": "httpd",
-           "Details": [
-             {
-               "Timestamp": "2015-06-20T12:00:00Z",
-               "Value": "OK",
-               "Summary": "httpd is ok",
-               "Message": "all checks ok"
-             }
-           ]
-         }
-       ]
-     }
-   ]
- }
- 
-```
-
-## [GET]: Multiple Metric Results for a specific host, on a specific day
-
-This method may be used to retrieve multiple service metric results for a specific host on a specific day
+This method can be used to retrieve a list of all metrics. This is an administrative method. The Metric list is common for all tenants
 
 ### Input
 
 ```
-/metric_result/{hostname}?[exec_time]
+GET /admin/metrics
 ```
 
-#### Path Parameters
-| Type | Description | Required | Default value |
-|------|-------------|----------|---------------|
-|`hostname`| hostname of service endpoint| YES |  |
+
+### Request headers
+
+```
+x-api-key: shared_key_value
+Accept: application/json
+```
+
+### Response
+
+Headers: `Status: 200 OK`
+
+#### Response body
+
+Json Response
+
+```json
+{
+  "status": {
+    "message": "Success",
+    "code": "200"
+  },
+  "data": [
+    {
+      "name": "test_metric_1",
+      "tags": [
+        "network",
+        "internal"
+      ]
+    },
+    {
+      "name": "test_metric_2",
+      "tags": [
+        "disk",
+        "agent"
+      ]
+    },
+    {
+      "name": "test_metric_3",
+      "tags": [
+        "aai"
+      ]
+    }
+  ]
+}
+```
+
+<a id='2'></a>
+
+## [PUT]: Update Metrics information
+This method is used to update the list of metrics. This is an administrative method. The list of metrics is common for all tenants
+
+### Input
+
+```
+PUT /admin/metrics
+```
+
+#### PUT BODY
+```json
+  [
+  {
+    "name": "metric1",
+    "tags": [
+      "tag1",
+      "tag2"
+    ]
+  }
+]
+```
+
+#### Request headers
+
+```
+x-api-key: shared_key_value
+Accept: application/json
+```
+
+### Response
+
+Headers: `Status: 200 OK`
+
+#### Response body
+
+Json Response
+
+```json
+{
+  "status": {
+    "message": "Metrics resource succesfully updated",
+    "code": "200"
+  },
+  "data": [
+    {
+      "name": "metric1",
+      "tags": [
+        "tag1",
+        "tag2"
+      ]
+    }
+  ]
+}
+```
+
+
+<a id='3'></a>
+
+## [GET]: List Metrics (as a tenant user)
+
+This method can be used to retrieve the list of metrics as a tenant user. The list of metrics is common for all tenants but accessible from each tenant.
+
+### Input
+
+```
+GET /metrics
+```
+
+
+### Request headers
+
+```
+x-api-key: shared_key_value
+Accept: application/json
+```
+
+### Response
+
+Headers: `Status: 200 OK`
+
+#### Response body
+
+Json Response
+
+```json
+{
+  "status": {
+    "message": "Success",
+    "code": "200"
+  },
+  "data": [
+    {
+      "name": "test_metric_1",
+      "tags": [
+        "network",
+        "internal"
+      ]
+    },
+    {
+      "name": "test_metric_2",
+      "tags": [
+        "disk",
+        "agent"
+      ]
+    },
+    {
+      "name": "test_metric_3",
+      "tags": [
+        "aai"
+      ]
+    }
+  ]
+}
+```
+
+
+<a id='4'></a>
+
+## [PUT]: List metrics by report (as a tenant user)
+This method is used to retrieve a list of metrics that are included in the metric profile of a specific report.
+
+### Input
+
+```
+PUT /metrics/by_report/{report_name}
+```
 
 #### Url Parameters
 
-| Type | Description | Required | Default value |
-|------|-------------|----------|---------------|
-|`exec_time`| The execution date of query in zulu format - timepart is irrelevant (can be 00:00:00Z) | YES |  |
-|`filter`| Filter metric results by statuses: non-ok, ok, critical, warning | NO |  |
+| Type          | Description              | Required | Default value |
+| ------------- | ------------------------ | -------- | ------------- |
+| `report_name` | target a specific report | YES      | none          |
+| `date`        | target a specific date   | NO       | today's date  |
 
-___Notes___:
-`exec_time` : The specific date of query in zulu format. The time part of the date is irrelevant because all metrics of that day are returned. ( GET /status/{report_name}/{lgroup_type}/{lgroup_name}/services/{service_name}/endpoints/{endpoint_name}/metrics List)
 
-#### Headers
+#### Request headers
+
 ```
 x-api-key: shared_key_value
-Accept: application/json or application/xml
+Accept: application/json
 ```
 
-#### Response Code
-```
-Status: 200 OK
-```
+### Response
 
-### Response body
+Headers: `Status: 200 OK`
 
-###### Example Request:
-URL:
-```
-/api/v2/metric_result/www.example.com?exec_time=2015-06-20T00:00:00Z
-```
-Headers:
-```
-x-api-key: shared_key_value
-Accept: application/json or application/xml
+#### Response body
 
-```
-###### Example Response:
+Json Response
 
-Code:
-```
-Status: 200 OK
-```
-Reponse body:
-```
+```json
+```json
 {
-   "root": [
-     {
-       "Name": "www.example.com",
-       "Metrics": [
-         {
-           "Name": "httpd_check",
-           "Service": "httpd",
-           "Details": [
-             {
-               "Timestamp": "2015-06-20T12:00:00Z",
-               "Value": "OK",
-               "Summary": "httpd is ok",
-               "Message": "all checks ok"
-             },
-              {
-               "Timestamp": "2015-06-20T18:00:00Z",
-               "Value": "CRITICAL",
-               "Summary": "httpd is critical",
-               "Message": "some checks failed"
-             },
-              {
-               "Timestamp": "2015-06-20T23:00:00Z",
-               "Value": "OK",
-               "Summary": "httpd is ok",
-               "Message": "all checks ok"
-             }
-           ]
-         },
-         {
-           "Name": "httpd_memory",
-           "Service": "httpd",
-           "Details": [
-             {
-               "Timestamp": "2015-06-20T06:00:00Z",
-               "Value": "OK",
-               "Summary": "memcheck ok",
-               "Message": "memory under 20%"
-             },
-             {
-               "Timestamp": "2015-06-20T09:00:00Z",
-               "Value": "OK",
-               "Summary": "memcheck ok",
-               "Message": "memory under 20%"
-             },
-             {
-               "Timestamp": "2015-06-20T18:00:00Z",
-               "Value": "OK",
-               "Summary": "memcheck ok",
-               "Message": "memory under 20%"
-             },
-           ]
-         }
-       ]
-     }
-   ]
- }
-```
-
-###### Example Request with filter parameter set to `non-ok`:
-URL:
-```
-/api/v2/metric_result/www.example.com?exec_time=2015-06-20T00:00:00Z&filter=non-ok
-```
-Headers:
-```
-x-api-key: shared_key_value
-Accept: application/json or application/xml
-
-```
-###### Example Response using fitler parameter set to `non-ok`:
-
-Code:
-```
-Status: 200 OK
-```
-Reponse body:
-```
-{
-   "root": [
-     {
-       "Name": "www.example.com",
-       "Metrics": [
-         {
-           "Name": "httpd_check",
-           "Service": "httpd",
-           "Details": [
-              {
-               "Timestamp": "2015-06-20T18:00:00Z",
-               "Value": "CRITICAL",
-               "Summary": "httpd is critical",
-               "Message": "some checks failed"
-              }
-           ]
-         }
-       ]
-     }
-   ]
- }
-```
-
-###### Example Request with filter parameter set to `ok`:
-URL:
-```
-/api/v2/metric_result/www.example.com?exec_time=2015-06-20T00:00:00Z&filter=ok
-```
-Headers:
-```
-x-api-key: shared_key_value
-Accept: application/json or application/xml
-
-```
-###### Example Response using fitler parameter set to `ok`:
-
-Code:
-```
-Status: 200 OK
-```
-Reponse body:
-```
-{
-   "root": [
-     {
-       "Name": "www.example.com",
-       "Metrics": [
-         {
-           "Name": "httpd_check",
-           "Service": "httpd",
-           "Details": [
-             {
-               "Timestamp": "2015-06-20T12:00:00Z",
-               "Value": "OK",
-               "Summary": "httpd is ok",
-               "Message": "all checks ok"
-             },
-             {
-               "Timestamp": "2015-06-20T23:00:00Z",
-               "Value": "OK",
-               "Summary": "httpd is ok",
-               "Message": "all checks ok"
-             }
-           ]
-         },
-         {
-           "Name": "httpd_memory",
-           "Service": "httpd",
-           "Details": [
-             {
-               "Timestamp": "2015-06-20T06:00:00Z",
-               "Value": "OK",
-               "Summary": "memcheck ok",
-               "Message": "memory under 20%"
-             },
-             {
-               "Timestamp": "2015-06-20T09:00:00Z",
-               "Value": "OK",
-               "Summary": "memcheck ok",
-               "Message": "memory under 20%"
-             },
-             {
-               "Timestamp": "2015-06-20T18:00:00Z",
-               "Value": "OK",
-               "Summary": "memcheck ok",
-               "Message": "memory under 20%"
-             },
-           ]
-         }
-       ]
-     }
-   ]
- }
-```
-
-### Extra endpoint information on metric results
-
-Some metric results have additional information regarding the specific service endpoint such as it's Url, certificat DN etc... If this information is available it will be displayed under each service endpoint along with status results. For example:
-
-
-
-```
-{
-   "root": [
-     {
-       "Name": "www.example.com",
-       "info": {
-                  "Url": "https://example.com/path/to/service/check"
-               },
-       "Metrics": [
-         {
-           "Name": "httpd_check",
-           "Service": "httpd",
-           "Details": [
-             {
-               "Timestamp": "2015-06-20T12:00:00Z",
-               "Value": "OK",
-               "Summary": "httpd is ok",
-               "Message": "all checks ok"
-             },
-             {
-               "Timestamp": "2015-06-20T23:00:00Z",
-               "Value": "OK",
-               "Summary": "httpd is ok",
-               "Message": "all checks ok"
-             }
-           ]
-         },
-         {
-           "Name": "httpd_memory",
-           "Service": "httpd",
-           "Details": [
-             {
-               "Timestamp": "2015-06-20T06:00:00Z",
-               "Value": "OK",
-               "Summary": "memcheck ok",
-               "Message": "memory under 20%"
-             },
-             {
-               "Timestamp": "2015-06-20T09:00:00Z",
-               "Value": "OK",
-               "Summary": "memcheck ok",
-               "Message": "memory under 20%"
-             },
-             {
-               "Timestamp": "2015-06-20T18:00:00Z",
-               "Value": "OK",
-               "Summary": "memcheck ok",
-               "Message": "memory under 20%"
-             },
-           ]
-         }
-       ]
-     }
-   ]
- }
+  "status": {
+    "message": "Success",
+    "code": "200"
+  },
+  "data": [
+    {
+      "name": "test_metric_1",
+      "tags": [
+        "network",
+        "internal"
+      ]
+    }
+  ]
+}
 ```


### PR DESCRIPTION
### Goal
superpoem associates metrics with tags for better description. This information doesn't exist yet in the argo-web-api. We must implement an api resource to hold this info as a list of metrics (described by `name` and `tags` fields)

### Implementation

The metric list is common for all tenants

There are two adminstrative calls to view and update the list:
- `PUT` `/api/v2/admin/metrics/` updates the metric list
- `GET` `/api/v2/admin/metrics/` returns the metric list

The metric list is also readable only from each tenants
There are two tenant-scoped calls to view the metric list:
- `PUT` `/api/v2/metrics` returns the whole metric list
- `GET` `/api/v2/metrics/by_report/{report_name}` returns only the metrics relevant to a report

Example response of a metric list:

```json
{
  "status": {
    "message": "Success",
    "code": "200"
  },
  "data": [
    {
      "name": "test_metric_1",
      "tags": [
        "network",
        "internal"
      ]
    },
    {
      "name": "test_metric_2",
      "tags": [
        "disk",
        "agent"
      ]
    },
    {
      "name": "test_metric_3",
      "tags": [
        "aai"
      ]
    }
  ]
}
```

- [x] Create a new package metrics to handle metrics-related calls
- [x] Create a metrics controller to support the api requests
- [x] Create metric related models for data orm
- [x] Create metric related views for responses
- [x] Add unit tests
- [x] Add documentation (docusaurus)
- [x] Update swagger