### PR TITLE
ARGO-4087 Fix date validation in api/v3 A/R calls

### DIFF
--- a/v3/ar/ar_test.go
+++ b/v3/ar/ar_test.go
@@ -607,6 +607,49 @@ func (suite *AvailabilityTestSuite) TestListEndpointIdNotFound() {
 
 }
 
+// TestOmitingStartEnd tests if the validator catches omissions of start or end date
+func (suite *AvailabilityTestSuite) TestOmittingStartEnd() {
+
+	urls := []string{
+		"/api/v3/results/Report_A/id/another-queue?end_time=2015-06-23T23:00:00Z",
+		"/api/v3/results/Report_A/id/another-queue?start_time=2015-06-23T23:00:00Z",
+		"/api/v3/results/Report_A",
+		"/api/v3/results/Report_A?start_time=2015-06-23T23:00:00Z",
+		"/api/v3/results/Report_A?end_time=2015-06-23T23:00:00Z",
+	}
+
+	expected := `{
+ "status": {
+  "message": "Bad Request",
+  "code": "400"
+ },
+ "errors": [
+  {
+   "message": "No time span set",
+   "code": "400",
+   "details": "Please use start_time and end_time url parameters to set the prefered time span"
+  }
+ ]
+}`
+
+	for _, url := range urls {
+		request, _ := http.NewRequest("GET", url, strings.NewReader(""))
+		request.Header.Set("x-api-key", suite.clientkey)
+		request.Header.Set("Accept", "application/json")
+
+		response := httptest.NewRecorder()
+
+		suite.router.ServeHTTP(response, request)
+
+		// Check that we must have a 200 ok code
+		suite.Equal(400, response.Code, "Incorrect HTTP response code")
+		// Compare the expected and actual xml response
+		suite.Equal(expected, response.Body.String(), "Response body mismatch")
+
+	}
+
+}
+
 // TestOptions tests responses in case the OPTIONS http verb is used
 func (suite *AvailabilityTestSuite) TestOptions() {
 

--- a/v3/ar/handlers.go
+++ b/v3/ar/handlers.go
@@ -214,7 +214,7 @@ func ListEndpointARByID(r *http.Request, cfg config.Config) (int, http.Header, [
 
 	// if user has not defined a start/end period construct by default the a/r period including the days of this month
 	if input.StartTime == "" && input.EndTime == "" {
-		input.StartTime = time.Now().UTC().Format("2006-01") + "01T00:00:00Z"
+		input.StartTime = time.Now().UTC().Format("2006-01") + "-01T00:00:00Z"
 		input.EndTime = time.Now().UTC().Format("2006-01-02") + "T23:59:59Z"
 	}
 

--- a/v3/ar/validations.go
+++ b/v3/ar/validations.go
@@ -48,11 +48,11 @@ func (query *basicQuery) Validate(db *mgo.Database) []ErrorResponse {
 		})
 	}
 
-	if query.StartTime == "" && query.EndTime == "" {
+	if query.StartTime == "" || query.EndTime == "" {
 		errs = append(errs, ErrorResponse{
 			Message: "No time span set",
 			Code:    "400",
-			Details: "Please use start_time and/or end_time url parameters to set the prefered time span",
+			Details: "Please use start_time and end_time url parameters to set the prefered time span",
 		})
 	} else {
 		if query.StartTime != "" {


### PR DESCRIPTION
- [x] Fix bug that when a user entered only start_time or end_time the validator gave it a pass (which is wrong)
- [x] When listing a/r results by id the user can choose to not provide start_time & end_time and he gets the results for all the days of the current month (till today). There was a typo when constructing the default start_time to be the start of the current month 