### PR TITLE
ARGO-3452 Fix threshold rule applied field value in status metrics

### DIFF
--- a/app/statusFlatMetrics/statusFlatMetrics_test.go
+++ b/app/statusFlatMetrics/statusFlatMetrics_test.go
@@ -640,7 +640,7 @@ func (suite *StatusFlatMetricsTestSuite) TestFlatListStatusMetrics() {
      "timestamp": "2015-05-01T01:00:00Z",
      "value": "CRITICAL",
      "actual_data": "latency=15s",
-     "threshold_rule_applied": "latency=15s",
+     "threshold_rule_applied": "latency=1s;0:5;10:60",
      "original_status": "OK"
     }
    ]

--- a/app/statusFlatMetrics/view.go
+++ b/app/statusFlatMetrics/view.go
@@ -98,7 +98,7 @@ func createFlatView(results []DataOutput, input InputParams, endDate string, lim
 		if details {
 			status.ActualData = row.ActualData
 			status.OriginalStatus = row.OriginalStatus
-			status.RuleApplied = row.ActualData
+			status.RuleApplied = row.RuleApplied
 		}
 		ppHost.Statuses = append(ppHost.Statuses, status)
 

--- a/app/statusMetrics/statusMetrics_test.go
+++ b/app/statusMetrics/statusMetrics_test.go
@@ -579,7 +579,7 @@ func (suite *StatusMetricsTestSuite) TestListStatusMetrics() {
            "timestamp": "2015-05-01T01:00:00Z",
            "value": "CRITICAL",
            "actual_data": "latency=15s",
-           "threshold_rule_applied": "latency=15s",
+           "threshold_rule_applied": "latency=1s;0:5;10:60",
            "original_status": "OK"
           },
           {
@@ -958,7 +958,7 @@ func (suite *StatusMetricsTestSuite) TestMultipleItemsDetails() {
            "timestamp": "2015-05-01T01:00:00Z",
            "value": "CRITICAL",
            "actual_data": "latency=15s",
-           "threshold_rule_applied": "latency=15s",
+           "threshold_rule_applied": "latency=1s;0:5;10:60",
            "original_status": "OK"
           },
           {

--- a/app/statusMetrics/view.go
+++ b/app/statusMetrics/view.go
@@ -135,7 +135,7 @@ func createView(results []DataOutput, input InputParams, endDate string, details
 		if details {
 			status.ActualData = row.ActualData
 			status.OriginalStatus = row.OriginalStatus
-			status.RuleApplied = row.ActualData
+			status.RuleApplied = row.RuleApplied
 		}
 		ppMetric.Statuses = append(ppMetric.Statuses, status)
 


### PR DESCRIPTION
### Issue
"threshold_rule_applied" field erroneously showed the "actual_data" field value instead of the actual rule applied

### Fix 
- [x] Fix erroneously field reference when creating the result views  
- [x] Update unit tests