### PR TITLE
ARGO-3874 Add info on the report about what is computed (ar,status,trends)

### DIFF
--- a/app/reports/reports_test.go
+++ b/app/reports/reports_test.go
@@ -655,6 +655,14 @@ func (suite *ReportTestSuite) TestCreateReport() {
             }
         }
     },
+	"computations": {
+		"ar": true,
+		"status": false,
+		"trends": [
+		 "flapping",
+		 "tags"
+		]
+	   },
 	"profiles": [
         {
 			"id": "6ac7d684-1f8e-4a02-a502-720e8f11e50b",
@@ -686,6 +694,75 @@ func (suite *ReportTestSuite) TestCreateReport() {
             "value": "Y"
         }
     ]
+}`
+
+	// create json input data for the request with wrong computation tags
+	postWrong := `{
+    "info": {
+        "name": "Foo_Report",
+        "description": "olalala"
+    },
+    "topology_schema": {
+        "group": {
+            "type": "ngi",
+            "group": {
+                "type": "site"
+            }
+        }
+    },
+	"computations": {
+		"ar": true,
+		"status": false,
+		"trends": [
+		 "flipflopping",
+		 "tags"
+		]
+	   },
+	"profiles": [
+        {
+			"id": "6ac7d684-1f8e-4a02-a502-720e8f11e50b",
+            "type": "metric"
+            
+        },
+		{
+			"id": "6ac7d684-1f8e-4a02-a502-720e8f11e523",
+            "type": "operations"
+         
+        },
+        {
+			"id": "6ac7d684-1f8e-4a02-a502-720e8f11e50bq",
+            "type": "aggregation"
+            
+        },
+		{
+			"id": "6ac7d684-1f8e-4a02-a502-720e8f11e533",
+			"type": "weights"
+		}
+    ],
+    "filter_tags": [
+        {
+            "name": "production",
+            "value": "Y"
+        },
+        {
+            "name": "monitored",
+            "value": "Y"
+        }
+    ]
+}`
+
+	errOutput := `{
+ "status": {
+  "message": "Unprocessable Entity",
+  "code": "422"
+ },
+ "errors": [
+  {
+   "message": "Invalid Trend Name",
+   "code": "422",
+   "details": "Trends with the name:flipflopping doesn't exist"
+  }
+ ]
 }`
 
 	// Prepare the request object
@@ -741,6 +818,14 @@ func (suite *ReportTestSuite) TestCreateReport() {
     "description": "olalala",
     "created": ".*",
     "updated": ".*"
+   },
+   "computations": {
+    "ar": true,
+    "status": false,
+    "trends": \[
+     "flapping",
+     "tags"
+    \]
    },
    "thresholds": {
     "availability": 80,
@@ -799,6 +884,26 @@ func (suite *ReportTestSuite) TestCreateReport() {
 	suite.Equal(200, code, "Incorrect Error Code")
 	// Compare the expected and actual xml response
 	suite.Regexp(responseJSON, output, "Response body mismatch")
+
+	// Prepare the request with wrong POST data
+	// Prepare the request object
+	request, _ = http.NewRequest("POST", "https://myapi.test.com/api/v2/reports", strings.NewReader(postWrong))
+	// add the content-type header to application/json
+	request.Header.Set("Accept", "application/json")
+	// add the authentication token which is seeded in testdb
+	request.Header.Set("x-api-key", "C4PK3Y")
+
+	response = httptest.NewRecorder()
+
+	// Execute the request in the controller
+	suite.router.ServeHTTP(response, request)
+
+	code = response.Code
+	output = response.Body.String()
+
+	suite.Equal(422, code, "Incorrect Error Code")
+	suite.Equal(errOutput, output, "Response body mismatch")
+
 }
 
 // TestUpdateReport function implements testing the http PUT update report request.
@@ -889,6 +994,15 @@ func (suite *ReportTestSuite) TestUpdateReport() {
     "description": "newdescription",
     "created": "2015-9-10 13:43:00",
     "updated": ".*"
+   },
+   "computations": {
+    "ar": true,
+    "status": true,
+    "trends": \[
+     "flapping",
+     "status",
+     "tags"
+    \]
    },
    "thresholds": {
     "availability": 60.33,
@@ -1113,6 +1227,15 @@ func (suite *ReportTestSuite) TestReadOneReport() {
     "created": "2015-9-10 13:43:00",
     "updated": "2015-10-11 13:43:00"
    },
+   "computations": {
+    "ar": true,
+    "status": true,
+    "trends": [
+     "flapping",
+     "status",
+     "tags"
+    ]
+   },
    "topology_schema": {
     "group": {
      "type": "NGI",
@@ -1198,6 +1321,15 @@ func (suite *ReportTestSuite) TestReadReports() {
     "created": "2015-10-08 13:43:00",
     "updated": "2015-10-09 13:43:00"
    },
+   "computations": {
+    "ar": true,
+    "status": true,
+    "trends": [
+     "flapping",
+     "status",
+     "tags"
+    ]
+   },
    "topology_schema": {
     "group": {
      "type": "ARCHIPELAGO",
@@ -1245,6 +1377,15 @@ func (suite *ReportTestSuite) TestReadReports() {
     "description": "report aaaaa",
     "created": "2015-9-10 13:43:00",
     "updated": "2015-10-11 13:43:00"
+   },
+   "computations": {
+    "ar": true,
+    "status": true,
+    "trends": [
+     "flapping",
+     "status",
+     "tags"
+    ]
    },
    "topology_schema": {
     "group": {

--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -6247,6 +6247,17 @@ definitions:
             type: string
           updated:
             type: string
+      computations: 
+        type: object
+        properties:
+          ar:
+            type: boolean
+          status:
+            type: boolean
+          trends:
+            type: array
+            items:
+              type: string
       thresholds:
         type: object
         properties:

--- a/website/docs/reports.md
+++ b/website/docs/reports.md
@@ -60,6 +60,15 @@ Json Response
                 "created": "2015-9-10 13:43:00",
                 "updated": "2015-10-11 13:43:00"
             },
+            "computations": {
+                "ar": true,
+                "status": true,
+                "trends": [
+                              "flapping",
+                              "status",
+                              "tags"
+                          ]
+            },
             "topology_schema": {
                 "group": {
                     "type": "NGI",
@@ -145,6 +154,15 @@ Accept: application/json
                 "type": "site"
             }
         }
+    },
+    "computations": {
+        "ar": true,
+        "status": true,
+        "trends": [
+                        "flapping",
+                        "status",
+                        "tags"
+                    ]
     },
     "thresholds": {
         "availability": 80.0,
@@ -232,6 +250,7 @@ Accept: application/json
         "name": "newname",
         "description": "newdescription"
     },
+    
     "topology_schema": {
         "group": {
             "type": "ngi",
@@ -470,3 +489,24 @@ During report creation, in case of wrong profile type reference defined or wrong
     ]
 }
 ```
