### PR TITLE
ARGO-3850 Fix status v3 grouping issue for endpoints that belong to m…

### DIFF
--- a/app/topology/topology_test.go
+++ b/app/topology/topology_test.go
@@ -1204,7 +1204,7 @@ func (suite *topologyTestSuite) SetupTest() {
 
 	// Seed database with group topology
 	c = session.DB(suite.tenantDbConf.Db).C(serviceTypeColName)
-	c.EnsureIndexKey("-date_integer", "group")
+	c.EnsureIndexKey("-date_integer", "name")
 	// Insert seed data
 	c.Insert(
 		bson.M{
@@ -2701,13 +2701,13 @@ func (suite *topologyTestSuite) TestListServiceTypes() {
  "data": [
   {
    "date": "2015-01-11",
-   "name": "DB",
-   "description": "A Database type of Service"
+   "name": "API",
+   "description": "An API type of Service"
   },
   {
    "date": "2015-01-11",
-   "name": "API",
-   "description": "An API type of Service"
+   "name": "DB",
+   "description": "A Database type of Service"
   }
  ]
 }`},
@@ -2723,13 +2723,13 @@ func (suite *topologyTestSuite) TestListServiceTypes() {
  "data": [
   {
    "date": "2015-04-12",
-   "name": "DB",
-   "description": "A Database type of Service"
+   "name": "API",
+   "description": "An API type of Service"
   },
   {
    "date": "2015-04-12",
-   "name": "API",
-   "description": "An API type of Service"
+   "name": "DB",
+   "description": "A Database type of Service"
   },
   {
    "date": "2015-04-12",
@@ -2772,7 +2772,6 @@ func (suite *topologyTestSuite) TestListServiceTypes() {
 		suite.Equal(exp.Code, code, "Response Code Mismatch on call:"+exp.Path)
 		// Compare the expected and actual json response
 		suite.Equal(exp.JSON, output, "Response body mismatch on call:"+exp.Path)
-
 	}
 }
 

--- a/v3/status/status_test.go
+++ b/v3/status/status_test.go
@@ -23,7 +23,6 @@
 package status
 
 import (
-	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -341,6 +340,37 @@ func (suite *StatusTestSuite) SetupTest() {
 		"status":             "CRITICAL",
 		"has_threshold_rule": true,
 	})
+	c.Insert(bson.M{
+		"report":         "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date_integer":   20150501,
+		"timestamp":      "2015-05-01T00:00:00Z",
+		"endpoint_group": "SITEA",
+		"service":        "CREAM-CE",
+		"host":           "cream03.example.foo",
+		"metric":         "emi.cream.CREAMCE-JobSubmit",
+		"status":         "OK",
+	})
+	c.Insert(bson.M{
+		"report":         "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date_integer":   20150501,
+		"timestamp":      "2015-05-01T04:40:00Z",
+		"endpoint_group": "SITEA",
+		"service":        "CREAM-CE",
+		"host":           "cream03.example.foo",
+		"metric":         "emi.cream.CREAMCE-JobSubmit",
+		"status":         "UNKNOWN",
+	})
+	c.Insert(bson.M{
+		"report":             "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date_integer":       20150501,
+		"timestamp":          "2015-05-01T06:00:00Z",
+		"endpoint_group":     "SITEA",
+		"service":            "CREAM-CE",
+		"host":               "cream03.example.foo",
+		"metric":             "emi.cream.CREAMCE-JobSubmit",
+		"status":             "CRITICAL",
+		"has_threshold_rule": true,
+	})
 
 }
 
@@ -425,6 +455,28 @@ func (suite *StatusTestSuite) TestListStatus() {
        "value": "OK"
       }
      ]
+    },
+    {
+     "hostname": "cream03.example.foo",
+     "service": "CREAM-CE",
+     "statuses": [
+      {
+       "timestamp": "2015-05-01T00:00:00Z",
+       "value": "OK"
+      },
+      {
+       "timestamp": "2015-05-01T04:40:00Z",
+       "value": "UNKNOWN"
+      },
+      {
+       "timestamp": "2015-05-01T06:00:00Z",
+       "value": "CRITICAL"
+      },
+      {
+       "timestamp": "2015-05-01T23:59:59Z",
+       "value": "CRITICAL"
+      }
+     ]
     }
    ]
   },
@@ -481,7 +533,6 @@ func (suite *StatusTestSuite) TestListStatus() {
 	suite.Equal(200, response.Code, "Incorrect HTTP response code")
 	// Compare the expected and actual json response
 	suite.Equal(expResponse, response.Body.String(), "Response body mismatch")
-	fmt.Println(response.Body.String())
 
 	request, _ = http.NewRequest("GET", "/api/v3/status/Report_A?start_time=2015-06-20T12:00:00Z&end_time=2015-06-23T23:00:00Z", strings.NewReader(""))
 	request.Header.Set("x-api-key", "AWRONGKEY")
@@ -503,7 +554,6 @@ func (suite *StatusTestSuite) TestListStatus() {
 	suite.Equal(401, response.Code, "Incorrect HTTP response code")
 	// Compare the expected and actual xml response
 	suite.Equal(unauthorizedresponse, response.Body.String(), "Response body mismatch")
-	fmt.Println(response.Body.String())
 
 	// Case of bad start_time input
 	request, _ = http.NewRequest("GET", "/api/v3/status/Report_A?start_time=2015-06-20AT12:00:00Z&end_time=2015-06-23T23:00:00Z", strings.NewReader(""))
@@ -531,7 +581,6 @@ func (suite *StatusTestSuite) TestListStatus() {
 	suite.Equal(400, response.Code, "Incorrect HTTP response code")
 	// Compare the expected and actual xml response
 	suite.Equal(badRequestResponse, response.Body.String(), "Response body mismatch")
-	fmt.Println(response.Body.String())
 
 	// Case of bad end_time input
 	request, _ = http.NewRequest("GET", "/api/v3/status/Report_A?start_time=2015-06-20T12:00:00Z&end_time=2015-06T23:00:00Z", strings.NewReader(""))
@@ -559,7 +608,6 @@ func (suite *StatusTestSuite) TestListStatus() {
 	suite.Equal(400, response.Code, "Incorrect HTTP response code")
 	// Compare the expected and actual xml response
 	suite.Equal(badRequestResponse, response.Body.String(), "Response body mismatch")
-	fmt.Println(response.Body.String())
 
 	// Case of using view=latest along with specifing start and end period
 	request, _ = http.NewRequest("GET", "/api/v3/status/Report_A?start_time=2015-06-20T12:00:00Z&end_time=2015-06-20T23:00:00Z&view=latest", strings.NewReader(""))
@@ -587,7 +635,6 @@ func (suite *StatusTestSuite) TestListStatus() {
 	suite.Equal(400, response.Code, "Incorrect HTTP response code")
 	// Compare the expected and actual xml response
 	suite.Equal(badRequestResponse, response.Body.String(), "Response body mismatch")
-	fmt.Println(response.Body.String())
 
 }
 

--- a/v3/status/views.go
+++ b/v3/status/views.go
@@ -78,7 +78,7 @@ func createCombinedView(resGroups []GroupData, resEndpoints []EndpointData, inpu
 		}
 
 		// check if item has an already created group
-		if ptrEndp, ok := indexEndp[row.Service+row.Hostname]; ok {
+		if ptrEndp, ok := indexEndp[row.EndpointGroup+row.Service+row.Hostname]; ok {
 			ptrEndp.Statuses = append(ptrEndp.Statuses, status)
 		} else {
 			newEndp := &endpointOUT{}
@@ -88,9 +88,9 @@ func createCombinedView(resGroups []GroupData, resEndpoints []EndpointData, inpu
 			newEndp.SuperGroup = row.EndpointGroup
 			newEndp.Statuses = make([]*statusOUT, 0)
 			newEndp.Statuses = append(newEndp.Statuses, status)
-			indexEndp[row.Service+row.Hostname] = newEndp
+			indexEndp[row.EndpointGroup+row.Service+row.Hostname] = newEndp
 			// add key to keysEndp to be used in sorted traversal
-			keysEndp = append(keysEndp, row.Service+row.Hostname)
+			keysEndp = append(keysEndp, row.EndpointGroup+row.Service+row.Hostname)
 		}
 
 	}


### PR DESCRIPTION
…ultiple groups

### Issue
**In status v3 call:** For tenants where the same endpoint belonged to several groups there was a grouping issue when composed the json response displaying only the occurrence of the endpoint in the first group and not in the others.

### Fix
- [x] Fixed createView method in api v3 status package to correctly group endpoint information and display it for all groups that the endpoint is a part of
- [x] Updated unit tests with an example that an endpoint belongs to multiple groups
- [x] Minor fix: Removed unnecessary debug print statements in unit-tests 
- [x] Minor fix: in service-type call unit tests with wrong index when initialising test database (which resulted in unit-test results that were not alphabetically ordered)