### PR TITLE
Bump version to v1.13.0

### DIFF
--- a/argo-web-api.spec
+++ b/argo-web-api.spec
@@ -3,7 +3,7 @@
 
 Name: argo-web-api
 Summary: A/R API
-Version: 1.12.0
+Version: 1.13.0
 Release: 1%{?dist}
 License: ASL 2.0
 Buildroot: %{_tmppath}/%{name}-buildroot
@@ -68,6 +68,8 @@ go clean
 %attr(0644,root,root) /usr/lib/systemd/system/argo-web-api.service
 
 %changelog
+* Mon Nov 7 2022 Konstantinos Kagkelidis <kaggis@gmail.com> 1.13.0-1%{dist}
+- Release of argo-web-api version 1.12.1
 * Thu Jun 9 2022 Konstantinos Kagkelidis <kaggis@gmail.com> 1.12.0-1%{dist}
 - Release of argo-web-api version 1.12.0
 * Wed Apr 6 2022 Konstantinos Kagkelidis <kaggis@gmail.com> 1.11.0-1%{dist}

--- a/version/version.go
+++ b/version/version.go
@@ -6,7 +6,7 @@ import (
 
 var (
 	// Release version of the service. Bump it up during new version release
-	Release = "1.12.0"
+	Release = "1.13.0"
 	// Commit hash provided during build
 	Commit = "Unknown"
 	// BuildTime provided during build


### PR DESCRIPTION
**Added:**

 - ARGO-4089 support OPTIONS for api v3 calls using resource-ids
 - ARGO-4048 add additional tags field list of service types
 - ARGO-4078 Implement api/v3 call to serve endpoint ar results by resource id
 - ARGO-4026 api v3 call to get status results by resource id

**Changed**

 - ARGO-3960 Update to docusaurus v.2.0. Add search plugin. Spellcheck docs

**Fixed**

 - ARGO-4087 Fix date validation in api/v3 A/R calls
 - ARGO-4084 Fix v3 ar results by resource-id call
