### PR TITLE
ARGO-4206 Add filter by service type when requesting metric results

### DIFF
--- a/app/metricResult/model.go
+++ b/app/metricResult/model.go
@@ -28,6 +28,7 @@ type metricResultQuery struct {
 	EndpointName string `bson:"hostname"`
 	MetricName   string `bson:"metric_name"`
 	ExecTime     string `bson:"exec_time"` // UTC time in W3C format
+	Service      string `bson:"service"`
 }
 
 // metricResultOutput structure holds mongo results

--- a/app/metricResult/view.go
+++ b/app/metricResult/view.go
@@ -103,48 +103,6 @@ func createMultipleMetricResultsView(results []metricResultOutput, format string
 
 }
 
-func createMetricResultView(result metricResultOutput, format string) ([]byte, error) {
-
-	docRoot := &root{}
-
-	// Exit here in case result is empty
-	if result.Hostname == "" {
-		output, err := xml.MarshalIndent(docRoot, "", "")
-		return output, err
-	}
-
-	hostname := &HostXML{
-		Name: result.Hostname,
-		Info: result.Info,
-	}
-	docRoot.Result = append(docRoot.Result, hostname)
-
-	metric := &MetricXML{
-		Name:    result.Metric,
-		Service: result.Service,
-	}
-	hostname.Metrics = append(hostname.Metrics, metric)
-
-	// we append the detailed results
-	metric.Details = append(metric.Details,
-		&StatusXML{
-			Timestamp:      fmt.Sprintf("%s", result.Timestamp),
-			Value:          fmt.Sprintf("%s", result.Status),
-			Summary:        fmt.Sprintf("%s", result.Summary),
-			Message:        fmt.Sprintf("%s", result.Message),
-			ActualData:     fmt.Sprintf("%s", result.ActualData),
-			RuleApplied:    fmt.Sprintf("%s", result.RuleApplied),
-			OriginalStatus: fmt.Sprintf("%s", result.OriginalStatus),
-		})
-
-	if strings.ToLower(format) == "application/json" {
-		return json.MarshalIndent(docRoot, " ", "  ")
-	}
-
-	return xml.MarshalIndent(docRoot, " ", "  ")
-
-}
-
 func createErrorMessage(message string, code int, format string) ([]byte, error) {
 
 	output := []byte("message placeholder")

--- a/website/docs/results/metric_results.md
+++ b/website/docs/results/metric_results.md
@@ -27,6 +27,7 @@ This method may be used to retrieve a specific service metric result.
 | Type | Description | Required | Default value |
 |------|-------------|----------|---------------|
 |`exec_time`| The execution date of query in zulu format| YES |  |
+|`service`| Filter by service type | NO |  |
 
 ___Notes___:
 `exec_time` : The execution date of query in zulu format. In order to get the correct execution time get status results for all metrics (under a given endpoint, service and endpoint group). ( GET /status/{report_name}/{lgroup_type}/{lgroup_name}/services/{service_name}/endpoints/{endpoint_name}/metrics List)
@@ -87,6 +88,49 @@ Response body:
  
 ```
 
+###### Example Request with service filter:
+URL:
+```
+/api/v2/metric_result/www.example.com/json_check?exec_time=2018-06-20T12:00:00Z&service=object-storage
+```
+Headers:
+```
+x-api-key: shared_key_value
+Accept: application/json or application/xml
+
+```
+###### Example Response:
+
+Code:
+```
+Status: 200 OK
+```
+Response body:
+```
+ {
+   "root": [
+     {
+       "Name": "www.example.com",
+       "Metrics": [
+         {
+           "Name": "write-obj",
+           "Service": "object-storage",
+           "Details": [
+             {
+               "Timestamp": "2015-06-20T12:00:00Z",
+               "Value": "OK",
+               "Summary": "file written",
+               "Message": "all checks ok"
+             }
+           ]
+         }
+       ]
+     }
+   ]
+ }
+ 
+```
+
 ## [GET]: Multiple Metric Results for a specific host, on a specific day
 
 This method may be used to retrieve multiple service metric results for a specific host on a specific day
@@ -101,6 +145,7 @@ This method may be used to retrieve multiple service metric results for a specif
 | Type | Description | Required | Default value |
 |------|-------------|----------|---------------|
 |`hostname`| hostname of service endpoint| YES |  |
+|`service`| Filter by service type | NO |  |
 
 #### Url Parameters
 
@@ -195,6 +240,60 @@ Response body:
                "Summary": "memcheck ok",
                "Message": "memory under 20%"
              },
+           ]
+         }
+       ]
+     }
+   ]
+ }
+```
+
+###### Example Request with filter by service type:
+URL:
+```
+/api/v2/metric_result/www.example.com?exec_time=2020-03-03T00:00:00Z&service=squid
+```
+Headers:
+```
+x-api-key: shared_key_value
+Accept: application/json or application/xml
+
+```
+###### Example Response:
+
+Code:
+```
+Status: 200 OK
+```
+Response body:
+```
+{
+   "root": [
+     {
+       "Name": "www.example.com",
+       "Metrics": [
+         {
+           "Name": "squid_check",
+           "Service": "squid",
+           "Details": [
+             {
+               "Timestamp": "2020-03-03T12:00:00Z",
+               "Value": "OK",
+               "Summary": "squid is ok",
+               "Message": "all checks ok"
+             },
+              {
+               "Timestamp": "2020-03-03T18:00:00Z",
+               "Value": "CRITICAL",
+               "Summary": "squid is critical",
+               "Message": "some checks failed"
+             },
+              {
+               "Timestamp": "2020-03-03T23:00:00Z",
+               "Value": "OK",
+               "Summary": "squid is ok",
+               "Message": "all checks ok"
+             }
            ]
          }
        ]

--- a/website/static/openapi/argo-web-api.yml
+++ b/website/static/openapi/argo-web-api.yml
@@ -5201,6 +5201,11 @@ paths:
         schema:
           type: string
           default: all
+      - name: service
+        in: query
+        description: filter by service type
+        schema:
+          type: string
       responses:
         200:
           description: Successful retrieval of multiple metric results
@@ -5306,6 +5311,11 @@ paths:
         schema:
           type: string
           default: 2006-01-01T00:04:05Z
+      - name: service
+        in: query
+        description: filter by service type
+        schema:
+          type: string
       responses:
         200:
           description: Successful retrieval of results


### PR DESCRIPTION
Add optional `service=` url parameter as a filter in requests that return low level metric results

- Add filter structure in controllers
- Add filter logic in queries
- Condense metric result rendering view in one function for both controllers
- Update unit tests with relevant scenarios
- Update docs
- Update swagger