### PR TITLE
ARGO-4096 Daily issues per group

### DIFF
--- a/app/issues/issues_test.go
+++ b/app/issues/issues_test.go
@@ -23,6 +23,7 @@
 package issues
 
 import (
+	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -151,6 +152,10 @@ func (suite *IssuesTestSuite) SetupTest() {
 		bson.M{
 			"resource": "issues.list_endpoints",
 			"roles":    []string{"editor", "viewer"},
+		},
+		bson.M{
+			"resource": "issues.list_group_metrics",
+			"roles":    []string{"editor", "viewer"},
 		})
 
 	// get dbconfiguration based on the tenant
@@ -205,6 +210,102 @@ func (suite *IssuesTestSuite) SetupTest() {
 		}})
 	// seed the status detailed metric data
 	c = session.DB(suite.tenantDbConf.Db).C("status_endpoints")
+	c.Insert(bson.M{
+		"report":         "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date_integer":   20150501,
+		"info":           bson.M{"Url": "http://example.foo/path/to/service"},
+		"timestamp":      "2015-05-01T00:00:00Z",
+		"endpoint_group": "HG-03-AUTH",
+		"service":        "CREAM-CE",
+		"host":           "cream01.afroditi.gr",
+
+		"status": "OK",
+	})
+	c.Insert(bson.M{
+		"report":         "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date_integer":   20150501,
+		"timestamp":      "2015-05-01T01:00:00Z",
+		"endpoint_group": "HG-03-AUTH",
+		"service":        "CREAM-CE",
+		"host":           "cream01.afroditi.gr",
+		"info":           bson.M{"Url": "http://example.foo/path/to/service"},
+
+		"status": "CRITICAL",
+	})
+	c.Insert(bson.M{
+		"report":         "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date_integer":   20150501,
+		"timestamp":      "2015-05-01T05:00:00Z",
+		"endpoint_group": "HG-03-AUTH",
+		"service":        "CREAM-CE",
+		"host":           "cream01.afroditi.gr",
+		"info":           bson.M{"Url": "http://example.foo/path/to/service"},
+
+		"status": "WARNING",
+	})
+	c.Insert(bson.M{
+		"report":         "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date_integer":   20150501,
+		"timestamp":      "2015-05-01T00:00:00Z",
+		"endpoint_group": "HG-03-AUTH",
+		"service":        "CREAM-CE",
+		"host":           "cream02.afroditi.gr",
+
+		"status": "WARNING",
+	})
+	c.Insert(bson.M{
+		"report":         "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date_integer":   20150501,
+		"timestamp":      "2015-05-01T08:47:00Z",
+		"endpoint_group": "HG-03-AUTH",
+		"service":        "CREAM-CE",
+		"host":           "cream02.afroditi.gr",
+
+		"status": "WARNING",
+	})
+	c.Insert(bson.M{
+		"report":         "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date_integer":   20150501,
+		"timestamp":      "2015-05-01T12:00:00Z",
+		"endpoint_group": "HG-03-AUTH",
+		"service":        "CREAM-CE",
+		"host":           "cream02.afroditi.gr",
+
+		"status": "OK",
+	})
+	c.Insert(bson.M{
+		"report":         "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date_integer":   20150501,
+		"timestamp":      "2015-05-01T00:00:00Z",
+		"endpoint_group": "HG-03-AUTH",
+		"service":        "CREAM-CE",
+		"host":           "cream03.afroditi.gr",
+
+		"status": "OK",
+	})
+	c.Insert(bson.M{
+		"report":         "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date_integer":   20150501,
+		"timestamp":      "2015-05-01T04:40:00Z",
+		"endpoint_group": "HG-03-AUTH",
+		"service":        "CREAM-CE",
+		"host":           "cream03.afroditi.gr",
+
+		"status": "UNKNOWN",
+	})
+	c.Insert(bson.M{
+		"report":         "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date_integer":   20150501,
+		"timestamp":      "2015-05-01T06:00:00Z",
+		"endpoint_group": "HG-03-AUTH",
+		"service":        "CREAM-CE",
+		"host":           "cream03.afroditi.gr",
+
+		"status": "CRITICAL",
+	})
+
+	// seed the status detailed metric data
+	c = session.DB(suite.tenantDbConf.Db).C("status_metrics")
 	c.Insert(bson.M{
 		"report":         "eba61a9e-22e9-4521-9e47-ecaa4a494364",
 		"date_integer":   20150501,
@@ -508,6 +609,87 @@ func (suite *IssuesTestSuite) TestIssuesEndpoints() {
 
 		expReq{
 			method: "GET",
+			url:    "/api/v2/issues/Report_A/groups/HG-03-AUTH/metrics?date=2015-05-01",
+			code:   200,
+			key:    "KEY1",
+			result: `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "service": "CREAM-CE",
+   "hostname": "cream01.afroditi.gr",
+   "metric": "emi.cream.CREAMCE-JobSubmit",
+   "status": "CRITICAL",
+   "info": {
+    "Url": "http://example.foo/path/to/service"
+   }
+  },
+  {
+   "service": "CREAM-CE",
+   "hostname": "cream01.afroditi.gr",
+   "metric": "emi.cream.CREAMCE-JobSubmit",
+   "status": "WARNING",
+   "info": {
+    "Url": "http://example.foo/path/to/service"
+   }
+  },
+  {
+   "service": "CREAM-CE",
+   "hostname": "cream02.afroditi.gr",
+   "metric": "emi.cream.CREAMCE-JobSubmit",
+   "status": "WARNING"
+  },
+  {
+   "service": "CREAM-CE",
+   "hostname": "cream03.afroditi.gr",
+   "metric": "emi.cream.CREAMCE-JobSubmit",
+   "status": "CRITICAL"
+  },
+  {
+   "service": "CREAM-CE",
+   "hostname": "cream03.afroditi.gr",
+   "metric": "emi.cream.CREAMCE-JobSubmit",
+   "status": "UNKNOWN"
+  }
+ ]
+}`,
+		},
+
+		expReq{
+			method: "GET",
+			url:    "/api/v2/issues/Report_A/groups/HG-03-AUTH/metrics?date=2015-05-01&filter=CRITICAL",
+			code:   200,
+			key:    "KEY1",
+			result: `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "service": "CREAM-CE",
+   "hostname": "cream01.afroditi.gr",
+   "metric": "emi.cream.CREAMCE-JobSubmit",
+   "status": "CRITICAL",
+   "info": {
+    "Url": "http://example.foo/path/to/service"
+   }
+  },
+  {
+   "service": "CREAM-CE",
+   "hostname": "cream03.afroditi.gr",
+   "metric": "emi.cream.CREAMCE-JobSubmit",
+   "status": "CRITICAL"
+  }
+ ]
+}`,
+		},
+
+		expReq{
+			method: "GET",
 			url:    "/api/v2/issues/Report_A/endpoints?date=2015-05-01&filter=MISSING",
 			code:   200,
 			key:    "KEY1",
@@ -532,7 +714,9 @@ func (suite *IssuesTestSuite) TestIssuesEndpoints() {
 
 		suite.Equal(expReq.code, response.Code, "Incorrect HTTP response code")
 		// Compare the expected and actual xml response
-		suite.Equal(expReq.result, response.Body.String(), "Response body mismatch")
+		if !(suite.Equal(expReq.result, response.Body.String(), "Response body mismatch")) {
+			fmt.Println(response.Body.String())
+		}
 
 	}
 
@@ -540,6 +724,24 @@ func (suite *IssuesTestSuite) TestIssuesEndpoints() {
 
 func (suite *IssuesTestSuite) TestOptionsIssuesEndpoints() {
 	request, _ := http.NewRequest("OPTIONS", "/api/v2/issues/Report_A/endpoints", strings.NewReader(""))
+
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code := response.Code
+	output := response.Body.String()
+	headers := response.HeaderMap
+
+	suite.Equal(200, code, "Error in response code")
+	suite.Equal("", output, "Expected empty response body")
+	suite.Equal("GET, OPTIONS", headers.Get("Allow"), "Error in Allow header response (supported resource verbs of resource)")
+	suite.Equal("text/plain; charset=utf-8", headers.Get("Content-Type"), "Error in Content-Type header response")
+
+}
+
+func (suite *IssuesTestSuite) TestOptionsIssuesGroups() {
+	request, _ := http.NewRequest("OPTIONS", "/api/v2/issues/Report_A/groups/test_group/metrics", strings.NewReader(""))
 
 	response := httptest.NewRecorder()
 

--- a/app/issues/model.go
+++ b/app/issues/model.go
@@ -38,6 +38,15 @@ type EndpointData struct {
 	Info          map[string]string `bson:"info" json:"info,omitempty"`
 }
 
+// GroupMetrics hold issues with metrics in a specific group
+type GroupMetrics struct {
+	Service  string            `bson:"service" json:"service,omitempty"`
+	Hostname string            `bson:"host" json:"hostname"`
+	Metric   string            `bson:"metric" json:"metric,omitempty"`
+	Status   string            `bson:"status" json:"status,omitempty"`
+	Info     map[string]string `bson:"info" json:"info,omitempty"`
+}
+
 // Message struct to hold the json/xml response
 type messageOUT struct {
 	XMLName xml.Name `xml:"root" json:"-"`

--- a/app/issues/routing.go
+++ b/app/issues/routing.go
@@ -35,6 +35,8 @@ func HandleSubrouter(s *mux.Router, confhandler *respond.ConfHandler) {
 
 var appRoutesV2 = []respond.AppRoutes{
 
+	{"issues.list_group_metrics", "GET", "/{report_name}/groups/{group_name}/metrics", ListGroupMetricIssues},
+	{"issues.options", "OPTIONS", "/{report_name}/groups/{group_name}/metrics", Options},
 	{"issues.list_endpoints", "GET", "/{report_name}/endpoints", FlatListEndpointTimelines},
 	{"issues.options", "OPTIONS", "/{report_name}/endpoints", Options},
 }

--- a/app/issues/view.go
+++ b/app/issues/view.go
@@ -45,6 +45,22 @@ func createEndpointListView(results []EndpointData, msg string, code int) ([]byt
 
 }
 
+// createGroupMetricsView constructs the json response for listing metric issues of a group
+func createGroupMetricsView(results []GroupMetrics, msg string, code int) ([]byte, error) {
+
+	docRoot := &respond.ResponseMessage{
+		Status: respond.StatusResponse{
+			Message: msg,
+			Code:    strconv.Itoa(code),
+		},
+	}
+	docRoot.Data = results
+
+	output, err := json.MarshalIndent(docRoot, "", " ")
+	return output, err
+
+}
+
 func createMessageOUT(message string, code int, format string) ([]byte, error) {
 
 	output := []byte("message placeholder")

--- a/scripts/mongodb/populate_default_roles.js
+++ b/scripts/mongodb/populate_default_roles.js
@@ -216,6 +216,10 @@ function populate_default_roles() {
             roles: ["admin", "editor", "viewer"]
         },
         {
+            resource: "issues.list_group_metrics",
+            roles: ["admin", "editor", "viewer"]
+        },
+        {
             resource: "downtimes.list",
             roles: ["admin", "editor", "viewer"]
         },

--- a/website/docs/results/issues.md
+++ b/website/docs/results/issues.md
@@ -61,7 +61,7 @@ Code:
 Status: 200 OK
 ```
 Response body:
-```
+```json
 {
  "status": {
   "message": "Success",
@@ -72,7 +72,7 @@ Response body:
    "timestamp": "2015-05-01T05:00:00Z",
    "endpoint_group": "SITE-A",
    "service": "web_portal",
-   "endpoint": web01.example.gr",
+   "endpoint": "web01.example.gr",
    "status": "WARNING",
    "info": {
     "Url": "http://example.foo/path/to/service"
@@ -107,7 +107,7 @@ Code:
 Status: 200 OK
 ```
 Response body:
-```
+```json
 {
  "status": {
   "message": "Success",
@@ -120,6 +120,130 @@ Response body:
    "service": "object-storage",
    "endpoint": "obj.storage.example.gr",
    "status": "CRITICAL"
+  }
+ ]
+}
+```
+
+### [GET]: Show Metric Issues for a given Group
+
+This method may be used to retrieve a list of problematic metrics that cause issues to a specific Group
+
+### Input
+
+```
+/issues/{report_name}/groups/{group_name}/metrics?date=2020-05-01&filter=CRITICAL
+```
+
+#### Path Parameters
+| Type | Description | Required | Default value |
+|------|-------------|----------|---------------|
+|`report_name`| name of the report| YES |  |
+|`group_name`| name of the group| YES |  |
+
+
+#### Url Parameters
+
+| Type | Description | Required | Default value |
+|------|-------------|----------|---------------|
+|`date`| Date to view problematic endpoints of | NO |  |
+|`filter`| Filter (optionally) problematic endpoints by status value| NO |  |
+
+
+
+#### Headers
+```
+x-api-key: shared_key_value
+Accept: application/json or application/xml
+```
+
+#### Response Code
+```
+Status: 200 OK
+```
+
+### Response body
+
+###### Example Request:
+URL:
+```
+/api/v2/issues/Critical/groups/SITE-A/metrics?date=2015-05-01
+```
+Headers:
+```
+x-api-key: shared_key_value
+Accept: application/json or application/xml
+
+```
+###### Example Response:
+
+Code:
+```
+Status: 200 OK
+```
+Response body:
+```json
+{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "service": "web_portal",
+   "hostname": "web01.example.gr",
+   "metric": "http_check",
+   "status": "WARNING",
+   "info": {
+    "Url": "http://example.foo/path/to/service"
+   }
+  },
+  {
+   "service": "web_portal",
+   "hostname": "web02.example.gr",
+   "metric": "http_check",
+   "status": "CRITICAL",
+   "info": {
+    "Url": "http://example2.foo/path/to/service"
+   }
+  }
+ ]
+}
+```
+
+###### Example Request with property filter=CRITICAL:
+URL:
+```
+/api/v2/issues/Critical/groups/SITE-A/metrics?date=2015-05-01&filter=CRITICAL
+```
+Headers:
+```
+x-api-key: shared_key_value
+Accept: application/json or application/xml
+
+```
+###### Example Response:
+
+Code:
+```
+Status: 200 OK
+```
+Response body:
+```json
+{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "service": "web_portal",
+   "hostname": "web02.example.gr",
+   "metric": "http_check",
+   "status": "CRITICAL",
+   "info": {
+    "Url": "http://example2.foo/path/to/service"
+   }
   }
  ]
 }

--- a/website/static/openapi/argo-web-api.yml
+++ b/website/static/openapi/argo-web-api.yml
@@ -7617,6 +7617,78 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status_error'
+                
+  /v2/issues/{REPORT_NAME}/groups/{GROUP_NAME}/metrics:
+    get:
+      tags:
+      - Issues
+      summary: List problematic metrics for a specific group
+      description: For a specific group, list metrics that are in problematic status (critical, warning,
+        missing etc)
+      operationId: issues.ListGroupMetrics
+      parameters:
+      - name: date
+        in: query
+        description: target date to retrieve results
+        schema:
+          type: string
+          default: todays_date in YYYY-MM-DD format
+      - name: x-api-key
+        in: header
+        description: the x-api-key
+        required: true
+        schema:
+          type: string
+          default: SecretKey123
+      - name: filter
+        in: query
+        description: name of the problematic status to filter by
+        schema:
+          type: string
+      - name: REPORT_NAME
+        in: path
+        description: name of the report
+        required: true
+        schema:
+          type: string
+      - name: GROUP_NAME
+        in: path
+        description: name of the group
+        required: true
+        schema:
+          type: string
+      responses:
+        200:
+          description: A list with problematic metrics
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GroupMetrics'
+        401:
+          description: Unauthorized user
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status_error'
+        404:
+          description: Item not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status_error'
+        406:
+          description: Content Not acceptable
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status_error'
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status_error'
+
   /v2/trends/{REPORT_NAME}/status/metrics:
     get:
       tags:
@@ -10484,6 +10556,24 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Metric_profile'
+    GroupMetrics:
+      type: object
+      properties:
+        status:
+          $ref: '#/components/schemas/Status'
+        data:
+          type: array
+          items:
+            type: object
+            properties:
+              service:
+                type: string
+              hostname:
+                type: string
+              metric: 
+                type: string
+              status:
+                type: string
     recomputation:
       type: object
       properties:


### PR DESCRIPTION
# Goal
For a specific group e.g. `SITE-A` list all problematic metrics for a day

# Implementation
Add a new endpoint under `/issues` path
`/api/v2/issues/{report_name}/groups/{group_name}/metrics?date=YYYY-MM-DD&filter={status}`
- `group_name` the name of the group (e.g. SITE-A)
- `filter` = optional  - show only metrics with CRITICAL, WARNING,MISSING etc. status

Response is in the following form:
```json
{
 "status": {
  "message": "Success",
  "code": "200"
 },
 "data": [
  {
   "service": "web_portal",
   "hostname": "web01.example.gr",
   "metric": "http_check",
   "status": "WARNING",
   "info": {
    "Url": "http://example.foo/path/to/service"
   }
  },
  {
   "service": "web_portal",
   "hostname": "web02.example.gr",
   "metric": "http_check",
   "status": "CRITICAL",
   "info": {
    "Url": "http://example2.foo/path/to/service"
   }
  }
 ]
}
```

- [x] Issues package: add new handler for displaying a list of Group Metrics that have issues
- [x] Issues package: add new aggregation query
- [x] Issues package: add new view
- [x] Issues package: update models
- [x] Issues package: add unit tests
- [x] Update docs
- [x] Update openapi v3 definition
