### PR TITLE
Version 1.13.2

### DIFF
--- a/argo-web-api.spec
+++ b/argo-web-api.spec
@@ -3,7 +3,7 @@
 
 Name: argo-web-api
 Summary: A/R API
-Version: 1.13.1
+Version: 1.13.2
 Release: 1%{?dist}
 License: ASL 2.0
 Buildroot: %{_tmppath}/%{name}-buildroot
@@ -68,6 +68,8 @@ go clean
 %attr(0644,root,root) /usr/lib/systemd/system/argo-web-api.service
 
 %changelog
+* Tue Feb 28 2023 Konstantinos Kagkelidis <kaggis@gmail.com> 1.13.2-1%{dist}
+- Release of argo-web-api version 1.13.2
 * Thu Feb 2 2023 Konstantinos Kagkelidis <kaggis@gmail.com> 1.13.1-1%{dist}
 - Release of argo-web-api version 1.13.1
 * Mon Nov 7 2022 Konstantinos Kagkelidis <kaggis@gmail.com> 1.13.0-1%{dist}

--- a/version/version.go
+++ b/version/version.go
@@ -6,7 +6,7 @@ import (
 
 var (
 	// Release version of the service. Bump it up during new version release
-	Release = "1.13.1"
+	Release = "1.13.2"
 	// Commit hash provided during build
 	Commit = "Unknown"
 	// BuildTime provided during build


### PR DESCRIPTION
**Added:**

- ARGO-4206 Add filter by service type when requesting metric results 

**Fixed:**

- ARGO-4226 In recomputations fix support for exclude monitoring source
