### PR TITLE
ARGO-4115 Configure dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+# Configure dependabot against devel branch for both go deps and docusaurus ./website npm deps
+
+version: 2
+updates:
+  - package-ecosystem: "gomod" 
+    directory: "/" 
+    target-branch: "devel"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "npm" 
+    directory: "/website" 
+    target-branch: "develop"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Configure dependabot updates against `devel` branch for both go deps and docusaurus deps (npm)