### PR TITLE
Fix v3 ar results by resource-id call

### DIFF
--- a/v3/ar/models.go
+++ b/v3/ar/models.go
@@ -139,7 +139,7 @@ type Endpoint struct {
 	Name       string            `json:"name"`
 	Service    string            `json:"service"`
 	Supergroup string            `json:"supergroup"`
-	Info       map[string]string `bson:"info"`
+	Info       map[string]string `json:"info"`
 	Results    []Availability    `json:"results,omitempty"`
 }
 

--- a/v3/ar/views.go
+++ b/v3/ar/views.go
@@ -153,7 +153,11 @@ func createEndpointResult(results []EndpointInterface, report reports.MongoInter
 			Availability{
 				Date:         timestamp.Format(customForm[1]),
 				Availability: fmt.Sprintf("%g", row.Availability),
-				Reliability:  fmt.Sprintf("%g", row.Reliability)})
+				Reliability:  fmt.Sprintf("%g", row.Reliability),
+				Unknown:      fmt.Sprintf("%g", row.Unknown),
+				Uptime:       fmt.Sprintf("%g", row.Up),
+				Downtime:     fmt.Sprintf("%g", row.Down),
+			})
 
 	}
 

--- a/website/docs/apiv3/v3results.md
+++ b/website/docs/apiv3/v3results.md
@@ -15,7 +15,7 @@ _Note_: These are v3 api calls implementations found under the path `/api/v3`
 
 <a id="1"></a>
 
-# [GET]: List Availability and Reliability results for top level supergroups and included groups
+## [GET]: List Availability and Reliability results for top level supergroups and included groups
 
 The following methods can be used to obtain a tenant's Availability and Reliability result metrics for all top level supergroups and included groups. The api authenticates the tenant using the api-key within the x-api-key header. User can specify time granularity (`monthly` or `daily`) for retrieved results and also format using the `Accept` header. 
 
@@ -50,11 +50,11 @@ The following methods can be used to obtain a tenant's Availability and Reliabil
 ##### Path
 
 ```
-/api/v2/results/Report_A?start_time=2015-06-20T12:00:00Z&end_time=2015-06-26T23:00:00Z 
+/api/v3/results/Report_A?start_time=2015-06-20T12:00:00Z&end_time=2015-06-26T23:00:00Z 
 ```
 or 
 ```
-/api/v2/results/Report_A?start_time=2015-06-20T12:00:00Z&end_time=2015-06-26T23:00:00Z&granularity=daily`
+/api/v3/results/Report_A?start_time=2015-06-20T12:00:00Z&end_time=2015-06-26T23:00:00Z&granularity=daily`
 ```
 
 ##### Headers
