### PR TITLE
Implement api/v3 call to serve endpoint ar results by resource id

### DIFF
--- a/v3/ar/ar_test.go
+++ b/v3/ar/ar_test.go
@@ -23,6 +23,7 @@
 package ar
 
 import (
+	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -163,6 +164,10 @@ func (suite *AvailabilityTestSuite) SetupTest() {
 	c = session.DB(suite.cfg.MongoDB.Db).C("roles")
 	c.Insert(
 		bson.M{
+			"resource": "v3.ar.list-by-id",
+			"roles":    []string{"editor", "viewer"},
+		},
+		bson.M{
 			"resource": "v3.ar.list",
 			"roles":    []string{"editor", "viewer"},
 		})
@@ -243,6 +248,52 @@ func (suite *AvailabilityTestSuite) SetupTest() {
 					"value": "",
 				},
 			},
+		})
+
+	// Seed endpoint data
+	c = session.DB(suite.tenantDbConf.Db).C("endpoint_ar")
+
+	// Insert seed data
+	c.Insert(
+		bson.M{
+			"report":       "eba61a9e-22e9-4521-9e47-ecaa4a49436",
+			"date":         20150622,
+			"name":         "host01",
+			"service":      "service01",
+			"supergroup":   "GROUP_A",
+			"up":           1,
+			"down":         0,
+			"unknown":      0,
+			"availability": 66.7,
+			"reliability":  54.6,
+			"weight":       5634,
+			"tags": []bson.M{
+				bson.M{
+					"name":  "",
+					"value": "",
+				},
+			},
+			"info": bson.M{"ID": "special-queue"},
+		},
+		bson.M{
+			"report":       "eba61a9e-22e9-4521-9e47-ecaa4a49436",
+			"date":         20150623,
+			"name":         "host01",
+			"service":      "service01",
+			"supergroup":   "GROUP_A",
+			"up":           1,
+			"down":         0,
+			"unknown":      0,
+			"availability": 100,
+			"reliability":  100,
+			"weight":       5634,
+			"tags": []bson.M{
+				bson.M{
+					"name":  "",
+					"value": "",
+				},
+			},
+			"info": bson.M{"ID": "special-queue"},
 		})
 
 	c = session.DB(suite.tenantDbConf.Db).C("reports")
@@ -439,6 +490,29 @@ func (suite *AvailabilityTestSuite) TestListEndpointGroupAvailability() {
 	suite.Equal(401, response.Code, "Incorrect HTTP response code")
 	// Compare the expected and actual xml response
 	suite.Equal(unauthorizedresponse, response.Body.String(), "Response body mismatch")
+
+}
+
+// TestListEndpointAvailability test if daily results are returned correctly for a specific id
+func (suite *AvailabilityTestSuite) TestListEndpointAvailability() {
+
+	request, _ := http.NewRequest("GET", "/api/v3/results/Report_A/id/special-queue?start_time=2015-06-20T12:00:00Z&end_time=2015-06-23T23:00:00Z", strings.NewReader(""))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	expected := `{
+   "id": "special-queue"
+ }`
+
+	// Check that we must have a 200 ok code
+	suite.Equal(200, response.Code, "Incorrect HTTP response code")
+	// Compare the expected and actual xml response
+	suite.Equal(expected, response.Body.String(), "Response body mismatch")
+	fmt.Println(response.Body.String())
 
 }
 

--- a/v3/ar/handlers.go
+++ b/v3/ar/handlers.go
@@ -160,6 +160,112 @@ func ListGroupAR(r *http.Request, cfg config.Config) (int, http.Header, []byte, 
 	return code, h, output, err
 }
 
