### PR TITLE
ARGO-4026 api v3 call to get status results by resource id

### DIFF
--- a/scripts/mongodb/populate_default_roles.js
+++ b/scripts/mongodb/populate_default_roles.js
@@ -290,6 +290,10 @@ function populate_default_roles() {
         {
             resource: "v3.status.list",
             roles: ["admin", "editor", "viewer", "admin_ui"]
+        },
+        {
+            resource: "v3.status.list-by-id",
+            roles: ["admin", "editor", "viewer", "admin_ui"]
         }
     ]);
     print("INFO\tPolulated default roles in 'roles' collection");

--- a/v3/status/models.go
+++ b/v3/status/models.go
@@ -33,6 +33,7 @@ type InputParams struct {
 	groupType string
 	group     string
 	format    string
+	ID        string
 }
 
 // GroupData struct holds the grouped queried data from datastore
@@ -55,6 +56,11 @@ type groupOUT struct {
 	Name      string         `json:"name"`
 	GroupType string         `json:"type"`
 	Statuses  []*statusOUT   `json:"statuses"`
+	Endpoints []*endpointOUT `json:"endpoints"`
+}
+
+type idOUT struct {
+	ID        string         `json:"id"`
 	Endpoints []*endpointOUT `json:"endpoints"`
 }
 
