### PR TITLE
ARGO-3928 organise downtimes by severity and classification

### DIFF
--- a/app/downtimes/model.go
+++ b/app/downtimes/model.go
@@ -9,10 +9,13 @@ type Downtimes struct {
 
 //Downtime holds downtime information for a specific host
 type Downtime struct {
-	HostName  string `bson:"hostname" json:"hostname"`
-	Service   string `bson:"service" json:"service"`
-	StartTime string `bson:"start_time" json:"start_time"`
-	EndTime   string `bson:"end_time" json:"end_time"`
+	HostName       string `bson:"hostname" json:"hostname"`
+	Service        string `bson:"service" json:"service"`
+	StartTime      string `bson:"start_time" json:"start_time"`
+	EndTime        string `bson:"end_time" json:"end_time"`
+	Description    string `bson:"description" json:"description,omitempty"`
+	Classification string `bson:"classification" json:"classification,omitempty"`
+	Severity       string `bson:"severity" json:"severity,omitempty"`
 }
 
 // Links struct to hold links

--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -1642,6 +1642,8 @@ paths:
       parameters:
         - $ref: "#/parameters/apiKey"
         - $ref: "#/parameters/profDate"
+        - $ref: "#/parameters/classification"
+        - $ref: "#/parameters/severity"
       responses:
         '200':
           description: A list of downtimes resources
@@ -4775,6 +4777,18 @@ parameters:
     type: string
     description: "Use view=details to enrich status results with additional information such as threshold rules that may have been applied. Use view=latest to display only the latest status for each item."
     default: "false"
+  classification:
+    name: "classification"
+    in: query
+    type: string
+    description: "use classification=scheduled or classification=unscheduled to filter downtimes"
+    default: ""
+  severity:
+    name: "severity"
+    in: query
+    type: string
+    description: "Use severity=outage or severity=warning to filter downtimes"
+    default: ""
 
 responses:
   Unauthorized:
@@ -6139,6 +6153,12 @@ definitions:
       start_time:
         type: string
       end_time:
+        type: string
+      classfication: 
+        type: string
+      severity:
+        type: string
+      description:
         type: string
           
   Weights:

--- a/website/docs/downtimes.md
+++ b/website/docs/downtimes.md
@@ -28,7 +28,8 @@ GET /downtimes?date=YYYY-MM-DD
 | Type   | Description                                                                                                                               | Required |
 | ------ | ----------------------------------------------------------------------------------------------------------------------------------------- | --------                                                                                           | NO       |
 | `date` | Date to retrieve a historic version of the downtime resource. If no date parameter is provided the most current resource will be returned | NO       |
-
+| `classification` | optionally filter downtimes by classification value | NO       |
+| `severity` | optionally filter downtiumes by severity value | NO       |
 ### Request headers
 
 ```
@@ -58,7 +59,10 @@ Json Response
                     "hostname": "host-A",
                     "service": "service-A",
                     "start_time": "2019-10-11T04:00:33Z",
-                    "end_time": "2019-10-11T15:33:00Z"
+                    "end_time": "2019-10-11T15:33:00Z",
+                    "description": "a simple optional description",
+                    "severity": "optional severity value like critical, warning",
+                    "classification": "optional classification value like outage, scheduled"
                 },
                 {
                     "hostname": "host-B",
@@ -78,6 +82,50 @@ Json Response
 }
 ```
 
+### Request downtimes and filter by severity and classification example
+
+In the following example we request the downtimes for the date 2022-05-11 that are of outage severity and classified as unscheduled
+
+```
+HTTP GET /api/v2/downtimes?date=2022-05-11&severity=outage&classification=outage
+```
+
+Response: `200 OK`
+Body:
+```json
+{
+    "status": {
+        "message": "Success",
+        "code": "200"
+    },
+    "data": [
+        {
+            "date": "2022-05-11",
+            "endpoints": [
+                {
+                    "hostname": "host-A",
+                    "service": "service-A",
+                    "start_time": "2022-05-11T04:00:33Z",
+                    "end_time": "2022-05-11T15:33:00Z",
+                    "severity": "outage",
+                    "classification": "unscheduled"
+                },
+                {
+                    "hostname": "host-B",
+                    "service": "service-B",
+                    "start_time": "2022-05-11T12:00:33Z",
+                    "end_time": "2022-05-11T12:33:00Z",
+                    "severity": "outage",
+                    "classification": "unscheduled",
+                    "description": "a simple description",
+                }
+            ]
+        }
+    ]
+}
+```
+
+__note__: `description`, `severity` and `classification` but quite useful to organise the kind of downtimes declared per day.
 
 
 <a id='2'></a>
@@ -114,13 +162,17 @@ Accept: application/json
             "hostname": "host-foo",
             "service": "service-new-foo",
             "start_time": "2019-10-11T23:10:00Z",
-            "end_time": "2019-10-11T23:25:00Z"
+            "end_time": "2019-10-11T23:25:00Z",
+            "classification": "unscheduled",
+            "severity": "outage",
         },
         {
             "hostname": "host-bar",
             "service": "service-new-bar",
             "start_time": "2019-10-11T23:40:00Z",
-            "end_time": "2019-10-11T23:55:00Z"
+            "end_time": "2019-10-11T23:55:00Z",
+            "classification": "unscheduled",
+            "severity": "outage",
         }
     ]
 }


### PR DESCRIPTION
ARGO-3926 Add description to downtimes

# 🎯 Goal
Add optional fields of `description`, `classification` and `severity` to downtimes. Old downtimes will display correctly without those fields. Also give the ability when listing downtimes to filter by classification and severity

# Implementation
👉  Ability to list downtimes by classification and severity example:
`HTTP GET /api/v2/downtimes?date=2022-05-11&classification=scheduled&severity=outage`
Response:
```json
{
    "status": {
        "message": "Success",
        "code": "200"
    },
    "data": [
        {
            "date": "2022-05-11",
            "endpoints": [
                {
                    "hostname": "host-A",
                    "service": "service-A",
                    "start_time": "2022-05-11T04:00:33Z",
                    "end_time": "2022-05-11T15:33:00Z",
                    "severity": "outage",
                    "classification": "scheduled"
                },
                {
                    "hostname": "host-B",
                    "service": "service-B",
                    "start_time": "2022-05-11T12:00:33Z",
                    "end_time": "2022-05-11T12:33:00Z",
                    "severity": "outage",
                    "classification": "scheduled",
                    "description": "a simple description",
                }
            ]
        }
    ]
}
```

- [x] Added new fields to downtimes model
- [x] Replaced old queries with the new prepFilterQuery which accepts classification and severity parameters
- [x] Add new unit tests showing handling descriptions, classifications and severities
- [x] Update docs
- [x] Update swagger