+// ListEndpointARByID lists endpoints a/r results for a specific resource id
+func ListEndpointARByID(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
+
+	//STANDARD DECLARATIONS START
+	code := http.StatusOK
+	h := http.Header{}
+	output := []byte("")
+	err := error(nil)
+	charset := "utf-8"
+	//STANDARD DECLARATIONS END
+
+	// Set Content-Type response Header value
+	contentType := r.Header.Get("Accept")
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+
+	// Parse the request into the input
+	urlValues := r.URL.Query()
+	vars := mux.Vars(r)
+
+	// Grab Tenant DB configuration from context
+	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
+
+	session, err := mongo.OpenSession(tenantDbConfig)
+	defer mongo.CloseSession(session)
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	report := reports.MongoInterface{}
+	err = mongo.FindOne(session, tenantDbConfig.Db, "reports", bson.M{"info.name": vars["report_name"]}, &report)
+
+	if err != nil {
+		code = http.StatusNotFound
+		message := "The report with the name " + vars["report_name"] + " does not exist"
+		output, err := createErrorMessage(message, code, contentType) //Render the response into XML or JSON
+		h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+		return code, h, output, err
+	}
+
+	input := GroupResultQuery{
+		basicQuery{
+			Name:        "",
+			Granularity: urlValues.Get("granularity"),
+			Format:      contentType,
+			StartTime:   urlValues.Get("start_time"),
+			EndTime:     urlValues.Get("end_time"),
+			Report:      report,
+			Vars:        vars,
+		}, "",
+	}
+
+	tenantDB := session.DB(tenantDbConfig.Db)
+	errs := input.Validate(tenantDB)
+	if len(errs) > 0 {
+		out := respond.BadRequestSimple
+		out.Errors = errs
+		output = out.MarshalTo(contentType)
+		code = 400
+		return code, h, output, err
+	}
+
+	results := []EndpointInterface{}
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	// Construct the query to mongodb based on the input
+	filter := bson.M{
+		"date":    bson.M{"$gte": input.StartTimeInt, "$lte": input.EndTimeInt},
+		"report":  report.ID,
+		"info.ID": input.Vars["id"],
+	}
+
+	// Prepare the group results
+	// Select the granularity of the search daily/monthly
+	if input.Granularity == "daily" {
+		customForm[0] = "20060102"
+		customForm[1] = "2006-01-02"
+		query := DailyGroup(filter)
+		err = mongo.Pipe(session, tenantDbConfig.Db, groupColName, query, &results)
+	} else if input.Granularity == "monthly" {
+		customForm[0] = "200601"
+		customForm[1] = "2006-01"
+		query := MonthlyGroup(filter)
+		err = mongo.Pipe(session, tenantDbConfig.Db, groupColName, query, &results)
+	}
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	output, err = createEndpointResult(results, report, input.Vars["id"])
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	return code, h, output, err
+}
+
 func Options(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
 
 	//STANDARD DECLARATIONS START

--- a/v3/ar/models.go
+++ b/v3/ar/models.go
@@ -87,6 +87,22 @@ type SuperGroupInterface struct {
 	SuperGroup   string  `bson:"supergroup"`
 }
 
+// EndpointInterface used to hold mongodb group information about endpoints
+type EndpointInterface struct {
+	Name         string            `bson:"name"`
+	Report       string            `bson:"report"`
+	Date         string            `bson:"date"`
+	Type         string            `bson:"type"`
+	Up           float64           `bson:"up"`
+	Down         float64           `bson:"down"`
+	Unknown      float64           `bson:"unknown"`
+	Availability float64           `bson:"availability"`
+	Reliability  float64           `bson:"reliability"`
+	Service      string            `bson:"service"`
+	SuperGroup   string            `bson:"supergroup"`
+	Info         map[string]string `bson:"info"`
+}
+
 //Availability struct for formating json
 type Availability struct {
 	Date         string `json:"date"`
@@ -110,6 +126,21 @@ type SuperGroup struct {
 	Type    string         `json:"type"`
 	Results []Availability `json:"results,omitempty"`
 	Groups  []*Group       `json:"groups,omitempty"`
+}
+
+// idOUT holds a/r information about endpoints with specific id
+type idOUT struct {
+	ID        string      `json:"id"`
+	Endpoints []*Endpoint `json:"endpoints,omitempty"`
+}
+
+// endpoint holds a/r information about a specific endpoint
+type Endpoint struct {
+	Name       string            `json:"name"`
+	Service    string            `json:"service"`
+	Supergroup string            `json:"supergroup"`
+	Info       map[string]string `bson:"info"`
+	Results    []Availability    `json:"results,omitempty"`
 }
 
 // errorMessage struct to hold the json/xml error response

--- a/v3/ar/routing.go
+++ b/v3/ar/routing.go
@@ -40,6 +40,12 @@ var arRoutes = []respond.AppRoutes{
 		SubrouterHandler: ListGroupAR,
 	},
 	{
+		Name:             "v3.ar.list-by-id",
+		Verb:             "GET",
+		Path:             "/{report_name}/id/{id}",
+		SubrouterHandler: ListEndpointARByID,
+	},
+	{
 		Name:             "v3.ar.options",
 		Verb:             "OPTIONS",
 		Path:             "/{report_name}",

--- a/v3/ar/views.go
+++ b/v3/ar/views.go
@@ -120,6 +120,47 @@ func createSuperGroupResult(results []SuperGroupInterface, report reports.MongoI
 
 }
 
+func createEndpointResult(results []EndpointInterface, report reports.MongoInterface, id string) ([]byte, error) {
+
+	docID := &idOUT{}
+	docID.ID = id
+	docID.Endpoints = make([]*Endpoint, 0)
+
+	prevEndpoint := ""
+	endpoint := &Endpoint{}
+
+	// we iterate through the results struct array
+	// keeping only the value of each row
+	for _, row := range results {
+		timestamp, _ := time.Parse(customForm[0], row.Date)
+
+		//if new superGroup does not match the previous superGroup value
+		//we create a new superGroup entry in the xml
+
+		if prevEndpoint != row.Name {
+			prevEndpoint = row.Name
+			endpoint = &Endpoint{
+				Name:       row.Name,
+				Service:    row.Service,
+				Supergroup: row.SuperGroup,
+				Info:       row.Info,
+			}
+			docID.Endpoints = append(docID.Endpoints, endpoint)
+		}
+
+		//we append the new availability values
+		endpoint.Results = append(endpoint.Results,
+			Availability{
+				Date:         timestamp.Format(customForm[1]),
+				Availability: fmt.Sprintf("%g", row.Availability),
+				Reliability:  fmt.Sprintf("%g", row.Reliability)})
+
+	}
+
+	return json.MarshalIndent(docID, " ", "  ")
+
+}
+
 func createResultView(resultsSuperGroups []SuperGroupInterface, resultsGroups []GroupInterface, report reports.MongoInterface, format string) ([]byte, error) {
 	docRoot := &root{}
 

--- a/website/docs/apiv3/v3results.md
+++ b/website/docs/apiv3/v3results.md
@@ -11,6 +11,7 @@ _Note_: These are v3 api calls implementations found under the path `/api/v3`
 | Name                                                                          | Description                                                                                                                                                                                                                              | Shortcut          |
 | ----------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
 | GET: List Availability and Reliability results for top level supergroups and included groups | This method retrieves the a/r results of all top level supergroups and their included groups | [Description](#1) |
+| GET: List Availability and Reliability results for specific endpoint using resource id | This method retrieves the a/r results of all endoints with specific resource id | [Description](#2) |
 
 <a id="1"></a>
 
@@ -215,6 +216,154 @@ Status: 200 OK
         }
       ]
     }
+  ]
+}
+```
+
+<a id="2"></a>
+
+# [GET]: List Availability and Reliability results for endpoints with specific resource-id
+
+The following methods can be used to obtain a tenant's Availability and Reliability result for the endpoints that have a specific resource-id. User can specify a period with `start_time` and `end_time` and granularity(`monthly` or `daily`) for retrieved results. `Accept` header is required. 
+
+### Input
+
+```
+/results/{report_name}/id/{resource-id}?[start_time]&[end_time]&[granularity]
+```
+
+#### Query Parameters
+
+| Type            | Description                                                                                     | Required | Default value |
+| --------------- | ----------------------------------------------------------------------------------------------- | -------- | ------------- |
+| `[start_time]`  | UTC time in W3C format                                                                          | YES      |
+| `[end_time]`    | UTC time in W3C format                                                                          | YES      |
+| `[granularity]` | Granularity of time that will be used to present data. Possible values are `monthly` or `daily` | NO       | `daily`       |
+
+#### Path Parameters
+
+| Name            | Description                                                                                           | Required | Default value |
+| --------------- | ----------------------------------------------------------------------------------------------------- | -------- | ------------- |
+| `{report_name}` | Name of the report that contains all the information about the profile, filter tags, group types etc. | YES      |
+| `{id}` | The resource id | YES      |
+
+### Example Request 1: default daily granularity with specific resource-id
+
+#### Request
+
+##### Method
+`HTTP GET`
+
+##### Path
+
+```
+/api/v2/results/Report_A/id/simple-queue?start_time=2015-06-20T12:00:00Z&end_time=2015-06-26T23:00:00Z 
+```
+or 
+```
+/api/v2/results/Report_A/id/simple-queue?start_time=2015-06-20T12:00:00Z&end_time=2015-06-26T23:00:00Z&granularity=daily`
+```
+
+##### Headers
+
+```
+x-api-key: "tenant_key_value"
+Accept: "application/json"
+```
+
+#### Response
+
+##### Code
+
+```
+Status: 200 OK
+```
+
+##### Body
+
+```json
+{
+  "id": "simple-queue",
+  "endpoints": [
+    {
+      "name": "host01.example",
+      "service": "service.queue",
+       "group": "Infra-01",
+            "info": {
+                "URL": "http://submit.queue01.example.com"
+            },
+      "results": [
+        {
+          "date": "2015-06-22",
+          "availability": "99.99999900000002",
+          "reliability": "99.99999900000002",
+          "unknown": "0",
+          "uptime": "1",
+          "downtime": "0"
+        },
+        {
+          "date": "2015-06-23",
+          "availability": "99.99999900000002",
+          "reliability": "99.99999900000002",
+          "unknown": "0",
+          "uptime": "1",
+          "downtime": "0"
+        }
+    ]
+  ]
+}
+```
+
+### Example Request 2: monthly granularity with specific resource-id
+
+#### Request
+
+##### Method
+`HTTP GET`
+
+##### Path
+
+```
+/api/v2/results/Report_A/id/simple-queue?start_time=2015-06-20T12:00:00Z&end_time=2015-06-26T23:00:00Z&granularity=monthly
+```
+##### Headers
+
+```
+x-api-key: "tenant_key_value"
+Accept: "application/json"
+```
+
+#### Response
+
+##### Code
+
+```
+Status: 200 OK
+```
+
+##### Body
+
+```json
+{
+  "id": "simple-queue",
+  "endpoints": [
+    {
+      "name": "host01.example",
+      "service": "service.queue",
+       "group": "Infra-01",
+            "info": {
+                "URL": "http://submit.queue01.example.com"
+            },
+      "results": [
+        {
+          "date": "2015-06",
+          "availability": "99.99999900000002",
+          "reliability": "99.99999900000002",
+          "unknown": "0",
+          "uptime": "1",
+          "downtime": "0"
+        }
+    ]
   ]
 }
 ```


### PR DESCRIPTION
# 🎯 goal
Give the ability to retrieve the latest ar results for an endpoint by providing it's resource-id 

# 🔨 Implementation
Create a new api method to retrieve status results for a *specific* endpoint

👉 `HTTP GET /api/v3/results/{report_name}/id/{resource_id}`
or
👉 `HTTP GET /api/v3/results/{report_name}/id/{resource_id}&start_time={value}&end_time={value}`


For example:
`HTTP GET /api/v3/results/Critical/id/simple-queue`