@@ -84,12 +84,12 @@ Status: 200 OK
         {
           "date": "2015-06-22",
           "availability": "68.13896116893515",
-          "reliability": "50.413931144915935"
+          "reliability": "68.13896116893515"
         },
         {
           "date": "2015-06-23",
           "availability": "75.36324059247399",
-          "reliability": "80.8138510808647"
+          "reliability": "75.36324059247399"
         }
       ],
       "groups": [
@@ -100,9 +100,9 @@ Status: 200 OK
             {
               "date": "2015-06-22",
               "availability": "66.7",
-              "reliability": "54.6",
+              "reliability": "66.7",
               "unknown": "0",
-              "uptime": "1",
+              "uptime": "66.7",
               "downtime": "0"
             },
             {
@@ -122,17 +122,17 @@ Status: 200 OK
             {
               "date": "2015-06-22",
               "availability": "70",
-              "reliability": "45",
+              "reliability": "70",
               "unknown": "0",
-              "uptime": "1",
+              "uptime": "0.70",
               "downtime": "0"
             },
             {
               "date": "2015-06-23",
               "availability": "43.5",
-              "reliability": "56",
+              "reliability": "43.5",
               "unknown": "0",
-              "uptime": "1",
+              "uptime": "0.435",
               "downtime": "0"
             }
           ]
@@ -153,7 +153,7 @@ Status: 200 OK
 ##### Path
 
 ```
-/api/v2/results/Report_A?start_time=2015-06-20T12:00:00Z&end_time=2015-06-26T23:00:00Z&granularity=monthly
+/api/v3/results/Report_A?start_time=2015-06-20T12:00:00Z&end_time=2015-06-26T23:00:00Z&granularity=monthly
 ```
 ##### Headers
 
@@ -181,8 +181,8 @@ Status: 200 OK
       "results": [
         {
           "date": "2015-06",
-          "availability": "71.75110088070457",
-          "reliability": "65.61389111289031"
+          "availability": "99.99999900000002",
+          "reliability": "99.99999900000002"
         }
       ],
       "groups": [
@@ -222,7 +222,7 @@ Status: 200 OK
 
 <a id="2"></a>
 
-# [GET]: List Availability and Reliability results for endpoints with specific resource-id
+## [GET]: List Availability and Reliability results for endpoints with specific resource-id
 
 The following methods can be used to obtain a tenant's Availability and Reliability result for the endpoints that have a specific resource-id. User can specify a period with `start_time` and `end_time` and granularity(`monthly` or `daily`) for retrieved results. `Accept` header is required. 
 
@@ -257,11 +257,11 @@ The following methods can be used to obtain a tenant's Availability and Reliabil
 ##### Path
 
 ```
-/api/v2/results/Report_A/id/simple-queue?start_time=2015-06-20T12:00:00Z&end_time=2015-06-26T23:00:00Z 
+/api/v3/results/Report_A/id/simple-queue?start_time=2015-06-20T12:00:00Z&end_time=2015-06-26T23:00:00Z 
 ```
 or 
 ```
-/api/v2/results/Report_A/id/simple-queue?start_time=2015-06-20T12:00:00Z&end_time=2015-06-26T23:00:00Z&granularity=daily`
+/api/v3/results/Report_A/id/simple-queue?start_time=2015-06-20T12:00:00Z&end_time=2015-06-26T23:00:00Z&granularity=daily`
 ```
 
 ##### Headers
@@ -288,10 +288,10 @@ Status: 200 OK
     {
       "name": "host01.example",
       "service": "service.queue",
-       "group": "Infra-01",
-            "info": {
-                "URL": "http://submit.queue01.example.com"
-            },
+      "group": "Infra-01",
+      "info": {
+        "URL": "http://submit.queue01.example.com"
+      },
       "results": [
         {
           "date": "2015-06-22",
@@ -309,7 +309,8 @@ Status: 200 OK
           "uptime": "1",
           "downtime": "0"
         }
-    ]
+      ]
+    }
   ]
 }
 ```
@@ -324,7 +325,7 @@ Status: 200 OK
 ##### Path
 
 ```
-/api/v2/results/Report_A/id/simple-queue?start_time=2015-06-20T12:00:00Z&end_time=2015-06-26T23:00:00Z&granularity=monthly
+/api/v3/results/Report_A/id/simple-queue?start_time=2015-06-20T12:00:00Z&end_time=2015-06-26T23:00:00Z&granularity=monthly
 ```
 ##### Headers
 
@@ -350,10 +351,10 @@ Status: 200 OK
     {
       "name": "host01.example",
       "service": "service.queue",
-       "group": "Infra-01",
-            "info": {
-                "URL": "http://submit.queue01.example.com"
-            },
+      "group": "Infra-01",
+      "info": {
+        "URL": "http://submit.queue01.example.com"
+      },
       "results": [
         {
           "date": "2015-06",
@@ -363,7 +364,8 @@ Status: 200 OK
           "uptime": "1",
           "downtime": "0"
         }
-    ]
+      ]
+    }
   ]
 }
 ```

--- a/website/static/openapi/argo-web-api.yml
+++ b/website/static/openapi/argo-web-api.yml
@@ -9417,6 +9417,143 @@ paths:
             application/json:
               schema:
                 type: string
