### PR TITLE
Bump to v.1.12.0

### DIFF
--- a/argo-web-api.spec
+++ b/argo-web-api.spec
@@ -68,6 +68,8 @@ go clean
 %attr(0644,root,root) /usr/lib/systemd/system/argo-web-api.service
 
 %changelog
+* Thu Jun 9 2022 Konstantinos Kagkelidis <kaggis@gmail.com> 1.12.0-1%{dist}
+- Release of argo-web-api version 1.12.0
 * Wed Apr 6 2022 Konstantinos Kagkelidis <kaggis@gmail.com> 1.11.0-1%{dist}
 - Release of argo-web-api version 1.11.0
 * Wed Sep 1 2021 Konstantinos Kagkelidis <kaggis@gmail.com> 1.10.0-1%{dist}

--- a/version/version.go
+++ b/version/version.go
@@ -6,7 +6,7 @@ import (
 
 var (
 	// Release version of the service. Bump it up during new version release
-	Release = "1.11.0"
+	Release = "1.12.0"
 	// Commit hash provided during build
 	Commit = "Unknown"
 	// BuildTime provided during build

--- a/website/package.json
+++ b/website/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "agora-sp",
+  "name": "argo-web-api",
   "version": "0.0.0",
   "private": true,
   "scripts": {


### PR DESCRIPTION
- Bump version to v.1.12.0 to prepare for release
- Minor fix in documentation config: correct project name