### PR TITLE
ARGO-3360 Support custom period in a/r results

### DIFF
--- a/app/results/Controller.go
+++ b/app/results/Controller.go
@@ -148,6 +148,7 @@ func FlatListEndpointResults(r *http.Request, cfg config.Config) (int, http.Head
 	}
 
 	// Select the granularity of the search daily/monthly
+	custom := false
 	if input.Granularity == "daily" {
 		customForm[0] = "20060102"
 		customForm[1] = "2006-01-02"
@@ -159,9 +160,14 @@ func FlatListEndpointResults(r *http.Request, cfg config.Config) (int, http.Head
 		query := FlatMonthlyEndpoint(filter, limit, skip)
 		err = mongo.Pipe(session, tenantDbConfig.Db, "endpoint_ar", query, &results)
 
+	} else if input.Granularity == "custom" {
+		customForm[0] = "20060102"
+		customForm[1] = "2006-01-02"
+		query := FlatCustomEndpoint(filter, limit, skip)
+		err = mongo.Pipe(session, tenantDbConfig.Db, "endpoint_ar", query, &results)
+		custom = true
 	}
 
-	// mongo.Find(session, tenantDbConfig.Db, "endpoint_group_ar", bson.M{}, "_id", &results)
 	if err != nil {
 		code = http.StatusInternalServerError
 		return code, h, output, err
@@ -174,7 +180,7 @@ func FlatListEndpointResults(r *http.Request, cfg config.Config) (int, http.Head
 		return code, h, output, err
 	}
 
-	output, err = createFlatEndpointResultView(results, report, input.Format, limit, skip)
+	output, err = createFlatEndpointResultView(results, report, input.Format, limit, skip, custom)
 
 	if err != nil {
 		code = http.StatusInternalServerError
@@ -282,6 +288,7 @@ func ListEndpointResults(r *http.Request, cfg config.Config) (int, http.Header, 
 	}
 
 	// Select the granularity of the search daily/monthly
+	custom := false
 	if input.Granularity == "daily" {
 		customForm[0] = "20060102"
 		customForm[1] = "2006-01-02"
@@ -292,6 +299,12 @@ func ListEndpointResults(r *http.Request, cfg config.Config) (int, http.Header, 
 		customForm[1] = "2006-01"
 		query := MonthlyEndpoint(filter)
 		err = mongo.Pipe(session, tenantDbConfig.Db, "endpoint_ar", query, &results)
+	} else if input.Granularity == "custom" {
+		customForm[0] = "200601"
+		customForm[1] = "2006-01"
+		query := CustomEndpoint(filter)
+		err = mongo.Pipe(session, tenantDbConfig.Db, "endpoint_ar", query, &results)
+		custom = true
 	}
 
 	// mongo.Find(session, tenantDbConfig.Db, "endpoint_group_ar", bson.M{}, "_id", &results)
@@ -307,7 +320,7 @@ func ListEndpointResults(r *http.Request, cfg config.Config) (int, http.Header, 
 		return code, h, output, err
 	}
 
-	output, err = createEndpointResultView(results, report, input.Format)
+	output, err = createEndpointResultView(results, report, input.Format, custom)
 
 	if err != nil {
 		code = http.StatusInternalServerError
@@ -316,175 +329,6 @@ func ListEndpointResults(r *http.Request, cfg config.Config) (int, http.Header, 
 
 	return code, h, output, err
 
-}
-
-// FlatDailyEndpoint query to aggregate daily endpoint a/r results from mongoDB
-func FlatDailyEndpoint(filter bson.M, limit int, skip int) []bson.M {
-
-	query := []bson.M{
-		{"$match": filter},
-		{"$project": bson.M{
-			"_id":          1,
-			"date":         bson.D{{"$substr", list{"$date", 0, 8}}},
-			"name":         1,
-			"availability": 1,
-			"reliability":  1,
-			"unknown":      1,
-			"up":           1,
-			"down":         1,
-			"supergroup":   1,
-			"service":      1,
-			"info":         1,
-			"report":       1}},
-		{"$sort": bson.D{
-			{"name", 1},
-			{"service", 1},
-			{"supergroup", 1},
-			{"date", 1},
-		}}}
-
-	if limit > 0 {
-		query = append(query, bson.M{"$skip": skip})
-		query = append(query, bson.M{"$limit": limit + 1})
-
-	}
-
-	return query
-}
-
-// DailyEndpoint query to aggregate daily endpoint a/r results from mongoDB
-func DailyEndpoint(filter bson.M) []bson.M {
-	query := []bson.M{
-		{"$match": filter},
-		{"$group": bson.M{
-			"_id": bson.M{
-				"id":           "$_id",
-				"date":         bson.D{{"$substr", list{"$date", 0, 8}}},
-				"name":         "$name",
-				"supergroup":   "$supergroup",
-				"service":      "$service",
-				"availability": "$availability",
-				"reliability":  "$reliability",
-				"unknown":      "$unknown",
-				"up":           "$up",
-				"down":         "$down",
-				"report":       "$report"},
-			"info": bson.M{"$first": "$info"},
-		}},
-
-		{"$project": bson.M{
-			"_id":          "$_id.id",
-			"date":         "$_id.date",
-			"name":         "$_id.name",
-			"availability": "$_id.availability",
-			"reliability":  "$_id.reliability",
-			"unknown":      "$_id.unknown",
-			"up":           "$_id.up",
-			"down":         "$_id.down",
-			"supergroup":   "$_id.supergroup",
-			"service":      "$_id.service",
-			"info":         "$info",
-			"report":       "$_id.report"}},
-		{"$sort": bson.D{
-			{"supergroup", 1},
-			{"service", 1},
-			{"name", 1},
-			{"date", 1}}}}
-
-	return query
-}
-
-// FlatMonthlyEndpoint query to aggregate monthly a/r results from mongoDB
-func FlatMonthlyEndpoint(filter bson.M, limit int, skip int) []bson.M {
-	query := []bson.M{
-		{"$match": filter},
-		{"$group": bson.M{
-			"_id": bson.M{
-				"date":       bson.D{{"$substr", list{"$date", 0, 6}}},
-				"name":       "$name",
-				"supergroup": "$supergroup",
-				"service":    "$service",
-				"report":     "$report"},
-			"avgup":      bson.M{"$avg": "$up"},
-			"avgunknown": bson.M{"$avg": "$unknown"},
-			"avgdown":    bson.M{"$avg": "$down"},
-			"info":       bson.M{"$first": "$info"}}},
-		{"$project": bson.M{
-			"date":       "$_id.date",
-			"name":       "$_id.name",
-			"supergroup": "$_id.supergroup",
-			"service":    "$_id.service",
-			"report":     "$_id.report",
-			"info":       "$info",
-			"unknown":    "$avgunknown",
-			"up":         "$avgup",
-			"down":       "$avgdown",
-			"availability": bson.M{
-				"$multiply": list{
-					bson.M{"$divide": list{
-						"$avgup", bson.M{"$subtract": list{1.00000001, "$avgunknown"}}}},
-					100}},
-			"reliability": bson.M{
-				"$multiply": list{
-					bson.M{"$divide": list{
-						"$avgup", bson.M{"$subtract": list{bson.M{"$subtract": list{1.00000001, "$avgunknown"}}, "$avgdown"}}}},
-					100}}}},
-		{"$sort": bson.D{
-			{"name", 1},
-			{"service", 1},
-			{"supergroup", 1},
-			{"date", 1}}}}
-
-	if limit > 0 {
-		query = append(query, bson.M{"$skip": skip})
-		query = append(query, bson.M{"$limit": limit + 1})
-
-	}
-
-	return query
-}
-
-// MonthlyEndpoint query to aggregate monthly a/r results from mongoDB
-func MonthlyEndpoint(filter bson.M) []bson.M {
-	query := []bson.M{
-		{"$match": filter},
-		{"$group": bson.M{
-			"_id": bson.M{
-				"date":       bson.D{{"$substr", list{"$date", 0, 6}}},
-				"name":       "$name",
-				"supergroup": "$supergroup",
-				"service":    "$service",
-				"report":     "$report"},
-			"avgup":      bson.M{"$avg": "$up"},
-			"avgunknown": bson.M{"$avg": "$unknown"},
-			"avgdown":    bson.M{"$avg": "$down"},
-			"info":       bson.M{"$first": "$info"}}},
-
-		{"$project": bson.M{
-			"date":       "$_id.date",
-			"name":       "$_id.name",
-			"supergroup": "$_id.supergroup",
-			"service":    "$_id.service",
-			"report":     "$_id.report",
-			"info":       "$info",
-			"unknown":    "$avgunknown",
-			"up":         "$avgup",
-			"down":       "$avgdown",
-			"availability": bson.M{
-				"$multiply": list{
-					bson.M{"$divide": list{
-						"$avgup", bson.M{"$subtract": list{1.00000001, "$avgunknown"}}}},
-					100}},
-			"reliability": bson.M{
-				"$multiply": list{
-					bson.M{"$divide": list{
-						"$avgup", bson.M{"$subtract": list{bson.M{"$subtract": list{1.00000001, "$avgunknown"}}, "$avgdown"}}}},
-					100}}}},
-		{"$sort": bson.D{
-			{"supergroup", 1},
-			{"name", 1},
-			{"date", 1}}}}
-	return query
 }
 
 // ListServiceFlavorResults is responsible for handling request to list service flavor results
@@ -578,6 +422,7 @@ func ListServiceFlavorResults(r *http.Request, cfg config.Config) (int, http.Hea
 	}
 
 	// Select the granularity of the search daily/monthly
+	custom := false
 	if input.Granularity == "daily" {
 		customForm[0] = "20060102"
 		customForm[1] = "2006-01-02"
@@ -588,6 +433,12 @@ func ListServiceFlavorResults(r *http.Request, cfg config.Config) (int, http.Hea
 		customForm[1] = "2006-01"
 		query := MonthlyServiceFlavor(filter)
 		err = mongo.Pipe(session, tenantDbConfig.Db, "service_ar", query, &results)
+	} else if input.Granularity == "custom" {
+		customForm[0] = "200601"
+		customForm[1] = "2006-01"
+		query := CustomServiceFlavor(filter)
+		err = mongo.Pipe(session, tenantDbConfig.Db, "service_ar", query, &results)
+		custom = true
 	}
 
 	// mongo.Find(session, tenantDbConfig.Db, "endpoint_group_ar", bson.M{}, "_id", &results)
@@ -603,7 +454,7 @@ func ListServiceFlavorResults(r *http.Request, cfg config.Config) (int, http.Hea
 		return code, h, output, err
 	}
 
-	output, err = createServiceFlavorResultView(results, report, input.Format)
+	output, err = createServiceFlavorResultView(results, report, input.Format, custom)
 
 	if err != nil {
 		code = http.StatusInternalServerError
@@ -702,6 +553,7 @@ func ListEndpointGroupResults(r *http.Request, cfg config.Config) (int, http.Hea
 	}
 
 	// Select the granularity of the search daily/monthly
+	custom := false
 	if input.Granularity == "daily" {
 		customForm[0] = "20060102"
 		customForm[1] = "2006-01-02"
@@ -712,6 +564,12 @@ func ListEndpointGroupResults(r *http.Request, cfg config.Config) (int, http.Hea
 		customForm[1] = "2006-01"
 		query := MonthlyEndpointGroup(filter)
 		err = mongo.Pipe(session, tenantDbConfig.Db, "endpoint_group_ar", query, &results)
+	} else if input.Granularity == "custom" {
+		customForm[0] = "200601"
+		customForm[1] = "2006-01"
+		query := CustomEndpointGroup(filter)
+		err = mongo.Pipe(session, tenantDbConfig.Db, "endpoint_group_ar", query, &results)
+		custom = true
 	}
 
 	// mongo.Find(session, tenantDbConfig.Db, "endpoint_group_ar", bson.M{}, "_id", &results)
@@ -727,7 +585,7 @@ func ListEndpointGroupResults(r *http.Request, cfg config.Config) (int, http.Hea
 		return code, h, output, err
 	}
 
-	output, err = createEndpointGroupResultView(results, report, input.Format)
+	output, err = createEndpointGroupResultView(results, report, input.Format, custom)
 
 	if err != nil {
 		code = http.StatusInternalServerError
@@ -813,6 +671,7 @@ func ListSuperGroupResults(r *http.Request, cfg config.Config) (int, http.Header
 		filter["supergroup"] = input.Name
 	}
 
+	custom := false
 	// Select the granularity of the search daily/monthly
 	if input.Granularity == "daily" {
 		customForm[0] = "20060102"
@@ -824,6 +683,12 @@ func ListSuperGroupResults(r *http.Request, cfg config.Config) (int, http.Header
 		customForm[1] = "2006-01"
 		query := MonthlySuperGroup(filter)
 		err = mongo.Pipe(session, tenantDbConfig.Db, "endpoint_group_ar", query, &results)
+	} else if input.Granularity == "custom" {
+		customForm[0] = "200601"
+		customForm[1] = "2006-01"
+		query := CustomSuperGroup(filter)
+		err = mongo.Pipe(session, tenantDbConfig.Db, "endpoint_group_ar", query, &results)
+		custom = true
 	}
 	// mongo.Find(session, tenantDbConfig.Db, "endpoint_group_ar", bson.M{}, "_id", &results)
 	if err != nil {
@@ -838,7 +703,7 @@ func ListSuperGroupResults(r *http.Request, cfg config.Config) (int, http.Header
 		return code, h, output, err
 	}
 
-	output, err = createSuperGroupView(results, report, input.Format)
+	output, err = createSuperGroupView(results, report, input.Format, custom)
 
 	if err != nil {
 		code = http.StatusInternalServerError
@@ -846,328 +711,6 @@ func ListSuperGroupResults(r *http.Request, cfg config.Config) (int, http.Header
 	}
 
 	return code, h, output, err
-}
-
-// DailyServiceFlavor query to aggregate daily SF results from mongoDB
-func DailyServiceFlavor(filter bson.M) []bson.M {
-	query := []bson.M{
-		{"$match": filter},
-		{"$group": bson.M{
-			"_id": bson.M{
-				"date":         bson.D{{"$substr", list{"$date", 0, 8}}},
-				"name":         "$name",
-				"supergroup":   "$supergroup",
-				"availability": "$availability",
-				"reliability":  "$reliability",
-				"unknown":      "$unknown",
-				"up":           "$up",
-				"down":         "$down",
-				"report":       "$report"}}},
-		{"$project": bson.M{
-			"date":         "$_id.date",
-			"name":         "$_id.name",
-			"availability": "$_id.availability",
-			"reliability":  "$_id.reliability",
-			"unknown":      "$_id.unknown",
-			"up":           "$_id.up",
-			"down":         "$_id.down",
-			"supergroup":   "$_id.supergroup",
-			"report":       "$_id.report"}},
-		{"$sort": bson.D{
-			{"supergroup", 1},
-			{"name", 1},
-			{"date", 1}}}}
-
-	return query
-}
-
-// MonthlyServiceFlavor query to aggregate daily SF results from mongoDB
-func MonthlyServiceFlavor(filter bson.M) []bson.M {
-	query := []bson.M{
-		{"$match": filter},
-		{"$group": bson.M{
-			"_id": bson.M{
-				"date":       bson.D{{"$substr", list{"$date", 0, 6}}},
-				"name":       "$name",
-				"supergroup": "$supergroup",
-				"report":     "$report"},
-			"avgup":      bson.M{"$avg": "$up"},
-			"avgunknown": bson.M{"$avg": "$unknown"},
-			"avgdown":    bson.M{"$avg": "$down"}}},
-		{"$project": bson.M{
-			"date":       "$_id.date",
-			"name":       "$_id.name",
-			"supergroup": "$_id.supergroup",
-			"report":     "$_id.report",
-			"unknown":    "$avgunknown",
-			"up":         "$avgup",
-			"down":       "$avgdown",
-			"availability": bson.M{
-				"$multiply": list{
-					bson.M{"$divide": list{
-						"$avgup", bson.M{"$subtract": list{1.00000001, "$avgunknown"}}}},
-					100}},
-			"reliability": bson.M{
-				"$multiply": list{
-					bson.M{"$divide": list{
-						"$avgup", bson.M{"$subtract": list{bson.M{"$subtract": list{1.00000001, "$avgunknown"}}, "$avgdown"}}}},
-					100}}}},
-		{"$sort": bson.D{
-			{"supergroup", 1},
-			{"name", 1},
-			{"date", 1}}}}
-	return query
-}
-
-// DailyEndpointGroup query to aggregate daily results from mongodb
-func DailyEndpointGroup(filter bson.M) []bson.M {
-	// Mongo aggregation pipeline
-	// Select all the records that match q
-	// Project to select just the first 8 digits of the date YYYYMMDD
-	// Sort by profile->supergroup->endpointGroup->datetime
-	query := []bson.M{
-		{"$match": filter},
-		{"$project": bson.M{
-			"date":         bson.M{"$substr": list{"$date", 0, 8}},
-			"availability": 1,
-			"reliability":  1,
-			"unknown":      1,
-			"up":           1,
-			"down":         1,
-			"report":       1,
-			"supergroup":   1,
-			"name":         1}},
-		{"$sort": bson.D{
-			{"report", 1},
-			{"supergroup", 1},
-			{"name", 1},
-			{"date", 1}}}}
-
-	return query
-}
-
-// MonthlyEndpointGroup query to aggregate monthly results from mongodb
-func MonthlyEndpointGroup(filter bson.M) []bson.M {
-
-	// Mongo aggregation pipeline
-	// Select all the records that match q
-	// Group them by the first six digits of their date (YYYYMM), their supergroup, their endpointGroup, their profile, etc...
-	// from that group find the average of the uptime, u, downtime
-	// Project the result to a better format and do this computation
-	// availability = (avgup/(1.00000001 - avgu))*100
-	// reliability = (avgup/((1.00000001 - avgu)-avgd))*100
-	// Sort the results by namespace->profile->supergroup->endpointGroup->datetime
-
-	query := []bson.M{
-		{"$match": filter},
-		{"$group": bson.M{
-			"_id": bson.M{
-				"date":       bson.M{"$substr": list{"$date", 0, 6}},
-				"name":       "$name",
-				"supergroup": "$supergroup",
-				"report":     "$report"},
-			"avgup":      bson.M{"$avg": "$up"},
-			"avgunknown": bson.M{"$avg": "$unknown"},
-			"avgdown":    bson.M{"$avg": "$down"}}},
-		{"$project": bson.M{
-			"date":       "$_id.date",
-			"name":       "$_id.name",
-			"report":     "$_id.report",
-			"supergroup": "$_id.supergroup",
-			"unknown":    "$avgunknown",
-			"up":         "$avgup",
-			"down":       "$avgdown",
-			"avgup":      1,
-			"avgunknown": 1,
-			"avgdown":    1,
-			"availability": bson.M{
-				"$multiply": list{
-					bson.M{"$divide": list{
-						"$avgup", bson.M{"$subtract": list{1.00000001, "$avgunknown"}}}},
-					100}},
-			"reliability": bson.M{
-				"$multiply": list{
-					bson.M{"$divide": list{
-						"$avgup", bson.M{"$subtract": list{bson.M{"$subtract": list{1.00000001, "$avgunknown"}}, "$avgdown"}}}},
-					100}}}},
-		{"$sort": bson.D{
-			{"report", 1},
-			{"supergroup", 1},
-			{"name", 1},
-			{"date", 1}}}}
-
-	return query
-}
-
-// DailySuperGroup function to build the MongoDB aggregation query for daily calculations
-func DailySuperGroup(filter bson.M) []bson.M {
-	// The following aggregation query consists of 5 grand steps
-	// 1. Match   : records for the specific date and report and supergroup(optional)
-	// 2. Project : all necessary fields (date,availability,reliability,report) etc but also
-	//              if avail >= 0 set an availability-weigh = weight + 1, else = 0
-	//							if rel >=0 set a reliability-weight = weight + 1, else = 0
-	//              keep also weight = weight + 1 (to compensate for zero values)
-	//
-	//              Keeping two extra weights (a/r) has the following result:
-	//               - If an item has undef availab. then it will have an weightAv=0 and will not affect sums
-	//                    for eg. avg_daily_supergroup_availability = (av1*w1 + av2*w2 + undefAv3*0) / (w1 + w1 + 0)
-	//               - If an item has undef reliab. then it will have an weightRel=0 and will not affect sums
-	//                    for eg. avg_daily_supergroup_reliability = (rel1*w2 + rel2*w2 + undefRel3*0) / (w1 + w1 + 0)
-	//
-	// 3. Group   : by supergroup and day and calculate the sum of weighted daily availabilites (and reliabilities also)
-	//              - availability(weighted_sum) = av1*w1 + av2*w2 + undefAv3*0 etc...
-	//              - reliability(weighted_sum) = rel1*w1 + rel2*w2 + undefRel3*0 etc...
-	//
-	// 4. Match   : assertion step - keep only items that have a valid weight > 0
-	// 5. Project : the previous results and try to find the weighted average of daily avail. and reliability by:
-	//              - divide the previous sum of weighted availabilities by the total weightAv
-	//                SPECIAL CASE: If total weightAv remains : 0 that means that total daily supergroup avail = undef
-	//                              so instead of a numeric value, add a "nan" string (will not be counted in monthly average)
-	//              - divide the previous sum of weighted availabilities by the total weightAv
-	//								SPECIAL CASE: If total weightRem remains : 0 that means that total daily supergroup rel = undef
-	//                              so instead of a numeric value, add a "nan" string (will not be counted in monthly average)
-	// 6. Project : the relevant fields to form the appropriate final response (date,supergroup,report,avail,rel)
-	// 7. Sort    : the final results by report, supergroup and then date
-	query := []bson.M{
-		{"$match": filter},
-		{"$project": bson.M{
-			"date":         1,
-			"availability": 1,
-			"reliability":  1,
-			"report":       1,
-			"supergroup":   1,
-			"weightAv":     bson.M{"$cond": list{bson.M{"$gte": list{"$availability", 0}}, bson.M{"$add": list{"$weight", 1}}, 0}},
-			"weightRel":    bson.M{"$cond": list{bson.M{"$gte": list{"$reliability", 0}}, bson.M{"$add": list{"$weight", 1}}, 0}},
-			"weight": bson.M{
-				"$add": list{"$weight", 1}}},
-		},
-		{"$group": bson.M{
-			"_id": bson.M{
-				"date":       bson.D{{"$substr", list{"$date", 0, 8}}},
-				"supergroup": "$supergroup",
-				"report":     "$report"},
-			"availability": bson.M{"$sum": bson.M{"$multiply": list{"$availability", "$weightAv"}}},
-			"reliability":  bson.M{"$sum": bson.M{"$multiply": list{"$reliability", "$weightRel"}}},
-			"weightAv":     bson.M{"$sum": "$weightAv"},
-			"weightRel":    bson.M{"$sum": "$weightRel"},
-			"weight":       bson.M{"$sum": "$weight"}},
-		},
-		{"$match": bson.M{
-			"weight": bson.M{"$gt": 0}},
-		},
-		{"$project": bson.M{
-			"date":         "$_id.date",
-			"supergroup":   "$_id.supergroup",
-			"report":       "$_id.report",
-			"availability": bson.M{"$cond": list{bson.M{"$gt": list{"$weightAv", 0}}, bson.M{"$divide": list{"$availability", "$weightAv"}}, "nan"}},
-			"reliability":  bson.M{"$cond": list{bson.M{"$gt": list{"$weightRel", 0}}, bson.M{"$divide": list{"$reliability", "$weightRel"}}, "nan"}}},
-		},
-		{"$project": bson.M{
-			"date":         "$_id.date",
-			"supergroup":   "$_id.supergroup",
-			"report":       "$_id.report",
-			"availability": 1,
-			"reliability":  1},
-		},
-		{"$sort": bson.D{
-			{"report", 1},
-			{"supergroup", 1},
-			{"date", 1}},
-		}}
-
-	return query
-}
-
-// MonthlySuperGroup function to build the MongoDB aggregation query for monthly calculations
-func MonthlySuperGroup(filter bson.M) []bson.M {
-
-	// The following aggregation query consists of 5 grand steps
-	// 1. Match   : records for the specific date and report and supergroup(optional)
-	// 2. Project : all necessary fields (date,availability,reliability,report) etc but also
-	//              if avail >= 0 set an availability-weigh = weight + 1, else = 0
-	//							if rel >=0 set a reliability-weight = weight + 1, else = 0
-	//              keep also weight = weight + 1 (to compensate for zero values)
-	//
-	//              Keeping two extra weights (a/r) has the following result:
-	//               - If an item has undef availab. then it will have an weightAv=0 and will not affect sums
-	//                    for eg. avg_daily_supergroup_availability = (av1*w1 + av2*w2 + undefAv3*0) / (w1 + w1 + 0)
-	//               - If an item has undef reliab. then it will have an weightRel=0 and will not affect sums
-	//                    for eg. avg_daily_supergroup_reliability = (rel1*w2 + rel2*w2 + undefRel3*0) / (w1 + w1 + 0)
-	//
-	// 3. Group   : by supergroup and day and calculate the sum of weighted daily availabilites (and reliabilities also)
-	//              - availability(weighted_sum) = av1*w1 + av2*w2 + undefAv3*0 etc...
-	//              - reliability(weighted_sum) = rel1*w1 + rel2*w2 + undefRel3*0 etc...
-	//
-	// 4. Match   : assertion step - keep only items that have a valid weight > 0
-	// 5. Project : the previous results and try to find the weighted average of daily avail. and reliability by:
-	//              - divide the previous sum of weighted availabilities by the total weightAv
-	//                SPECIAL CASE: If total weightAv remains : 0 that means that total daily supergroup avail = undef
-	//                              so instead of a numeric value, add a "nan" string (will not be counted in monthly average)
-	//              - divide the previous sum of weighted availabilities by the total weightAv
-	//								SPECIAL CASE: If total weightRem remains : 0 that means that total daily supergroup rel = undef
-	//                              so instead of a numeric value, add a "nan" string (will not be counted in monthly average)
-	// 6. Group   : by first date part (month, eg: 201608) to calculate monthly average avail and rel.
-	//							- monthly availability avg = avg(daily_availabilities) ~ but items with "nan" values will be neglected
-	//						  - monthly reliability avg = avg(daily_reliabilities) ~ but items with "nan" values will be neglected
-	//
-	// 7. Project : the relevant fields to form the appropriate final response (date,supergroup,report,avail,rel)
-	// 8. Sort    : the final results by report, supergroup and then date
-
-	query := []bson.M{
-		{"$match": filter},
-		{"$project": bson.M{
-			"date":         1,
-			"availability": 1,
-			"reliability":  1,
-			"report":       1,
-			"supergroup":   1,
-			"weightAv":     bson.M{"$cond": list{bson.M{"$gte": list{"$availability", 0}}, bson.M{"$add": list{"$weight", 1}}, 0}},
-			"weightRel":    bson.M{"$cond": list{bson.M{"$gte": list{"$reliability", 0}}, bson.M{"$add": list{"$weight", 1}}, 0}},
-			"weight": bson.M{
-				"$add": list{"$weight", 1}}},
-		},
-		{"$group": bson.M{
-			"_id": bson.M{
-				"date":       bson.D{{"$substr", list{"$date", 0, 8}}},
-				"supergroup": "$supergroup",
-				"report":     "$report"},
-			"availability": bson.M{"$sum": bson.M{"$multiply": list{"$availability", "$weightAv"}}},
-			"reliability":  bson.M{"$sum": bson.M{"$multiply": list{"$reliability", "$weightRel"}}},
-			"weightAv":     bson.M{"$sum": "$weightAv"},
-			"weightRel":    bson.M{"$sum": "$weightRel"},
-			"weight":       bson.M{"$sum": "$weight"}},
-		},
-		{"$match": bson.M{
-			"weight": bson.M{"$gt": 0}},
-		},
-		{"$project": bson.M{
-			"date":         "$_id.date",
-			"supergroup":   "$_id.supergroup",
-			"report":       "$_id.report",
-			"availability": bson.M{"$cond": list{bson.M{"$gt": list{"$weightAv", 0}}, bson.M{"$divide": list{"$availability", "$weightAv"}}, "nan"}},
-			"reliability":  bson.M{"$cond": list{bson.M{"$gt": list{"$weightRel", 0}}, bson.M{"$divide": list{"$reliability", "$weightRel"}}, "nan"}}},
-		},
-		{"$group": bson.M{
-			"_id": bson.M{
-				"date":       bson.D{{"$substr", list{"$date", 0, 6}}},
-				"supergroup": "$supergroup", "report": "$report"},
-			"availability": bson.M{"$avg": "$availability"},
-			"reliability":  bson.M{"$avg": "$reliability"}},
-		},
-		{"$project": bson.M{
-			"date":         "$_id.date",
-			"supergroup":   "$_id.supergroup",
-			"report":       "$_id.report",
-			"availability": 1,
-			"reliability":  1},
-		},
-		{"$sort": bson.D{
-			{"report", 1},
-			{"supergroup", 1},
-			{"date", 1}},
-		}}
-
-	return query
 }
 
 func Options(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {

--- a/app/results/Model.go
+++ b/app/results/Model.go
@@ -143,7 +143,7 @@ type SuperGroupInterface struct {
 //Availability struct for formating xml/json
 type Availability struct {
 	XMLName      xml.Name `xml:"results" json:"-"`
-	Timestamp    string   `xml:"timestamp,attr" json:"timestamp"`
+	Timestamp    string   `xml:"timestamp,attr,omitempty" json:"timestamp,omitempty"`
 	Availability string   `xml:"availability,attr" json:"availability"`
 	Reliability  string   `xml:"reliability,attr" json:"reliability"`
 	Unknown      string   `xml:"unknown,attr,omitempty" json:"unknown,omitempty"`
@@ -230,11 +230,11 @@ func (query *basicQuery) Validate(db *mgo.Database) []ErrorResponse {
 	query.Granularity = strings.ToLower(query.Granularity)
 	if query.Granularity == "" {
 		query.Granularity = "daily"
-	} else if query.Granularity != "daily" && query.Granularity != "monthly" {
+	} else if query.Granularity != "daily" && query.Granularity != "monthly" && query.Granularity != "custom" {
 		errs = append(errs, ErrorResponse{
 			Message: "Wrong Granularity",
 			Code:    "400",
-			Details: fmt.Sprintf("%s is not accepted as granularity parameter, please provide either daily or monthly", query.Granularity),
+			Details: fmt.Sprintf("%s is not accepted as granularity parameter, please provide either daily, monthly or custom", query.Granularity),
 		})
 	}
 

--- a/app/results/View.go
+++ b/app/results/View.go
@@ -34,7 +34,7 @@ import (
 	"github.com/ARGOeu/argo-web-api/app/reports"
 )
 
-func createEndpointResultView(results []EndpointInterface, report reports.MongoInterface, format string) ([]byte, error) {
+func createEndpointResultView(results []EndpointInterface, report reports.MongoInterface, format string, custom bool) ([]byte, error) {
 	docRoot := &root{}
 
 	prevServiceFlavorGroup := ""
@@ -82,9 +82,13 @@ func createEndpointResultView(results []EndpointInterface, report reports.MongoI
 			serviceEndpointGroup.Endpoints = append(serviceEndpointGroup.Endpoints, endpoint)
 		}
 		//we append the new availability values
+		prepDate := timestamp.Format(customForm[1])
+		if custom {
+			prepDate = ""
+		}
 		endpoint.Availability = append(endpoint.Availability,
 			&Availability{
-				Timestamp:    timestamp.Format(customForm[1]),
+				Timestamp:    prepDate,
 				Availability: fmt.Sprintf("%g", row.Availability),
 				Reliability:  fmt.Sprintf("%g", row.Reliability),
 				Unknown:      fmt.Sprintf("%g", row.Unknown),
@@ -100,7 +104,7 @@ func createEndpointResultView(results []EndpointInterface, report reports.MongoI
 
 }
 
-func createFlatEndpointResultView(results []EndpointInterface, report reports.MongoInterface, format string, limit int, skip int) ([]byte, error) {
+func createFlatEndpointResultView(results []EndpointInterface, report reports.MongoInterface, format string, limit int, skip int, custom bool) ([]byte, error) {
 
 	docRoot := &pageRoot{}
 
@@ -136,9 +140,13 @@ func createFlatEndpointResultView(results []EndpointInterface, report reports.Mo
 
 		}
 		//we append the new availability values
+		prepDate := timestamp.Format(customForm[1])
+		if custom {
+			prepDate = ""
+		}
 		endpoint.Availability = append(endpoint.Availability,
 			&Availability{
-				Timestamp:    timestamp.Format(customForm[1]),
+				Timestamp:    prepDate,
 				Availability: fmt.Sprintf("%g", row.Availability),
 				Reliability:  fmt.Sprintf("%g", row.Reliability),
 				Unknown:      fmt.Sprintf("%g", row.Unknown),
@@ -164,7 +172,7 @@ func createFlatEndpointResultView(results []EndpointInterface, report reports.Mo
 
 }
 
-func createServiceFlavorResultView(results []ServiceFlavorInterface, report reports.MongoInterface, format string) ([]byte, error) {
+func createServiceFlavorResultView(results []ServiceFlavorInterface, report reports.MongoInterface, format string, custom bool) ([]byte, error) {
 
 	docRoot := &root{}
 
@@ -199,9 +207,13 @@ func createServiceFlavorResultView(results []ServiceFlavorInterface, report repo
 			serviceFlavorGroup.ServiceFlavor = append(serviceFlavorGroup.ServiceFlavor, serviceFlavor)
 		}
 		//we append the new availability values
+		prepDate := timestamp.Format(customForm[1])
+		if custom {
+			prepDate = ""
+		}
 		serviceFlavor.Availability = append(serviceFlavor.Availability,
 			&Availability{
-				Timestamp:    timestamp.Format(customForm[1]),
+				Timestamp:    prepDate,
 				Availability: fmt.Sprintf("%g", row.Availability),
 				Reliability:  fmt.Sprintf("%g", row.Reliability),
 				Unknown:      fmt.Sprintf("%g", row.Unknown),
@@ -217,7 +229,7 @@ func createServiceFlavorResultView(results []ServiceFlavorInterface, report repo
 
 }
 
-func createEndpointGroupResultView(results []EndpointGroupInterface, report reports.MongoInterface, format string) ([]byte, error) {
+func createEndpointGroupResultView(results []EndpointGroupInterface, report reports.MongoInterface, format string, custom bool) ([]byte, error) {
 
 	docRoot := &root{}
 
@@ -253,9 +265,13 @@ func createEndpointGroupResultView(results []EndpointGroupInterface, report repo
 			superGroup.Endpoints = append(superGroup.Endpoints, endpointGroup)
 		}
 		//we append the new availability values
+		prepDate := timestamp.Format(customForm[1])
+		if custom {
+			prepDate = ""
+		}
 		endpointGroup.Availability = append(endpointGroup.Availability,
 			&Availability{
-				Timestamp:    timestamp.Format(customForm[1]),
+				Timestamp:    prepDate,
 				Availability: fmt.Sprintf("%g", row.Availability),
 				Reliability:  fmt.Sprintf("%g", row.Reliability),
 				Unknown:      fmt.Sprintf("%g", row.Unknown),
@@ -270,7 +286,7 @@ func createEndpointGroupResultView(results []EndpointGroupInterface, report repo
 
 }
 
-func createSuperGroupView(results []SuperGroupInterface, report reports.MongoInterface, format string) ([]byte, error) {
+func createSuperGroupView(results []SuperGroupInterface, report reports.MongoInterface, format string, custom bool) ([]byte, error) {
 
 	docRoot := &root{}
 
@@ -293,9 +309,13 @@ func createSuperGroupView(results []SuperGroupInterface, report reports.MongoInt
 			docRoot.Result = append(docRoot.Result, superGroup)
 		}
 		//we append the new availability values
+		prepDate := timestamp.Format(customForm[1])
+		if custom {
+			prepDate = ""
+		}
 		superGroup.Results = append(superGroup.Results,
 			&Availability{
-				Timestamp:    timestamp.Format(customForm[1]),
+				Timestamp:    prepDate,
 				Availability: fmt.Sprintf("%g", row.Availability),
 				Reliability:  fmt.Sprintf("%g", row.Reliability)})
 	}

--- a/app/results/endpoint_test.go
+++ b/app/results/endpoint_test.go
@@ -447,6 +447,69 @@ func (suite *endpointAvailabilityTestSuite) TestListEndpointAvailabilityMonthly(
 	suite.Equal(endpointAvailabilityJSON, responseBody, "Response body mismatch")
 
 }
+
+func (suite *endpointAvailabilityTestSuite) TestListEndpointAvailabilityCustom() {
+
+	request, _ := http.NewRequest("GET", "/api/v2/results/Report_A/SITE/ST01/services/service_a/endpoints?start_time=2015-06-22T00:00:00Z&end_time=2015-06-23T23:59:59Z&granularity=custom", strings.NewReader(""))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+	responseBody := response.Body.String()
+	endpointAvailabilityJSON := `{
+   "results": [
+     {
+       "name": "ST01",
+       "type": "SITE",
+       "serviceflavors": [
+         {
+           "name": "service_a",
+           "type": "service",
+           "endpoints": [
+             {
+               "name": "e01",
+               "type": "endpoint",
+               "info": {
+                 "Url": "https://foo.example.url"
+               },
+               "results": [
+                 {
+                   "availability": "76.26534166743393",
+                   "reliability": "91.61418757296076",
+                   "unknown": "0.00521",
+                   "uptime": "0.75868",
+                   "downtime": "0.166665"
+                 }
+               ]
+             },
+             {
+               "name": "e02",
+               "type": "endpoint",
+               "results": [
+                 {
+                   "availability": "98.43749901562502",
+                   "reliability": "98.43749901562502",
+                   "unknown": "0",
+                   "uptime": "0.984375",
+                   "downtime": "0"
+                 }
+               ]
+             }
+           ]
+         }
+       ]
+     }
+   ]
+ }`
+
+	// Check that we must have a 200 ok code
+	suite.Equal(200, response.Code, "Incorrect HTTP response code")
+	// Compare the expected and actual xml response
+	suite.Equal(endpointAvailabilityJSON, responseBody, "Response body mismatch")
+
+}
 func (suite *endpointAvailabilityTestSuite) TestFlatAllEndpoints() {
 
 	request, _ := http.NewRequest("GET", "/api/v2/results/Report_A/endpoints?start_time=2015-06-20T12:00:00Z&end_time=2015-06-23T23:00:00Z&granularity=daily", strings.NewReader(""))
@@ -1180,6 +1243,122 @@ func (suite *endpointAvailabilityTestSuite) TestMonthlyFlatAllEndpointsPaginated
      }
    ],
    "pageSize": 2
+ }`,
+			code: 200,
+		},
+	}
+
+	for _, expReq := range expReqs {
+		request, _ := http.NewRequest(expReq.method, expReq.url, strings.NewReader(""))
+		request.Header.Set("x-api-key", suite.clientkey)
+		request.Header.Set("Accept", "application/json")
+
+		response := httptest.NewRecorder()
+
+		suite.router.ServeHTTP(response, request)
+
+		suite.Equal(expReq.code, response.Code, "Incorrect HTTP response code")
+		// Compare the expected and actual xml response
+		suite.Equal(expReq.result, response.Body.String(), "Response body mismatch")
+
+	}
+
+}
+
+func (suite *endpointAvailabilityTestSuite) TestCustomFlatAllEndpointsPaginated() {
+
+	type expReq struct {
+		method string
+		url    string
+		code   int
+		result string
+	}
+
+	expReqs := []expReq{
+		expReq{
+			method: "GET",
+			url:    "/api/v2/results/Report_A/endpoints?start_time=2015-06-20T12:00:00Z&end_time=2015-06-23T23:00:00Z&granularity=custom&pageSize=-1",
+			result: `{
+   "results": [
+     {
+       "name": "e01",
+       "service": "service_a",
+       "supergroup": "ST01",
+       "type": "endpoint",
+       "info": {
+         "Url": "https://foo.example.url"
+       },
+       "results": [
+         {
+           "availability": "76.26534166743393",
+           "reliability": "91.61418757296076",
+           "unknown": "0.00521",
+           "uptime": "0.75868",
+           "downtime": "0.166665"
+         }
+       ]
+     },
+     {
+       "name": "e02",
+       "service": "service_a",
+       "supergroup": "ST01",
+       "type": "endpoint",
+       "results": [
+         {
+           "availability": "98.43749901562502",
+           "reliability": "98.43749901562502",
+           "unknown": "0",
+           "uptime": "0.984375",
+           "downtime": "0"
+         }
+       ]
+     },
+     {
+       "name": "e03",
+       "service": "service_b",
+       "supergroup": "ST02",
+       "type": "endpoint",
+       "results": [
+         {
+           "availability": "96.87499903125001",
+           "reliability": "96.87499903125001",
+           "unknown": "0",
+           "uptime": "0.96875",
+           "downtime": "0"
+         }
+       ]
+     },
+     {
+       "name": "e03",
+       "service": "service_b",
+       "supergroup": "STX",
+       "type": "endpoint",
+       "results": [
+         {
+           "availability": "96.87499903125001",
+           "reliability": "96.87499903125001",
+           "unknown": "0",
+           "uptime": "0.96875",
+           "downtime": "0"
+         }
+       ]
+     },
+     {
+       "name": "e03",
+       "service": "service_x",
+       "supergroup": "ST02",
+       "type": "endpoint",
+       "results": [
+         {
+           "availability": "96.87499903125001",
+           "reliability": "96.87499903125001",
+           "unknown": "0",
+           "uptime": "0.96875",
+           "downtime": "0"
+         }
+       ]
+     }
+   ]
  }`,
 			code: 200,
 		},

--- a/app/results/endpointgroup_test.go
+++ b/app/results/endpointgroup_test.go
@@ -623,6 +623,61 @@ func (suite *endpointGroupAvailabilityTestSuite) TestStrictSlashEndpointGroupRes
 
 }
 
+// TestListAllEndpointGroupAvailabilityCustom tests if a/r results are returned correctly over a custom period
+func (suite *endpointGroupAvailabilityTestSuite) TestListAllEndpointGroupAvailabilityCustom() {
+
+	request, _ := http.NewRequest("GET", "/api/v2/results/Report_A/SITES?start_time=2015-06-20T12:00:00Z&end_time=2015-06-23T23:00:00Z&granularity=custom", strings.NewReader(""))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	endpointGroupAvailabilityJSON := `{
+   "results": [
+     {
+       "name": "GROUP_A",
+       "type": "GROUP",
+       "endpoints": [
+         {
+           "name": "ST01",
+           "type": "SITES",
+           "results": [
+             {
+               "availability": "99.99999900000002",
+               "reliability": "99.99999900000002",
+               "unknown": "0",
+               "uptime": "1",
+               "downtime": "0"
+             }
+           ]
+         },
+         {
+           "name": "ST02",
+           "type": "SITES",
+           "results": [
+             {
+               "availability": "99.99999900000002",
+               "reliability": "99.99999900000002",
+               "unknown": "0",
+               "uptime": "1",
+               "downtime": "0"
+             }
+           ]
+         }
+       ]
+     }
+   ]
+ }`
+
+	// Check that we must have a 200 ok code
+	suite.Equal(200, response.Code, "Incorrect HTTP response code")
+	// Compare the expected and actual xml response
+	suite.Equal(endpointGroupAvailabilityJSON, response.Body.String(), "Response body mismatch")
+
+}
+
 //TearDownTest to tear down every test
 func (suite *endpointGroupAvailabilityTestSuite) TearDownTest() {
 

--- a/app/results/queries.go
+++ b/app/results/queries.go
@@ -1,13 +1,422 @@
-package ar
+/*
+ * Copyright (c) 2015 GRNET S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS
+ * IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ *
+ * The views and conclusions contained in the software and
+ * documentation are those of the authors and should not be
+ * interpreted as representing official policies, either expressed
+ * or implied, of GRNET S.A.
+ *
+ */
 
-import "gopkg.in/mgo.v2/bson"
+package results
 
-// datastore collection name that contains aggregations profile records
-const groupColName = "endpoint_group_ar"
-const endpointColName = "endpoint_ar"
+import (
+	"gopkg.in/mgo.v2/bson"
+)
 
-// MonthlyGroup query to aggregate monthly results from mongodb
-func MonthlyGroup(filter bson.M) []bson.M {
+// FlatDailyEndpoint query to aggregate daily endpoint a/r results from mongoDB
+func FlatDailyEndpoint(filter bson.M, limit int, skip int) []bson.M {
+
+	query := []bson.M{
+		{"$match": filter},
+		{"$project": bson.M{
+			"_id":          1,
+			"date":         bson.D{{"$substr", list{"$date", 0, 8}}},
+			"name":         1,
+			"availability": 1,
+			"reliability":  1,
+			"unknown":      1,
+			"up":           1,
+			"down":         1,
+			"supergroup":   1,
+			"service":      1,
+			"info":         1,
+			"report":       1}},
+		{"$sort": bson.D{
+			{"name", 1},
+			{"service", 1},
+			{"supergroup", 1},
+			{"date", 1},
+		}}}
+
+	if limit > 0 {
+		query = append(query, bson.M{"$skip": skip})
+		query = append(query, bson.M{"$limit": limit + 1})
+
+	}
+
+	return query
+}
+
+// DailyEndpoint query to aggregate daily endpoint a/r results from mongoDB
+func DailyEndpoint(filter bson.M) []bson.M {
+	query := []bson.M{
+		{"$match": filter},
+		{"$group": bson.M{
+			"_id": bson.M{
+				"id":           "$_id",
+				"date":         bson.D{{"$substr", list{"$date", 0, 8}}},
+				"name":         "$name",
+				"supergroup":   "$supergroup",
+				"service":      "$service",
+				"availability": "$availability",
+				"reliability":  "$reliability",
+				"unknown":      "$unknown",
+				"up":           "$up",
+				"down":         "$down",
+				"report":       "$report"},
+			"info": bson.M{"$first": "$info"},
+		}},
+
+		{"$project": bson.M{
+			"_id":          "$_id.id",
+			"date":         "$_id.date",
+			"name":         "$_id.name",
+			"availability": "$_id.availability",
+			"reliability":  "$_id.reliability",
+			"unknown":      "$_id.unknown",
+			"up":           "$_id.up",
+			"down":         "$_id.down",
+			"supergroup":   "$_id.supergroup",
+			"service":      "$_id.service",
+			"info":         "$info",
+			"report":       "$_id.report"}},
+		{"$sort": bson.D{
+			{"supergroup", 1},
+			{"service", 1},
+			{"name", 1},
+			{"date", 1}}}}
+
+	return query
+}
+
+// FlatMonthlyEndpoint query to aggregate monthly a/r results from mongoDB
+func FlatMonthlyEndpoint(filter bson.M, limit int, skip int) []bson.M {
+	query := []bson.M{
+		{"$match": filter},
+		{"$group": bson.M{
+			"_id": bson.M{
+				"date":       bson.D{{"$substr", list{"$date", 0, 6}}},
+				"name":       "$name",
+				"supergroup": "$supergroup",
+				"service":    "$service",
+				"report":     "$report"},
+			"avgup":      bson.M{"$avg": "$up"},
+			"avgunknown": bson.M{"$avg": "$unknown"},
+			"avgdown":    bson.M{"$avg": "$down"},
+			"info":       bson.M{"$first": "$info"}}},
+		{"$project": bson.M{
+			"date":       "$_id.date",
+			"name":       "$_id.name",
+			"supergroup": "$_id.supergroup",
+			"service":    "$_id.service",
+			"report":     "$_id.report",
+			"info":       "$info",
+			"unknown":    "$avgunknown",
+			"up":         "$avgup",
+			"down":       "$avgdown",
+			"availability": bson.M{
+				"$multiply": list{
+					bson.M{"$divide": list{
+						"$avgup", bson.M{"$subtract": list{1.00000001, "$avgunknown"}}}},
+					100}},
+			"reliability": bson.M{
+				"$multiply": list{
+					bson.M{"$divide": list{
+						"$avgup", bson.M{"$subtract": list{bson.M{"$subtract": list{1.00000001, "$avgunknown"}}, "$avgdown"}}}},
+					100}}}},
+		{"$sort": bson.D{
+			{"name", 1},
+			{"service", 1},
+			{"supergroup", 1},
+			{"date", 1}}}}
+
+	if limit > 0 {
+		query = append(query, bson.M{"$skip": skip})
+		query = append(query, bson.M{"$limit": limit + 1})
+
+	}
+
+	return query
+}
+
+// FlatCustomEndpoint query to aggregate a/r results for a custom period of time from mongoDB
+func FlatCustomEndpoint(filter bson.M, limit int, skip int) []bson.M {
+	query := []bson.M{
+		{"$match": filter},
+		{"$group": bson.M{
+			"_id": bson.M{
+				"name":       "$name",
+				"supergroup": "$supergroup",
+				"service":    "$service",
+				"report":     "$report"},
+			"avgup":      bson.M{"$avg": "$up"},
+			"avgunknown": bson.M{"$avg": "$unknown"},
+			"avgdown":    bson.M{"$avg": "$down"},
+			"info":       bson.M{"$first": "$info"}}},
+		{"$project": bson.M{
+			"name":       "$_id.name",
+			"supergroup": "$_id.supergroup",
+			"service":    "$_id.service",
+			"report":     "$_id.report",
+			"info":       "$info",
+			"unknown":    "$avgunknown",
+			"up":         "$avgup",
+			"down":       "$avgdown",
+			"availability": bson.M{
+				"$multiply": list{
+					bson.M{"$divide": list{
+						"$avgup", bson.M{"$subtract": list{1.00000001, "$avgunknown"}}}},
+					100}},
+			"reliability": bson.M{
+				"$multiply": list{
+					bson.M{"$divide": list{
+						"$avgup", bson.M{"$subtract": list{bson.M{"$subtract": list{1.00000001, "$avgunknown"}}, "$avgdown"}}}},
+					100}}}},
+		{"$sort": bson.D{
+			{"name", 1},
+			{"service", 1},
+			{"supergroup", 1}}}}
+
+	if limit > 0 {
+		query = append(query, bson.M{"$skip": skip})
+		query = append(query, bson.M{"$limit": limit + 1})
+
+	}
+
+	return query
+}
+
+// MonthlyEndpoint query to aggregate monthly a/r results from mongoDB
+func MonthlyEndpoint(filter bson.M) []bson.M {
+	query := []bson.M{
+		{"$match": filter},
+		{"$group": bson.M{
+			"_id": bson.M{
+				"date":       bson.D{{"$substr", list{"$date", 0, 6}}},
+				"name":       "$name",
+				"supergroup": "$supergroup",
+				"service":    "$service",
+				"report":     "$report"},
+			"avgup":      bson.M{"$avg": "$up"},
+			"avgunknown": bson.M{"$avg": "$unknown"},
+			"avgdown":    bson.M{"$avg": "$down"},
+			"info":       bson.M{"$first": "$info"}}},
+
+		{"$project": bson.M{
+			"date":       "$_id.date",
+			"name":       "$_id.name",
+			"supergroup": "$_id.supergroup",
+			"service":    "$_id.service",
+			"report":     "$_id.report",
+			"info":       "$info",
+			"unknown":    "$avgunknown",
+			"up":         "$avgup",
+			"down":       "$avgdown",
+			"availability": bson.M{
+				"$multiply": list{
+					bson.M{"$divide": list{
+						"$avgup", bson.M{"$subtract": list{1.00000001, "$avgunknown"}}}},
+					100}},
+			"reliability": bson.M{
+				"$multiply": list{
+					bson.M{"$divide": list{
+						"$avgup", bson.M{"$subtract": list{bson.M{"$subtract": list{1.00000001, "$avgunknown"}}, "$avgdown"}}}},
+					100}}}},
+		{"$sort": bson.D{
+			{"supergroup", 1},
+			{"name", 1},
+			{"date", 1}}}}
+	return query
+}
+
+// CustomEndpoint query to aggregate a/r results over a custom period of time from mongoDB
+func CustomEndpoint(filter bson.M) []bson.M {
+	query := []bson.M{
+		{"$match": filter},
+		{"$group": bson.M{
+			"_id": bson.M{
+				"name":       "$name",
+				"supergroup": "$supergroup",
+				"service":    "$service",
+				"report":     "$report"},
+			"avgup":      bson.M{"$avg": "$up"},
+			"avgunknown": bson.M{"$avg": "$unknown"},
+			"avgdown":    bson.M{"$avg": "$down"},
+			"info":       bson.M{"$first": "$info"}}},
+
+		{"$project": bson.M{
+			"name":       "$_id.name",
+			"supergroup": "$_id.supergroup",
+			"service":    "$_id.service",
+			"report":     "$_id.report",
+			"info":       "$info",
+			"unknown":    "$avgunknown",
+			"up":         "$avgup",
+			"down":       "$avgdown",
+			"availability": bson.M{
+				"$multiply": list{
+					bson.M{"$divide": list{
+						"$avgup", bson.M{"$subtract": list{1.00000001, "$avgunknown"}}}},
+					100}},
+			"reliability": bson.M{
+				"$multiply": list{
+					bson.M{"$divide": list{
+						"$avgup", bson.M{"$subtract": list{bson.M{"$subtract": list{1.00000001, "$avgunknown"}}, "$avgdown"}}}},
+					100}}}},
+		{"$sort": bson.D{
+			{"supergroup", 1},
+			{"name", 1}}}}
+	return query
+}
+
+// DailyServiceFlavor query to aggregate daily SF results from mongoDB
+func DailyServiceFlavor(filter bson.M) []bson.M {
+	query := []bson.M{
+		{"$match": filter},
+		{"$group": bson.M{
+			"_id": bson.M{
+				"date":         bson.D{{"$substr", list{"$date", 0, 8}}},
+				"name":         "$name",
+				"supergroup":   "$supergroup",
+				"availability": "$availability",
+				"reliability":  "$reliability",
+				"unknown":      "$unknown",
+				"up":           "$up",
+				"down":         "$down",
+				"report":       "$report"}}},
+		{"$project": bson.M{
+			"date":         "$_id.date",
+			"name":         "$_id.name",
+			"availability": "$_id.availability",
+			"reliability":  "$_id.reliability",
+			"unknown":      "$_id.unknown",
+			"up":           "$_id.up",
+			"down":         "$_id.down",
+			"supergroup":   "$_id.supergroup",
+			"report":       "$_id.report"}},
+		{"$sort": bson.D{
+			{"supergroup", 1},
+			{"name", 1},
+			{"date", 1}}}}
+
+	return query
+}
+
+// MonthlyServiceFlavor query to aggregate daily SF results from mongoDB
+func MonthlyServiceFlavor(filter bson.M) []bson.M {
+	query := []bson.M{
+		{"$match": filter},
+		{"$group": bson.M{
+			"_id": bson.M{
+				"date":       bson.D{{"$substr", list{"$date", 0, 6}}},
+				"name":       "$name",
+				"supergroup": "$supergroup",
+				"report":     "$report"},
+			"avgup":      bson.M{"$avg": "$up"},
+			"avgunknown": bson.M{"$avg": "$unknown"},
+			"avgdown":    bson.M{"$avg": "$down"}}},
+		{"$project": bson.M{
+			"date":       "$_id.date",
+			"name":       "$_id.name",
+			"supergroup": "$_id.supergroup",
+			"report":     "$_id.report",
+			"unknown":    "$avgunknown",
+			"up":         "$avgup",
+			"down":       "$avgdown",
+			"availability": bson.M{
+				"$multiply": list{
+					bson.M{"$divide": list{
+						"$avgup", bson.M{"$subtract": list{1.00000001, "$avgunknown"}}}},
+					100}},
+			"reliability": bson.M{
+				"$multiply": list{
+					bson.M{"$divide": list{
+						"$avgup", bson.M{"$subtract": list{bson.M{"$subtract": list{1.00000001, "$avgunknown"}}, "$avgdown"}}}},
+					100}}}},
+		{"$sort": bson.D{
+			{"supergroup", 1},
+			{"name", 1},
+			{"date", 1}}}}
+	return query
+}
+
+// CustomServiceFlavor query to aggregate SF results over a custom period of time from mongoDB
+func CustomServiceFlavor(filter bson.M) []bson.M {
+	query := []bson.M{
+		{"$match": filter},
+		{"$group": bson.M{
+			"_id": bson.M{
+				"name":       "$name",
+				"supergroup": "$supergroup",
+				"report":     "$report"},
+			"avgup":      bson.M{"$avg": "$up"},
+			"avgunknown": bson.M{"$avg": "$unknown"},
+			"avgdown":    bson.M{"$avg": "$down"}}},
+		{"$project": bson.M{
+			"name":       "$_id.name",
+			"supergroup": "$_id.supergroup",
+			"report":     "$_id.report",
+			"unknown":    "$avgunknown",
+			"up":         "$avgup",
+			"down":       "$avgdown",
+			"availability": bson.M{
+				"$multiply": list{
+					bson.M{"$divide": list{
+						"$avgup", bson.M{"$subtract": list{1.00000001, "$avgunknown"}}}},
+					100}},
+			"reliability": bson.M{
+				"$multiply": list{
+					bson.M{"$divide": list{
+						"$avgup", bson.M{"$subtract": list{bson.M{"$subtract": list{1.00000001, "$avgunknown"}}, "$avgdown"}}}},
+					100}}}},
+		{"$sort": bson.D{
+			{"supergroup", 1},
+			{"name", 1}}}}
+	return query
+}
+
+// DailyEndpointGroup query to aggregate daily results from mongodb
+func DailyEndpointGroup(filter bson.M) []bson.M {
+	// Mongo aggregation pipeline
+	// Select all the records that match q
+	// Project to select just the first 8 digits of the date YYYYMMDD
+	// Sort by profile->supergroup->endpointGroup->datetime
+	query := []bson.M{
+		{"$match": filter},
+		{"$project": bson.M{
+			"date":         bson.M{"$substr": list{"$date", 0, 8}},
+			"availability": 1,
+			"reliability":  1,
+			"unknown":      1,
+			"up":           1,
+			"down":         1,
+			"report":       1,
+			"supergroup":   1,
+			"name":         1}},
+		{"$sort": bson.D{
+			{"report", 1},
+			{"supergroup", 1},
+			{"name", 1},
+			{"date", 1}}}}
+
+	return query
+}
+
+// MonthlyEndpointGroup query to aggregate monthly results from mongodb
+func MonthlyEndpointGroup(filter bson.M) []bson.M {
 
 	// Mongo aggregation pipeline
 	// Select all the records that match q
@@ -59,8 +468,8 @@ func MonthlyGroup(filter bson.M) []bson.M {
 	return query
 }
 
-// CustomGroup query to aggregate custom results from mongodb
-func CustomGroup(filter bson.M) []bson.M {
+// CustomEndpointGroup query to aggregate results over a custom period from mongodb
+func CustomEndpointGroup(filter bson.M) []bson.M {
 
 	// Mongo aggregation pipeline
 	// Select all the records that match q
@@ -216,6 +625,94 @@ func MonthlySuperGroup(filter bson.M) []bson.M {
 	//              - divide the previous sum of weighted availabilities by the total weightAv
 	//								SPECIAL CASE: If total weightRem remains : 0 that means that total daily supergroup rel = undef
 	//                              so instead of a numeric value, add a "nan" string (will not be counted in monthly average)
+	// 6. Group   : by supergroup and report to calculate ar for custom period
+	//							- custom period availability avg = avg(daily_availabilities) ~ but items with "nan" values will be neglected
+	//						  - custom period reliability avg = avg(daily_reliabilities) ~ but items with "nan" values will be neglected
+	//
+	// 7. Project : the relevant fields to form the appropriate final response (supergroup,report,avail,rel)
+	// 8. Sort    : the final results by report, supergroup
+
+	query := []bson.M{
+		{"$match": filter},
+		{"$project": bson.M{
+			"date":         1,
+			"availability": 1,
+			"reliability":  1,
+			"supergroup":   1,
+			"weightAv":     bson.M{"$cond": list{bson.M{"$gte": list{"$availability", 0}}, bson.M{"$add": list{"$weight", 1}}, 0}},
+			"weightRel":    bson.M{"$cond": list{bson.M{"$gte": list{"$reliability", 0}}, bson.M{"$add": list{"$weight", 1}}, 0}},
+			"weight": bson.M{
+				"$add": list{"$weight", 1}}},
+		},
+		{"$group": bson.M{
+			"_id": bson.M{
+				"date":       bson.D{{"$substr", list{"$date", 0, 8}}},
+				"supergroup": "$supergroup",
+				"report":     "$report"},
+			"availability": bson.M{"$sum": bson.M{"$multiply": list{"$availability", "$weightAv"}}},
+			"reliability":  bson.M{"$sum": bson.M{"$multiply": list{"$reliability", "$weightRel"}}},
+			"weightAv":     bson.M{"$sum": "$weightAv"},
+			"weightRel":    bson.M{"$sum": "$weightRel"},
+			"weight":       bson.M{"$sum": "$weight"}},
+		},
+		{"$match": bson.M{
+			"weight": bson.M{"$gt": 0}},
+		},
+		{"$project": bson.M{
+			"date":         "$_id.date",
+			"supergroup":   "$_id.supergroup",
+			"report":       "$_id.report",
+			"availability": bson.M{"$cond": list{bson.M{"$gt": list{"$weightAv", 0}}, bson.M{"$divide": list{"$availability", "$weightAv"}}, "nan"}},
+			"reliability":  bson.M{"$cond": list{bson.M{"$gt": list{"$weightRel", 0}}, bson.M{"$divide": list{"$reliability", "$weightRel"}}, "nan"}}},
+		},
+		{"$group": bson.M{
+			"_id": bson.M{
+				"supergroup": "$supergroup", "report": "$report"},
+			"availability": bson.M{"$avg": "$availability"},
+			"reliability":  bson.M{"$avg": "$reliability"}},
+		},
+		{"$project": bson.M{
+			"supergroup":   "$_id.supergroup",
+			"report":       "$_id.report",
+			"availability": 1,
+			"reliability":  1},
+		},
+		{"$sort": bson.D{
+			{"report", 1},
+			{"supergroup", 1}},
+		}}
+
+	return query
+}
+
+// CustomSuperGroup function to build the MongoDB aggregation query for custom period aggregation
+func CustomSuperGroup(filter bson.M) []bson.M {
+
+	// The following aggregation query consists of 5 grand steps
+	// 1. Match   : records for the specific date and report and supergroup(optional)
+	// 2. Project : all necessary fields (date,availability,reliability,report) etc but also
+	//              if avail >= 0 set an availability-weigh = weight + 1, else = 0
+	//							if rel >=0 set a reliability-weight = weight + 1, else = 0
+	//              keep also weight = weight + 1 (to compensate for zero values)
+	//
+	//              Keeping two extra weights (a/r) has the following result:
+	//               - If an item has undef availab. then it will have an weightAv=0 and will not affect sums
+	//                    for eg. avg_daily_supergroup_availability = (av1*w1 + av2*w2 + undefAv3*0) / (w1 + w1 + 0)
+	//               - If an item has undef reliab. then it will have an weightRel=0 and will not affect sums
+	//                    for eg. avg_daily_supergroup_reliability = (rel1*w2 + rel2*w2 + undefRel3*0) / (w1 + w1 + 0)
+	//
+	// 3. Group   : by supergroup and day and calculate the sum of weighted daily availabilites (and reliabilities also)
+	//              - availability(weighted_sum) = av1*w1 + av2*w2 + undefAv3*0 etc...
+	//              - reliability(weighted_sum) = rel1*w1 + rel2*w2 + undefRel3*0 etc...
+	//
+	// 4. Match   : assertion step - keep only items that have a valid weight > 0
+	// 5. Project : the previous results and try to find the weighted average of daily avail. and reliability by:
+	//              - divide the previous sum of weighted availabilities by the total weightAv
+	//                SPECIAL CASE: If total weightAv remains : 0 that means that total daily supergroup avail = undef
+	//                              so instead of a numeric value, add a "nan" string (will not be counted in monthly average)
+	//              - divide the previous sum of weighted availabilities by the total weightAv
+	//								SPECIAL CASE: If total weightRem remains : 0 that means that total daily supergroup rel = undef
+	//                              so instead of a numeric value, add a "nan" string (will not be counted in monthly average)
 	// 6. Group   : by first date part (month, eg: 201608) to calculate monthly average avail and rel.
 	//							- monthly availability avg = avg(daily_availabilities) ~ but items with "nan" values will be neglected
 	//						  - monthly reliability avg = avg(daily_reliabilities) ~ but items with "nan" values will be neglected
@@ -276,255 +773,6 @@ func MonthlySuperGroup(filter bson.M) []bson.M {
 			{"supergroup", 1},
 			{"date", 1}},
 		}}
-
-	return query
-}
-
-// CustomSuperGroup function to build the MongoDB aggregation query for monthly calculations
-func CustomSuperGroup(filter bson.M) []bson.M {
-
-	// The following aggregation query consists of 5 grand steps
-	// 1. Match   : records for the specific date and report and supergroup(optional)
-	// 2. Project : all necessary fields (date,availability,reliability,report) etc but also
-	//              if avail >= 0 set an availability-weigh = weight + 1, else = 0
-	//							if rel >=0 set a reliability-weight = weight + 1, else = 0
-	//              keep also weight = weight + 1 (to compensate for zero values)
-	//
-	//              Keeping two extra weights (a/r) has the following result:
-	//               - If an item has undef availab. then it will have an weightAv=0 and will not affect sums
-	//                    for eg. avg_daily_supergroup_availability = (av1*w1 + av2*w2 + undefAv3*0) / (w1 + w1 + 0)
-	//               - If an item has undef reliab. then it will have an weightRel=0 and will not affect sums
-	//                    for eg. avg_daily_supergroup_reliability = (rel1*w2 + rel2*w2 + undefRel3*0) / (w1 + w1 + 0)
-	//
-	// 3. Group   : by supergroup and day and calculate the sum of weighted daily availabilites (and reliabilities also)
-	//              - availability(weighted_sum) = av1*w1 + av2*w2 + undefAv3*0 etc...
-	//              - reliability(weighted_sum) = rel1*w1 + rel2*w2 + undefRel3*0 etc...
-	//
-	// 4. Match   : assertion step - keep only items that have a valid weight > 0
-	// 5. Project : the previous results and try to find the weighted average of daily avail. and reliability by:
-	//              - divide the previous sum of weighted availabilities by the total weightAv
-	//                SPECIAL CASE: If total weightAv remains : 0 that means that total daily supergroup avail = undef
-	//                              so instead of a numeric value, add a "nan" string (will not be counted in monthly average)
-	//              - divide the previous sum of weighted availabilities by the total weightAv
-	//								SPECIAL CASE: If total weightRem remains : 0 that means that total daily supergroup rel = undef
-	//                              so instead of a numeric value, add a "nan" string (will not be counted in monthly average)
-	// 6. Group   : by supergroup to calculate average avail and rel over custom period
-	//							- custom period availability avg = avg(daily_availabilities) ~ but items with "nan" values will be neglected
-	//						  - custom period reliability avg = avg(daily_reliabilities) ~ but items with "nan" values will be neglected
-	//
-	// 7. Project : the relevant fields to form the appropriate final response (date,supergroup,report,avail,rel)
-	// 8. Sort    : the final results by report, supergroup
-
-	query := []bson.M{
-		{"$match": filter},
-		{"$project": bson.M{
-			"date":         1,
-			"availability": 1,
-			"reliability":  1,
-			"report":       1,
-			"supergroup":   1,
-			"weightAv":     bson.M{"$cond": list{bson.M{"$gte": list{"$availability", 0}}, bson.M{"$add": list{"$weight", 1}}, 0}},
-			"weightRel":    bson.M{"$cond": list{bson.M{"$gte": list{"$reliability", 0}}, bson.M{"$add": list{"$weight", 1}}, 0}},
-			"weight": bson.M{
-				"$add": list{"$weight", 1}}},
-		},
-		{"$group": bson.M{
-			"_id": bson.M{
-				"date":       bson.D{{"$substr", list{"$date", 0, 8}}},
-				"supergroup": "$supergroup",
-				"report":     "$report"},
-			"availability": bson.M{"$sum": bson.M{"$multiply": list{"$availability", "$weightAv"}}},
-			"reliability":  bson.M{"$sum": bson.M{"$multiply": list{"$reliability", "$weightRel"}}},
-			"weightAv":     bson.M{"$sum": "$weightAv"},
-			"weightRel":    bson.M{"$sum": "$weightRel"},
-			"weight":       bson.M{"$sum": "$weight"}},
-		},
-		{"$match": bson.M{
-			"weight": bson.M{"$gt": 0}},
-		},
-		{"$project": bson.M{
-			"date":         "$_id.date",
-			"supergroup":   "$_id.supergroup",
-			"report":       "$_id.report",
-			"availability": bson.M{"$cond": list{bson.M{"$gt": list{"$weightAv", 0}}, bson.M{"$divide": list{"$availability", "$weightAv"}}, "nan"}},
-			"reliability":  bson.M{"$cond": list{bson.M{"$gt": list{"$weightRel", 0}}, bson.M{"$divide": list{"$reliability", "$weightRel"}}, "nan"}}},
-		},
-		{"$group": bson.M{
-			"_id": bson.M{
-				"supergroup": "$supergroup", "report": "$report"},
-			"availability": bson.M{"$avg": "$availability"},
-			"reliability":  bson.M{"$avg": "$reliability"}},
-		},
-		{"$project": bson.M{
-			"supergroup":   "$_id.supergroup",
-			"report":       "$_id.report",
-			"availability": 1,
-			"reliability":  1},
-		},
-		{"$sort": bson.D{
-			{"report", 1},
-			{"supergroup", 1}},
-		}}
-
-	return query
-}
-
-// DailyGroup query to aggregate daily results from mongodb
-func DailyGroup(filter bson.M) []bson.M {
-	// Mongo aggregation pipeline
-	// Select all the records that match q
-	// Project to select just the first 8 digits of the date YYYYMMDD
-	// Sort by profile->supergroup->endpointGroup->datetime
-	query := []bson.M{
-		{"$match": filter},
-		{"$project": bson.M{
-			"date":         bson.M{"$substr": list{"$date", 0, 8}},
-			"availability": 1,
-			"reliability":  1,
-			"unknown":      1,
-			"up":           1,
-			"down":         1,
-			"report":       1,
-			"supergroup":   1,
-			"name":         1}},
-		{"$sort": bson.D{
-			{"report", 1},
-			{"supergroup", 1},
-			{"name", 1},
-			{"date", 1}}}}
-
-	return query
-}
-
-// DailyEndpoint query to aggregate daily endpoint a/r results from mongoDB
-// Mongo aggregation pipeline
-// Select all the records that match q
-// Project to select just the first 8 digits of the date YYYYMMDD
-// Sort by name->service->supergroup->date
-func DailyEndpoint(filter bson.M) []bson.M {
-
-	query := []bson.M{
-		{"$match": filter},
-		{"$project": bson.M{
-			"_id":          1,
-			"date":         bson.D{{"$substr", list{"$date", 0, 8}}},
-			"name":         1,
-			"availability": 1,
-			"reliability":  1,
-			"unknown":      1,
-			"up":           1,
-			"down":         1,
-			"supergroup":   1,
-			"service":      1,
-			"info":         1,
-			"report":       1}},
-		{"$sort": bson.D{
-			{"name", 1},
-			{"service", 1},
-			{"supergroup", 1},
-			{"date", 1},
-		}}}
-
-	return query
-}
-
-// MonthlyEndpoint query to aggregate monthly a/r results from mongoDB
-// Mongo aggregation pipeline
-// Select all the records that match q
-// Group them by the first six digits of their date (YYYYMM), their name, their supergroup, their service, etc...
-// from that group find the average of the uptime, u, downtime
-// Project the result to a better format and do this computation
-// availability = (avgup/(1.00000001 - avgu))*100
-// reliability = (avgup/((1.00000001 - avgu)-avgd))*100
-// Sort the results by name->service->supergroup->date
-func MonthlyEndpoint(filter bson.M) []bson.M {
-	query := []bson.M{
-		{"$match": filter},
-		{"$group": bson.M{
-			"_id": bson.M{
-				"date":       bson.D{{"$substr", list{"$date", 0, 6}}},
-				"name":       "$name",
-				"supergroup": "$supergroup",
-				"service":    "$service",
-				"report":     "$report"},
-			"avgup":      bson.M{"$avg": "$up"},
-			"avgunknown": bson.M{"$avg": "$unknown"},
-			"avgdown":    bson.M{"$avg": "$down"},
-			"info":       bson.M{"$first": "$info"}}},
-		{"$project": bson.M{
-			"date":       "$_id.date",
-			"name":       "$_id.name",
-			"supergroup": "$_id.supergroup",
-			"service":    "$_id.service",
-			"report":     "$_id.report",
-			"info":       "$info",
-			"unknown":    "$avgunknown",
-			"up":         "$avgup",
-			"down":       "$avgdown",
-			"availability": bson.M{
-				"$multiply": list{
-					bson.M{"$divide": list{
-						"$avgup", bson.M{"$subtract": list{1.00000001, "$avgunknown"}}}},
-					100}},
-			"reliability": bson.M{
-				"$multiply": list{
-					bson.M{"$divide": list{
-						"$avgup", bson.M{"$subtract": list{bson.M{"$subtract": list{1.00000001, "$avgunknown"}}, "$avgdown"}}}},
-					100}}}},
-		{"$sort": bson.D{
-			{"name", 1},
-			{"service", 1},
-			{"supergroup", 1},
-			{"date", 1}}}}
-
-	return query
-}
-
-// CustomEndpoint query to aggregate a/r results from over a custom periodmongoDB
-// Mongo aggregation pipeline
-// Select all the records that match q
-// Group them by their name, their supergroup, their service, etc...
-// from that group find the average of the uptime, u, downtime
-// Project the result to a better format and do this computation
-// availability = (avgup/(1.00000001 - avgu))*100
-// reliability = (avgup/((1.00000001 - avgu)-avgd))*100
-// Sort the results by name->service->supergroup
-func CustomEndpoint(filter bson.M) []bson.M {
-	query := []bson.M{
-		{"$match": filter},
-		{"$group": bson.M{
-			"_id": bson.M{
-				"name":       "$name",
-				"supergroup": "$supergroup",
-				"service":    "$service",
-				"report":     "$report"},
-			"avgup":      bson.M{"$avg": "$up"},
-			"avgunknown": bson.M{"$avg": "$unknown"},
-			"avgdown":    bson.M{"$avg": "$down"},
-			"info":       bson.M{"$first": "$info"}}},
-		{"$project": bson.M{
-			"name":       "$_id.name",
-			"supergroup": "$_id.supergroup",
-			"service":    "$_id.service",
-			"report":     "$_id.report",
-			"info":       "$info",
-			"unknown":    "$avgunknown",
-			"up":         "$avgup",
-			"down":       "$avgdown",
-			"availability": bson.M{
-				"$multiply": list{
-					bson.M{"$divide": list{
-						"$avgup", bson.M{"$subtract": list{1.00000001, "$avgunknown"}}}},
-					100}},
-			"reliability": bson.M{
-				"$multiply": list{
-					bson.M{"$divide": list{
-						"$avgup", bson.M{"$subtract": list{bson.M{"$subtract": list{1.00000001, "$avgunknown"}}, "$avgdown"}}}},
-					100}}}},
-		{"$sort": bson.D{
-			{"name", 1},
-			{"service", 1},
-			{"supergroup", 1}}}}
 
 	return query
 }

--- a/app/results/serviceflavor_test.go
+++ b/app/results/serviceflavor_test.go
@@ -375,6 +375,60 @@ func (suite *serviceFlavorAvailabilityTestSuite) TestListServiceFlavorAvailabili
 
 }
 
+func (suite *serviceFlavorAvailabilityTestSuite) TestListServiceFlavorAvailabilityCustom() {
+
+	request, _ := http.NewRequest("GET", "/api/v2/results/Report_A/SITE/ST01/services?start_time=2015-06-22T00:00:00Z&end_time=2015-06-23T23:59:59Z&granularity=custom", strings.NewReader(""))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+	responseBody := response.Body.String()
+	serviceFlavorAvailabilityJSON := `{
+   "results": [
+     {
+       "name": "ST01",
+       "type": "SITE",
+       "serviceflavors": [
+         {
+           "name": "SF01",
+           "type": "service",
+           "results": [
+             {
+               "availability": "76.26534166743393",
+               "reliability": "91.61418757296076",
+               "unknown": "0.00521",
+               "uptime": "0.75868",
+               "downtime": "0.166665"
+             }
+           ]
+         },
+         {
+           "name": "SF02",
+           "type": "service",
+           "results": [
+             {
+               "availability": "98.43749901562502",
+               "reliability": "98.43749901562502",
+               "unknown": "0",
+               "uptime": "0.984375",
+               "downtime": "0"
+             }
+           ]
+         }
+       ]
+     }
+   ]
+ }`
+
+	// Check that we must have a 200 ok code
+	suite.Equal(200, response.Code, "Incorrect HTTP response code")
+	// Compare the expected and actual xml response
+	suite.Equal(serviceFlavorAvailabilityJSON, responseBody, "Response body mismatch")
+
+}
+
 // TestListServiceFlavorAvailabilityDaily tests if daily results are returned correctly
 func (suite *serviceFlavorAvailabilityTestSuite) TestListServiceFlavorAvailabilityDaily() {
 

--- a/app/results/supergroup_test.go
+++ b/app/results/supergroup_test.go
@@ -23,6 +23,7 @@
 package results
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -514,6 +515,50 @@ func (suite *SuperGroupAvailabilityTestSuite) TestListAllSuperGroupAvailability(
 	suite.Equal(200, response.Code, "Incorrect HTTP response code")
 	// Compare the expected and actual xml response
 	suite.Equal(SuperGroupAvailabilityJSON, output, "Response body mismatch")
+
+}
+
+// TestListAllSuperGroupAvailabilityCustom test if results are returned correctly for a custom period
+func (suite *SuperGroupAvailabilityTestSuite) TestListAllSuperGroupAvailabilityCustom() {
+
+	request, _ := http.NewRequest("GET", "/api/v2/results/Report_A/GROUP?start_time=2015-06-20T12:00:00Z&end_time=2015-06-26T23:00:00Z&granularity=custom", strings.NewReader(""))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	SuperGroupAvailabilityJSON := `{
+   "results": [
+     {
+       "name": "GROUP_A",
+       "type": "GROUP",
+       "results": [
+         {
+           "availability": "71.75110088070457",
+           "reliability": "65.61389111289031"
+         }
+       ]
+     },
+     {
+       "name": "GROUP_B",
+       "type": "GROUP",
+       "results": [
+         {
+           "availability": "46.930783242258656",
+           "reliability": "80"
+         }
+       ]
+     }
+   ]
+ }`
+
+	// Check that we must have a 200 ok code
+	suite.Equal(200, response.Code, "Incorrect HTTP response code")
+	// Compare the expected and actual xml response
+	suite.Equal(SuperGroupAvailabilityJSON, response.Body.String(), "Response body mismatch")
+	fmt.Println(response.Body.String())
 
 }
 

--- a/doc/v2/docs/errors.md
+++ b/doc/v2/docs/errors.md
@@ -11,7 +11,7 @@ Bad request              | 400 | One or more checks may have failed. More detail
 Wrong start_time         | 400 | Use start_time url parameter in zulu format (like `2006-01-02T15:04:05Z`) to indicate the query start time
 Wrong end_time           | 400 | Use end_time url parameter in zulu format (like `2006-01-02T15:04:05Z`) to indicate the query end time
 Wrong exec_time          | 400 | Use exec_time url parameter in zulu format (like `2006-01-02T15:04:05Z`) to indicate the exact probe execution time
-Wrong granularity        | 400 | The parameter value can be either `daily` or `monthly`
+Wrong granularity        | 400 | The parameter value can be either `daily`,  `monthly` or `custom`
 Unauthorized             | 401 | The client needs to provide a correct authentication token using the header `x-api-key` 
 Forbidden                | 403 | Access to the resource is forbidden due to authorization policy enforced
 Item not found           | 404 | Either the path is not found or no results are available for the given query

--- a/doc/v2/docs/validations.md
+++ b/doc/v2/docs/validations.md
@@ -177,7 +177,7 @@ In case the parameter value is malformed (neither `daily` nor `monthly`) the fol
   {
    "message": "Wrong Granularity",
    "code": "400",
-   "details": "%s is not accepted as granularity parameter, please provide either daily or monthly"
+   "details": "%s is not accepted as granularity parameter, please provide either daily, monthly or custom"
   }
  ]
 }

--- a/respond/validators.go
+++ b/respond/validators.go
@@ -127,11 +127,11 @@ func ValidateResultsParams(queries url.Values) []ErrorResponse {
 
 	if queries["granularity"] != nil {
 		granularity := queries["granularity"][0]
-		if granularity != "daily" && granularity != "monthly" {
+		if granularity != "daily" && granularity != "monthly" && granularity != "custom" {
 			errs = append(errs, ErrorResponse{
 				Message: "Wrong Granularity",
 				Code:    fmt.Sprintf("%d", http.StatusBadRequest),
-				Details: fmt.Sprintf("%s is not accepted as granularity parameter, please provide either daily or monthly", granularity),
+				Details: fmt.Sprintf("%s is not accepted as granularity parameter, please provide either daily, monthly or custom", granularity),
 			})
 		}
 	}

--- a/v3/ar/ar_test.go
+++ b/v3/ar/ar_test.go
@@ -492,6 +492,70 @@ func (suite *AvailabilityTestSuite) TestListEndpointGroupAvailability() {
 
 }
 
+// TestListEndpointAvailabilityCustom test if daily results are returned correctly for a specific id
+func (suite *AvailabilityTestSuite) TestListGroupAvailCustom() {
+
+	request, _ := http.NewRequest("GET", "/api/v3/results/Report_A?start_time=2015-06-20T12:00:00Z&end_time=2015-06-23T23:00:00Z&granularity=monthly", strings.NewReader(""))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	expected := `{
+   "results": [
+     {
+       "name": "GROUP_A",
+       "type": "GROUP",
+       "results": [
+         {
+           "date": "2015-06",
+           "availability": "71.75110088070457",
+           "reliability": "65.61389111289031"
+         }
+       ],
+       "groups": [
+         {
+           "name": "ST01",
+           "type": "SITES",
+           "results": [
+             {
+               "date": "2015-06",
+               "availability": "99.99999900000002",
+               "reliability": "99.99999900000002",
+               "unknown": "0",
+               "uptime": "1",
+               "downtime": "0"
+             }
+           ]
+         },
+         {
+           "name": "ST02",
+           "type": "SITES",
+           "results": [
+             {
+               "date": "2015-06",
+               "availability": "99.99999900000002",
+               "reliability": "99.99999900000002",
+               "unknown": "0",
+               "uptime": "1",
+               "downtime": "0"
+             }
+           ]
+         }
+       ]
+     }
+   ]
+ }`
+
+	// Check that we must have a 200 ok code
+	suite.Equal(200, response.Code, "Incorrect HTTP response code")
+	// Compare the expected and actual xml response
+	suite.Equal(expected, response.Body.String(), "Response body mismatch")
+
+}
+
 // TestListEndpointAvailability test if daily results are returned correctly for a specific id
 func (suite *AvailabilityTestSuite) TestListEndpointAvailabilityDaily() {
 
@@ -566,6 +630,46 @@ func (suite *AvailabilityTestSuite) TestListEndpointAvailabilityMonthly() {
        "results": [
          {
            "date": "2015-06",
+           "availability": "99.99999900000002",
+           "reliability": "99.99999900000002",
+           "unknown": "0",
+           "uptime": "1",
+           "downtime": "0"
+         }
+       ]
+     }
+   ]
+ }`
+
+	// Check that we must have a 200 ok code
+	suite.Equal(200, response.Code, "Incorrect HTTP response code")
+	// Compare the expected and actual xml response
+	suite.Equal(expected, response.Body.String(), "Response body mismatch")
+
+}
+
+func (suite *AvailabilityTestSuite) TestListEndpointAvailabilityCustom() {
+
+	request, _ := http.NewRequest("GET", "/api/v3/results/Report_A/id/special-queue?start_time=2015-06-20T12:00:00Z&end_time=2015-06-23T23:00:00Z&granularity=custom", strings.NewReader(""))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	expected := `{
+   "id": "special-queue",
+   "endpoints": [
+     {
+       "name": "host01",
+       "service": "service01",
+       "supergroup": "GROUP_A",
+       "info": {
+         "ID": "special-queue"
+       },
+       "results": [
+         {
            "availability": "99.99999900000002",
            "reliability": "99.99999900000002",
            "unknown": "0",

--- a/v3/ar/handlers.go
+++ b/v3/ar/handlers.go
@@ -115,6 +115,7 @@ func ListGroupAR(r *http.Request, cfg config.Config) (int, http.Header, []byte, 
 
 	// Prepare the supergroup results
 	// Select the granularity of the search daily/monthly
+	custom := false
 	if input.Granularity == "daily" {
 		customForm[0] = "20060102"
 		customForm[1] = "2006-01-02"
@@ -125,6 +126,12 @@ func ListGroupAR(r *http.Request, cfg config.Config) (int, http.Header, []byte, 
 		customForm[1] = "2006-01"
 		query := MonthlySuperGroup(filter)
 		err = mongo.Pipe(session, tenantDbConfig.Db, groupColName, query, &resultsSuperGroups)
+	} else if input.Granularity == "custom" {
+		customForm[0] = "200601"
+		customForm[1] = "2006-01"
+		query := CustomSuperGroup(filter)
+		err = mongo.Pipe(session, tenantDbConfig.Db, groupColName, query, &resultsSuperGroups)
+		custom = true
 	}
 
 	if err != nil {
@@ -144,6 +151,12 @@ func ListGroupAR(r *http.Request, cfg config.Config) (int, http.Header, []byte, 
 		customForm[1] = "2006-01"
 		query := MonthlyGroup(filter)
 		err = mongo.Pipe(session, tenantDbConfig.Db, groupColName, query, &resultsGroups)
+	} else if input.Granularity == "custom" {
+		customForm[0] = "200601"
+		customForm[1] = "2006-01"
+		query := CustomGroup(filter)
+		err = mongo.Pipe(session, tenantDbConfig.Db, groupColName, query, &resultsGroups)
+		custom = true
 	}
 
 	if err != nil {
@@ -151,7 +164,7 @@ func ListGroupAR(r *http.Request, cfg config.Config) (int, http.Header, []byte, 
 		return code, h, output, err
 	}
 
-	output, err = createResultView(resultsSuperGroups, resultsGroups, report, input.Format)
+	output, err = createResultView(resultsSuperGroups, resultsGroups, report, input.Format, custom)
 
 	if err != nil {
 		code = http.StatusInternalServerError
@@ -244,6 +257,7 @@ func ListEndpointARByID(r *http.Request, cfg config.Config) (int, http.Header, [
 
 	// Prepare the group results
 	// Select the granularity of the search daily/monthly
+	custom := false
 	if input.Granularity == "daily" {
 		customForm[0] = "20060102"
 		customForm[1] = "2006-01-02"
@@ -254,6 +268,12 @@ func ListEndpointARByID(r *http.Request, cfg config.Config) (int, http.Header, [
 		customForm[1] = "2006-01"
 		query := MonthlyEndpoint(filter)
 		err = mongo.Pipe(session, tenantDbConfig.Db, endpointColName, query, &results)
+	} else if input.Granularity == "custom" {
+		customForm[0] = "200601"
+		customForm[1] = "2006-01"
+		query := CustomEndpoint(filter)
+		err = mongo.Pipe(session, tenantDbConfig.Db, endpointColName, query, &results)
+		custom = true
 	}
 
 	if err != nil {
@@ -270,7 +290,7 @@ func ListEndpointARByID(r *http.Request, cfg config.Config) (int, http.Header, [
 		return code, h, output, err
 	}
 
-	output, err = createEndpointResult(results, report, input.Vars["id"])
+	output, err = createEndpointResult(results, report, input.Vars["id"], custom)
 
 	if err != nil {
 		code = http.StatusInternalServerError

--- a/v3/ar/models.go
+++ b/v3/ar/models.go
@@ -105,7 +105,7 @@ type EndpointInterface struct {
 
 //Availability struct for formating json
 type Availability struct {
-	Date         string `json:"date"`
+	Date         string `json:"date,omitempty"`
 	Availability string `json:"availability"`
 	Reliability  string `json:"reliability"`
 	Unknown      string `json:"unknown,omitempty"`

--- a/v3/ar/validations.go
+++ b/v3/ar/validations.go
@@ -40,11 +40,11 @@ func (query *basicQuery) Validate(db *mgo.Database) []ErrorResponse {
 	query.Granularity = strings.ToLower(query.Granularity)
 	if query.Granularity == "" {
 		query.Granularity = "daily"
-	} else if query.Granularity != "daily" && query.Granularity != "monthly" {
+	} else if query.Granularity != "daily" && query.Granularity != "monthly" && query.Granularity != "custom" {
 		errs = append(errs, ErrorResponse{
 			Message: "Wrong Granularity",
 			Code:    "400",
-			Details: fmt.Sprintf("%s is not accepted as granularity parameter, please provide either daily or monthly", query.Granularity),
+			Details: fmt.Sprintf("%s is not accepted as granularity parameter, please provide either daily, monthly or custom", query.Granularity),
 		})
 	}
 

--- a/v3/ar/views.go
+++ b/v3/ar/views.go
@@ -32,7 +32,7 @@ import (
 	"github.com/ARGOeu/argo-web-api/app/reports"
 )
 
-func createGroupResult(results []GroupInterface, report reports.MongoInterface, format string) []*SuperGroup {
+func createGroupResult(results []GroupInterface, report reports.MongoInterface, format string, custom bool) []*SuperGroup {
 
 	result := []*SuperGroup{}
 
@@ -68,9 +68,14 @@ func createGroupResult(results []GroupInterface, report reports.MongoInterface, 
 			superGroup.Groups = append(superGroup.Groups, group)
 		}
 		//we append the new availability values
+		// if custom period is selected delete timestamps so no dates appear on a/r results
+		prepDate := timestamp.Format(customForm[1])
+		if custom {
+			prepDate = ""
+		}
 		group.Availability = append(group.Availability,
 			Availability{
-				Date:         timestamp.Format(customForm[1]),
+				Date:         prepDate,
 				Availability: fmt.Sprintf("%g", row.Availability),
 				Reliability:  fmt.Sprintf("%g", row.Reliability),
 				Unknown:      fmt.Sprintf("%g", row.Unknown),
@@ -83,7 +88,7 @@ func createGroupResult(results []GroupInterface, report reports.MongoInterface, 
 
 }
 
-func createSuperGroupResult(results []SuperGroupInterface, report reports.MongoInterface, format string) []*SuperGroup {
+func createSuperGroupResult(results []SuperGroupInterface, report reports.MongoInterface, format string, custom bool) []*SuperGroup {
 
 	result := []*SuperGroup{}
 
@@ -108,9 +113,14 @@ func createSuperGroupResult(results []SuperGroupInterface, report reports.MongoI
 		}
 
 		//we append the new availability values
+		// if custom period is selected delete timestamps so no dates appear on a/r results
+		prepDate := timestamp.Format(customForm[1])
+		if custom {
+			prepDate = ""
+		}
 		superGroup.Results = append(superGroup.Results,
 			Availability{
-				Date:         timestamp.Format(customForm[1]),
+				Date:         prepDate,
 				Availability: fmt.Sprintf("%g", row.Availability),
 				Reliability:  fmt.Sprintf("%g", row.Reliability)})
 
@@ -120,7 +130,7 @@ func createSuperGroupResult(results []SuperGroupInterface, report reports.MongoI
 
 }
 
-func createEndpointResult(results []EndpointInterface, report reports.MongoInterface, id string) ([]byte, error) {
+func createEndpointResult(results []EndpointInterface, report reports.MongoInterface, id string, custom bool) ([]byte, error) {
 
 	docID := &idOUT{}
 	docID.ID = id
@@ -148,10 +158,15 @@ func createEndpointResult(results []EndpointInterface, report reports.MongoInter
 			docID.Endpoints = append(docID.Endpoints, endpoint)
 		}
 
-		//we append the new availability values
+		// if custom period is selected delete timestamps so no dates appear on a/r results
+		prepDate := timestamp.Format(customForm[1])
+		if custom {
+			prepDate = ""
+		}
 		endpoint.Results = append(endpoint.Results,
+
 			Availability{
-				Date:         timestamp.Format(customForm[1]),
+				Date:         prepDate,
 				Availability: fmt.Sprintf("%g", row.Availability),
 				Reliability:  fmt.Sprintf("%g", row.Reliability),
 				Unknown:      fmt.Sprintf("%g", row.Unknown),
@@ -165,11 +180,11 @@ func createEndpointResult(results []EndpointInterface, report reports.MongoInter
 
 }
 
-func createResultView(resultsSuperGroups []SuperGroupInterface, resultsGroups []GroupInterface, report reports.MongoInterface, format string) ([]byte, error) {
+func createResultView(resultsSuperGroups []SuperGroupInterface, resultsGroups []GroupInterface, report reports.MongoInterface, format string, custom bool) ([]byte, error) {
 	docRoot := &root{}
 
-	groupResult := createGroupResult(resultsGroups, report, format)
-	superGroupResult := createSuperGroupResult(resultsSuperGroups, report, format)
+	groupResult := createGroupResult(resultsGroups, report, format, custom)
+	superGroupResult := createSuperGroupResult(resultsSuperGroups, report, format, custom)
 
 	docRoot.Result = groupResult
 	for i := range docRoot.Result {

--- a/website/docs/apiv3/v3results.md
+++ b/website/docs/apiv3/v3results.md
@@ -17,7 +17,7 @@ _Note_: These are v3 api calls implementations found under the path `/api/v3`
 
 ## [GET]: List Availability and Reliability results for top level supergroups and included groups
 
-The following methods can be used to obtain a tenant's Availability and Reliability result metrics for all top level supergroups and included groups. The api authenticates the tenant using the api-key within the x-api-key header. User can specify time granularity (`monthly` or `daily`) for retrieved results and also format using the `Accept` header. 
+The following methods can be used to obtain a tenant's Availability and Reliability result metrics for all top level supergroups and included groups. The api authenticates the tenant using the api-key within the x-api-key header. User can specify time granularity (`monthly`, `daily` or `custom`) for retrieved results and also format using the `Accept` header. 
 
 ### Input
 
@@ -31,7 +31,7 @@ The following methods can be used to obtain a tenant's Availability and Reliabil
 | --------------- | ----------------------------------------------------------------------------------------------- | -------- | ------------- |
 | `[start_time]`  | UTC time in W3C format                                                                          | YES      |
 | `[end_time]`    | UTC time in W3C format                                                                          | YES      |
-| `[granularity]` | Granularity of time that will be used to present data. Possible values are `monthly` or `daily` | NO       | `daily`       |
+| `[granularity]` | Granularity of time that will be used to present data. Possible values are `monthly`,  `daily` or `custom` | NO       | `daily`       |
 
 #### Path Parameters
 
@@ -220,11 +220,87 @@ Status: 200 OK
 }
 ```
 
+### Example Request 3: Custom granularity
+This request returns availability/reliability score numbers for the whole custom period defined between `start_time` and `end_time`. 
+This means that for each item the user will receive one availability and reliability result concerning the whole period (instead of multiple daily or monthly results)
+
+#### Request
+
+##### Method
+`HTTP GET`
+
+##### Path
+
+```
+/api/v3/results/Report_A?start_time=2015-06-20T12:00:00Z&end_time=2015-06-26T23:00:00Z&granularity=custom
+```
+##### Headers
+
+```
+x-api-key: "tenant_key_value"
+Accept: "application/json"
+```
+
+#### Response
+
+##### Code
+
+```
+Status: 200 OK
+```
+
+##### Body
+
+```json
+{
+  "results": [
+    {
+      "name": "GROUP_A",
+      "type": "GROUP",
+      "results": [
+        {
+          "availability": "99.99999900000002",
+          "reliability": "99.99999900000002"
+        }
+      ],
+      "groups": [
+        {
+          "name": "ST01",
+          "type": "SITES",
+          "results": [
+            {
+              "availability": "99.99999900000002",
+              "reliability": "99.99999900000002",
+              "unknown": "0",
+              "uptime": "1",
+              "downtime": "0"
+            }
+          ]
+        },
+        {
+          "name": "ST02",
+          "type": "SITES",
+          "results": [
+            {
+              "availability": "99.99999900000002",
+              "reliability": "99.99999900000002",
+              "unknown": "0",
+              "uptime": "1",
+              "downtime": "0"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
 <a id="2"></a>
 
 ## [GET]: List Availability and Reliability results for endpoints with specific resource-id
 
-The following methods can be used to obtain a tenant's Availability and Reliability result for the endpoints that have a specific resource-id. User can specify a period with `start_time` and `end_time` and granularity(`monthly` or `daily`) for retrieved results. `Accept` header is required. 
+The following methods can be used to obtain a tenant's Availability and Reliability result for the endpoints that have a specific resource-id. User can specify a period with `start_time` and `end_time` and granularity(`monthly`, `daily` or `custom`) for retrieved results. `Accept` header is required. 
 
 ### Input
 
@@ -238,7 +314,7 @@ The following methods can be used to obtain a tenant's Availability and Reliabil
 | --------------- | ----------------------------------------------------------------------------------------------- | -------- | ------------- |
 | `[start_time]`  | UTC time in W3C format                                                                          | YES      |
 | `[end_time]`    | UTC time in W3C format                                                                          | YES      |
-| `[granularity]` | Granularity of time that will be used to present data. Possible values are `monthly` or `daily` | NO       | `daily`       |
+| `[granularity]` | Granularity of time that will be used to present data. Possible values are `monthly`, `daily` or `custom` | NO       | `daily`       |
 
 #### Path Parameters
 
@@ -358,6 +434,62 @@ Status: 200 OK
       "results": [
         {
           "date": "2015-06",
+          "availability": "99.99999900000002",
+          "reliability": "99.99999900000002",
+          "unknown": "0",
+          "uptime": "1",
+          "downtime": "0"
+        }
+      ]
+    }
+  ]
+}
+```
+
+### Example Request 3: custom period granularity with specific resource-id
+This request returns availability/reliability score numbers for the whole custom period defined between `start_time` and `end_time`. 
+This means that for each item with the specific resource-id the user will receive one availability and reliability result concerning the whole period (instead of multiple daily or monthly results)
+
+#### Request
+
+##### Method
+`HTTP GET`
+
+##### Path
+
+```
+/api/v3/results/Report_A/id/simple-queue?start_time=2015-06-20T12:00:00Z&end_time=2015-06-26T23:00:00Z&granularity=custom
+```
+##### Headers
+
+```
+x-api-key: "tenant_key_value"
+Accept: "application/json"
+```
+
+#### Response
+
+##### Code
+
+```
+Status: 200 OK
+```
+
+##### Body
+
+```json
+{
+  "id": "simple-queue",
+  "endpoints": [
+    {
+      "name": "host01.example",
+      "service": "service.queue",
+      "group": "Infra-01",
+      "info": {
+        "URL": "http://submit.queue01.example.com"
+      },
+      "results": [
+        {
           "availability": "99.99999900000002",
           "reliability": "99.99999900000002",
           "unknown": "0",

--- a/website/docs/results/results.md
+++ b/website/docs/results/results.md
@@ -8,17 +8,17 @@ sidebar_position: 1
 
 | Name                                                                          | Description                                                                                                                                                                                                                              | Shortcut          |
 | ----------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
-| GET: List Availability and Reliability results for a group of endpoint groups | This method retrieves the results of a specified group of endpoint group or multiple groups of endpoint groups of a specific type that where computed based on a given report. Results can be retrieved on daily or monthly granularity. | [Description](#1) |
-| GET: List Availability and Reliability results for an endpoint group          | This method retrieves the results of a specified endpoint group or multiple endpoint groups of a specific type that where computed based on a given report. Results can be retrieved on daily or monthly granularity.                    | [Description](#2) |
-| GET: List Availability and Reliability results for a Service Flavor           | This method retrieves the results of a specified service flavor that where computed based on a given report. Results can be retrieved on daily or monthly granularity.                                                                   | [Description](#3) |
-| GET: List Availability and Reliability results for an Endpoint                | This method retrieves the results of a specified service endpoint that where computed based on a given report. Results can be retrieved on daily or monthly granularity.                                                                 | [Description](#4) |
-| GET: Flat List of all endpoints Availability and Reliability results                | This method retrieves the results in a flat list of all service endpoints that where computed based on a given report. Results can be retrieved on daily or monthly granularity. Pagination is supported.                                                                 | [Description](#5) |
+| GET: List Availability and Reliability results for a group of endpoint groups | This method retrieves the results of a specified group of endpoint group or multiple groups of endpoint groups of a specific type that where computed based on a given report. Results can be retrieved on daily, monthly or custom granularity. | [Description](#1) |
+| GET: List Availability and Reliability results for an endpoint group          | This method retrieves the results of a specified endpoint group or multiple endpoint groups of a specific type that where computed based on a given report. Results can be retrieved on daily, monthly or custom granularity.                    | [Description](#2) |
+| GET: List Availability and Reliability results for a Service Flavor           | This method retrieves the results of a specified service flavor that where computed based on a given report. Results can be retrieved on daily, monthly or custom granularity.                                                                   | [Description](#3) |
+| GET: List Availability and Reliability results for an Endpoint                | This method retrieves the results of a specified service endpoint that where computed based on a given report. Results can be retrieved on daily, monthly or custom granularity.                                                                 | [Description](#4) |
+| GET: Flat List of all endpoints Availability and Reliability results                | This method retrieves the results in a flat list of all service endpoints that where computed based on a given report. Results can be retrieved on daily, monthly or custom granularity. Pagination is supported.                                                                 | [Description](#5) |
 
 <a id="1"></a>
 
 # [GET]: List Availabilities and Reliabilities for groups of Endpoint Groups
 
-The following methods can be used to obtain a tenant's Availability and Reliability result metrics per Group of Endpoint Groups. The api authenticates the tenant using the api-key within the x-api-key header. User can specify time granularity (`monthly` or `daily`) for retrieved results and also format using the `Accept` header. Depending on the form of the request the user can request a single group of endpoint groups results or a bulk of group of endpoint groups results filtered by their type.
+The following methods can be used to obtain a tenant's Availability and Reliability result metrics per Group of Endpoint Groups. The api authenticates the tenant using the api-key within the x-api-key header. User can specify time granularity (`monthly`, `daily` or `custom`) for retrieved results and also format using the `Accept` header. Depending on the form of the request the user can request a single group of endpoint groups results or a bulk of group of endpoint groups results filtered by their type.
 
 ## [GET] Group of Endpoint groups
 
@@ -36,7 +36,7 @@ or
 | --------------- | ----------------------------------------------------------------------------------------------- | -------- | ------------- |
 | `[start_time]`  | UTC time in W3C format                                                                          | YES      |
 | `[end_time]`    | UTC time in W3C format                                                                          | YES      |
-| `[granularity]` | Granularity of time that will be used to present data. Possible values are `monthly` or `daily` | NO       | `daily`       |
+| `[granularity]` | Granularity of time that will be used to present data. Possible values are `monthly`, `daily` or `custom` | NO       | `daily`       |
 
 #### Path Parameters
 
@@ -80,7 +80,7 @@ Status: 200 OK
 
 # [GET]: List Availabilities and Reliabilities for Endpoint Groups
 
-The following methods can be used to obtain a tenant's Availability and Reliability result metrics per Endpoint Group. The api authenticates the tenant using the api-key within the x-api-key header. User can specify time granularity (`monthly` or `daily`) for retrieved results and also format using the `Accept` header. Depending on the form of the request the user can request a single endpoint group results or a bulk of endpoint group results filtered by their type and if necessary their "top-level" group.
+The following methods can be used to obtain a tenant's Availability and Reliability result metrics per Endpoint Group. The api authenticates the tenant using the api-key within the x-api-key header. User can specify time granularity (`monthly`, `daily` or `custom`) for retrieved results and also format using the `Accept` header. Depending on the form of the request the user can request a single endpoint group results or a bulk of endpoint group results filtered by their type and if necessary their "top-level" group.
 
 ## [GET] Endpoint Groups
 
@@ -102,7 +102,7 @@ or simpler
 | --------------- | ----------------------------------------------------------------------------------------------- | -------- | ------------- |
 | `[start_time]`  | UTC time in W3C format                                                                          | YES      |
 | `[end_time]`    | UTC time in W3C format                                                                          | YES      |
-| `[granularity]` | Granularity of time that will be used to present data. Possible values are `monthly` or `daily` | NO       | `daily`       |
+| `[granularity]` | Granularity of time that will be used to present data. Possible values are `monthly`, `daily` or `custom` | NO       | `daily`       |
 
 #### Path Parameters
 
@@ -150,7 +150,7 @@ Status: 200 OK
 
 # [GET]: List Availabilities and Reliabilities for Service Flavors
 
-The following methods can be used to obtain a tenant's Availability and Reliability result metrics per given Service Flavor(s). The api authenticates the tenant using the api-key within the x-api-key header. The user can specify time granularity (`monthly` or `daily`) for retrieved results and also format using the `Accept` header. Depending on the form of the request the user can request a single service flavor results or a bulk of service flavor results.
+The following methods can be used to obtain a tenant's Availability and Reliability result metrics per given Service Flavor(s). The api authenticates the tenant using the api-key within the x-api-key header. The user can specify time granularity (`monthly`, `daily` or `custom`) for retrieved results and also format using the `Accept` header. Depending on the form of the request the user can request a single service flavor results or a bulk of service flavor results.
 
 ## [GET] Service Flavors
 
@@ -172,7 +172,7 @@ or
 | --------------- | ----------------------------------------------------------------------------------------------- | -------- | ------------- |
 | `[start_time]`  | UTC time in W3C format                                                                          | YES      |
 | `[end_time]`    | UTC time in W3C format                                                                          | YES      |
-| `[granularity]` | Granularity of time that will be used to present data. Possible values are `monthly` or `daily` | NO       | `daily`       |
+| `[granularity]` | Granularity of time that will be used to present data. Possible values are `monthly`, `daily` or `custom` | NO       | `daily`       |
 
 #### Path Parameters
 
@@ -225,7 +225,7 @@ Status: 200 OK
 
 # [GET]: List Availabilities and Reliabilities for Endpoints
 
-The following methods can be used to obtain a tenant's Availability and Reliability result metrics for endpoints under a specific service or group. The api authenticates the tenant using the api-key within the x-api-key header. The user can specify time granularity (`monthly` or `daily`) for retrieved results and also format using the `Accept` header. Depending on the form of the request the user can request a single service flavor results or a bulk of endpoint results.
+The following methods can be used to obtain a tenant's Availability and Reliability result metrics for endpoints under a specific service or group. The api authenticates the tenant using the api-key within the x-api-key header. The user can specify time granularity (`monthly`, `daily` or `custom`) for retrieved results and also format using the `Accept` header. Depending on the form of the request the user can request a single service flavor results or a bulk of endpoint results.
 
 ## [GET] Endpoints A/R
 
@@ -261,7 +261,7 @@ or
 | --------------- | ----------------------------------------------------------------------------------------------- | -------- | ------------- |
 | `[start_time]`  | UTC time in W3C format                                                                          | YES      |
 | `[end_time]`    | UTC time in W3C format                                                                          | YES      |
-| `[granularity]` | Granularity of time that will be used to present data. Possible values are `monthly` or `daily` | NO       | `daily`       |
+| `[granularity]` | Granularity of time that will be used to present data. Possible values are `monthly`, `daily` or `custom` | NO       | `daily`       |
 
 #### Path Parameters
 
@@ -531,7 +531,7 @@ Some service endpoint a/r have additional information regarding the specific ser
 
 # [GET]: Flat List Availabilities and Reliabilities for all service Endpoints
 
-The following methods can be used to obtain a tenant's flat list of all service endpoints Availability and Reliability result. The api authenticates the tenant using the api-key within the x-api-key header. The user can specify time granularity (`monthly` or `daily`) for retrieved results and also format using the `Accept` header. Pagination is also supported by using the optional parameters `pageSize` to define the size of each result page and `nextPageToken` to proceed to the next available page of results.
+The following methods can be used to obtain a tenant's flat list of all service endpoints Availability and Reliability result. The api authenticates the tenant using the api-key within the x-api-key header. The user can specify time granularity (`monthly`, `daily` or `custom`) for retrieved results and also format using the `Accept` header. Pagination is also supported by using the optional parameters `pageSize` to define the size of each result page and `nextPageToken` to proceed to the next available page of results.
 ## [GET] Endpoints A/R
 
 ### Input
@@ -549,7 +549,7 @@ Request a flat list of all endpoint a/r
 | --------------- | ----------------------------------------------------------------------------------------------- | -------- | ------------- |
 | `[start_time]`  | UTC time in W3C format                                                                          | YES      |
 | `[end_time]`    | UTC time in W3C format                                                                          | YES      |
-| `[granularity]` | Granularity of time that will be used to present data. Possible values are `monthly` or `daily` | NO       | `daily`       |
+| `[granularity]` | Granularity of time that will be used to present data. Possible values are `monthly`, `daily` or `custom` | NO       | `daily`       |
 | `[pageSize]` | How many results to return per request (-1 means return all results) | NO       | -1       |
 | `[nextPageToken]` | token to proceed to the next page | NO       |  |
 

--- a/website/docs/validation_and_errors/errors.md
+++ b/website/docs/validation_and_errors/errors.md
@@ -13,7 +13,7 @@ Bad request              | 400 | One or more checks may have failed. More detail
 Wrong start_time         | 400 | Use start_time url parameter in zulu format (like `2006-01-02T15:04:05Z`) to indicate the query start time
 Wrong end_time           | 400 | Use end_time url parameter in zulu format (like `2006-01-02T15:04:05Z`) to indicate the query end time
 Wrong exec_time          | 400 | Use exec_time url parameter in zulu format (like `2006-01-02T15:04:05Z`) to indicate the exact probe execution time
-Wrong granularity        | 400 | The parameter value can be either `daily` or `monthly`
+Wrong granularity        | 400 | The parameter value can be either `daily`, `monthly` or `custom`
 Unauthorized             | 401 | The client needs to provide a correct authentication token using the header `x-api-key` 
 Forbidden                | 403 | Access to the resource is forbidden due to authorization policy enforced
 Item not found           | 404 | Either the path is not found or no results are available for the given query

--- a/website/docs/validation_and_errors/validations.md
+++ b/website/docs/validation_and_errors/validations.md
@@ -167,7 +167,7 @@ In case the parameter value is malformed (not in zulu expected format) the follo
 
 The `granularity` query parameter is used *optionally* under the `/results` resource to indicate the granularity level. It's value may be either monthly or daily. If not set by the user `monthly` is used.
 
-In case the parameter value is malformed (neither `daily` nor `monthly`) the following response is returned:
+In case the parameter value is malformed (neither `daily`, `monthly` or `custom`) the following response is returned:
 
 ```json
 {
@@ -179,7 +179,7 @@ In case the parameter value is malformed (neither `daily` nor `monthly`) the fol
   {
    "message": "Wrong Granularity",
    "code": "400",
-   "details": "%s is not accepted as granularity parameter, please provide either daily or monthly"
+   "details": "%s is not accepted as granularity parameter, please provide either daily, monthly or custom"
   }
  ]
 }

--- a/website/static/openapi/argo-web-api.yml
+++ b/website/static/openapi/argo-web-api.yml
@@ -4971,7 +4971,7 @@ paths:
           default: 2006-01-03T15:04:05Z
       - name: granularity
         in: query
-        description: daily or monthly granularity
+        description: daily, monthly or custom granularity
         schema:
           type: string
           default: daily
@@ -5089,7 +5089,7 @@ paths:
           default: 2006-01-03T15:04:05Z
       - name: granularity
         in: query
-        description: daily or monthly granularity
+        description: daily, monthly or custom granularity
         schema:
           type: string
           default: daily
@@ -5443,7 +5443,7 @@ paths:
           default: 2006-01-03T15:04:05Z
       - name: granularity
         in: query
-        description: daily or monthly granularity
+        description: daily, monthly or custom granularity
         schema:
           type: string
           default: daily
@@ -5591,7 +5591,7 @@ paths:
           default: 2006-01-03T15:04:05Z
       - name: granularity
         in: query
-        description: daily or monthly granularity
+        description: daily, monthly or custom granularity
         schema:
           type: string
           default: daily
@@ -5718,7 +5718,7 @@ paths:
           default: 2006-01-03T15:04:05Z
       - name: granularity
         in: query
-        description: daily or monthly granularity
+        description: daily, monthly or custom granularity
         schema:
           type: string
           default: daily
@@ -5852,7 +5852,7 @@ paths:
           default: 2006-01-03T15:04:05Z
       - name: granularity
         in: query
-        description: daily or monthly granularity
+        description: daily, monthly or custom granularity
         schema:
           type: string
           default: daily
@@ -5993,7 +5993,7 @@ paths:
           default: 2006-01-03T15:04:05Z
       - name: granularity
         in: query
-        description: daily or monthly granularity
+        description: daily, monthly or custom granularity
         schema:
           type: string
           default: daily
@@ -6148,7 +6148,7 @@ paths:
           default: 2006-01-03T15:04:05Z
       - name: granularity
         in: query
-        description: daily or monthly granularity
+        description: daily, monthly or custom granularity
         schema:
           type: string
           default: daily
@@ -6235,7 +6235,7 @@ paths:
       summary: List A/R results of all endpoints (under a given service)
       description: This method retrieves the results of endpoints under a specific
         service that where computed based on a given report. Results can be retrieved
-        on daily or monthly granularity.
+        on daily, monthly or custom granularity.
       operationId: resultsServiceEndpoints
       parameters:
       - name: x-api-key
@@ -6282,7 +6282,7 @@ paths:
           default: 2006-01-03T15:04:05Z
       - name: granularity
         in: query
-        description: daily or monthly granularity
+        description: daily, monthly or custom granularity
         schema:
           type: string
           default: daily
@@ -6423,7 +6423,7 @@ paths:
           default: 2006-01-03T15:04:05Z
       - name: granularity
         in: query
-        description: daily or monthly granularity
+        description: daily, monthly or custom granularity
         schema:
           type: string
           default: daily
@@ -6571,7 +6571,7 @@ paths:
           default: 2006-01-03T15:04:05Z
       - name: granularity
         in: query
-        description: daily or monthly granularity
+        description: daily, monthly or custom granularity
         schema:
           type: string
           default: daily
@@ -6712,7 +6712,7 @@ paths:
           default: 2006-01-03T15:04:05Z
       - name: granularity
         in: query
-        description: daily or monthly granularity
+        description: daily, monthly or custom granularity
         schema:
           type: string
           default: daily
@@ -6799,7 +6799,7 @@ paths:
       summary: List A/R results of all endpoints (under a given group)
       description: This method retrieves the results of endpoints under a specific
         group that where computed based on a given report. Results can be retrieved
-        on daily or monthly granularity.
+        on daily, monthly or custom granularity.
       operationId: resultsEndpoints
       parameters:
       - name: x-api-key
@@ -6846,7 +6846,7 @@ paths:
           default: 2006-01-03T15:04:05Z
       - name: granularity
         in: query
-        description: daily or monthly granularity
+        description: daily, monthly or custom granularity
         schema:
           type: string
           default: daily
@@ -6973,7 +6973,7 @@ paths:
           default: 2006-01-03T15:04:05Z
       - name: granularity
         in: query
-        description: daily or monthly granularity
+        description: daily, monthly or custom granularity
         schema:
           type: string
           default: daily
@@ -7059,7 +7059,7 @@ paths:
       - Results
       summary: Flat List A/R results of all endpoints
       description: This method returns a flat list of all endpoint a/r results based
-        on a given report. Results can be retrieved on daily or monthly granularity.
+        on a given report. Results can be retrieved on daily, monthly or custom granularity.
       operationId: resultsFlatEndpoints
       parameters:
       - name: x-api-key
@@ -7092,7 +7092,7 @@ paths:
           default: 2006-01-03T15:04:05Z
       - name: granularity
         in: query
-        description: daily or monthly granularity
+        description: daily, monthly or custom granularity
         schema:
           type: string
           default: daily
@@ -7172,7 +7172,7 @@ paths:
       summary: List A/R results for a given endpoint group
       description: his method retrieves the results of a specified endpoint group
         or multiple endpoint groups of a specific type that where computed based on
-        a given report. Results can be retrieved on daily or monthly granularity.
+        a given report. Results can be retrieved on daily, monthly or custom granularity.
       operationId: resultsEndpointGroupWithServiceFilter
       parameters:
       - name: x-api-key
@@ -7233,7 +7233,7 @@ paths:
           default: 2006-01-03T15:04:05Z
       - name: granularity
         in: query
-        description: daily or monthly granularity
+        description: daily, monthly or custom granularity
         schema:
           type: string
           default: daily
@@ -7313,7 +7313,7 @@ paths:
       summary: List A/R results for a given type of supergroup
       description: his method retrieves the results of a specified endpoint group
         or multiple endpoint groups of a specific type that where computed based on
-        a given report. Results can be retrieved on daily or monthly granularity.
+        a given report. Results can be retrieved on daily, monthly or custom granularity.
       operationId: resultsEndpointGroupWithoutSuperGroup
       parameters:
       - name: x-api-key
@@ -7353,7 +7353,7 @@ paths:
           default: 2006-01-03T15:04:05Z
       - name: granularity
         in: query
-        description: daily or monthly granularity
+        description: daily, monthly or custom granularity
         schema:
           type: string
           default: daily
@@ -7433,7 +7433,7 @@ paths:
       summary: List A/R results for a given endpoint group
       description: This method retrieves the results of a specified endpoint group
         or multiple endpoint groups of a specific type that where computed based on
-        a given report. Results can be retrieved on daily or monthly granularity.
+        a given report. Results can be retrieved on daily, monthly or custom granularity.
       operationId: resultsGroupWithServiceFilter
       parameters:
       - name: x-api-key
@@ -7480,7 +7480,7 @@ paths:
           default: 2006-01-03T15:04:05Z
       - name: granularity
         in: query
-        description: daily or monthly granularity
+        description: daily, monthly or custom granularity
         schema:
           type: string
           default: daily
@@ -9369,7 +9369,7 @@ paths:
           default: 2006-01-03T15:04:05Z
       - name: granularity
         in: query
-        description: daily or monthly granularity
+        description: daily, monthly or custom granularity
         schema:
           type: string
           default: daily
@@ -11620,7 +11620,7 @@ components:
     Granularity:
       name: granularity
       in: query
-      description: daily or monthly granularity
+      description: daily, monthly or custom granularity
       schema:
         type: string
         default: daily


### PR DESCRIPTION
# Goal
Unit now the user can specify a period with start_time and end_time and get results in two ways
- by date (daily)
- by month (monthly)
We provide a third granularity option with `custom` that allows the user to get a/r results for the whole custom period that he has defined

# Implementation


We need to provide another version of the `Monthly` or `Daily` queries as `Custom` such as
- EndpointCustom
- SupergroupCustom
- ServiceCustom
- EndpointCustom 
aggregations

Each such aggregation will not group items by date (day/month) so as to be able to aggregate over the whole set of daily days that the user has specified


### api/v2/results:

- [x] Reorganised queries in their own `queries.go` file
- [x] Created custom period version of aggregation query for supergroups
- [x] Created custom period version of aggregation query for groups
- [x] Created custom period version of aggregation query for services
- [x] Created custom period version of aggregation query for endpoints
- [x] Created custom period version of aggregation query for endpoints displayed in flat list with pagination
- [x] Updated /api/v2/results handlers input to receive granularity option: `custom` and call the corresponding aggregation query
- [x] Updated validators to recognise `granularity=custom`
- [x] Added unit tests
- [x] Updated docs & swagger

### api/v3/ar:

- [x] Created custom period version of aggregation query for groups
- [x] Created custom period version of aggregation query for endpoints
- [x] Updated /api/v3 handlers input to receive granularity option `custom` and call the corresponding aggregation query
- [x] Added unit tests
- [x] Updated docs & swagger