+                
+  /v3/results/{report_name}/id/{resource_id}:
+    get:
+      tags:
+      - Availability & Reliability Results (v3)
+      summary: List Status result for a specific endpoint by providing it's resource id
+      description: this method retrieves the latest status result or the status timeline for a specific endpoint by providing its resource-id
+      operationId: arEndpointsByID
+      externalDocs:
+        description: Argo-web-api documentation on ar results (v3)
+        url: https://argoeu.github.io/argo-web-api/docs/apiv3/v3_ar_results#get-list-availability-and-reliability-results-for-endpoints-with-specific-resource-id
+      parameters:
+      - name: x-api-key
+        in: header
+        description: the x-api-key
+        required: true
+        schema:
+          type: string
+          default: SecretKey123
+      - name: report_name
+        in: path
+        description: report the probes belong to
+        required: true
+        schema:
+          type: string
+          default: Default
+      - name: resource_id
+        in: path
+        description: the resource id of the endpoint
+        required: true
+        schema:
+          type: string
+          default: resource-id
+      - name: start_time
+        in: query
+        description: start date of query in zulu format
+        required: false
+        schema:
+          type: string
+          default: 2006-01-01T00:04:05Z
+      - name: end_time
+        in: query
+        description: end date of query in zulu format
+        required: false
+        schema:
+          type: string
+          default: 2006-01-03T15:04:05Z
+      responses:
+        200:
+          description: Successful retrieval of latest availability/reliability results
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ArEndpointsIdResponse'
+              examples:
+                daily a/r results:
+                  value:
+                    id: simple.queue.101
+                    endpoints:
+                      - name: q01.example.com
+                        service: compute.queue
+                        group: infra01
+                        info:
+                          id: simple.queue.101
+                          url: https://q01.example.com/broker
+                        results:
+                         - date: '2022-10-12'
+                           availability: 100
+                           reliability: 100
+                           uptime: 1
+                           unknown: 0
+                           downtime: 0
+                         - date: '2022-10-13'
+                           availability: 80
+                           reliability: 80
+                           uptime: 0.8
+                           unknown: 0
+                           downtime: 0   
+                monthly a/r results:
+                  value:
+                    id: simple.queue.101
+                    endpoints:
+                      - name: q01.example.com
+                        service: compute.queue
+                        group: infra01
+                        info:
+                          id: simple.queue.101
+                          url: https://q01.example.com/broker
+                        results:
+                         - date: '2022-10'
+                           availability: 98.53
+                           reliability: 98.53
+                           uptime: 0.9853
+                           unknown: 0
+                           downtime: 0
+                      
+             
+
+        400:
+          description: Item not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status_error'
+        401:
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                  code:
+                    type: string
+                  details:
+                    type: string
+        406:
+          description: Content Not acceptable
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status_error'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status_error'
+        500:
+          description: internal server error
+          content:
+            application/json:
+              schema:
+                type: string                
+                
+
   /v3/status/{report_name}:
     get:
       tags:
@@ -9518,7 +9655,7 @@ paths:
       operationId: statusEndpointsByID
       externalDocs:
         description: Argo-web-api documentation on Status results (v3)
-        url: https://docs.github.com/enterprise-server@3.6/rest/overview/resources-in-the-rest-api#root-endpoint
+        url: https://argoeu.github.io/argo-web-api/docs/apiv3/v3_status_results#get-list-latest-status-result-for-a-specific-endpoint-using-its-resource-id
       parameters:
       - name: x-api-key
         in: header
@@ -9533,25 +9670,23 @@ paths:
         required: true
         schema:
           type: string
-          default: CRITICAL
+          default: Default
       - name: resource_id
         in: path
         description: the resource id of the endpoint
         required: true
         schema:
           type: string
-          default: CRITICAL
+          default: resource-id
       - name: start_time
         in: query
         description: start date of query in zulu format
-        required: true
         schema:
           type: string
           default: 2006-01-01T00:04:05Z
       - name: end_time
         in: query
         description: end date of query in zulu format
-        required: true
         schema:
           type: string
           default: 2006-01-03T15:04:05Z
@@ -9721,6 +9856,10 @@ components:
         description:
           type: string
           description: short description of the service type
+        tags:
+          type: array
+          items:
+            type: string
     MetricList:
       type: array
       items:
@@ -9800,6 +9939,41 @@ components:
                       type: string
                     status:
                       type: string
+    ArEndpointsIdResponse:
+      type: object
+      properties:
+        id: 
+          type: string
+        endpoints:
+          type: array
+          items:
+            type: object
+            properties:
+              name:
+                type: string
+              service:
+                type: string
+              group:
+                type: string
+              info:
+                type: object
+              results:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    date:
+                      type: string
+                    availability:
+                      type: number
+                    reliability:
+                      type: number
+                    unknown:
+                      type: number
+                    uptime:
+                      type: number
+                    downtime:
+                      type: number
     FactorsResponse:
       type: object
       properties:


### PR DESCRIPTION
- [x] Doc fixes
- [x] Openapi Definition fix (swagger)
- [x] Add unit tests about daily/monthly granularity and not found cases
- [x] Replace generic a/r query with a specific one tailored to the endpoint data model so as to have the correct fields of service and info be projected during the aggregation
- [x] Allow having start and end time parameters optional. If user omits start end end time he will get daily/monthly results for the current month