### PR TITLE
ARGO-4207 provide automatically combined endpoints in topology of combined tenants

### DIFF
--- a/app/topology/controller.go
+++ b/app/topology/controller.go
@@ -267,6 +267,7 @@ func ListEndpoints(r *http.Request, cfg config.Config) (int, http.Header, []byte
 
 	urlValues := r.URL.Query()
 	dateStr := urlValues.Get("date")
+	mode := urlValues.Get("mode")
 
 	// Grab Tenant DB configuration from context
 	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
@@ -274,8 +275,6 @@ func ListEndpoints(r *http.Request, cfg config.Config) (int, http.Header, []byte
 	// Open session to tenant database
 	session, err := mongo.OpenSession(tenantDbConfig)
 	defer mongo.CloseSession(session)
-
-	colEndpoint := session.DB(tenantDbConfig.Db).C(endpointColName)
 
 	dt, dateStr, err := utils.ParseZuluDate(dateStr)
 	if err != nil {
@@ -291,19 +290,34 @@ func ListEndpoints(r *http.Request, cfg config.Config) (int, http.Header, []byte
 	fltr.Service = urlValues["service"]
 	fltr.Tags = urlValues.Get("tags")
 
-	expDate := getCloseDate(colEndpoint, dt)
+	results, expDate, err := getEndpointResults(tenantDbConfig, dt, fltr)
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
 
-	results := []Endpoint{}
+	if mode == "combined" {
+		// check for feeds
+		dbConfigs := (getComboDBConfigs(tenantDbConfig, cfg))
+		for _, dbConfig := range dbConfigs {
+			// append subresults to list of combined results
+			subResults := []Endpoint{}
+			subResults, expDate, err = getEndpointResults(dbConfig.Config, dt, fltr)
+			if err != nil {
+				code = http.StatusInternalServerError
+				return code, h, output, err
+			}
+			// tag results with tenant name
+			for i := range subResults {
+				subResults[i].Tenant = dbConfig.Tenant
+			}
+			results = append(results, subResults...)
+		}
+	}
 
 	if expDate < 0 {
 		output, _ = respond.MarshalContent(respond.ErrNotFoundQuery, contentType, "", " ")
 		code = 404
-		return code, h, output, err
-	}
-
-	err = colEndpoint.Find(prepEndpointQuery(expDate, fltr)).All(&results)
-	if err != nil {
-		code = http.StatusInternalServerError
 		return code, h, output, err
 	}
 
@@ -317,6 +331,26 @@ func ListEndpoints(r *http.Request, cfg config.Config) (int, http.Header, []byte
 
 	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
 	return code, h, output, err
+}
+
+// getEndpointResults accepts an date in integer format YYYYMMDD, a tenand db configuration,
+// a filter endpoint object and returns relevant topology endpoints
+func getEndpointResults(dbConfig config.MongoConfig, dateInt int, filterE fltrEndpoint) ([]Endpoint, int, error) {
+	subResults := []Endpoint{}
+	session, err := mongo.OpenSession(dbConfig)
+	defer mongo.CloseSession(session)
+	if err != nil {
+		return subResults, -1, err
+	}
+
+	colEndpoint := session.DB(dbConfig.Db).C(endpointColName)
+	expDate := getCloseDate(colEndpoint, dateInt)
+	if expDate < 0 {
+		return subResults, expDate, err
+	}
+	err = colEndpoint.Find(prepEndpointQuery(expDate, filterE)).All(&subResults)
+
+	return subResults, expDate, err
 }
 
 // CreateEndpoints Creates a list of endpoints for a specific date
@@ -1121,6 +1155,7 @@ func ListEndpointsByReport(r *http.Request, cfg config.Config) (int, http.Header
 	vars := mux.Vars(r)
 	urlValues := r.URL.Query()
 	dateStr := urlValues.Get("date")
+	mode := urlValues.Get("mode")
 	reportName := vars["report"]
 
 	// Grab Tenant DB configuration from context
@@ -1130,7 +1165,6 @@ func ListEndpointsByReport(r *http.Request, cfg config.Config) (int, http.Header
 	session, err := mongo.OpenSession(tenantDbConfig)
 	defer mongo.CloseSession(session)
 
-	colGroup := session.DB(tenantDbConfig.Db).C(groupColName)
 	colReports := session.DB(tenantDbConfig.Db).C("reports")
 	//get the report
 
@@ -1170,22 +1204,35 @@ func ListEndpointsByReport(r *http.Request, cfg config.Config) (int, http.Header
 		fEndpoint.GroupType = append(fEndpoint.GroupType, egroupType)
 	}
 
-	expDate := getCloseDate(colGroup, dt)
+	results, expDate, err := getGroupEndpointResults(tenantDbConfig, dt, fGroup, fEndpoint)
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
 
-	results := []Endpoint{}
+	if mode == "combined" {
+		// check for feeds
+		dbConfigs := (getComboDBConfigs(tenantDbConfig, cfg))
+		for _, dbConfig := range dbConfigs {
+			// append subresults to list of combined results
+			subResults := []Endpoint{}
+			subResults, expDate, err = getGroupEndpointResults(dbConfig.Config, dt, fGroup, fEndpoint)
+			if err != nil {
+				code = http.StatusInternalServerError
+				return code, h, output, err
+			}
+
+			// tag results with tenant name
+			for i := range subResults {
+				subResults[i].Tenant = dbConfig.Tenant
+			}
+			results = append(results, subResults...)
+		}
+	}
 
 	if expDate < 0 {
 		output, _ = respond.MarshalContent(respond.ErrNotFoundQuery, contentType, "", " ")
 		code = 404
-		return code, h, output, err
-	}
-
-	query := prepGroupEndpointAggr(expDate, fGroup, fEndpoint)
-
-	colGroup.Pipe(query).All(&results)
-
-	if err != nil {
-		code = http.StatusInternalServerError
 		return code, h, output, err
 	}
 
@@ -1199,6 +1246,27 @@ func ListEndpointsByReport(r *http.Request, cfg config.Config) (int, http.Header
 
 	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
 	return code, h, output, err
+}
+
+// getGroupEndpointResults accepts an date in integer format YYYYMMDD, a tenand db configuration,
+// a filter group object and a filter endpoint object and returns relevant topology endpoints
+func getGroupEndpointResults(dbConfig config.MongoConfig, dateInt int, filterG fltrGroup, filterE fltrEndpoint) ([]Endpoint, int, error) {
+	subResults := []Endpoint{}
+	session, err := mongo.OpenSession(dbConfig)
+	defer mongo.CloseSession(session)
+	if err != nil {
+		return subResults, -1, err
+	}
+
+	colGroup := session.DB(dbConfig.Db).C(groupColName)
+	expDate := getCloseDate(colGroup, dateInt)
+	if expDate < 0 {
+		return subResults, expDate, err
+	}
+
+	query := prepGroupEndpointAggr(expDate, filterG, filterE)
+	colGroup.Pipe(query).All(&subResults)
+	return subResults, expDate, err
 }
 
 //ListGroupsByReport lists group topology by report

--- a/app/topology/controller.go
+++ b/app/topology/controller.go
@@ -1221,6 +1221,7 @@ func ListGroupsByReport(r *http.Request, cfg config.Config) (int, http.Header, [
 	vars := mux.Vars(r)
 	urlValues := r.URL.Query()
 	dateStr := urlValues.Get("date")
+	mode := urlValues.Get("mode")
 	reportName := vars["report"]
 
 	// Grab Tenant DB configuration from context
@@ -1230,7 +1231,6 @@ func ListGroupsByReport(r *http.Request, cfg config.Config) (int, http.Header, [
 	session, err := mongo.OpenSession(tenantDbConfig)
 	defer mongo.CloseSession(session)
 
-	colGroup := session.DB(tenantDbConfig.Db).C(groupColName)
 	colReports := session.DB(tenantDbConfig.Db).C("reports")
 	//get the report
 
@@ -1255,6 +1255,7 @@ func ListGroupsByReport(r *http.Request, cfg config.Config) (int, http.Header, [
 		output, _ = respond.MarshalContent(respond.ErrBadRequestDetails(err.Error()), contentType, "", " ")
 		return code, h, output, err
 	}
+
 	fGroup := fltrGroup{}
 	fGroup, _ = getReportFilters(report)
 
@@ -1262,19 +1263,35 @@ func ListGroupsByReport(r *http.Request, cfg config.Config) (int, http.Header, [
 		fGroup.GroupType = append(fGroup.GroupType, groupType)
 	}
 
-	expDate := getCloseDate(colGroup, dt)
-
-	results := []Group{}
-
-	if expDate < 0 {
-		output, _ = respond.MarshalContent(respond.ErrNotFoundQuery, contentType, "", " ")
-		code = 404
+	results, expDate, err := getGroupResults(tenantDbConfig, dt, fGroup)
+	if err != nil {
+		code = http.StatusInternalServerError
 		return code, h, output, err
 	}
 
-	err = colGroup.Find(prepGroupQuery(expDate, fGroup)).All(&results)
-	if err != nil {
-		code = http.StatusInternalServerError
+	if mode == "combined" {
+		// check for feeds
+		dbConfigs := (getComboDBConfigs(tenantDbConfig, cfg))
+		for _, dbConfig := range dbConfigs {
+			// append subresults to list of combined results
+			subResults := []Group{}
+			subResults, expDate, err = getGroupResults(dbConfig.Config, dt, fGroup)
+			if err != nil {
+				code = http.StatusInternalServerError
+				return code, h, output, err
+			}
+			// tag results with tenant name
+			for i := range subResults {
+				subResults[i].Tenant = dbConfig.Tenant
+			}
+			results = append(results, subResults...)
+		}
+	}
+
+	// check if nothing found
+	if expDate < 0 {
+		output, _ = respond.MarshalContent(respond.ErrNotFoundQuery, contentType, "", " ")
+		code = 404
 		return code, h, output, err
 	}
 
@@ -1599,15 +1616,10 @@ func ListGroups(r *http.Request, cfg config.Config) (int, http.Header, []byte, e
 
 	urlValues := r.URL.Query()
 	dateStr := urlValues.Get("date")
+	mode := urlValues.Get("mode")
 
 	// Grab Tenant DB configuration from context
 	tenantDbConfig := context.Get(r, "tenant_conf").(config.MongoConfig)
-
-	// Open session to tenant database
-	session, err := mongo.OpenSession(tenantDbConfig)
-	defer mongo.CloseSession(session)
-
-	colGroup := session.DB(tenantDbConfig.Db).C(groupColName)
 
 	dt, dateStr, err := utils.ParseZuluDate(dateStr)
 	if err != nil {
@@ -1622,19 +1634,35 @@ func ListGroups(r *http.Request, cfg config.Config) (int, http.Header, []byte, e
 	fltr.Subgroup = urlValues["subgroup"]
 	fltr.Tags = urlValues.Get("tags")
 
-	expDate := getCloseDate(colGroup, dt)
-
-	results := []Group{}
-
-	if expDate < 0 {
-		output, _ = respond.MarshalContent(respond.ErrNotFoundQuery, contentType, "", " ")
-		code = 404
+	results, expDate, err := getGroupResults(tenantDbConfig, dt, fltr)
+	if err != nil {
+		code = http.StatusInternalServerError
 		return code, h, output, err
 	}
 
-	err = colGroup.Find(prepGroupQuery(expDate, fltr)).All(&results)
-	if err != nil {
-		code = http.StatusInternalServerError
+	if mode == "combined" {
+		// check for feeds
+		dbConfigs := (getComboDBConfigs(tenantDbConfig, cfg))
+		for _, dbConfig := range dbConfigs {
+			// append subresults to list of combined results
+			subResults := []Group{}
+			subResults, expDate, err = getGroupResults(dbConfig.Config, dt, fltr)
+			if err != nil {
+				code = http.StatusInternalServerError
+				return code, h, output, err
+			}
+			// tag results with tenant name
+			for i := range subResults {
+				subResults[i].Tenant = dbConfig.Tenant
+			}
+			results = append(results, subResults...)
+		}
+	}
+
+	// check if nothing found
+	if expDate < 0 {
+		output, _ = respond.MarshalContent(respond.ErrNotFoundQuery, contentType, "", " ")
+		code = 404
 		return code, h, output, err
 	}
 
@@ -1648,6 +1676,26 @@ func ListGroups(r *http.Request, cfg config.Config) (int, http.Header, []byte, e
 
 	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
 	return code, h, output, err
+}
+
+// getGroupResults accepts an date in integer format YYYYMMDD, a tenand db configuration
+// and a filter group object and returns relevant topology groups
+func getGroupResults(dbConfig config.MongoConfig, dateInt int, fltr fltrGroup) ([]Group, int, error) {
+	subResults := []Group{}
+	session, err := mongo.OpenSession(dbConfig)
+	defer mongo.CloseSession(session)
+	if err != nil {
+		return subResults, -1, err
+	}
+
+	subGroups := session.DB(dbConfig.Db).C(groupColName)
+	expDate := getCloseDate(subGroups, dateInt)
+	if expDate < 0 {
+		return subResults, expDate, err
+	}
+	subGroups.Find(prepGroupQuery(expDate, fltr)).All(&subResults)
+
+	return subResults, expDate, err
 }
 
 // DeleteGroups deletes a list of groups topology for a specific date

--- a/app/topology/model.go
+++ b/app/topology/model.go
@@ -79,6 +79,7 @@ type Endpoint struct {
 	Hostname      string            `bson:"hostname" json:"hostname"`
 	Notifications *Notifications    `bson:"notifications" json:"notifications,omitempty"`
 	Tags          map[string]string `bson:"tags" json:"tags"`
+	Tenant        string            `json:"tenant,omitempty"`
 }
 
 // Group includes information on  of group group topology

--- a/app/topology/model.go
+++ b/app/topology/model.go
@@ -90,6 +90,7 @@ type Group struct {
 	Subgroup      string            `bson:"subgroup" json:"subgroup"`
 	Notifications *Notifications    `bson:"notifications" json:"notifications,omitempty"`
 	Tags          map[string]string `bson:"tags" json:"tags"`
+	Tenant        string            `json:"tenant,omitempty"`
 }
 
 // ServiceType includes information about an available service type

--- a/website/docs/topology/topology_endpoints.md
+++ b/website/docs/topology/topology_endpoints.md
@@ -127,6 +127,7 @@ GET /topology/endpoints?date=YYYY-MM-DD
 | `service`  | filter by service             | NO       |               |
 | `hostname` | filter by hostname            | NO       |               |
 | `tags`     | filter by tag key:value pairs | NO       |               |
+| `mode`     | if stating `mode=combined` then if the tenant has data feeds from other tenants their endpoint topology items will be combined in the final results | NO       | empty |
 
 _note_ : user can use wildcard \* in filters
 _note_ : when using tag filters the query string must follow the pattern: `?tags=key1:value1,key2:value2`
@@ -198,6 +199,62 @@ Status: 200 OK
 }
 ```
 
+### Combined tenant example
+
+If the tenant is configured to receive data from other tenants in its data feeds the combined mode can be used when retrieving topology endpoint items. In this mode the list of items is enriched with items from tenants specified in the data feeds. Items from those tenants receive an extra `tenant` field to signify their origin. To enable the combine mode use the optional url parameter `mode=combined`
+
+
+#### Example Request
+```
+GET /topology/endpoints?date=2015-07-22?mode=combined
+```
+
+#### Response Code
+
+```
+Status: 200 OK
+```
+
+#### Response body
+
+```json
+{
+    "status": {
+        "message": "Success",
+        "code": "200"
+    },
+    "data": [
+        {
+            "date": "2019-12-12",
+            "group": "SITE_X",
+            "hostname": "host01.site-y.foo",
+            "type": "SITES",
+            "service": "x.service.foo",
+            "tags": {
+                "scope": "TENANT",
+                "production": "1",
+                "monitored": "1"
+            },
+            "tenant": "TENANT_A"
+        },
+        {
+            "date": "2019-12-12",
+            "group": "SITE_Y",
+            "hostname": "host01.site-y.foo",
+            "type": "SITES",
+            "service": "y.service.foo",
+            "tags": {
+                "scope": "TENANT",
+                "production": "1",
+                "monitored": "1"
+            },
+            "tenant": "TENANT_B"
+        }
+    ]
+}
+```
+
+
 <a id='3'></a>
 
 ## [DELETE]: Delete endpoint topology for a specific date
@@ -251,6 +308,7 @@ GET /topology/endpoint/by_report/{report-name}?date=YYYY-MM-DD
 | ------------- | ------------------------ | -------- | ------------- |
 | `report-name` | target a specific report | YES      | none          |
 | `date`        | target a specific date   | NO       | today's date  |
+| `mode`     | if stating `mode=combined` then if the tenant has data feeds from other tenants their endpoint topology items will be combined in the final results | NO       | empty |
 
 #### Headers
 

--- a/website/docs/topology/topology_groups.md
+++ b/website/docs/topology/topology_groups.md
@@ -136,6 +136,7 @@ GET /topology/groups?date=YYYY-MM-DD
 | `type`     | filter by group type          | NO       |               |
 | `subgroup` | filter by subgroup            | NO       |               |
 | `tags`     | filter by tag key:value pairs | NO       |               |
+| `mode`     | if stating `mode=combined` then if the tenant has data feeds from other tenants their group topology items will be combined in the final results | NO       | empty |
 
 _note_ : user can use wildcard \* in filters
 _note_ : when using tag filters the query string must follow the pattern: `?tags=key1:value1,key2:value2`
@@ -197,6 +198,57 @@ Status: 200 OK
 }
 ```
 
+### Combined tenant example
+
+If the tenant is configured to receive data from other tenants in its data feeds the combined mode can be used when retrieving topology group items. In this mode the list of items is enriched with items from tenants specified in the data feeds. Items from those tenants receive an extra `tenant` field to signify their origin. To enable the combine mode use the optional url parameter `mode=combined`
+
+
+#### Example Request
+```
+GET /topology/groups?date=2015-07-22?mode=combined
+```
+
+#### Response Code
+
+```
+Status: 200 OK
+```
+
+#### Response body
+
+```json
+{
+    "status": {
+        "message": "Success",
+        "code": "200"
+    },
+    "data": [
+        {
+            "date": "2015-07-22",
+            "group": "TENANT1-NGIA",
+            "type": "NGIS",
+            "subgroup": "SITEX",
+            "tags": {
+                "certification": "Certified",
+                "infrastructure": "Production"
+            },
+            "tenant":"TENANT1"
+        },
+        {
+            "date": "2015-07-22",
+            "group": "TENANT2-NGIA",
+            "type": "NGIS",
+            "subgroup": "SITEZ",
+            "tags": {
+                "certification": "Certified",
+                "infrastructure": "Production"
+            },
+            "tenant":"TENANT2"
+        }
+    ]
+}
+```
+
 <a id='3'></a>
 
 ## [DELETE]: Delete group topology for a specific date
@@ -250,6 +302,7 @@ GET /topology/groups/by_report/{report-name}?date=YYYY-MM-DD
 | ------------- | ------------------------ | -------- | ------------- |
 | `report-name` | target a specific report | YES      | none          |
 | `date`        | target a specific date   | NO       | today's date  |
+| `mode`     | if stating `mode=combined` then if the tenant has data feeds from other tenants their group topology items will be combined in the final results | NO       | empty |
 
 #### Headers
 

--- a/website/static/openapi/argo-web-api.yml
+++ b/website/static/openapi/argo-web-api.yml
@@ -3353,6 +3353,11 @@ paths:
         schema:
           type: string
           default: todays_date in YYYY-MM-DD format
+      - name: mode
+        in: query
+        description: optional to be used as mode=combined when the tenant supports combined
+        schema:
+          type: string
       responses:
         200:
           description: Topology resource listed
@@ -3510,6 +3515,11 @@ paths:
         schema:
           type: string
           default: todays_date in YYYY-MM-DD format
+      - name: mode
+        in: query
+        description: optional to be used as mode=combined when the tenant supports combined
+        schema:
+          type: string
       responses:
         200:
           description: filtered topology resources listed based on report
@@ -10026,6 +10036,9 @@ components:
           type: object
           properties: {}
           description: key value tags
+        tenant:
+          type: string
+          description: appears only in output when querying groups in mode=combined
     TopologyEndpoints:
       type: array
       items:

--- a/website/static/openapi/argo-web-api.yml
+++ b/website/static/openapi/argo-web-api.yml
@@ -2933,6 +2933,12 @@ paths:
         schema:
           type: string
           default: todays_date in YYYY-MM-DD format
+      - name: mode
+        in: query
+        description: optional to be used as mode=combined when the tenant supports combined
+        schema:
+          type: string
+        
       responses:
         200:
           description: Topology resources listed
@@ -3101,6 +3107,11 @@ paths:
         schema:
           type: string
           default: todays_date in YYYY-MM-DD format
+      - name: mode
+        in: query
+        description: optional to be used as mode=combined when the tenant supports combined
+        schema:
+          type: string
       responses:
         200:
           description: filtered topology resources listed based on report
@@ -10039,6 +10050,9 @@ components:
           type: object
           properties: {}
           description: key value tags
+        tenant:
+          type: string
+          description: appears only in output when querying groups in mode=combined
     TopologyServiceTypes:
       type: array
       items:


### PR DESCRIPTION
### 🎯 Goal
When using a "combined" tenant give the ability to request the list of all endpoint topology items in the tenants included in the combined feed

### 🏗️ Implementation
Extend the `/topology/endpoints` call with an extra `mode=combined` parameter such as
`/api/v2/topology/endpoints?mode=combined` which returns a list with all group topology items found in the tenants included in the combined data feeds. Items retrieved from included tenants receive an extra field `tenant` to identify their source

Do the same for `/topology/endpoints/by_report/{report_name}?mode=combined`

- [x] Create two flexible method that retrieves endpoints types based on tenant and based on group filters (when dealing with reports)
- [x] Extent ListEndpoints and ListEndpointsByReport handlers to parse optional `mode=combined` parameter and use the above methods to query all included tenants for additional endpoint items
- [x] add unit tests
- [x] update docs