### PR TITLE
ARGO-4196 Get status timelines for all endpoints in a specific group

### DIFF
--- a/app/statusEndpoints/controller.go
+++ b/app/statusEndpoints/controller.go
@@ -298,7 +298,10 @@ func prepareQuery(input InputParams, reportID string) bson.M {
 		"date_integer":   bson.M{"$gte": input.startTime, "$lte": input.endTime},
 		"report":         reportID,
 		"endpoint_group": input.group,
-		"service":        input.service,
+	}
+
+	if len(input.service) > 0 {
+		filter["service"] = input.service
 	}
 
 	if len(input.hostname) > 0 {

--- a/app/statusEndpoints/routing.go
+++ b/app/statusEndpoints/routing.go
@@ -48,6 +48,10 @@ var appRoutesV2 = []respond.AppRoutes{
 
 	{"status.options", "OPTIONS", "/{report_name}/{group_type}/{group_name}/services/{service_name}/endpoints/{endpoint_name}", Options},
 	{"status.options", "OPTIONS", "/{report_name}/{group_type}/{group_name}/services/{service_name}/endpoints", Options},
+
+	{"status.get", "GET", "/{report_name}/{group_type}/{group_name}/endpoints", routeCheckGroup},
+	{"status.get", "GET", "/{report_name}/{group_type}/{group_name}/endpoints", routeCheckGroup},
+
 	{"status.get", "GET", "/{report_name}/endpoints", routeCheckGroup},
 	{"status.options", "OPTIONS", "/{report_name}/endpoints", Options},
 }

--- a/app/statusEndpoints/statusEndpoints_test.go
+++ b/app/statusEndpoints/statusEndpoints_test.go
@@ -303,6 +303,37 @@ func (suite *StatusEndpointsTestSuite) SetupTest() {
 		"status":             "CRITICAL",
 		"has_threshold_rule": true,
 	})
+	c.Insert(bson.M{
+		"report":         "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date_integer":   20150501,
+		"timestamp":      "2015-05-01T00:00:00Z",
+		"endpoint_group": "HG-03-AUTH",
+		"service":        "STORAGE",
+		"host":           "storage.example.foo",
+		"metric":         "check.storage",
+		"status":         "OK",
+	})
+	c.Insert(bson.M{
+		"report":         "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date_integer":   20150501,
+		"timestamp":      "2015-05-01T06:40:00Z",
+		"endpoint_group": "HG-03-AUTH",
+		"service":        "STORAGE",
+		"host":           "storage.example.foo",
+		"metric":         "check.storage",
+		"status":         "WARNING",
+	})
+	c.Insert(bson.M{
+		"report":             "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+		"date_integer":       20150501,
+		"timestamp":          "2015-05-01T09:00:00Z",
+		"endpoint_group":     "HG-03-AUTH",
+		"service":            "STORAGE",
+		"host":               "storage.example.foo",
+		"metric":             "check.storage",
+		"status":             "CRITICAL",
+		"has_threshold_rule": true,
+	})
 
 	// get dbconfiguration based on the tenant
 	// Prepare the request object
