### PR TITLE
Fix metric-details filter by service regression

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,6 +26,8 @@ pipeline {
                 export CGO_CFLAGS"=-O2 -fstack-protector --param=ssp-buffer-size=4 -D_FORTIFY_SOURCE=2"
                 go build -buildmode=pie -ldflags "-s -w -linkmode=external -extldflags '-z relro -z now'"
                 """
+
+                archiveArtifacts artifacts: '**/argo-web-api'
             }
         }
         stage('Test') {

--- a/app/metricResult/controller.go
+++ b/app/metricResult/controller.go
@@ -62,6 +62,7 @@ func GetMultipleMetricResults(r *http.Request, cfg config.Config) (int, http.Hea
 	input := metricResultQuery{
 		EndpointName: vars["endpoint_name"],
 		ExecTime:     urlValues.Get("exec_time"),
+		Service:      urlValues.Get("service"),
 	}
 
 	filter := urlValues.Get("filter")
@@ -140,33 +141,33 @@ func GetMetricResult(r *http.Request, cfg config.Config) (int, http.Header, []by
 		EndpointName: vars["endpoint_name"],
 		MetricName:   vars["metric_name"],
 		ExecTime:     urlValues.Get("exec_time"),
+		Service:      urlValues.Get("service"),
 	}
 
-	result := metricResultOutput{}
+	results := []metricResultOutput{}
 
 	metricCol := cfg.MongoClient.Database(tenantDbConfig.Db).Collection("status_metrics")
 
 	// Query the detailed metric results
-	err = metricCol.FindOne(context.TODO(), prepQuery(input, reportID)).Decode(&result)
+	cursor, err := metricCol.Find(context.TODO(), prepQuery(input, reportID))
 
-	// if not found or other issue
 	if err != nil {
-		if err == mongo.ErrNoDocuments {
-			code = http.StatusNotFound
-			message := "Metric not found!"
-			output, err := createErrorMessage(message, code, contentType)
-			h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
-			return code, h, output, err
-		} else {
-			code = http.StatusInternalServerError
-			message := "Internal Server Error!"
-			output, err := createErrorMessage(message, code, contentType)
-			h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
-			return code, h, output, err
-		}
+		code = http.StatusInternalServerError
+		return code, h, output, err
 	}
 
-	output, err = createMetricResultView(result, contentType)
+	defer cursor.Close(context.TODO())
+	cursor.All(context.TODO(), &results)
+
+	if len(results) == 0 {
+		code = http.StatusNotFound
+		message := "Metric not found!"
+		output, err := createErrorMessage(message, code, contentType)
+		h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+		return code, h, output, err
+	}
+
+	output, err = createMultipleMetricResultsView(results, contentType)
 
 	if err != nil {
 		code = http.StatusInternalServerError
@@ -195,6 +196,11 @@ func prepQuery(input metricResultQuery, reportID string) bson.M {
 		"time_integer": tsInt,
 	}
 
+	// filter by service type
+	if input.Service != "" {
+		query["service"] = input.Service
+	}
+
 	if reportID != "" {
 		query["report"] = reportID
 	}
@@ -215,6 +221,11 @@ func prepMultipleQuery(input metricResultQuery, filter string) []bson.M {
 	matchQuery := bson.M{
 		"date_integer": tsYMD,
 		"host":         input.EndpointName,
+	}
+
+	// filter by service type
+	if input.Service != "" {
+		matchQuery["service"] = input.Service
 	}
 
 	// convert to lower case for agility in checks

--- a/app/metricResult/metric_test.go
+++ b/app/metricResult/metric_test.go
@@ -193,6 +193,36 @@ func (suite *metricResultTestSuite) SetupTest() {
 		"summary":            "Cream status is ok",
 		"message":            "Cream job submission test return value of ok",
 	})
+	c.InsertOne(context.TODO(), bson.M{
+		"monitoring_box":     "nagios3.hellasgrid.gr",
+		"date_integer":       20200501,
+		"timestamp":          "2020-05-01T05:00:00Z",
+		"service":            "CREAM-CE",
+		"host":               "cream01.afroditi.gr",
+		"metric":             "emi.cream.CREAMCE-JobSubmit",
+		"info":               bson.M{"URL": "http://creamce.example.com"},
+		"status":             "OK",
+		"time_integer":       50000,
+		"previous_state":     "CRITICAL",
+		"previous_timestamp": "2020-05-01T01:00:00Z",
+		"summary":            "Cream status is ok",
+		"message":            "Cream job submission test return value of ok",
+	})
+	c.InsertOne(context.TODO(), bson.M{
+		"monitoring_box":     "nagios3.hellasgrid.gr",
+		"date_integer":       20200501,
+		"timestamp":          "2020-05-01T05:00:00Z",
+		"service":            "CREAM-CE2",
+		"host":               "cream01.afroditi.gr",
+		"metric":             "emi.cream.CREAMCE-JobSubmit",
+		"info":               bson.M{"URL": "http://creamce.example.com"},
+		"status":             "OK",
+		"time_integer":       50000,
+		"previous_state":     "CRITICAL",
+		"previous_timestamp": "2020-05-01T01:00:00Z",
+		"summary":            "Cream status is ok",
+		"message":            "Cream job submission test return value of ok",
+	})
 
 }
 
@@ -362,6 +392,117 @@ func (suite *metricResultTestSuite) TestMultipleMetricResults() {
 	suite.Equal(200, response.Code, "Incorrect HTTP response code")
 	// Compare the expected and actual xml response
 	suite.Equal(respJSON, response.Body.String(), "Response body mismatch")
+
+}
+
+func (suite *metricResultTestSuite) TestFilters() {
+
+	type TestReq struct {
+		Path string
+		Code int
+		JSON string
+	}
+	expected := []TestReq{
+		{
+			Path: "/api/v2/metric_result/cream01.afroditi.gr?exec_time=2020-05-01T05:00:00Z&service=CREAM-CE",
+			Code: 200,
+			JSON: `{
+   "root": [
+     {
+       "Name": "cream01.afroditi.gr",
+       "info": {
+         "URL": "http://creamce.example.com"
+       },
+       "Metrics": [
+         {
+           "Name": "emi.cream.CREAMCE-JobSubmit",
+           "Service": "CREAM-CE",
+           "Details": [
+             {
+               "Timestamp": "2020-05-01T05:00:00Z",
+               "Value": "OK",
+               "Summary": "Cream status is ok",
+               "Message": "Cream job submission test return value of ok"
+             }
+           ]
+         }
+       ]
+     }
+   ]
+ }`},
+		{
+			Path: "/api/v2/metric_result/cream01.afroditi.gr?exec_time=2020-05-01T05:00:00Z&service=CREAM-CE2",
+			Code: 200,
+			JSON: `{
+   "root": [
+     {
+       "Name": "cream01.afroditi.gr",
+       "info": {
+         "URL": "http://creamce.example.com"
+       },
+       "Metrics": [
+         {
+           "Name": "emi.cream.CREAMCE-JobSubmit",
+           "Service": "CREAM-CE2",
+           "Details": [
+             {
+               "Timestamp": "2020-05-01T05:00:00Z",
+               "Value": "OK",
+               "Summary": "Cream status is ok",
+               "Message": "Cream job submission test return value of ok"
+             }
+           ]
+         }
+       ]
+     }
+   ]
+ }`},
+
+		{
+			Path: "/api/v2/metric_result/cream01.afroditi.gr/emi.cream.CREAMCE-JobSubmit?exec_time=2020-05-01T05:00:00Z&service=CREAM-CE2",
+			Code: 200,
+			JSON: `{
+   "root": [
+     {
+       "Name": "cream01.afroditi.gr",
+       "info": {
+         "URL": "http://creamce.example.com"
+       },
+       "Metrics": [
+         {
+           "Name": "emi.cream.CREAMCE-JobSubmit",
+           "Service": "CREAM-CE2",
+           "Details": [
+             {
+               "Timestamp": "2020-05-01T05:00:00Z",
+               "Value": "OK",
+               "Summary": "Cream status is ok",
+               "Message": "Cream job submission test return value of ok"
+             }
+           ]
+         }
+       ]
+     }
+   ]
+ }`},
+	}
+
+	for _, exp := range expected {
+		request, _ := http.NewRequest("GET", exp.Path, strings.NewReader(""))
+		request.Header.Set("x-api-key", suite.clientkey)
+		request.Header.Set("Accept", "application/json")
+		response := httptest.NewRecorder()
+
+		suite.router.ServeHTTP(response, request)
+
+		code := response.Code
+		output := response.Body.String()
+
+		// Check that we must have a 200 ok code
+		suite.Equal(exp.Code, code, "Response Code Mismatch on call:"+exp.Path)
+		// Compare the expected and actual json response
+		suite.Equal(exp.JSON, output, "Response body mismatch on call:"+exp.Path)
+	}
 
 }
 

--- a/app/metricResult/model.go
+++ b/app/metricResult/model.go
@@ -28,6 +28,7 @@ type metricResultQuery struct {
 	EndpointName string `bson:"hostname"`
 	MetricName   string `bson:"metric_name"`
 	ExecTime     string `bson:"exec_time"` // UTC time in W3C format
+	Service      string `bson:"service"`
 }
 
 // metricResultOutput structure holds mongo results

--- a/app/metricResult/view.go
+++ b/app/metricResult/view.go
@@ -25,7 +25,6 @@ package metricResult
 import (
 	"encoding/json"
 	"encoding/xml"
-	"fmt"
 	"strings"
 )
 
@@ -79,13 +78,13 @@ func createMultipleMetricResultsView(results []metricResultOutput, format string
 		// we append the detailed results
 		metric.Details = append(metric.Details,
 			&StatusXML{
-				Timestamp:      fmt.Sprintf("%s", result.Timestamp),
-				Value:          fmt.Sprintf("%s", result.Status),
-				Summary:        fmt.Sprintf("%s", result.Summary),
-				Message:        fmt.Sprintf("%s", result.Message),
-				ActualData:     fmt.Sprintf("%s", result.ActualData),
-				RuleApplied:    fmt.Sprintf("%s", result.RuleApplied),
-				OriginalStatus: fmt.Sprintf("%s", result.OriginalStatus),
+				Timestamp:      result.Timestamp,
+				Value:          result.Status,
+				Summary:        result.Summary,
+				Message:        result.Message,
+				ActualData:     result.ActualData,
+				RuleApplied:    result.RuleApplied,
+				OriginalStatus: result.OriginalStatus,
 			})
 
 		prevMetric = result.Metric
@@ -103,51 +102,9 @@ func createMultipleMetricResultsView(results []metricResultOutput, format string
 
 }
 
-func createMetricResultView(result metricResultOutput, format string) ([]byte, error) {
-
-	docRoot := &root{}
-
-	// Exit here in case result is empty
-	if result.Hostname == "" {
-		output, err := xml.MarshalIndent(docRoot, "", "")
-		return output, err
-	}
-
-	hostname := &HostXML{
-		Name: result.Hostname,
-		Info: result.Info,
-	}
-	docRoot.Result = append(docRoot.Result, hostname)
-
-	metric := &MetricXML{
-		Name:    result.Metric,
-		Service: result.Service,
-	}
-	hostname.Metrics = append(hostname.Metrics, metric)
-
-	// we append the detailed results
-	metric.Details = append(metric.Details,
-		&StatusXML{
-			Timestamp:      fmt.Sprintf("%s", result.Timestamp),
-			Value:          fmt.Sprintf("%s", result.Status),
-			Summary:        fmt.Sprintf("%s", result.Summary),
-			Message:        fmt.Sprintf("%s", result.Message),
-			ActualData:     fmt.Sprintf("%s", result.ActualData),
-			RuleApplied:    fmt.Sprintf("%s", result.RuleApplied),
-			OriginalStatus: fmt.Sprintf("%s", result.OriginalStatus),
-		})
-
-	if strings.ToLower(format) == "application/json" {
-		return json.MarshalIndent(docRoot, " ", "  ")
-	}
-
-	return xml.MarshalIndent(docRoot, " ", "  ")
-
-}
-
 func createErrorMessage(message string, code int, format string) ([]byte, error) {
 
-	output := []byte("message placeholder")
+	var output []byte
 	err := error(nil)
 	docRoot := &errorMessage{}
 

--- a/website/docs/results/metric_results.md
+++ b/website/docs/results/metric_results.md
@@ -27,6 +27,7 @@ This method may be used to retrieve a specific service metric result.
 | Type | Description | Required | Default value |
 |------|-------------|----------|---------------|
 |`exec_time`| The execution date of query in zulu format| YES |  |
+|`service`| Filter by service type | NO | |
 
 ___Notes___:
 `exec_time` : The execution date of query in zulu format. In order to get the correct execution time get status results for all metrics (under a given endpoint, service and endpoint group). ( GET /status/\{report_name\}/\{lgroup_type\}/\{lgroup_name\}/services/\{service_name\}/endpoints/\{endpoint_name\}/metrics List)
@@ -87,6 +88,48 @@ Response body:
  
 ```
 
+###### Example Request with service filter:
+URL:
+```
+/api/v2/metric_result/www.example.com/json_check?exec_time=2018-06-20T12:00:00Z&service=object-storage
+```
+Headers:
+```
+x-api-key: shared_key_value
+Accept: application/json or application/xml
+```
+###### Example Response:
+
+Code:
+```
+Status: 200 OK
+```
+Response body:
+```
+ {
+   "root": [
+     {
+       "Name": "www.example.com",
+       "Metrics": [
+         {
+           "Name": "write-obj",
+           "Service": "object-storage",
+           "Details": [
+             {
+               "Timestamp": "2015-06-20T12:00:00Z",
+               "Value": "OK",
+               "Summary": "file written",
+               "Message": "all checks ok"
+             }
+           ]
+         }
+       ]
+     }
+   ]
+ }
+ 
+```
+
 ## [GET]: Multiple Metric Results for a specific host, on a specific day
 
 This method may be used to retrieve multiple service metric results for a specific host on a specific day
@@ -101,6 +144,7 @@ This method may be used to retrieve multiple service metric results for a specif
 | Type | Description | Required | Default value |
 |------|-------------|----------|---------------|
 |`hostname`| hostname of service endpoint| YES |  |
+|`service`| Filter by service type | NO | |
 
 #### Url Parameters
 
@@ -195,6 +239,59 @@ Response body:
                "Summary": "memcheck ok",
                "Message": "memory under 20%"
              },
+           ]
+         }
+       ]
+     }
+   ]
+ }
+```
+
+###### Example Request with filter by service type:
+URL:
+```
+/api/v2/metric_result/www.example.com?exec_time=2020-03-03T00:00:00Z&service=squid
+```
+Headers:
+```
+x-api-key: shared_key_value
+Accept: application/json or application/xml
+```
+###### Example Response:
+
+Code:
+```
+Status: 200 OK
+```
+Response body:
+```
+{
+   "root": [
+     {
+       "Name": "www.example.com",
+       "Metrics": [
+         {
+           "Name": "squid_check",
+           "Service": "squid",
+           "Details": [
+             {
+               "Timestamp": "2020-03-03T12:00:00Z",
+               "Value": "OK",
+               "Summary": "squid is ok",
+               "Message": "all checks ok"
+             },
+              {
+               "Timestamp": "2020-03-03T18:00:00Z",
+               "Value": "CRITICAL",
+               "Summary": "squid is critical",
+               "Message": "some checks failed"
+             },
+              {
+               "Timestamp": "2020-03-03T23:00:00Z",
+               "Value": "OK",
+               "Summary": "squid is ok",
+               "Message": "all checks ok"
+             }
            ]
          }
        ]

--- a/website/static/openapi/argo-web-api.yml
+++ b/website/static/openapi/argo-web-api.yml
@@ -5346,6 +5346,11 @@ paths:
         schema:
           type: string
           default: all
+      - name: service
+        in: query
+        description: filter by service type
+        schema:
+          type: string      
       responses:
         200:
           description: Successful retrieval of multiple metric results
@@ -5451,6 +5456,11 @@ paths:
         schema:
           type: string
           default: 2006-01-01T00:04:05Z
+      - name: service
+        in: query
+        description: filter by service type
+        schema:
+          type: string      
       responses:
         200:
           description: Successful retrieval of results


### PR DESCRIPTION
Fix regression by re-adding the following:

Add optional `service=` url parameter as a filter in requests that return low level metric results

- Add filter structure in controllers
- Add filter logic in queries
- Condense metric result rendering view in one function for both controllers
- Update unit tests with relevant scenarios
- Update docs
- Update swagger