### PR TITLE
ARGO-4185 Add title field to service types

### DIFF
--- a/app/topology/model.go
+++ b/app/topology/model.go
@@ -93,6 +93,7 @@ type ServiceType struct {
 	Date        string   `bson:"date" json:"date"`
 	DateInt     int      `bson:"date_integer" json:"-"`
 	Name        string   `bson:"name" json:"name"`
+	Title       string   `bson:"title" json:"title"`
 	Description string   `bson:"description" json:"description"`
 	Tags        []string `bson:"tags" json:"tags,omitempty"`
 }

--- a/app/topology/topology_test.go
+++ b/app/topology/topology_test.go
@@ -23,6 +23,7 @@
 package topology
 
 import (
+	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -1211,36 +1212,42 @@ func (suite *topologyTestSuite) SetupTest() {
 			"date":         "2015-01-11",
 			"date_integer": 20150111,
 			"name":         "DB",
+			"title":        "Database Service",
 			"description":  "A Database type of Service",
 		},
 		bson.M{
 			"date":         "2015-01-11",
 			"date_integer": 20150111,
 			"name":         "API",
+			"title":        "Web API Service",
 			"description":  "An API type of Service",
 		},
 		bson.M{
 			"date":         "2015-04-12",
 			"date_integer": 20150412,
 			"name":         "DB",
+			"title":        "Database Service",
 			"description":  "A Database type of Service",
 		},
 		bson.M{
 			"date":         "2015-04-12",
 			"date_integer": 20150412,
 			"name":         "API",
+			"title":        "Web API Service",
 			"description":  "An API type of Service",
 		},
 		bson.M{
 			"date":         "2015-04-12",
 			"date_integer": 20150412,
 			"name":         "STORAGE",
+			"title":        "Data Storage Service",
 			"description":  "A Storage type of Service",
 		},
 		bson.M{
 			"date":         "2015-06-13",
 			"date_integer": 20150613,
 			"name":         "STORAGE",
+			"title":        "Data Storage Service",
 			"description":  "A Storage type of Service",
 			"tags":         []string{"poem"},
 		})
@@ -1420,16 +1427,19 @@ func (suite *topologyTestSuite) TestCreateServiceTypeTopology() {
   {
    "date": "2019-03-03",
    "name": "Service_A",
+   "title": "Service A",
    "description": "a short descritpion of service type a"
   },
   {
    "date": "2019-03-03",
    "name": "Service_B",
+   "title": "Service B",
    "description": "a short descritpion of service type b"
   },
   {
    "date": "2019-03-03",
    "name": "Service_C",
+   "title": "Service C",
    "description": "a short descritpion of service type c"
   }
  ]
@@ -1438,14 +1448,17 @@ func (suite *topologyTestSuite) TestCreateServiceTypeTopology() {
 	jsonInput := `[
   {
     "name": "Service_A",
+	"title": "Service A",
     "description": "a short descritpion of service type a"
   },
   {
     "name": "Service_B",
+	"title": "Service B",
     "description": "a short descritpion of service type b"
   },
   {
     "name": "Service_C",
+	"title": "Service C",
     "description": "a short descritpion of service type c"
   }
 ]`
@@ -2703,11 +2716,13 @@ func (suite *topologyTestSuite) TestListServiceTypes() {
   {
    "date": "2015-01-11",
    "name": "API",
+   "title": "Web API Service",
    "description": "An API type of Service"
   },
   {
    "date": "2015-01-11",
    "name": "DB",
+   "title": "Database Service",
    "description": "A Database type of Service"
   }
  ]
@@ -2725,16 +2740,19 @@ func (suite *topologyTestSuite) TestListServiceTypes() {
   {
    "date": "2015-04-12",
    "name": "API",
+   "title": "Web API Service",
    "description": "An API type of Service"
   },
   {
    "date": "2015-04-12",
    "name": "DB",
+   "title": "Database Service",
    "description": "A Database type of Service"
   },
   {
    "date": "2015-04-12",
    "name": "STORAGE",
+   "title": "Data Storage Service",
    "description": "A Storage type of Service"
   }
  ]
@@ -2752,6 +2770,7 @@ func (suite *topologyTestSuite) TestListServiceTypes() {
   {
    "date": "2015-06-13",
    "name": "STORAGE",
+   "title": "Data Storage Service",
    "description": "A Storage type of Service",
    "tags": [
     "poem"
@@ -2775,7 +2794,9 @@ func (suite *topologyTestSuite) TestListServiceTypes() {
 		// Check that we must have a 200 ok code
 		suite.Equal(exp.Code, code, "Response Code Mismatch on call:"+exp.Path)
 		// Compare the expected and actual json response
-		suite.Equal(exp.JSON, output, "Response body mismatch on call:"+exp.Path)
+		if !(suite.Equal(exp.JSON, output, "Response body mismatch on call:"+exp.Path)) {
+			fmt.Println(output)
+		}
 	}
 }
 

--- a/website/docs/topology/topology_service_types.md
+++ b/website/docs/topology/topology_service_types.md
@@ -44,14 +44,17 @@ Accept: application/json
 [
   {
     "name": "Service_Type_A",
+    "title": "Service of type A",
     "description": "a short descritpion of service type a"
   },
   {
     "name": "Service_Type_B",
+    "title": "Service of type B",
     "description": "a short descritpion of service type b"
   },
   {
     "name": "Service_Type_C",
+    "title": "Service of type C",
     "description": "a short descritpion of service type c",
     "tags": ["special-service", "beta"]
   }
@@ -144,16 +147,19 @@ Status: 200 OK
     {
       "date": "2019-03-03",
       "name": "Service_Type_A",
+      "title": "Service of type A",
       "description": "a short descritpion of service type a"
     },
     {
       "date": "2019-03-03",
       "name": "Service_Type_B",
+      "title": "Service of type B",
       "description": "a short descritpion of service type b"
     },
     {
       "date": "2019-03-03",
       "name": "Service_Type_C",
+      "title": "Service of type C",
       "description": "a short descritpion of service type c",
       "tags": ["special-service", "beta"]
     }

--- a/website/static/openapi/argo-web-api.yml
+++ b/website/static/openapi/argo-web-api.yml
@@ -3153,7 +3153,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Self_reference'
+                $ref: '#/components/schemas/TopologyServiceTypes'
         401:
           description: Unauthorized user
           content:
@@ -9925,6 +9925,9 @@ components:
         name:
           type: string
           description: name of the service type
+        title:
+          type: string
+          description: A User friendly (human readable) title for the specific service type
         description:
           type: string
           description: short description of the service type
@@ -11399,6 +11402,8 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/User'
+    
+            
     TopologyTags_list:
       type: object
       properties:


### PR DESCRIPTION
Add an extra field named `"title"` in the service type resource. The title will contain a more user-friendly and human readable name for the service it self 

example
```json
{
  "name": "namespace.obj.datastore"
  "title": "Object Datatastore Service"
  "description": "A Service type representing instances of object datastores"
  "tags" : [ "datastore", "objects" ]
} 
```