@@ -754,6 +785,139 @@ func (suite *StatusEndpointsTestSuite) TestMultipleItems() {
         },
         {
          "timestamp": "2015-05-01T06:00:00Z",
+         "value": "CRITICAL"
+        },
+        {
+         "timestamp": "2015-05-01T23:59:59Z",
+         "value": "CRITICAL"
+        }
+       ]
+      }
+     ]
+    }
+   ]
+  }
+ ]
+}`
+
+	// init the response placeholder
+	response := httptest.NewRecorder()
+	// Prepare the request object for second tenant
+	request, _ := http.NewRequest("GET", fullurl1, strings.NewReader(""))
+	// add json accept header
+	request.Header.Set("Accept", "application/json")
+	// add the authentication token which is seeded in testdb
+	request.Header.Set("x-api-key", "KEY1")
+	// Serve the http request
+	suite.router.ServeHTTP(response, request)
+	// Check that we must have a 200 ok code
+	suite.Equal(200, response.Code, "Internal Server Error")
+	// Compare the expected and actual xml response
+	suite.Equal(respJSON1, response.Body.String(), "Response body mismatch")
+
+}
+
+func (suite *StatusEndpointsTestSuite) TestGroupEndpoints() {
+
+	fullurl1 := "/api/v2/status/Report_A/SITES/HG-03-AUTH" +
+		"/endpoints" +
+		"?start_time=2015-05-01T00:00:00Z&end_time=2015-05-01T23:00:00Z"
+
+	respJSON1 := `{
+ "groups": [
+  {
+   "name": "HG-03-AUTH",
+   "type": "SITES",
+   "services": [
+    {
+     "name": "CREAM-CE",
+     "type": "service",
+     "endpoints": [
+      {
+       "name": "cream01.afroditi.gr",
+       "info": {
+        "Url": "http://example.foo/path/to/service"
+       },
+       "statuses": [
+        {
+         "timestamp": "2015-05-01T00:00:00Z",
+         "value": "OK"
+        },
+        {
+         "timestamp": "2015-05-01T01:00:00Z",
+         "value": "CRITICAL"
+        },
+        {
+         "timestamp": "2015-05-01T05:00:00Z",
+         "value": "OK"
+        },
+        {
+         "timestamp": "2015-05-01T23:59:59Z",
+         "value": "OK"
+        }
+       ]
+      },
+      {
+       "name": "cream02.afroditi.gr",
+       "statuses": [
+        {
+         "timestamp": "2015-05-01T00:00:00Z",
+         "value": "OK"
+        },
+        {
+         "timestamp": "2015-05-01T08:47:00Z",
+         "value": "WARNING"
+        },
+        {
+         "timestamp": "2015-05-01T12:00:00Z",
+         "value": "OK"
+        },
+        {
+         "timestamp": "2015-05-01T23:59:59Z",
+         "value": "OK"
+        }
+       ]
+      },
+      {
+       "name": "cream03.afroditi.gr",
+       "statuses": [
+        {
+         "timestamp": "2015-05-01T00:00:00Z",
+         "value": "OK"
+        },
+        {
+         "timestamp": "2015-05-01T04:40:00Z",
+         "value": "UNKNOWN"
+        },
+        {
+         "timestamp": "2015-05-01T06:00:00Z",
+         "value": "CRITICAL"
+        },
+        {
+         "timestamp": "2015-05-01T23:59:59Z",
+         "value": "CRITICAL"
+        }
+       ]
+      }
+     ]
+    },
+    {
+     "name": "STORAGE",
+     "type": "service",
+     "endpoints": [
+      {
+       "name": "storage.example.foo",
+       "statuses": [
+        {
+         "timestamp": "2015-05-01T00:00:00Z",
+         "value": "OK"
+        },
+        {
+         "timestamp": "2015-05-01T06:40:00Z",
+         "value": "WARNING"
+        },
+        {
+         "timestamp": "2015-05-01T09:00:00Z",
          "value": "CRITICAL"
         },
         {

--- a/website/docs/results/status.md
+++ b/website/docs/results/status.md
@@ -9,7 +9,7 @@ sidebar_position: 2
 | Name  | Description | Shortcut |
 |-------|-------------|----------|
 | GET: List Service Metric Status Timelines | This method may be used to retrieve a specific service metric status timeline (applies on a specific service endpoint).|<a href="#1">Description</a>|
-| GET: List Service Endpoint Status Timelines | This method may be used to retrieve a specific service endpoint status timeline (applies on a specific service type). | <a href="#2">Description</a>|
+| GET: List Service Endpoint Status Timelines | This method may be used to retrieve a specific service endpoint status timeline (for a specific group and/or for a specific service type inside that group). | <a href="#2">Description</a>|
 | GET: List Service  Status Timelines |This method may be used to retrieve a specific service type status timeline (applies for a specific service endpoint group). | <a href="#3">Description</a>|
 | GET: List Endpoint Group Status Timelines| This method may be used to retrieve endpoint group status timelines. | <a href="#4">Description</a>|
 | GET: Metric Result | This method may be used to retrieve a specific and detailed metric result. | <a href="#5">Description</a>|
@@ -386,6 +386,10 @@ This method may be used to retrieve a specific service endpoint status timeline 
 ```
 /status/{report}/{endpoint_group_type}/{endpoint_group_name}/services/{service_type}/endpoints/{hostname}?[start_time]&[end_time]
 ```
+##### List All endpoints in a specific group:
+```
+/status/{report}/{group_type}/{group_name}/endpoints?[start_time]&[end_time]
+```
 
 #### Path Parameters
 | Type | Description | Required | Default value |
@@ -597,6 +601,139 @@ Response body (JSON):
       ]
     }
   ]
+}
+```
+
+#### List all endpoints included in a specific group
+For a specific group, return all endpoints included - grouped by service type
+
+##### Example Request:
+URL:
+```
+/status/EGI_CRITICAL/SITES/HG-03-AUTH/endpoints?start_time=2015-05-01T00:00:00Z&end_time=2015-05-01T23:59:59Z
+```
+Headers:
+```
+x-api-key: shared_key_value
+Accept: application/json or application/xml
+
+```
+##### Example Response:
+Code:
+```
+Status: 200 OK
+```
+
+Response body (JSON):
+```json
+{
+ "groups": [
+  {
+   "name": "HG-03-AUTH",
+   "type": "SITES",
+   "services": [
+    {
+     "name": "CREAM-CE",
+     "type": "service",
+     "endpoints": [
+      {
+       "name": "cream01.afroditi.gr",
+       "info": {
+        "Url": "http://example.foo/path/to/service"
+       },
+       "statuses": [
+        {
+         "timestamp": "2015-05-01T00:00:00Z",
+         "value": "OK"
+        },
+        {
+         "timestamp": "2015-05-01T01:00:00Z",
+         "value": "CRITICAL"
+        },
+        {
+         "timestamp": "2015-05-01T05:00:00Z",
+         "value": "OK"
+        },
+        {
+         "timestamp": "2015-05-01T23:59:59Z",
+         "value": "OK"
+        }
+       ]
+      },
+      {
+       "name": "cream02.afroditi.gr",
+       "statuses": [
+        {
+         "timestamp": "2015-05-01T00:00:00Z",
+         "value": "OK"
+        },
+        {
+         "timestamp": "2015-05-01T08:47:00Z",
+         "value": "WARNING"
+        },
+        {
+         "timestamp": "2015-05-01T12:00:00Z",
+         "value": "OK"
+        },
+        {
+         "timestamp": "2015-05-01T23:59:59Z",
+         "value": "OK"
+        }
+       ]
+      },
+      {
+       "name": "cream03.afroditi.gr",
+       "statuses": [
+        {
+         "timestamp": "2015-05-01T00:00:00Z",
+         "value": "OK"
+        },
+        {
+         "timestamp": "2015-05-01T04:40:00Z",
+         "value": "UNKNOWN"
+        },
+        {
+         "timestamp": "2015-05-01T06:00:00Z",
+         "value": "CRITICAL"
+        },
+        {
+         "timestamp": "2015-05-01T23:59:59Z",
+         "value": "CRITICAL"
+        }
+       ]
+      }
+     ]
+    },
+    {
+     "name": "STORAGE",
+     "type": "service",
+     "endpoints": [
+      {
+       "name": "storage.example.foo",
+       "statuses": [
+        {
+         "timestamp": "2015-05-01T00:00:00Z",
+         "value": "OK"
+        },
+        {
+         "timestamp": "2015-05-01T06:40:00Z",
+         "value": "WARNING"
+        },
+        {
+         "timestamp": "2015-05-01T09:00:00Z",
+         "value": "CRITICAL"
+        },
+        {
+         "timestamp": "2015-05-01T23:59:59Z",
+         "value": "CRITICAL"
+        }
+       ]
+      }
+     ]
+    }
+   ]
+  }
+ ]
 }
 ```
 

--- a/website/static/openapi/argo-web-api.yml
+++ b/website/static/openapi/argo-web-api.yml
@@ -4398,9 +4398,8 @@ paths:
       - Status
       summary: List status results for all endpoints (under a given service and endpoint
         group)
-      description: This method may be used to retrieve a specific service endpoint
-        status timeline (applies on a specific service type)
-      operationId: statusEndpointID
+      description: This method may be used to retrieve all endpoint status timelines of a specific group and service type 
+      operationId: statusEndpoints
       parameters:
       - name: x-api-key
         in: header
@@ -4985,6 +4984,125 @@ paths:
             application/xml:
               schema:
                 $ref: '#/components/schemas/FlatEndpointStatusResponse'
+        400:
+          description: Item not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status_error'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/Status_error'
+        401:
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                  code:
+                    type: string
+                  details:
+                    type: string
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                  code:
+                    type: string
+                  details:
+                    type: string
+        406:
+          description: Content Not acceptable
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status_error'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/Status_error'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status_error'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/Status_error'
+        500:
+          description: internal server error
+          content:
+            application/json:
+              schema:
+                type: string
+            application/xml:
+              schema:
+                type: string
+  /v2/status/{report_name}/{lgroup_type}/{lgroup_name}/endpoints:
+    get:
+      tags:
+      - Status
+      summary: List status results for all endpoints (under a given group)
+      description: This method may be used to retrieve endpoint status timelines under a given group
+      operationId: statusEndpointsGroup
+      parameters:
+      - name: x-api-key
+        in: header
+        description: the x-api-key
+        required: true
+        schema:
+          type: string
+          default: SecretKey123
+      - name: report_name
+        in: path
+        description: report the probes belong to
+        required: true
+        schema:
+          type: string
+          default: CRITICAL
+      - name: end_time
+        in: query
+        description: end date of query in zulu format
+        required: true
+        schema:
+          type: string
+          default: 2006-01-03T15:04:05Z
+      - name: start_time
+        in: query
+        description: start date of query in zulu format
+        required: true
+        schema:
+          type: string
+          default: 2006-01-01T00:04:05Z
+      - name: lgroup_type
+        in: path
+        description: endpoing group type of the probes
+        required: true
+        schema:
+          type: string
+          default: EndpointGroup
+      - name: lgroup_name
+        in: path
+        description: endpoint group names of the probes
+        required: true
+        schema:
+          type: string
+          default: Group_A
+      responses:
+        200:
+          description: Successful retrieval of statuses
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusEndpointResponse'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/StatusEndpointResponse'
         400:
           description: Item not found
           content:


### PR DESCRIPTION
## 🎯 Goal: Retrieve status timelines for all endpoints included in a group

Till now in order to view status timelines for endpoints in a group a user had to follow the path selecting a specific service type: 
```
/v2/status/REPORT-A/SERVICEGROUPS(or SITES)/GROUP-A/services/SERVICE-TYPE-A/endpoints
```
User now can quickly retrieve status timelines for all endpoints included in a group (without having to specify a service-type):
```
/v2/status/REPORT-A/SERVICEGROUPS(or SITES)/GROUP-A/endpoints
```
## 🏗️ Implementation
- [x] Extend ListEndpoints method to have the service type argument optional. If no service argument is given the query retrieves all endpoints of a group
- [x] Extend routing to be able to call ListEndpoints method (with no service type argument) under the new path `/v2/status/{report-name}/{group-name}/endpoints`
- [x] Extend unit tests to cover this case
- [x] Update openapi description
- [x] Update docs. Minor Fixes