### PR TITLE
ARGO-4208 Provide automatically combined groups in topology of combined tenants

### DIFF
--- a/app/topology/controller.go
+++ b/app/topology/controller.go
@@ -1221,6 +1221,7 @@ func ListGroupsByReport(r *http.Request, cfg config.Config) (int, http.Header, [
 	vars := mux.Vars(r)
 	urlValues := r.URL.Query()
 	dateStr := urlValues.Get("date")
+	mode := urlValues.Get("mode")
 	reportName := vars["report"]
 
 	// Grab Tenant DB configuration from context
@@ -1230,7 +1231,6 @@ func ListGroupsByReport(r *http.Request, cfg config.Config) (int, http.Header, [
 	session, err := mongo.OpenSession(tenantDbConfig)
 	defer mongo.CloseSession(session)
 
-	colGroup := session.DB(tenantDbConfig.Db).C(groupColName)
 	colReports := session.DB(tenantDbConfig.Db).C("reports")
 	//get the report
 
@@ -1255,6 +1255,7 @@ func ListGroupsByReport(r *http.Request, cfg config.Config) (int, http.Header, [
 		output, _ = respond.MarshalContent(respond.ErrBadRequestDetails(err.Error()), contentType, "", " ")
 		return code, h, output, err
 	}
+
 	fGroup := fltrGroup{}
 	fGroup, _ = getReportFilters(report)
 
@@ -1262,19 +1263,35 @@ func ListGroupsByReport(r *http.Request, cfg config.Config) (int, http.Header, [
 		fGroup.GroupType = append(fGroup.GroupType, groupType)
 	}
 
-	expDate := getCloseDate(colGroup, dt)
-
-	results := []Group{}
-
-	if expDate < 0 {
-		output, _ = respond.MarshalContent(respond.ErrNotFoundQuery, contentType, "", " ")
-		code = 404
+	results, expDate, err := getGroupResults(tenantDbConfig, dt, fGroup)
+	if err != nil {
+		code = http.StatusInternalServerError
 		return code, h, output, err
 	}
 
-	err = colGroup.Find(prepGroupQuery(expDate, fGroup)).All(&results)
-	if err != nil {
-		code = http.StatusInternalServerError
+	if mode == "combined" {
+		// check for feeds
+		dbConfigs := (getComboDBConfigs(tenantDbConfig, cfg))
+		for _, dbConfig := range dbConfigs {
+			// append subresults to list of combined results
+			subResults := []Group{}
+			subResults, expDate, err = getGroupResults(dbConfig.Config, dt, fGroup)
+			if err != nil {
+				code = http.StatusInternalServerError
+				return code, h, output, err
+			}
+			// tag results with tenant name
+			for i := range subResults {
+				subResults[i].Tenant = dbConfig.Tenant
+			}
+			results = append(results, subResults...)
+		}
+	}
+
+	// check if nothing found
+	if expDate < 0 {
+		output, _ = respond.MarshalContent(respond.ErrNotFoundQuery, contentType, "", " ")
+		code = 404
 		return code, h, output, err
 	}
 
@@ -1599,15 +1616,10 @@ func ListGroups(r *http.Request, cfg config.Config) (int, http.Header, []byte, e
 
 	urlValues := r.URL.Query()
 	dateStr := urlValues.Get("date")
+	mode := urlValues.Get("mode")
 
 	// Grab Tenant DB configuration from context
 	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
-
-	// Open session to tenant database
-	session, err := mongo.OpenSession(tenantDbConfig)
-	defer mongo.CloseSession(session)
-
-	colGroup := session.DB(tenantDbConfig.Db).C(groupColName)
 
 	dt, dateStr, err := utils.ParseZuluDate(dateStr)
 	if err != nil {
@@ -1622,19 +1634,35 @@ func ListGroups(r *http.Request, cfg config.Config) (int, http.Header, []byte, e
 	fltr.Subgroup = urlValues["subgroup"]
 	fltr.Tags = urlValues.Get("tags")
 
-	expDate := getCloseDate(colGroup, dt)
-
-	results := []Group{}
-
-	if expDate < 0 {
-		output, _ = respond.MarshalContent(respond.ErrNotFoundQuery, contentType, "", " ")
-		code = 404
+	results, expDate, err := getGroupResults(tenantDbConfig, dt, fltr)
+	if err != nil {
+		code = http.StatusInternalServerError
 		return code, h, output, err
 	}
 
-	err = colGroup.Find(prepGroupQuery(expDate, fltr)).All(&results)
-	if err != nil {
-		code = http.StatusInternalServerError
+	if mode == "combined" {
+		// check for feeds
+		dbConfigs := (getComboDBConfigs(tenantDbConfig, cfg))
+		for _, dbConfig := range dbConfigs {
+			// append subresults to list of combined results
+			subResults := []Group{}
+			subResults, expDate, err = getGroupResults(dbConfig.Config, dt, fltr)
+			if err != nil {
+				code = http.StatusInternalServerError
+				return code, h, output, err
+			}
+			// tag results with tenant name
+			for i := range subResults {
+				subResults[i].Tenant = dbConfig.Tenant
+			}
+			results = append(results, subResults...)
+		}
+	}
+
+	// check if nothing found
+	if expDate < 0 {
+		output, _ = respond.MarshalContent(respond.ErrNotFoundQuery, contentType, "", " ")
+		code = 404
 		return code, h, output, err
 	}
 
@@ -1648,6 +1676,26 @@ func ListGroups(r *http.Request, cfg config.Config) (int, http.Header, []byte, e
 
 	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
 	return code, h, output, err
+}
+
+// getGroupResults accepts an date in integer format YYYYMMDD, a tenand db configuration
+// and a filter group object and returns relevant topology groups
+func getGroupResults(dbConfig config.MongoConfig, dateInt int, fltr fltrGroup) ([]Group, int, error) {
+	subResults := []Group{}
+	session, err := mongo.OpenSession(dbConfig)
+	defer mongo.CloseSession(session)
+	if err != nil {
+		return subResults, -1, err
+	}
+
+	subGroups := session.DB(dbConfig.Db).C(groupColName)
+	expDate := getCloseDate(subGroups, dateInt)
+	if expDate < 0 {
+		return subResults, expDate, err
+	}
+	subGroups.Find(prepGroupQuery(expDate, fltr)).All(&subResults)
+
+	return subResults, expDate, err
 }
 
 // DeleteGroups deletes a list of groups topology for a specific date

--- a/app/topology/model.go
+++ b/app/topology/model.go
@@ -90,6 +90,7 @@ type Group struct {
 	Subgroup      string            `bson:"subgroup" json:"subgroup"`
 	Notifications *Notifications    `bson:"notifications" json:"notifications,omitempty"`
 	Tags          map[string]string `bson:"tags" json:"tags"`
+	Tenant        string            `json:"tenant,omitempty"`
 }
 
 // ServiceType includes information about an available service type

--- a/website/docs/topology/topology_groups.md
+++ b/website/docs/topology/topology_groups.md
@@ -136,6 +136,7 @@ GET /topology/groups?date=YYYY-MM-DD
 | `type`     | filter by group type          | NO       |               |
 | `subgroup` | filter by subgroup            | NO       |               |
 | `tags`     | filter by tag key:value pairs | NO       |               |
+| `mode`     | if stating `mode=combined` then if the tenant has data feeds from other tenants their group topology items will be combined in the final results | NO       | empty |
 
 _note_ : user can use wildcard \* in filters
 _note_ : when using tag filters the query string must follow the pattern: `?tags=key1:value1,key2:value2`
@@ -197,6 +198,57 @@ Status: 200 OK
 }
 ```
 
+### Combined tenant example
+
+If the tenant is configured to receive data from other tenants in its data feeds the combined mode can be used when retrieving topology group items. In this mode the list of items is enriched with items from tenants specified in the data feeds. Items from those tenants receive an extra `tenant` field to signify their origin. To enable the combine mode use the optional url parameter `mode=combined`
+
+
+#### Example Request
+```
+GET /topology/groups?date=2015-07-22?mode=combined
+```
+
+#### Response Code
+
+```
+Status: 200 OK
+```
+
+#### Response body
+
+```json
+{
+    "status": {
+        "message": "Success",
+        "code": "200"
+    },
+    "data": [
+        {
+            "date": "2015-07-22",
+            "group": "TENANT1-NGIA",
+            "type": "NGIS",
+            "subgroup": "SITEX",
+            "tags": {
+                "certification": "Certified",
+                "infrastructure": "Production"
+            },
+            "tenant":"TENANT1"
+        },
+        {
+            "date": "2015-07-22",
+            "group": "TENANT2-NGIA",
+            "type": "NGIS",
+            "subgroup": "SITEZ",
+            "tags": {
+                "certification": "Certified",
+                "infrastructure": "Production"
+            },
+            "tenant":"TENANT2"
+        }
+    ]
+}
+```
+
 <a id='3'></a>
 
 ## [DELETE]: Delete group topology for a specific date
@@ -250,6 +302,7 @@ GET /topology/groups/by_report/{report-name}?date=YYYY-MM-DD
 | ------------- | ------------------------ | -------- | ------------- |
 | `report-name` | target a specific report | YES      | none          |
 | `date`        | target a specific date   | NO       | today's date  |
+| `mode`     | if stating `mode=combined` then if the tenant has data feeds from other tenants their group topology items will be combined in the final results | NO       | empty |
 
 #### Headers
 

--- a/website/static/openapi/argo-web-api.yml
+++ b/website/static/openapi/argo-web-api.yml
@@ -2933,6 +2933,12 @@ paths:
         schema:
           type: string
           default: todays_date in YYYY-MM-DD format
+      - name: mode
+        in: query
+        description: optional to be used as mode=combined when the tenant supports combined
+        schema:
+          type: string
+        
       responses:
         200:
           description: Topology resources listed
@@ -3101,6 +3107,11 @@ paths:
         schema:
           type: string
           default: todays_date in YYYY-MM-DD format
+      - name: mode
+        in: query
+        description: optional to be used as mode=combined when the tenant supports combined
+        schema:
+          type: string
       responses:
         200:
           description: filtered topology resources listed based on report
@@ -10039,6 +10050,9 @@ components:
           type: object
           properties: {}
           description: key value tags
+        tenant:
+          type: string
+          description: appears only in output when querying groups in mode=combined
     TopologyServiceTypes:
       type: array
       items:


### PR DESCRIPTION
### 🎯 Goal
When using a "combined" tenant give the ability to request the list of all group topology items in the tenants included in the combined feed

### 🏗️ Implementation
Extend the `/topology/groups` call with an extra `mode=combined` parameter such as
`/api/v2/topology/groups?mode=combined` which returns a list with all group topology items found in the tenants included in the combined data feeds. Items retrieved from included tenants receive an extra field `tenant` to identify their source

Do the same for `/topology/groups/by_report/{report_name}?mode=combined`


- [x] Create a flexible method that retrieves group types based on tenant
- [x] Extent ListGroups and ListGroupsByReport handlers to parse optional `mode=combined` parameter and use the above methods to query all included tenants for additional group items
- [x] add unit tests
- [x] update docs