@@ -86,7 +92,7 @@ type EndpointData struct {
 type endpointOUT struct {
 	Name       string            `json:"hostname"`
 	Service    string            `json:"service,omitempty"`
-	SuperGroup string            `json:"-"`
+	SuperGroup string            `json:"group,omitempty"`
 	Info       map[string]string `json:"info,omitempty"`
 	Statuses   []*statusOUT      `json:"statuses"`
 }

--- a/v3/status/queries.go
+++ b/v3/status/queries.go
@@ -1,6 +1,8 @@
 package status
 
-import "gopkg.in/mgo.v2/bson"
+import (
+	"gopkg.in/mgo.v2/bson"
+)
 
 const statusGroupColName = "status_endpoint_groups"
 const statusEndpointColName = "status_endpoints"
@@ -24,6 +26,10 @@ func queryEndpoints(input InputParams, reportID string) bson.M {
 	filter := bson.M{
 		"date_integer": bson.M{"$gte": input.startTime, "$lte": input.endTime},
 		"report":       reportID,
+	}
+
+	if input.ID != "" {
+		filter["info.ID"] = input.ID
 	}
 
 	return filter

--- a/v3/status/routing.go
+++ b/v3/status/routing.go
@@ -40,6 +40,12 @@ var arRoutes = []respond.AppRoutes{
 		SubrouterHandler: ListStatus,
 	},
 	{
+		Name:             "v3.status.list-by-id",
+		Verb:             "GET",
+		Path:             "/{report_name}/id/{id}",
+		SubrouterHandler: ListStatusByID,
+	},
+	{
 		Name:             "v3.status.options",
 		Verb:             "OPTIONS",
 		Path:             "/{report_name}",

--- a/v3/status/views.go
+++ b/v3/status/views.go
@@ -118,6 +118,8 @@ func createCombinedView(resGroups []GroupData, resEndpoints []EndpointData, inpu
 			value.Statuses = append(value.Statuses, extraStatus)
 
 			ptrGroup.Endpoints = append(ptrGroup.Endpoints, value)
+			// clear supergroup value from endpoint it self so as not to be printed in json output
+			value.SuperGroup = ""
 
 		}
 
@@ -140,6 +142,84 @@ func createCombinedView(resGroups []GroupData, resEndpoints []EndpointData, inpu
 	}
 
 	output, err = respond.MarshalContent(docRoot, input.format, "", " ")
+	return output, err
+
+}
+
+func createViewByID(resEndpoints []EndpointData, input InputParams, endDate string, details bool, latest bool) ([]byte, error) {
+
+	// calculate part of the timestamp that closes the timeline of each item
+	var extraTS string
+
+	tsNow := time.Now().UTC()
+	today := tsNow.Format("2006-01-02")
+
+	if endDate == today {
+		extraTS = "T" + strings.Split(tsNow.Format(zuluForm), "T")[1]
+	} else {
+		extraTS = "T23:59:59Z"
+	}
+
+	output := []byte("reponse output")
+	err := error(nil)
+
+	docID := &idOUT{}
+	docID.ID = input.ID
+	docID.Endpoints = make([]*endpointOUT, 0)
+
+	// make index map to keep track of different endpoint
+	indexEndp := make(map[string]*endpointOUT)
+	keysEndp := make([]string, 0)
+
+	for _, row := range resEndpoints {
+		// prepare status information to be added
+		status := &statusOUT{}
+		status.Timestamp = row.Timestamp
+		status.Value = row.Status
+		if details {
+			status.AffectedByThresholdRule = row.HasThresholdRule
+		}
+
+		if ptrEndp, ok := indexEndp[row.EndpointGroup+row.Service+row.Hostname]; ok {
+			ptrEndp.Statuses = append(ptrEndp.Statuses, status)
+		} else {
+			newEndp := &endpointOUT{}
+			newEndp.Info = row.Info
+			newEndp.Name = row.Hostname
+			newEndp.Service = row.Service
+			newEndp.SuperGroup = row.EndpointGroup
+			newEndp.Statuses = make([]*statusOUT, 0)
+			newEndp.Statuses = append(newEndp.Statuses, status)
+			indexEndp[row.EndpointGroup+row.Service+row.Hostname] = newEndp
+			// add key to keysEndp to be used in sorted traversal
+			keysEndp = append(keysEndp, row.EndpointGroup+row.Service+row.Hostname)
+		}
+
+	}
+
+	sort.Strings(keysEndp)
+
+	// repeat over group items and add them to the response root
+
+	for _, key := range keysEndp {
+		value := indexEndp[key]
+		// check if endpoint supergroup is indexed in groups
+
+		// add extra status that closes the timeline
+		// get last status of the existing timeline
+		lastStatus := value.Statuses[len(value.Statuses)-1]
+		extraStatus := &statusOUT{}
+		extraStatus.Timestamp = strings.Split(lastStatus.Timestamp, "T")[0] + extraTS
+		extraStatus.Value = lastStatus.Value
+		if latest == true {
+			value.Statuses = nil
+		}
+		value.Statuses = append(value.Statuses, extraStatus)
+		docID.Endpoints = append(docID.Endpoints, value)
+
+	}
+
+	output, err = respond.MarshalContent(docID, input.format, "", " ")
 	return output, err
 
 }

--- a/website/docs/apiv3/v3status.md
+++ b/website/docs/apiv3/v3status.md
@@ -11,10 +11,11 @@ _Note_: These are v3 api calls implementations found under the path `/api/v3`
 | Name                                                                          | Description                                                                                                                                                                                                                              | Shortcut          |
 | ----------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
 | GET: List Status Results | This method retrieves the status results of all top level supergroups and their included endpoints | [Description](#1) |
+| GET: List Latest status result of endpoint by resource-id | This method retrieves the latest status result of a specific endpoint using as reference it's resource id| [Description](#2) |
 
 <a id="1"></a>
 
-# [GET]: List Status results for top level groups and included endpoints
+## [GET]: List Status results for top level groups and included endpoints
 
 The following methods can be used to obtain a tenant's Status timeline results for all top level groups and included endpoints. The api authenticates the tenant using the api-key within the x-api-key header. User can specify time granularity (`monthly` or `daily`) for retrieved results and also format using the `Accept` header. 
 
@@ -24,7 +25,7 @@ The following methods can be used to obtain a tenant's Status timeline results f
 /status/{report_name}?start_time={value}&end_time={value}&view={value}
 ```
 
-#### Query Parameters
+### Query Parameters
 
 | Type            | Description                                                                                     | Required | Default value |
 | --------------- | ----------------------------------------------------------------------------------------------- | -------- | ------------- |
@@ -32,14 +33,14 @@ The following methods can be used to obtain a tenant's Status timeline results f
 | `end_time`    |  UTC time in W3C format                                                                          | NO       | time right now (UTC, W3C format)
 | `view`        | `view=details` to display verbose details in results (such as threshold rules etc.) and `view=latest` to display only display the latest status value for each item                                                                        | NO       | 
 
-#### Path Parameters
+### Path Parameters
 
 | Name            | Description                                                                                           | Required | Default value |
 | --------------- | ----------------------------------------------------------------------------------------------------- | -------- | ------------- |
 | `{report_name}` | Name of the report that contains all the information about the profile, filter tags, group types etc. | YES      |
 
 
-#### Notes
+### Notes
 If user omits start_time and end_time parameters during the request the argo-web-api will respond with the latest status results of the current day
 
 ### Example Request 1: Status results (for today or for a specific period)
@@ -296,5 +297,232 @@ Status: 200 OK
       ]
     }
   ]
+}
+```
+
+
+<a id="2"></a>
+
+## [GET]: List latest status result for a specific endpoint using it's resource-id
+The following method can be used in it's simplest form to retrieve the latest status result of an endpoint, providing it's resource-id. User can specify with the parameter `?view=details` to view the most recent timeline of results for this endpoint. Additionaly can use the `start_time` and `end_time` parameters to view the detailed timeline of results for this specific endpoint under a certain period of time
+
+### Input (simplest form)
+
+```
+/status/{report_name}/id/{resource-id}
+```
+
+### Input (advanced form)
+```
+/status/{report_name}/id/{resource-id}?view=details&start_time={value}&end_time={value}
+```
+
+#### Query Parameters
+
+| Type            | Description                                                                                     | Required | Default value |
+| --------------- | ----------------------------------------------------------------------------------------------- | -------- | ------------- |
+| `start_time`  | UTC time in W3C format                                                                          | NO       | beginning of the current day (UTC, W3C format)
+| `end_time`    |  UTC time in W3C format                                                                          | NO       | time right now (UTC, W3C format)
+| `view`        | `view=details` to display the full timeline of results   | NO       | 
+
+#### Path Parameters
+
+| Name            | Description                                                                                           | Required | Default value |
+| --------------- | ----------------------------------------------------------------------------------------------------- | -------- | ------------- |
+| `{report_name}` | Name of the report that contains all the information about the profile, filter tags, group types etc. | YES      |
+| `{id}` | The resource-id corresponding to a specific endpoint | YES      |
+
+
+#### Notes
+By default the request in it's simplest form will return the latest status result for the endpoint. With `view=details` the user can examine a detailed timeline for the current day, or specify a different period of time (using `start_time` and `end_time`)
+
+### Example Request 1: Latest status result for endpoint with id: simple-queue
+
+#### Request
+
+##### Method
+`HTTP GET`
+
+##### Path
+
+
+```
+/api/v2/status/Report_A/id/simple-queue
+```
+
+##### Headers
+
+```
+x-api-key: "tenant_key_value"
+Accept: "application/json"
+```
+
+#### Response
+
+##### Code
+
+```
+Status: 200 OK
+```
+
+##### Body
+
+```json
+{
+    "id": "simple-queue",
+    "endpoints": [
+        {
+            "hostname": "queue01.example.com",
+            "service": "compute.queue",
+            "group": "Infra-01",
+            "info": {
+                "URL": "http://submit.queue01.example.com"
+            },
+            "statuses": [
+                {
+                    "timestamp": "2022-10-12T13:25:26Z",
+                    "value": "OK"
+                }
+            ]
+        }
+    ]
+}
+```
+
+### Example Request 2: Todays timeline of status results for endpoint with id: simple-queue
+
+#### Request
+
+##### Method
+`HTTP GET`
+
+##### Path
+
+
+```
+/api/v2/status/Report_A/id/simple-queue?view=details
+```
+
+##### Headers
+
+```
+x-api-key: "tenant_key_value"
+Accept: "application/json"
+```
+
+#### Response
+
+##### Code
+
+```
+Status: 200 OK
+```
+
+##### Body
+
+```json
+{
+    "id": "simple-queue",
+    "endpoints": [
+        {
+            "hostname": "queue01.example.com",
+            "service": "compute.queue",
+            "group": "Infra-01",
+            "info": {
+                "URL": "http://submit.queue01.example.com"
+            },
+            "statuses": [
+                {
+                    "timestamp": "2022-10-12T00:00:00Z",
+                    "value": "OK"
+                },
+                {
+                    "timestamp": "2022-10-12T09:53:00Z",
+                    "value": "WARNING"
+                },
+                {
+                    "timestamp": "2022-10-12T10:09:33Z",
+                    "value": "WARNING"
+                },
+                {
+                    "timestamp": "2022-10-12T13:25:26Z",
+                    "value": "OK"
+                }
+            ]
+        }
+    ]
+}
+```
+
+### Example Request 3: Timeline of status results for endpoint with id: simple-queue between 1st and 3rd of September 2022
+
+#### Request
+
+##### Method
+`HTTP GET`
+
+##### Path
+
+
+```
+/api/v2/status/Report_A/id/simple-queue?view=details&start_date=2022-09-01T00:00:00Z&end_time=end_time=2022-09-03T23:59:59Z
+```
+
+##### Headers
+
+```
+x-api-key: "tenant_key_value"
+Accept: "application/json"
+```
+
+#### Response
+
+##### Code
+
+```
+Status: 200 OK
+```
+
+##### Body
+
+```json
+{
+    "id": "simple-queue",
+    "endpoints": [
+        {
+            "hostname": "queue01.example.com",
+            "service": "compute.queue",
+            "group": "Infra-01",
+            "info": {
+                "URL": "http://submit.queue01.example.com"
+            },
+            "statuses": [
+                {
+                    "timestamp": "2022-09-01T00:00:00Z",
+                    "value": "OK"
+                },
+                {
+                    "timestamp": "2022-09-02T00:00:00Z",
+                    "value": "OK"
+                },
+                {
+                    "timestamp": "2022-09-02T12:04:55Z",
+                    "value": "CRITICAL"
+                },
+                {
+                    "timestamp": "2022-09-02T22:05:33Z",
+                    "value": "OK"
+                },
+                {
+                    "timestamp": "2022-10-03T00:00:00Z",
+                    "value": "OK"
+                },
+                {
+                    "timestamp": "2022-09-03T23:59:59Z",
+                    "value": "OK"
+                },
+            ]
+        }
+    ]
 }
 ```

--- a/website/static/openapi/argo-web-api.yml
+++ b/website/static/openapi/argo-web-api.yml
@@ -9469,6 +9469,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/StatusGroupsEndpointsResponse'
+            
         400:
           description: Item not found
           content:
@@ -9506,6 +9507,134 @@ paths:
             application/json:
               schema:
                 type: string
+                
+                
+  /v3/status/{report_name}/id/{resource_id}:
+    get:
+      tags:
+      - Status Results (v3)
+      summary: List Status result for a specific endpoint by providing it's resource id
+      description: this method retrieves the latest status result or the status timeline for a specific endpoint by providing its resource-id
+      operationId: statusEndpointsByID
+      externalDocs:
+        description: Argo-web-api documentation on Status results (v3)
+        url: https://docs.github.com/enterprise-server@3.6/rest/overview/resources-in-the-rest-api#root-endpoint
+      parameters:
+      - name: x-api-key
+        in: header
+        description: the x-api-key
+        required: true
+        schema:
+          type: string
+          default: SecretKey123
+      - name: report_name
+        in: path
+        description: report the probes belong to
+        required: true
+        schema:
+          type: string
+          default: CRITICAL
+      - name: resource_id
+        in: path
+        description: the resource id of the endpoint
+        required: true
+        schema:
+          type: string
+          default: CRITICAL
+      - name: start_time
+        in: query
+        description: start date of query in zulu format
+        required: true
+        schema:
+          type: string
+          default: 2006-01-01T00:04:05Z
+      - name: end_time
+        in: query
+        description: end date of query in zulu format
+        required: true
+        schema:
+          type: string
+          default: 2006-01-03T15:04:05Z
+      - name: view
+        in: query
+        description: Use view=latest to display the latest (current) status of the endpoint. Use view=details to display the full timeline of events (status changes) for the item
+        schema:
+          type: string
+          default: "false"
+      responses:
+        200:
+          description: Successful retrieval of latest status result or timeline
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusEndpointsIdResponse'
+              examples:
+                latest status result:
+                  value:
+                    id: simple.queue.101
+                    endpoints:
+                      - hostname: q01.example.com
+                        service: compute.queue
+                        group: Infra-01
+                        statuses:
+                         - timestamp: '2022-10-12T00:00:00Z'
+                           status: OK
+                status timeline:
+                  value:
+                    id: simple.queue.101
+                    endpoints:
+                      - hostname: q01.example.com
+                        service: compute.queue
+                        group: Infra-01
+                        statuses:
+                         - timestamp: '2022-10-12T00:00:00Z'
+                           status: OK
+                         - timestamp: '2022-10-12T05:00:00Z'
+                           status: WARNING
+                         - timestamp: '2022-10-12T12:35:00Z'
+                           status: OK
+                         - timestamp: '2022-10-12T23:59:59'
+                           status: OK
+             
+
+        400:
+          description: Item not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status_error'
+        401:
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                  code:
+                    type: string
+                  details:
+                    type: string
+        406:
+          description: Content Not acceptable
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status_error'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status_error'
+        500:
+          description: internal server error
+          content:
+            application/json:
+              schema:
+                type: string
+                
 components:
   schemas:
     Endpoint_list:
@@ -9646,6 +9775,31 @@ components:
                             type: string
                           status:
                             type: string
+    StatusEndpointsIdResponse:
+      type: object
+      properties:
+        id: 
+          type: string
+        endpoints:
+          type: array
+          items:
+            type: object
+            properties:
+              hostname:
+                type: string
+              service:
+                type: string
+              info:
+                type: object
+              statuses:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    timestamp:
+                      type: string
+                    status:
+                      type: string
     FactorsResponse:
       type: object
       properties:


### PR DESCRIPTION
# 🎯 goal
Give the ability to retrieve the latest status results for an endpoint by providing it's resource-id 

# 🔨 Implementation
Create a new api method to retrieve status results for a *specific* endpoint

👉 `HTTP GET /api/v3/status/{report_name}/id/{resource_id}`
or
👉 `HTTP GET /api/v3/status/{report_name}/id/{resource_id}?view=details&start_time={value}&end_time={value}`


For example:
`HTTP GET /api/v3/status/Critical/id/simple-queue`


```json
{
    "id": "simple-queue",
    "endpoints": [
        {
            "hostname": "queue01.example.com",
            "service": "compute.queue",
            "group": "Infra-01",
            "info": {
                "URL": "http://submit.queue01.example.com"
            },
            "statuses": [
                {
                    "timestamp": "2022-10-12T13:25:26Z",
                    "value": "OK"
                }
            ]
        }
    ]
}
```

The method can also return a full timeline of status results when `view=details` url parameter is used. Also user can define a specific period for the timeline to extend

Example:

`HTTP GET /api/v2/status/Report_A/id/simple-queue?view=details&start_date=2022-09-01T00:00:00Z&end_time=end_time=2022-09-03T23:59:59Z`

```json
{
    "id": "simple-queue",
    "endpoints": [
        {
            "hostname": "queue01.example.com",
            "service": "compute.queue",
            "group": "Infra-01",
            "info": {
                "URL": "http://submit.queue01.example.com"
            },
            "statuses": [
                {
                    "timestamp": "2022-09-01T00:00:00Z",
                    "value": "OK"
                },
                {
                    "timestamp": "2022-09-02T00:00:00Z",
                    "value": "OK"
                },
                {
                    "timestamp": "2022-09-02T12:04:55Z",
                    "value": "CRITICAL"
                },
                {
                    "timestamp": "2022-09-02T22:05:33Z",
                    "value": "OK"
                },
                {
                    "timestamp": "2022-10-03T00:00:00Z",
                    "value": "OK"
                },
                {
                    "timestamp": "2022-09-03T23:59:59Z",
                    "value": "OK"
                },
            ]
        }
    ]
}
```

- [x] In v3 package add a new handler `ListStatusByID`
- [x] Add new models for responses and datastore queries
- [x] Update datastore query to retrieve results using the `info.ID` nested field in MongoDB
- [x] Add new view for rendering the results
- [x] Add unit tests for the new method
- [x] Add openapi definition
- [x] Add docs

 