### PR TITLE
ARGO-3408 Serve threshold flag trough web-api

### DIFF
--- a/app/statusEndpointGroups/controller.go
+++ b/app/statusEndpointGroups/controller.go
@@ -83,6 +83,13 @@ func ListEndpointGroupTimelines(r *http.Request, cfg config.Config) (int, http.H
 		contentType,
 	}
 
+	// This is going to be used to determine a detailed view or not of the results
+	view := urlValues.Get("view")
+	details := false
+	if view == "details" {
+		details = true
+	}
+
 	dataSrc := urlValues.Get("datasource")
 	// If hbase bypass mongo session
 	if dataSrc == "hbase" {
@@ -102,7 +109,7 @@ func ListEndpointGroupTimelines(r *http.Request, cfg config.Config) (int, http.H
 		doResults := hbaseToDataOutput(hbResults)
 
 		// Render the reults into xml
-		output, errHb = createView(doResults, input, urlValues.Get("end_time")) //Render the results into JSON/XML format
+		output, errHb = createView(doResults, input, urlValues.Get("end_time"), details) //Render the results into JSON/XML format
 
 		h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
 		return code, h, output, errHb
@@ -148,7 +155,7 @@ func ListEndpointGroupTimelines(r *http.Request, cfg config.Config) (int, http.H
 		}
 	}
 
-	output, err = createView(results, input, urlValues.Get("end_time")) //Render the results into JSON/XML format
+	output, err = createView(results, input, urlValues.Get("end_time"), details) //Render the results into JSON/XML format
 
 	return code, h, output, err
 }

--- a/app/statusEndpointGroups/model.go
+++ b/app/statusEndpointGroups/model.go
@@ -39,11 +39,12 @@ type InputParams struct {
 
 // DataOutput struct holds the queried data from datastore
 type DataOutput struct {
-	Report        string `bson:"report"`
-	Timestamp     string `bson:"timestamp"`
-	EndpointGroup string `bson:"endpoint_group"`
-	Status        string `bson:"status"`
-	DateInteger   string `bson:"date_integer"`
+	Report           string `bson:"report"`
+	Timestamp        string `bson:"timestamp"`
+	EndpointGroup    string `bson:"endpoint_group"`
+	Status           string `bson:"status"`
+	DateInteger      string `bson:"date_integer"`
+	HasThresholdRule bool   `bson:"has_threshold_rule"`
 }
 
 // xml response related structs
@@ -61,9 +62,10 @@ type endpointGroupOUT struct {
 }
 
 type statusOUT struct {
-	XMLName   xml.Name `xml:"status" json:"-"`
-	Timestamp string   `xml:"timestamp,attr" json:"timestamp"`
-	Value     string   `xml:"value,attr" json:"value"`
+	XMLName                 xml.Name `xml:"status" json:"-"`
+	Timestamp               string   `xml:"timestamp,attr" json:"timestamp"`
+	Value                   string   `xml:"value,attr" json:"value"`
+	AffectedByThresholdRule bool     `xml:"-" json:"affected_by_threshold_rule,omitempty"`
 }
 
 // Message struct to hold the json/xml response

--- a/app/statusEndpointGroups/statusEndpointGroups_test.go
+++ b/app/statusEndpointGroups/statusEndpointGroups_test.go
@@ -248,11 +248,12 @@ func (suite *StatusEndpointGroupsTestSuite) SetupTest() {
 		"status":         "WARNING",
 	})
 	c.Insert(bson.M{
-		"report":         "eba61a9e-22e9-4521-9e47-ecaa4a494364",
-		"date_integer":   20150501,
-		"timestamp":      "2015-05-01T17:53:00Z",
-		"endpoint_group": "HG-02-AUTH",
-		"status":         "CRITICAL",
+		"report":             "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date_integer":       20150501,
+		"timestamp":          "2015-05-01T17:53:00Z",
+		"endpoint_group":     "HG-02-AUTH",
+		"status":             "CRITICAL",
+		"has_threshold_rule": true,
 	})
 
 	// get dbconfiguration based on the tenant