+
+<a id='7'></a>
+
+## Notes on Computations field
+Computations field is used per report to define what kind of computations should run per report execution. Each report can produce availability/reliability (ar) results, status timelines and specific trends such as top flapping items, top items in status Critical,Warning etc.. and also top issues reported by tags. User can specify exactly what needs to be computed when a report runs by using the special `computations` field and define the following:
+
+```json
+{
+    "computations": {
+        "ar": true,
+        "status": true,
+        "trends": [
+                        "flapping",
+                        "status",
+                        "tags"
+                    ]
+    }
+}
+```
+
+This information is automatically picked up by the analytics engine and the specified computation are executed. When creating or updating a report the `computations` field is optional. If the User omits it then the default value will include that everything should be computed.


### PR DESCRIPTION
### Goal
Add additional information on the report body stating what should and is being computed (ar, status and specifically which trends)

### Implementation
The additional information of what each report computes is specified in the body of the report with the special field `computations`. The json is presented below: 

```json
{
    "computations": {
        "ar": true,
        "status": true,
        "trends": [
                        "flapping",
                        "status",
                        "tags"
                    ]
    }
}
```

If the user wants ar computations to be executed specified `"ar": true` - same for status (`"status": true`)
Also in the "trends" array user can specify specific trends that need to be computed

- [x] Update Report model with computations information
- [x] Add validation on computations.trends field
- [x] Update unit tests
- [x] Update documentation
- [x] Update swagger

