### PR TITLE
ARGO-3690 Provide proper not found response when requesting details a…

### DIFF
--- a/app/metricResult/controller.go
+++ b/app/metricResult/controller.go
@@ -149,6 +149,23 @@ func GetMetricResult(r *http.Request, cfg config.Config) (int, http.Header, []by
 	// Query the detailed metric results
 	err = metricCol.Find(prepQuery(input, reportID)).One(&result)
 
+	// if not found or other issue
+	if err != nil {
+		if err.Error() == "not found" {
+			code = http.StatusNotFound
+			message := "Metric not found!"
+			output, err := createErrorMessage(message, code, contentType)
+			h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+			return code, h, output, err
+		} else {
+			code = http.StatusInternalServerError
+			message := "Internal Server Error!"
+			output, err := createErrorMessage(message, code, contentType)
+			h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+			return code, h, output, err
+		}
+	}
+
 	output, err = createMetricResultView(result, contentType)
 
 	if err != nil {

--- a/app/metricResult/metric_test.go
+++ b/app/metricResult/metric_test.go
@@ -266,6 +266,11 @@ func (suite *metricResultTestSuite) TestReadStatusDetail() {
    ]
  }`
 
+	respNotFound := `{
+   "message": "Metric not found!",
+   "code": 404
+ }`
+
 	request, _ := http.NewRequest("GET", "/api/v2/metric_result/cream01.afroditi.gr/emi.cream.CREAMCE-JobSubmit?exec_time=2015-05-01T01:00:00Z", strings.NewReader(""))
 	request.Header.Set("x-api-key", suite.clientkey)
 	request.Header.Set("Accept", "application/xml")
@@ -289,13 +294,13 @@ func (suite *metricResultTestSuite) TestReadStatusDetail() {
 	// Check returned xml when no results are available for a given timestamp
 	request, _ = http.NewRequest("GET", "/api/v2/metric_result/cream01.afroditi.gr/emi.cream.CREAMCE-JobSubmit?exec_time=2015-05-01T01:01:00Z", strings.NewReader(""))
 	request.Header.Set("x-api-key", suite.clientkey)
-	request.Header.Set("Accept", "application/xml")
+	request.Header.Set("Accept", "application/json")
 	response = httptest.NewRecorder()
 	suite.router.ServeHTTP(response, request)
 	// Check that we must have a 200 ok code
-	suite.Equal(200, response.Code, "Incorrect HTTP response code")
+	suite.Equal(404, response.Code, "Incorrect HTTP response code")
 	// Compare the expected and actual xml response
-	suite.Equal("<root></root>", response.Body.String(), "Response body mismatch")
+	suite.Equal(respNotFound, response.Body.String(), "Response body mismatch")
 
 	// Check returned xml when no results are available for a given timestamp
 	request, _ = http.NewRequest("GET", "/api/v2/metric_result/cream01.afroditi.gr/emi.cream.CREAMCE-JobSubmit?exec_time=2015-05-01T00:00:00Z", strings.NewReader(""))


### PR DESCRIPTION
…bout a metric results that doesn't exist

### Issue 

When calling `HTTP GET /api/v2/metric_result/{metric}/{host}?exec_time=YYYY-MM-DDT00:00:00Z`
If the metric doesn't exist api responds incorrectly with an empty `<root></root>` xml response. 
This is should be fixed by replying with a proper Metric Not Found message in JSON

### Implementation

Updated metricResult handler to check for results not found and display a proper JSON message (along with 404 status code) such as:
```json
{
  "message": "Metric not found!",
  "code": 404
}
```

- [x] Update metricResult handler
- [x] Add unit test