@@ -634,6 +635,78 @@ func (suite *StatusEndpointGroupsTestSuite) TestMultipleItems() {
     {
      "timestamp": "2015-05-01T17:53:00Z",
      "value": "CRITICAL"
+    },
+    {
+     "timestamp": "2015-05-01T23:59:59Z",
+     "value": "CRITICAL"
+    }
+   ]
+  }
+ ]
+}`
+
+	// init the response placeholder
+	response := httptest.NewRecorder()
+	// Prepare the request object for second tenant
+	request, _ := http.NewRequest("GET", fullurl1, strings.NewReader(""))
+	// add json accept header
+	request.Header.Set("Accept", "application/json")
+	// add the authentication token which is seeded in testdb
+	request.Header.Set("x-api-key", "KEY1")
+	// Serve the http request
+	suite.router.ServeHTTP(response, request)
+	// Check that we must have a 200 ok code
+	suite.Equal(200, response.Code, "Internal Server Error")
+	// Compare the expected and actual xml response
+	suite.Equal(respJSON1, response.Body.String(), "Response body mismatch")
+
+}
+
+func (suite *StatusEndpointGroupsTestSuite) TestThresholds() {
+
+	fullurl1 := "/api/v2/status/Report_A/SITES" +
+		"?start_time=2015-05-01T00:00:00Z&end_time=2015-05-01T23:00:00Z&view=details"
+
+	respJSON1 := `{
+ "groups": [
+  {
+   "name": "HG-03-AUTH",
+   "type": "SITES",
+   "statuses": [
+    {
+     "timestamp": "2015-05-01T00:00:00Z",
+     "value": "OK"
+    },
+    {
+     "timestamp": "2015-05-01T01:00:00Z",
+     "value": "CRITICAL"
+    },
+    {
+     "timestamp": "2015-05-01T05:00:00Z",
+     "value": "OK"
+    },
+    {
+     "timestamp": "2015-05-01T23:59:59Z",
+     "value": "OK"
+    }
+   ]
+  },
+  {
+   "name": "HG-02-AUTH",
+   "type": "SITES",
+   "statuses": [
+    {
+     "timestamp": "2015-05-01T00:00:00Z",
+     "value": "OK"
+    },
+    {
+     "timestamp": "2015-05-01T03:00:00Z",
+     "value": "WARNING"
+    },
+    {
+     "timestamp": "2015-05-01T17:53:00Z",
+     "value": "CRITICAL",
+     "affected_by_threshold_rule": true
     },
     {
      "timestamp": "2015-05-01T23:59:59Z",

--- a/app/statusEndpointGroups/view.go
+++ b/app/statusEndpointGroups/view.go
@@ -52,7 +52,7 @@ func hbaseToDataOutput(hResults []*hrpc.Result) []DataOutput {
 	return dResult
 }
 
-func createView(results []DataOutput, input InputParams, endDate string) ([]byte, error) {
+func createView(results []DataOutput, input InputParams, endDate string, details bool) ([]byte, error) {
 
 	// calculate part of the timestamp that closes the timeline of each item
 	var extraTS string
@@ -107,6 +107,10 @@ func createView(results []DataOutput, input InputParams, endDate string) ([]byte
 		status := &statusOUT{}
 		status.Timestamp = row.Timestamp
 		status.Value = row.Status
+		if details {
+			status.AffectedByThresholdRule = row.HasThresholdRule
+		}
+
 		ppEndpointGroup.Statuses = append(ppEndpointGroup.Statuses, status)
 
 	}

--- a/app/statusEndpoints/controller.go
+++ b/app/statusEndpoints/controller.go
@@ -110,6 +110,13 @@ func FlatListEndpointTimelines(r *http.Request, cfg config.Config) (int, http.He
 		contentType,
 	}
 
+	// This is going to be used to determine a detailed view or not of the results
+	view := urlValues.Get("view")
+	details := false
+	if view == "details" {
+		details = true
+	}
+
 	dataSrc := urlValues.Get("datasource")
 	// If hbase bypass mongo session
 	if dataSrc == "hbase" {
@@ -127,7 +134,7 @@ func FlatListEndpointTimelines(r *http.Request, cfg config.Config) (int, http.He
 		// Convert hbase results to data output format
 		doResults := hbaseToDataOutput(hbResults)
 		// Render the reults into xml
-		output, err = createView(doResults, input, urlValues.Get("end_time")) //Render the results into JSON/XML format
+		output, err = createView(doResults, input, urlValues.Get("end_time"), details) //Render the results into JSON/XML format
 
 		h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
 		return code, h, output, errHb
@@ -171,7 +178,7 @@ func FlatListEndpointTimelines(r *http.Request, cfg config.Config) (int, http.He
 		}
 	}
 
-	output, err = createView(results, input, urlValues.Get("end_time")) //Render the results into JSON/XML format
+	output, err = createView(results, input, urlValues.Get("end_time"), details) //Render the results into JSON/XML format
 
 	return code, h, output, err
 }
@@ -211,6 +218,13 @@ func ListEndpointTimelines(r *http.Request, cfg config.Config) (int, http.Header
 		contentType,
 	}
 
+	// This is going to be used to determine a detailed view or not of the results
+	view := urlValues.Get("view")
+	details := false
+	if view == "details" {
+		details = true
+	}
+
 	dataSrc := urlValues.Get("datasource")
 	// If hbase bypass mongo session
 	if dataSrc == "hbase" {
@@ -228,7 +242,7 @@ func ListEndpointTimelines(r *http.Request, cfg config.Config) (int, http.Header
 		// Convert hbase results to data output format
 		doResults := hbaseToDataOutput(hbResults)
 		// Render the reults into xml
-		output, err = createView(doResults, input, urlValues.Get("end_time")) //Render the results into JSON/XML format
+		output, err = createView(doResults, input, urlValues.Get("end_time"), details) //Render the results into JSON/XML format
 
 		h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
 		return code, h, output, errHb
@@ -272,7 +286,7 @@ func ListEndpointTimelines(r *http.Request, cfg config.Config) (int, http.Header
 		}
 	}
 
-	output, err = createView(results, input, urlValues.Get("end_time")) //Render the results into JSON/XML format
+	output, err = createView(results, input, urlValues.Get("end_time"), details) //Render the results into JSON/XML format
 
 	return code, h, output, err
 }

--- a/app/statusEndpoints/model.go
+++ b/app/statusEndpoints/model.go
@@ -41,14 +41,15 @@ type InputParams struct {
 
 // DataOutput struct holds the queried data from datastore
 type DataOutput struct {
-	Report        string            `bson:"report"`
-	Timestamp     string            `bson:"timestamp"`
-	EndpointGroup string            `bson:"endpoint_group"`
-	Service       string            `bson:"service"`
-	Hostname      string            `bson:"host"`
-	Status        string            `bson:"status"`
-	DateInt       string            `bson:"date_integer"`
-	Info          map[string]string `bson:"info"`
+	Report           string            `bson:"report"`
+	Timestamp        string            `bson:"timestamp"`
+	EndpointGroup    string            `bson:"endpoint_group"`
+	Service          string            `bson:"service"`
+	Hostname         string            `bson:"host"`
+	Status           string            `bson:"status"`
+	DateInt          string            `bson:"date_integer"`
+	HasThresholdRule bool              `bson:"has_threshold_rule"`
+	Info             map[string]string `bson:"info"`
 }
 
 // json/xml response related structs
@@ -89,9 +90,10 @@ type endpointOUT struct {
 }
 
 type statusOUT struct {
-	XMLName   xml.Name `xml:"status" json:"-"`
-	Timestamp string   `xml:"timestamp,attr" json:"timestamp"`
-	Value     string   `xml:"value,attr" json:"value"`
+	XMLName                 xml.Name `xml:"status" json:"-"`
+	Timestamp               string   `xml:"timestamp,attr" json:"timestamp"`
+	Value                   string   `xml:"value,attr" json:"value"`
+	AffectedByThresholdRule bool     `xml:"-" json:"affected_by_threshold_rule,omitempty"`
 }
 
 // Message struct to hold the json/xml response

--- a/app/statusEndpoints/statusEndpoints_test.go
+++ b/app/statusEndpoints/statusEndpoints_test.go
@@ -293,14 +293,15 @@ func (suite *StatusEndpointsTestSuite) SetupTest() {
 		"status":         "UNKNOWN",
 	})
 	c.Insert(bson.M{
-		"report":         "eba61a9e-22e9-4521-9e47-ecaa4a494364",
-		"date_integer":   20150501,
-		"timestamp":      "2015-05-01T06:00:00Z",
-		"endpoint_group": "HG-03-AUTH",
-		"service":        "CREAM-CE",
-		"host":           "cream03.afroditi.gr",
-		"metric":         "emi.cream.CREAMCE-JobSubmit",
-		"status":         "CRITICAL",
+		"report":             "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date_integer":       20150501,
+		"timestamp":          "2015-05-01T06:00:00Z",
+		"endpoint_group":     "HG-03-AUTH",
+		"service":            "CREAM-CE",
+		"host":               "cream03.afroditi.gr",
+		"metric":             "emi.cream.CREAMCE-JobSubmit",
+		"status":             "CRITICAL",
+		"has_threshold_rule": true,
 	})
 
 	// get dbconfiguration based on the tenant
@@ -754,6 +755,113 @@ func (suite *StatusEndpointsTestSuite) TestMultipleItems() {
         {
          "timestamp": "2015-05-01T06:00:00Z",
          "value": "CRITICAL"
+        },
+        {
+         "timestamp": "2015-05-01T23:59:59Z",
+         "value": "CRITICAL"
+        }
+       ]
+      }
+     ]
+    }
+   ]
+  }
+ ]
+}`
+
+	// init the response placeholder
+	response := httptest.NewRecorder()
+	// Prepare the request object for second tenant
+	request, _ := http.NewRequest("GET", fullurl1, strings.NewReader(""))
+	// add json accept header
+	request.Header.Set("Accept", "application/json")
+	// add the authentication token which is seeded in testdb
+	request.Header.Set("x-api-key", "KEY1")
+	// Serve the http request
+	suite.router.ServeHTTP(response, request)
+	// Check that we must have a 200 ok code
+	suite.Equal(200, response.Code, "Internal Server Error")
+	// Compare the expected and actual xml response
+	suite.Equal(respJSON1, response.Body.String(), "Response body mismatch")
+
+}
+
+func (suite *StatusEndpointsTestSuite) TestThresholds() {
+
+	fullurl1 := "/api/v2/status/Report_A/SITES/HG-03-AUTH" +
+		"/services/CREAM-CE/endpoints" +
+		"?start_time=2015-05-01T00:00:00Z&end_time=2015-05-01T23:00:00Z&view=details"
+
+	respJSON1 := `{
+ "groups": [
+  {
+   "name": "HG-03-AUTH",
+   "type": "SITES",
+   "services": [
+    {
+     "name": "CREAM-CE",
+     "type": "service",
+     "endpoints": [
+      {
+       "name": "cream01.afroditi.gr",
+       "info": {
+        "Url": "http://example.foo/path/to/service"
+       },
+       "statuses": [
+        {
+         "timestamp": "2015-05-01T00:00:00Z",
+         "value": "OK"
+        },
+        {
+         "timestamp": "2015-05-01T01:00:00Z",
+         "value": "CRITICAL"
+        },
+        {
+         "timestamp": "2015-05-01T05:00:00Z",
+         "value": "OK"
+        },
+        {
+         "timestamp": "2015-05-01T23:59:59Z",
+         "value": "OK"
+        }
+       ]
+      },
+      {
+       "name": "cream02.afroditi.gr",
+       "statuses": [
+        {
+         "timestamp": "2015-05-01T00:00:00Z",
+         "value": "OK"
+        },
+        {
+         "timestamp": "2015-05-01T08:47:00Z",
+         "value": "WARNING"
+        },
+        {
+         "timestamp": "2015-05-01T12:00:00Z",
+         "value": "OK"
+        },
+        {
+         "timestamp": "2015-05-01T23:59:59Z",
+         "value": "OK"
+        }
+       ]
+      },
+      {
+       "name": "cream03.afroditi.gr",
+       "statuses": [
+        {
+         "timestamp": "2015-05-01T00:00:00Z",
+         "value": "OK"
+        },
+        {
+         "timestamp": "2015-05-01T04:40:00Z",
+         "value": "UNKNOWN"
+        },
+        {
+         "timestamp": "2015-05-01T06:00:00Z",
+         "value": "CRITICAL",
+         "affected_by_threshold_rule": true
         },
         {
          "timestamp": "2015-05-01T23:59:59Z",

--- a/app/statusEndpoints/view.go
+++ b/app/statusEndpoints/view.go
@@ -56,7 +56,7 @@ func hbaseToDataOutput(hResults []*hrpc.Result) []DataOutput {
 	return dResult
 }
 
-func createView(results []DataOutput, input InputParams, endDate string) ([]byte, error) {
+func createView(results []DataOutput, input InputParams, endDate string, details bool) ([]byte, error) {
 
 	// calculate part of the timestamp that closes the timeline of each item
 	var extraTS string
@@ -134,6 +134,10 @@ func createView(results []DataOutput, input InputParams, endDate string) ([]byte
 		status := &statusOUT{}
 		status.Timestamp = row.Timestamp
 		status.Value = row.Status
+		if details {
+			status.AffectedByThresholdRule = row.HasThresholdRule
+		}
+
 		ppHost.Statuses = append(ppHost.Statuses, status)
 
 	}

--- a/app/statusFlatEndpoints/controller.go
+++ b/app/statusFlatEndpoints/controller.go
@@ -110,6 +110,13 @@ func FlatListEndpointTimelines(r *http.Request, cfg config.Config) (int, http.He
 		contentType,
 	}
 
+	// This is going to be used to determine a detailed view or not of the results
+	view := urlValues.Get("view")
+	details := false
+	if view == "details" {
+		details = true
+	}
+
 	dataSrc := urlValues.Get("datasource")
 	// If hbase bypass mongo session
 	if dataSrc == "hbase" {
@@ -127,7 +134,7 @@ func FlatListEndpointTimelines(r *http.Request, cfg config.Config) (int, http.He
 		// Convert hbase results to data output format
 		doResults := hbaseToDataOutput(hbResults)
 		// Render the reults into xml
-		output, err = createFlatView(doResults, input, urlValues.Get("end_time"), limit, skip) //Render the results into JSON/XML format
+		output, err = createFlatView(doResults, input, urlValues.Get("end_time"), limit, skip, details) //Render the results into JSON/XML format
 
 		h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
 		return code, h, output, errHb
@@ -171,7 +178,7 @@ func FlatListEndpointTimelines(r *http.Request, cfg config.Config) (int, http.He
 		}
 	}
 
-	output, err = createFlatView(results, input, urlValues.Get("end_time"), limit, skip) //Render the results into JSON/XML format
+	output, err = createFlatView(results, input, urlValues.Get("end_time"), limit, skip, details) //Render the results into JSON/XML format
 
 	return code, h, output, err
 }

--- a/app/statusFlatEndpoints/model.go
+++ b/app/statusFlatEndpoints/model.go
@@ -41,14 +41,15 @@ type InputParams struct {
 
 // DataOutput struct holds the queried data from datastore
 type DataOutput struct {
-	Report        string            `bson:"report"`
-	Timestamp     string            `bson:"timestamp"`
-	EndpointGroup string            `bson:"endpoint_group"`
-	Service       string            `bson:"service"`
-	Hostname      string            `bson:"host"`
-	Status        string            `bson:"status"`
-	DateInt       string            `bson:"date_integer"`
-	Info          map[string]string `bson:"info"`
+	Report           string            `bson:"report"`
+	Timestamp        string            `bson:"timestamp"`
+	EndpointGroup    string            `bson:"endpoint_group"`
+	Service          string            `bson:"service"`
+	Hostname         string            `bson:"host"`
+	Status           string            `bson:"status"`
+	DateInt          string            `bson:"date_integer"`
+	Info             map[string]string `bson:"info"`
+	HasThresholdRule bool              `bson:"has_threshold_rule"`
 }
 
 // json/xml response related structs
@@ -70,9 +71,10 @@ type endpointOUT struct {
 }
 
 type statusOUT struct {
-	XMLName   xml.Name `xml:"status" json:"-"`
-	Timestamp string   `xml:"timestamp,attr" json:"timestamp"`
-	Value     string   `xml:"value,attr" json:"value"`
+	XMLName                 xml.Name `xml:"status" json:"-"`
+	Timestamp               string   `xml:"timestamp,attr" json:"timestamp"`
+	Value                   string   `xml:"value,attr" json:"value"`
+	AffectedByThresholdRule bool     `xml:"-" json:"affected_by_threshold_rule,omitempty"`
 }
 
 // Message struct to hold the json/xml response

--- a/app/statusFlatEndpoints/statusFlatEndpoints_test.go
+++ b/app/statusFlatEndpoints/statusFlatEndpoints_test.go
@@ -293,14 +293,15 @@ func (suite *StatusEndpointsTestSuite) SetupTest() {
 		"status":         "UNKNOWN",
 	})
 	c.Insert(bson.M{
-		"report":         "eba61a9e-22e9-4521-9e47-ecaa4a494364",
-		"date_integer":   20150501,
-		"timestamp":      "2015-05-01T06:00:00Z",
-		"endpoint_group": "HG-03-AUTH",
-		"service":        "CREAM-CE",
-		"host":           "cream03.afroditi.gr",
-		"metric":         "emi.cream.CREAMCE-JobSubmit",
-		"status":         "CRITICAL",
+		"report":             "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date_integer":       20150501,
+		"timestamp":          "2015-05-01T06:00:00Z",
+		"endpoint_group":     "HG-03-AUTH",
+		"service":            "CREAM-CE",
+		"host":               "cream03.afroditi.gr",
+		"metric":             "emi.cream.CREAMCE-JobSubmit",
+		"status":             "CRITICAL",
+		"has_threshold_rule": true,
 	})
 
 	// get dbconfiguration based on the tenant
@@ -744,6 +745,35 @@ func (suite *StatusEndpointsTestSuite) TestFlatListStatusEndpoints() {
     {
      "timestamp": "2015-05-01T06:00:00Z",
      "value": "CRITICAL"
+    },
+    {
+     "timestamp": "2015-05-01T23:59:59Z",
+     "value": "CRITICAL"
+    }
+   ]
+  }
+ ],
+ "pageSize": 4
+}`,
+		},
+
+		expReq{
+			method: "GET",
+			url: "/api/v2/status/Report_A/endpoints" +
+				"?start_time=2015-05-01T00:00:00Z&end_time=2015-05-01T23:00:00Z&pageSize=4&nextPageToken=OA==&view=details",
+			code: 200,
+			key:  "KEY1",
+			result: `{
+ "endpoints": [
+  {
+   "name": "cream03.afroditi.gr",
+   "service": "CREAM-CE",
+   "supergroup": "HG-03-AUTH",
+   "statuses": [
+    {
+     "timestamp": "2015-05-01T06:00:00Z",
+     "value": "CRITICAL",
+     "affected_by_threshold_rule": true
     },
     {
      "timestamp": "2015-05-01T23:59:59Z",

--- a/app/statusFlatEndpoints/view.go
+++ b/app/statusFlatEndpoints/view.go
@@ -56,7 +56,7 @@ func hbaseToDataOutput(hResults []*hrpc.Result) []DataOutput {
 	return dResult
 }
 
-func createFlatView(results []DataOutput, input InputParams, endDate string, limit int, skip int) ([]byte, error) {
+func createFlatView(results []DataOutput, input InputParams, endDate string, limit int, skip int, details bool) ([]byte, error) {
 
 	// calculate part of the timestamp that closes the timeline of each item
 	var extraTS string
@@ -128,6 +128,10 @@ func createFlatView(results []DataOutput, input InputParams, endDate string, lim
 		status := &statusOUT{}
 		status.Timestamp = row.Timestamp
 		status.Value = row.Status
+		if details {
+			status.AffectedByThresholdRule = row.HasThresholdRule
+		}
+
 		ppHost.Statuses = append(ppHost.Statuses, status)
 
 	}

--- a/app/statusServices/controller.go
+++ b/app/statusServices/controller.go
@@ -83,6 +83,13 @@ func ListServiceTimelines(r *http.Request, cfg config.Config) (int, http.Header,
 		contentType,
 	}
 
+	// This is going to be used to determine a detailed view or not of the results
+	view := urlValues.Get("view")
+	details := false
+	if view == "details" {
+		details = true
+	}
+
 	dataSrc := urlValues.Get("datasource")
 	// If hbase bypass mongo session
 	if dataSrc == "hbase" {
@@ -100,7 +107,7 @@ func ListServiceTimelines(r *http.Request, cfg config.Config) (int, http.Header,
 		// Convert hbase results to data output format
 		doResults := hbaseToDataOutput(hbResults)
 		// Render the reults into xml
-		output, err = createView(doResults, input, urlValues.Get("end_time")) //Render the results into XML format
+		output, err = createView(doResults, input, urlValues.Get("end_time"), details) //Render the results into XML format
 
 		h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
 		return code, h, output, errHb
@@ -144,7 +151,7 @@ func ListServiceTimelines(r *http.Request, cfg config.Config) (int, http.Header,
 		}
 	}
 
-	output, err = createView(results, input, urlValues.Get("end_time")) //Render the results into XML format
+	output, err = createView(results, input, urlValues.Get("end_time"), details) //Render the results into XML format
 
 	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
 	return code, h, output, err

--- a/app/statusServices/model.go
+++ b/app/statusServices/model.go
@@ -40,12 +40,13 @@ type InputParams struct {
 
 // DataOutput struct holds the queried data from datastore
 type DataOutput struct {
-	Report        string `bson:"report"`
-	Timestamp     string `bson:"timestamp"`
-	EndpointGroup string `bson:"endpoint_group"`
-	Service       string `bson:"service"`
-	Status        string `bson:"status"`
-	DateInteger   string `bson:"date_integer"`
+	Report           string `bson:"report"`
+	Timestamp        string `bson:"timestamp"`
+	EndpointGroup    string `bson:"endpoint_group"`
+	Service          string `bson:"service"`
+	Status           string `bson:"status"`
+	DateInteger      string `bson:"date_integer"`
+	HasThresholdRule bool   `bson:"has_threshold_rule"`
 }
 
 // xml/json response related structs
@@ -70,9 +71,10 @@ type serviceOUT struct {
 }
 
 type statusOUT struct {
-	XMLName   xml.Name `xml:"status" json:"-"`
-	Timestamp string   `xml:"timestamp,attr" json:"timestamp"`
-	Value     string   `xml:"value,attr" json:"value"`
+	XMLName                 xml.Name `xml:"status" json:"-"`
+	Timestamp               string   `xml:"timestamp,attr" json:"timestamp"`
+	Value                   string   `xml:"value,attr" json:"value"`
+	AffectedByThresholdRule bool     `xml:"-" json:"affected_by_threshold_rule,omitempty"`
 }
 
 // Message struct to hold the xml/json response

--- a/app/statusServices/view.go
+++ b/app/statusServices/view.go
@@ -53,7 +53,7 @@ func hbaseToDataOutput(hResults []*hrpc.Result) []DataOutput {
 	return dResult
 }
 
-func createView(results []DataOutput, input InputParams, endDate string) ([]byte, error) {
+func createView(results []DataOutput, input InputParams, endDate string, details bool) ([]byte, error) {
 
 	// calculate part of the timestamp that closes the timeline of each item
 	var extraTS string
@@ -121,6 +121,10 @@ func createView(results []DataOutput, input InputParams, endDate string) ([]byte
 		status := &statusOUT{}
 		status.Timestamp = row.Timestamp
 		status.Value = row.Status
+		if details {
+			status.AffectedByThresholdRule = row.HasThresholdRule
+		}
+
 		ppService.Statuses = append(ppService.Statuses, status)
 
 	}

--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -4756,6 +4756,8 @@ definitions:
         type: string
       value:
         type: string
+      affected_by_threshold_rule:
+        type: boolean
 
   results:
     type: array

--- a/website/docs/status.md
+++ b/website/docs/status.md
@@ -646,7 +646,55 @@ Some service endpoint status results have additional information regarding the s
     }
   ]
 }
+```
 
+### Threshold rule information in status endpoint timelines
+
+By using the url parameter `view=details` the argo-web-api will enrich the status timeline results with additional information in case a threshold rule has been applied to the results. For example:
+
+```
+{
+  "groups": [
+    {
+      "name": "HG-03-AUTH",
+      "type": "SITES",
+      "services": [
+        {
+          "name": "CREAM-CE",
+          "type": "service",
+          "endpoints": [
+            {
+              "name": "cream01.afroditi.gr",
+              "info": {
+                  "Url": "https://cream01.afroditi.gr/path/to/service"
+               },
+              "statuses": [
+                {
+                  "timestamp": "2015-04-30T23:59:00Z",
+                  "value": "OK"
+                },
+                {
+                  "timestamp": "2015-05-01T01:00:00Z",
+                  "value": "CRITICAL",
+                  "affected_by_threshold_rule": true
+                },
+                {
+                  "timestamp": "2015-05-01T02:00:00Z",
+                  "value": "OK"
+                },
+                {
+                  "timestamp": "2015-05-01T23:59:59Z",
+                  "value": "OK"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
 
 <a id="3"></a>
 
@@ -864,6 +912,48 @@ Response body (JSON):
 }
 ```
 
+### Threshold rule information in status service timelines
+
+By using the url parameter `view=details` the argo-web-api will enrich the status timeline results with additional information in case a threshold rule has been applied to the results. For example:
+
+
+```
+{
+  "groups": [
+    {
+      "name": "HG-03-AUTH",
+      "type": "SITES",
+      "services": [
+        {
+          "name": "CREAM-CE",
+          "type": "service",
+          "statuses": [
+            {
+              "timestamp": "2015-04-30T23:59:00Z",
+              "value": "OK"
+            },
+            {
+              "timestamp": "2015-05-01T01:00:00Z",
+              "value": "CRITICAL",
+              "affected_by_threshold_rule": true
+            },
+            {
+              "timestamp": "2015-05-01T02:00:00Z",
+              "value": "OK"
+            },
+            {
+              "timestamp": "2015-05-01T23:59:59Z",
+              "value": "OK"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+
 <a id="4"></a>
 
 
@@ -1048,6 +1138,41 @@ Response body (JSON):
         {
           "timestamp": "2015-05-01T02:00:00Z",
           "value": "WARNING"
+        },
+        {
+          "timestamp": "2015-05-01T05:00:00Z",
+          "value": "OK"
+        },
+        {
+          "timestamp": "2015-05-01T23:59:59Z",
+          "value": "OK"
+        }
+      ]
+    }
+  ]
+}
+```
+
+### Threshold rule information in status endpoint group timelines
+
+By using the url parameter `view=details` the argo-web-api will enrich the status timeline results with additional information in case a threshold rule has been applied to the results. For example:
+
+
+```
+{
+  "groups": [
+    {
+      "name": "HG-03-AUTH",
+      "type": "SITES",
+      "statuses": [
+        {
+          "timestamp": "2015-05-01T00:00:00Z",
+          "value": "CRITICAL"
+        },
+        {
+          "timestamp": "2015-05-01T02:00:00Z",
+          "value": "WARNING",
+          "affected_by_threshold_rule": true
         },
         {
           "timestamp": "2015-05-01T05:00:00Z",
@@ -1422,3 +1547,51 @@ Status: 200 OK
   "pageSize": 2
 }
 ```
+
+### Threshold rule information in flat status endpoint group timelines
+
+By using the url parameter `view=details` the argo-web-api will enrich the status timeline results with additional information in case a threshold rule has been applied to the results. For example:
+
+
+
+```
+{
+  "results": [
+    {
+      "type":"endpoint_metric",
+      "name": "someservice.example.gr",
+      "service": "someService",
+      "supergroup": "GROUPA",
+      "metric": "someService-FileTransfer",
+      "statuses": [
+        {
+          "timestamp": "2015-05-01T05:00:00Z",
+          "value": "OK"
+        }
+      ]
+    },
+    {
+      "type":"endpoint_metric",
+      "name": "someservice2.example.gr",
+      "service": "someService",
+      "supergroup": "GROUPA",
+      "metric": "someService-FileTransfer",
+      "statuses": [
+        {
+          "timestamp": "2015-04-30T23:59:00Z",
+          "value": "OK",
+          "affected_by_threshold_rule": true
+        },
+        {
+          "timestamp": "2015-05-01T00:00:00Z",
+          "value": "OK"
+        }
+      ]
+    }
+  ],
+  "nextPageToken": "NA==",
+  "pageSize": 2
+}
+```
+
+


### PR DESCRIPTION
## Goal
Display info if a status has been affected by a threshold rules on top level results:
- endpoints
- services
- groups

## Example usage

By using the url parameter `view=details` the argo-web-api will enrich the status timeline results with additional information in case a threshold rule has been applied to the results. For example:


```json
{
  "groups": [
    {
      "name": "SITE-A",
      "type": "SITES",
      "services": [
        {
          "name": "SERVICE-A",
          "type": "service",
          "statuses": [
            {
              "timestamp": "2015-04-30T23:59:00Z",
              "value": "OK"
            },
            {
              "timestamp": "2015-05-01T01:00:00Z",
              "value": "CRITICAL",
              "affected_by_threshold_rule": true
            },
            {
              "timestamp": "2015-05-01T02:00:00Z",
              "value": "OK"
            },
            {
              "timestamp": "2015-05-01T23:59:59Z",
              "value": "OK"
            }
          ]
        }
      ]
    }
  ]
}
```

## Implementation
- [x] Add logic to controller in statusEndpoints package
- [x] Add logic to controller in statusFlatEndpoints package
- [x] Add logic to controller in statusServices package
- [x] Add logic to controller in statusEndpointGroups package
- [x] Update unit tests
- [x] Update docs