### PR TITLE
ARGO-3802 Display api v3 status results in sorted order. Add paramete…

### DIFF
--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -4596,7 +4596,7 @@ paths:
         - $ref: "#/parameters/reportName"
         - $ref: "#/parameters/startDate"
         - $ref: "#/parameters/endDate"
-        - $ref: "#/parameters/Granularity"
+        - $ref: "#/parameters/statusView"
       responses:
         200:
           description: "Successful retrieval of status timelines"
@@ -4768,6 +4768,12 @@ parameters:
     in: query
     type: string
     description: "the servce will return only the latest entry grouped by endpoint_group/host/service/metric"
+    default: "false"
+  statusView:
+    name: "view"
+    in: query
+    type: string
+    description: "Use view=details to enrich status results with additional information such as threshold rules that may have been applied. Use view=latest to display only the latest status for each item."
     default: "false"
 
 responses:

--- a/v3/status/helpers.go
+++ b/v3/status/helpers.go
@@ -7,7 +7,10 @@ import (
 
 // parseZuluDate is used to parse a zulu formatted date to integer
 func parseZuluDate(dateStr string) (int, error) {
-	parsedTime, _ := time.Parse(zuluForm, dateStr)
+	parsedTime, err := time.Parse(zuluForm, dateStr)
+	if err != nil {
+		return -1, err
+	}
 	return strconv.Atoi(parsedTime.Format(ymdForm))
 }
 

--- a/website/docs/v3status.md
+++ b/website/docs/v3status.md
@@ -20,15 +20,16 @@ The following methods can be used to obtain a tenant's Status timeline results f
 ### Input
 
 ```
-/status/{report_name}?[start_time]&[end_time]
+/status/{report_name}?start_time={value}&end_time={value}&view={value}
 ```
 
 #### Query Parameters
 
 | Type            | Description                                                                                     | Required | Default value |
 | --------------- | ----------------------------------------------------------------------------------------------- | -------- | ------------- |
-| `[start_time]`  | UTC time in W3C format                                                                          | YES      |
-| `[end_time]`    | UTC time in W3C format                                                                          | YES      |
+| `start_time`  | UTC time in W3C format                                                                          | NO       | beginning of the current day (UTC, W3C format)
+| `end_time`    |  UTC time in W3C format                                                                          | NO       | time right now (UTC, W3C format)
+| `view`        | `view=details` to display verbose details in results (such as threshold rules etc.) and `view=latest` to display only display the latest status value for each item                                                                        | NO       | 
 
 #### Path Parameters
 
@@ -37,7 +38,10 @@ The following methods can be used to obtain a tenant's Status timeline results f
 | `{report_name}` | Name of the report that contains all the information about the profile, filter tags, group types etc. | YES      |
 
 
-### Example Request 1: default daily granularity
+#### Notes
+If user omits start_time and end_time parameters during the request the argo-web-api will respond with the latest status results of the current day
+
+### Example Request 1: Status results (for today or for a specific period)
 
 #### Request
 
@@ -45,6 +49,14 @@ The following methods can be used to obtain a tenant's Status timeline results f
 `HTTP GET`
 
 ##### Path
+
+For today's results just issue:
+
+```
+/api/v2/status/Report_A
+```
+
+For results in a specific period:
 
 ```
 /api/v2/status/Report_A?start_time=2015-06-20T12:00:00Z&end_time=2015-06-26T23:00:00Z 
@@ -181,6 +193,101 @@ Status: 200 OK
             },
             {
               "timestamp": "2015-05-01T23:59:59Z",
+              "value": "CRITICAL"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+### Example Request 2: Display only latest status results
+
+#### Request
+
+##### Method
+`HTTP GET`
+
+##### Path
+
+
+```
+/api/v2/status/Report_A?latest=true
+```
+
+##### Headers
+
+```
+x-api-key: "tenant_key_value"
+Accept: "application/json"
+```
+
+#### Response
+
+##### Code
+
+```
+Status: 200 OK
+```
+
+##### Body
+
+```json
+{
+  "groups": [
+    {
+      "name": "SITEA",
+      "type": "SITES",
+      "statuses": [
+        {
+          "timestamp": "2022-05-11T15:00:00Z",
+          "value": "OK"
+        }
+      ],
+      "endpoints": [
+        {
+          "hostname": "cream01.example.foo",
+          "service": "CREAM-CE",
+          "info": {
+            "Url": "http://example.foo/path/to/service"
+          },
+          "statuses": [
+            {
+              "timestamp": "2022-05-11T15:00:00Z",
+              "value": "OK"
+            }
+          ]
+        },
+        {
+          "hostname": "cream02.example.foo",
+          "service": "CREAM-CE",
+          "statuses": [
+            {
+              "timestamp": "2022-05-11T15:00:00Z",
+              "value": "OK"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "SITEB",
+      "type": "SITES",
+      "statuses": [
+        {
+          "timestamp": "2022-05-11T15:00:00Z",
+          "value": "CRITICAL"
+        }
+      ],
+      "endpoints": [
+        {
+          "hostname": "cream03.example.foo",
+          "service": "CREAM-CE",
+          "statuses": [
+            {
+              "timestamp": "2022-05-11T15:00:00Z",
               "value": "CRITICAL"
             }
           ]


### PR DESCRIPTION
…r for display latest status results. Make start end time optional

### Main issue: Sorting
Results were not correctly sorted in api v3 status due to the hashmaps used to compose the results not being traversable in a sorted order. Used an array of sorted keys to traverse the hashmaps instead. 
The results are displayed sorted by:
- group
- then service
- then hostname

### Other issues
- [x] Made start_time & end_time optional. If user doesn't declare a start_time and end_time period api displays today's status results
- [x] Made an additional parameter `view=latest` which if specified displays only the latest status for each item
- [x] Added missing validation checks on url parameters
- [x] Updated docs
- [x] Added unit tests
- [x] Minor fixes in swagger