### PR TITLE
ARGO-5002 Support applied status recomputations

### DIFF
--- a/app/recomputations2/Controller.go
+++ b/app/recomputations2/Controller.go
@@ -179,19 +179,20 @@ func SubmitRecomputation(r *http.Request, cfg config.Config) (int, http.Header, 
 	history := []HistoryItem{statusItem}
 
 	recomputation := MongoInterface{
-		ID:               utils.NewUUID(),
-		RequesterName:    recompSubmission.RequesterName,
-		RequesterEmail:   recompSubmission.RequesterEmail,
-		StartTime:        recompSubmission.StartTime,
-		EndTime:          recompSubmission.EndTime,
-		Reason:           recompSubmission.Reason,
-		Report:           recompSubmission.Report,
-		Exclude:          recompSubmission.Exclude,
-		ExcludeMetrics:   recompSubmission.ExcludeMetrics,
-		ExcludeMonSource: recompSubmission.ExcludeMonSource,
-		Timestamp:        now.Format("2006-01-02T15:04:05Z"),
-		Status:           "pending",
-		History:          history,
+		ID:                   utils.NewUUID(),
+		RequesterName:        recompSubmission.RequesterName,
+		RequesterEmail:       recompSubmission.RequesterEmail,
+		StartTime:            recompSubmission.StartTime,
+		EndTime:              recompSubmission.EndTime,
+		Reason:               recompSubmission.Reason,
+		Report:               recompSubmission.Report,
+		Exclude:              recompSubmission.Exclude,
+		ExcludeMetrics:       recompSubmission.ExcludeMetrics,
+		ExcludeMonSource:     recompSubmission.ExcludeMonSource,
+		AppliedStatusChanges: recompSubmission.AppliedStatusChanges,
+		Timestamp:            now.Format("2006-01-02T15:04:05Z"),
+		Status:               "pending",
+		History:              history,
 	}
 
 	rCol := cfg.MongoClient.Database(tenantDbConfig.Db).Collection(recomputationsColl)
@@ -446,16 +447,17 @@ func Update(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 	}
 
 	recomputation := MongoInterface{
-		ID:             vars["ID"],
-		RequesterName:  recompSubmission.RequesterName,
-		RequesterEmail: recompSubmission.RequesterEmail,
-		StartTime:      recompSubmission.StartTime,
-		EndTime:        recompSubmission.EndTime,
-		Reason:         recompSubmission.Reason,
-		Report:         recompSubmission.Report,
-		Exclude:        recompSubmission.Exclude,
-		Status:         result.Status,
-		Timestamp:      result.Timestamp,
+		ID:                   vars["ID"],
+		RequesterName:        recompSubmission.RequesterName,
+		RequesterEmail:       recompSubmission.RequesterEmail,
+		StartTime:            recompSubmission.StartTime,
+		EndTime:              recompSubmission.EndTime,
+		Reason:               recompSubmission.Reason,
+		Report:               recompSubmission.Report,
+		Exclude:              recompSubmission.Exclude,
+		Status:               result.Status,
+		Timestamp:            result.Timestamp,
+		AppliedStatusChanges: result.AppliedStatusChanges,
 	}
 
 	replaceResult, err := rCol.ReplaceOne(context.TODO(), query, recomputation)

--- a/app/recomputations2/Model.go
+++ b/app/recomputations2/Model.go
@@ -29,16 +29,17 @@ type IncomingRequest struct {
 }
 
 type IncomingRecomputation struct {
-	ID               string             `xml:"id" json:"id" bson:"id,omitempty"`
-	StartTime        string             `xml:"start_time,attr" json:"start_time" bson:"start_time,omitempty"`
-	RequesterName    string             `xml:"requester_name" json:"requester_name" bson:"requester_name,omitempty" `
-	RequesterEmail   string             `xml:"requester_email" json:"requester_email" bson:"requester_email,omitempty" `
-	EndTime          string             `xml:"end_time,attr" json:"end_time" bson:"end_time,omitempty"`
-	Reason           string             `xml:"reason,attr" json:"reason" bson:"reason,omitempty"`
-	Report           string             `xml:"report,attr" json:"report" bson:"report,omitempty"`
-	Exclude          []string           `xml:"exclude" json:"exclude" bson:"exclude,omitempty"`
-	ExcludeMonSource []ExcludeMonSource `bson:"exclude_monitoring_source" json:"exclude_monitoring_source,omitempty"`
-	ExcludeMetrics   []ExcludedMetric   `bson:"exclude_metrics" json:"exclude_metrics,omitempty"`
+	ID                   string                `xml:"id" json:"id" bson:"id,omitempty"`
+	StartTime            string                `xml:"start_time,attr" json:"start_time" bson:"start_time,omitempty"`
+	RequesterName        string                `xml:"requester_name" json:"requester_name" bson:"requester_name,omitempty" `
+	RequesterEmail       string                `xml:"requester_email" json:"requester_email" bson:"requester_email,omitempty" `
+	EndTime              string                `xml:"end_time,attr" json:"end_time" bson:"end_time,omitempty"`
+	Reason               string                `xml:"reason,attr" json:"reason" bson:"reason,omitempty"`
+	Report               string                `xml:"report,attr" json:"report" bson:"report,omitempty"`
+	Exclude              []string              `xml:"exclude" json:"exclude" bson:"exclude,omitempty"`
+	ExcludeMonSource     []ExcludeMonSource    `bson:"exclude_monitoring_source" json:"exclude_monitoring_source,omitempty"`
+	ExcludeMetrics       []ExcludedMetric      `bson:"exclude_metrics" json:"exclude_metrics,omitempty"`
+	AppliedStatusChanges []AppliedStatusChange `bson:"applied_status_changes" json:"applied_status_changes,omitempty"`
 }
 
 type SelfReference struct {
@@ -55,20 +56,31 @@ type IncomingStatus struct {
 }
 
 type MongoInterface struct {
-	XMLName          xml.Name           `bson:"-" xml:"recomputation" json:"-"`
-	ID               string             `bson:"id" xml:"id" json:"id"`
-	RequesterName    string             `bson:"requester_name" xml:"requester_name" json:"requester_name"`
-	RequesterEmail   string             `bson:"requester_email" xml:"requester_email" json:"requester_email"`
-	Reason           string             `bson:"reason" xml:"reason" json:"reason"`
-	StartTime        string             `bson:"start_time" xml:"start_time" json:"start_time"`
-	EndTime          string             `bson:"end_time" xml:"end_time" json:"end_time"`
-	Report           string             `bson:"report" xml:"report" json:"report"`
-	Exclude          []string           `bson:"exclude" xml:"exclude>group" json:"exclude"`
-	Status           string             `bson:"status" xml:"status" json:"status"`
-	Timestamp        string             `bson:"timestamp" xml:"timestamp" json:"timestamp"`
-	History          []HistoryItem      `bson:"history" xml:"history" json:"history"`
-	ExcludeMetrics   []ExcludedMetric   `bson:"exclude_metrics" json:"exclude_metrics,omitempty"`
-	ExcludeMonSource []ExcludeMonSource `bson:"exclude_monitoring_source" json:"exclude_monitoring_source,omitempty"`
+	XMLName              xml.Name              `bson:"-" xml:"recomputation" json:"-"`
+	ID                   string                `bson:"id" xml:"id" json:"id"`
+	RequesterName        string                `bson:"requester_name" xml:"requester_name" json:"requester_name"`
+	RequesterEmail       string                `bson:"requester_email" xml:"requester_email" json:"requester_email"`
+	Reason               string                `bson:"reason" xml:"reason" json:"reason"`
+	StartTime            string                `bson:"start_time" xml:"start_time" json:"start_time"`
+	EndTime              string                `bson:"end_time" xml:"end_time" json:"end_time"`
+	Report               string                `bson:"report" xml:"report" json:"report"`
+	Exclude              []string              `bson:"exclude" xml:"exclude>group" json:"exclude"`
+	Status               string                `bson:"status" xml:"status" json:"status"`
+	Timestamp            string                `bson:"timestamp" xml:"timestamp" json:"timestamp"`
+	History              []HistoryItem         `bson:"history" xml:"history" json:"history"`
+	ExcludeMetrics       []ExcludedMetric      `bson:"exclude_metrics" json:"exclude_metrics,omitempty"`
+	ExcludeMonSource     []ExcludeMonSource    `bson:"exclude_monitoring_source" json:"exclude_monitoring_source,omitempty"`
+	AppliedStatusChanges []AppliedStatusChange `bson:"applied_status_changes" json:"applied_status_changes,omitempty"`
+}
+
+// Additional field to represent items that have applied statuses on them
+// Items can be metrics, endpoints, services or groups
+type AppliedStatusChange struct {
+	Metric   string `bson:"metric" json:"metric,omitempty"`
+	Hostname string `bson:"hostname" json:"hostname,omitempty"`
+	Service  string `bson:"service"  json:"service,omitempty"`
+	Group    string `bson:"group" json:"group,omitempty"`
+	State    string `bson:"state" json:"state,omitempty"`
 }
 
 type ExcludeMonSource struct {


### PR DESCRIPTION
_⚠️ This PR is opened against feature branch go1.22-mongo6.0 which is not merged yet in devel. After testing this implementation we can proceed with finally merging go1.22-mongo6.0 feature branch in the devel branch_

### Goal
Argo was required to support a new kind of recomputations named applied statuses recomputations where a requestor can ask to apply specific statuses over a period of time on timelines of groups, services, endpoints and/or metrics. This new kind of recomputations is supported by adding an extra field "applied_status_changes" so the recomputation body becomes like the following example:

```json
{
  "id": "56db4f1a-f331-46ca-b0fd-4555b4aa1cfc",
  "requester_name": "requester",
  "requester_email": "request@request.gr",
  "reason": "testing_compute_engine",
  "start_time": "2022-01-12T00:00:00Z",
  "end_time": "2022-01-15T00:00:00Z",
  "report": "Critical",
  "applied_status_changes": [
    {
      "service": "Service_X",
      "state": "CRITICAL"
    },
    {
      "group": "GROUP_XX",
      "state": "OK"
    },
    {
      "metric": "Metric_XXX",
      "hostname": "Hostname_XXX",
      "state": "EXCLUDED"
    },
    {
      "metric": "Metric_XXXX",
      "group": "Group_XXXX",
      "state": "WARNING"
    }
  ]
}
```

This needs to be supported in the web-api both when inputing and/or retrieving recomputation information. 

### Implementation
- [x] Update recomputation model to use new field with new nested structure
- [x] Update recomputation controller method when inserting a new recomputation
- [x] Add unit tests
