### PR TITLE
ARGO-4226 In recomputations fix support for exclude monitoring source…

### DIFF
--- a/app/recomputations2/Controller.go
+++ b/app/recomputations2/Controller.go
@@ -120,9 +120,8 @@ func ListOne(r *http.Request, cfg config.Config) (int, http.Header, []byte, erro
 	// Grab Tenant DB configuration from context
 	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
 
-	filter := IncomingRecomputation{
-		ID: vars["ID"],
-	}
+	filter := bson.M{"id": vars["ID"]}
+
 	session, err := mongo.OpenSession(tenantDbConfig)
 	defer mongo.CloseSession(session)
 
@@ -132,6 +131,7 @@ func ListOne(r *http.Request, cfg config.Config) (int, http.Header, []byte, erro
 	}
 
 	result := MongoInterface{}
+
 	err = mongo.FindOne(session, tenantDbConfig.Db, recomputationsColl, filter, &result)
 
 	if err != nil {
@@ -196,17 +196,19 @@ func SubmitRecomputation(r *http.Request, cfg config.Config) (int, http.Header, 
 	history := []HistoryItem{statusItem}
 
 	recomputation := MongoInterface{
-		ID:             mongo.NewUUID(),
-		RequesterName:  recompSubmission.RequesterName,
-		RequesterEmail: recompSubmission.RequesterEmail,
-		StartTime:      recompSubmission.StartTime,
-		EndTime:        recompSubmission.EndTime,
-		Reason:         recompSubmission.Reason,
-		Report:         recompSubmission.Report,
-		Exclude:        recompSubmission.Exclude,
-		Timestamp:      now.Format("2006-01-02T15:04:05Z"),
-		Status:         "pending",
-		History:        history,
+		ID:               mongo.NewUUID(),
+		RequesterName:    recompSubmission.RequesterName,
+		RequesterEmail:   recompSubmission.RequesterEmail,
+		StartTime:        recompSubmission.StartTime,
+		EndTime:          recompSubmission.EndTime,
+		Reason:           recompSubmission.Reason,
+		Report:           recompSubmission.Report,
+		Exclude:          recompSubmission.Exclude,
+		ExcludeMetrics:   recompSubmission.ExcludeMetrics,
+		ExcludeMonSource: recompSubmission.ExcludeMonSource,
+		Timestamp:        now.Format("2006-01-02T15:04:05Z"),
+		Status:           "pending",
+		History:          history,
 	}
 
 	err = mongo.Insert(session, tenantDbConfig.Db, recomputationsColl, recomputation)

--- a/app/recomputations2/Model.go
+++ b/app/recomputations2/Model.go
@@ -29,14 +29,16 @@ type IncomingRequest struct {
 }
 
 type IncomingRecomputation struct {
-	ID             string   `xml:"id" json:"id" bson:"id,omitempty"`
-	StartTime      string   `xml:"start_time,attr" json:"start_time" bson:"start_time,omitempty"`
-	RequesterName  string   `xml:"requester_name" json:"requester_name" bson:"requester_name,omitempty" `
-	RequesterEmail string   `xml:"requester_email" json:"requester_email" bson:"requester_email,omitempty" `
-	EndTime        string   `xml:"end_time,attr" json:"end_time" bson:"end_time,omitempty"`
-	Reason         string   `xml:"reason,attr" json:"reason" bson:"reason,omitempty"`
-	Report         string   `xml:"report,attr" json:"report" bson:"report,omitempty"`
-	Exclude        []string `xml:"exclude" json:"exclude" bson:"exclude,omitempty"`
+	ID               string             `xml:"id" json:"id" bson:"id,omitempty"`
+	StartTime        string             `xml:"start_time,attr" json:"start_time" bson:"start_time,omitempty"`
+	RequesterName    string             `xml:"requester_name" json:"requester_name" bson:"requester_name,omitempty" `
+	RequesterEmail   string             `xml:"requester_email" json:"requester_email" bson:"requester_email,omitempty" `
+	EndTime          string             `xml:"end_time,attr" json:"end_time" bson:"end_time,omitempty"`
+	Reason           string             `xml:"reason,attr" json:"reason" bson:"reason,omitempty"`
+	Report           string             `xml:"report,attr" json:"report" bson:"report,omitempty"`
+	Exclude          []string           `xml:"exclude" json:"exclude" bson:"exclude,omitempty"`
+	ExcludeMonSource []ExcludeMonSource `bson:"exclude_monitoring_source" json:"exclude_monitoring_source,omitempty"`
+	ExcludeMetrics   []ExcludedMetric   `bson:"exclude_metrics" json:"exclude_metrics,omitempty"`
 }
 
 type SelfReference struct {
@@ -53,23 +55,30 @@ type IncomingStatus struct {
 }
 
 type MongoInterface struct {
-	XMLName        xml.Name         `bson:"-" xml:"recomputation" json:"-"`
-	ID             string           `bson:"id" xml:"id" json:"id"`
-	RequesterName  string           `bson:"requester_name" xml:"requester_name" json:"requester_name"`
-	RequesterEmail string           `bson:"requester_email" xml:"requester_email" json:"requester_email"`
-	Reason         string           `bson:"reason" xml:"reason" json:"reason"`
-	StartTime      string           `bson:"start_time" xml:"start_time" json:"start_time"`
-	EndTime        string           `bson:"end_time" xml:"end_time" json:"end_time"`
-	Report         string           `bson:"report" xml:"report" json:"report"`
-	Exclude        []string         `bson:"exclude" xml:"exclude>group" json:"exclude"`
-	Status         string           `bson:"status" xml:"status" json:"status"`
-	Timestamp      string           `bson:"timestamp" xml:"timestamp" json:"timestamp"`
-	History        []HistoryItem    `bson:"history" xml:"history" json:"history"`
-	ExcludeMetrics []ExcludedMetric `bson:"exclude_metrics" json:"exclude_metrics,omitempty"`
+	XMLName          xml.Name           `bson:"-" xml:"recomputation" json:"-"`
+	ID               string             `bson:"id" xml:"id" json:"id"`
+	RequesterName    string             `bson:"requester_name" xml:"requester_name" json:"requester_name"`
+	RequesterEmail   string             `bson:"requester_email" xml:"requester_email" json:"requester_email"`
+	Reason           string             `bson:"reason" xml:"reason" json:"reason"`
+	StartTime        string             `bson:"start_time" xml:"start_time" json:"start_time"`
+	EndTime          string             `bson:"end_time" xml:"end_time" json:"end_time"`
+	Report           string             `bson:"report" xml:"report" json:"report"`
+	Exclude          []string           `bson:"exclude" xml:"exclude>group" json:"exclude"`
+	Status           string             `bson:"status" xml:"status" json:"status"`
+	Timestamp        string             `bson:"timestamp" xml:"timestamp" json:"timestamp"`
+	History          []HistoryItem      `bson:"history" xml:"history" json:"history"`
+	ExcludeMetrics   []ExcludedMetric   `bson:"exclude_metrics" json:"exclude_metrics,omitempty"`
+	ExcludeMonSource []ExcludeMonSource `bson:"exclude_monitoring_source" json:"exclude_monitoring_source,omitempty"`
+}
+
+type ExcludeMonSource struct {
+	Host      string `bson:"host" json:"host"`
+	StartTime string `bson:"start_time" json:"start_time"`
+	EndTime   string `bson:"end_time" json:"end_time"`
 }
 
 type ExcludedMetric struct {
-	Metric   string `bson:"metric" json:"metric"`
+	Metric   string `bson:"metric" json:"metric,omitempty"`
 	Hostname string `bson:"hostname" json:"timestamp,omitempty"`
 	Service  string `bson:"service"  json:"service,omitempty"`
 	Group    string `bson:"group" json:"group,omitempty"`

--- a/website/docs/results/recomputations.md
+++ b/website/docs/results/recomputations.md
@@ -419,7 +419,7 @@ For example:
     },
     {
      "metric": "check-2",
-     "timestamp": "host1.example.com"
+     "hostname": "host1.example.com"
     },
     {
      "metric": "check-3",
@@ -431,3 +431,28 @@ For example:
 
   If you specify a rule that includes only a `metric` then this type of metric will be excluded globally from all endpoints and groups
   If you specify a rule that includes a `metric` and another field such as `hostname`, `service` or `group` then the rule is scoped accordingly to a specific group or service type or hostname and the metric that belongs there. The field `metric` is mandatory.
+
+  # Recomputations that exclude monitoring sources
+
+There is also the ability to run a recomputation and exclude a monitoring source (e.g. specific monitoring box). This is especially usefull in HA situations where one of the available monitoring sources might have issues for a specific period of time.
+
+For example:
+
+```json
+{
+   "id": "6ac7d684-1f8e-4a02-a502-720e8f11e777",
+   "requester_name": "John Doe",
+   "requester_email": "johndoe@example.com",
+   "reason": "issue with metric checks",
+   "start_time": "2022-01-10T12:00:00Z",
+   "end_time": "2022-01-10T23:00:00Z",
+   "report": "Default",
+   "exclude_monitoring_source": [
+    {
+        "host":"monitoring_node01.example.foo",
+        "start_time": "2022-01-10T12:00:00Z",
+        "end_time": "2022-01-10T23:00:00Z"
+    }
+   ]
+}
+```

--- a/website/static/openapi/argo-web-api.yml
+++ b/website/static/openapi/argo-web-api.yml
@@ -10720,6 +10720,39 @@ components:
           description: Comma separated list of excluded endpoint groups
           items:
             type: string
+        exclude_metrics:
+          type: array
+          description: list of metric items to be excluded with scope (hostname, group etc)
+          items:
+            type: object
+            properties:
+              metric:
+                type: string
+                description: name of the metric to be excluded
+              hostname:
+                type: string
+                description: hostname under which the metric will be excluded
+              group:
+                type: string
+                description: groupname under which the metric will be excluded
+              service:
+                type: string
+                description: name of the service type under which the metric will be excluded
+        exclude_monitoring_source:
+          type: array
+          description: Comma separated list of excluded endpoint groups
+          items:
+            type: object
+            properties:
+              host:
+                type: string
+                description: monitoring host to be excluded
+              start_time:
+                type: string
+                description: ISO timestamp in UTC for the start of the exclusion period
+              end_time:
+                type: string
+                description: ISO timestamp in UTC for the end of the exclusion period
         status:
           type: string
           description: Can be one of approved, rejected, pending, running or done


### PR DESCRIPTION
… fields

Fix support for `exclude_monitoring_source` and `exclude_metrics` fields both when submitting a recomputation and when reading one. Add relevant unit test