### PR TITLE
ARGO-3657 Fix docs to correctly display metric/tags docs in sidebar

### DIFF
--- a/website/docs/metrics.md
+++ b/website/docs/metrics.md
@@ -1,6 +1,6 @@
 ---
 id: metrics
-title: Metrics
+title: Available Metrics and Tags
 ---
 ## API Calls
 

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -1,6 +1,6 @@
 module.exports = {
   someSidebar: {
-    'Tenants & Feeds': ['tenants', 'feeds', 'downtimes', 'topology_endpoints', 'topology_groups', 'weights'],
+    'Tenants & Feeds': ['tenants', 'feeds', 'downtimes', 'topology_endpoints', 'topology_groups', 'weights', 'metrics'],
     'Profiles & Reports': ['operations_profiles', 'metric_profiles', 'aggregation_profiles', 'threshold_profiles', 'reports'],
     'Results' : ['ar_results', 'status_results', 'issues', 'trends', 'metric_results', 'topology_stats', 'recomputations'],
     'Validations & Errors': ['validations', 'errors']


### PR DESCRIPTION
Fix: Display Doc about list of metric/tags that was missing from content sidebar