### PR TITLE
add documentation for POST recomputations

### DIFF
--- a/website/docs/results/recomputations.md
+++ b/website/docs/results/recomputations.md
@@ -2,6 +2,7 @@
 id: recomputations
 title: Recomputation Requests
 sidebar_position: 7
+
 ---
 
 ## API Calls for listing existing and creating new recomputation requests
@@ -16,7 +17,9 @@ POST: change status  | This method can be used to change status of a specific re
 DELETE: Reset status of recomputation  | This method can be used to reset status of a specific recomputation. | [ Description](#6)
 
 
-## [GET]: List Recomputation Requests {#1}
+<a id='1'></a>
+
+## [GET]: List Recomputation Requests
 This method can be used to retrieve a list of current Recomputation requests.
 
 ### Input
@@ -31,6 +34,7 @@ GET /recomputations
 | -------- | --------------------------------------------------------------------------------------------------------------------------------------- | -------- |
 | `report` | Filter recomputations by report name                                                                                                    | NO       |
 | `date`   | Specific date to retrieve all relevant recomputations that their period include this date                                               | NO       |
+
 
 
 
@@ -206,8 +210,9 @@ Json Response
 }
 ```
 
+<a id='2'></a>
 
-## [GET]: Get specific recomputation request by id {#2}
+## [GET]: Get specific recomputation request by id
 This method can be used to retrieve a specific recomputation request by its id
 
 ### Input
@@ -264,8 +269,9 @@ Json Response
 ```
 
 
+<a id='3'></a>
 
-## [POST]: Create a new recomputation request {#3}
+## [POST]: Create a new recomputation request
 This method can be used to insert a new recomputation request onto the Compute Engine.
 
 ### Input
@@ -283,21 +289,77 @@ Accept: application/json
 
 #### Parameters
 
-Type         | Description                                                                                                                                            | Required | Default value
------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ | -------- | -------------
-`start_time` | UTC time in W3C format                                                                                                                                 | YES      |
-`end_time`   | UTC time in W3C format                                                                                                                                 | YES      |
-`reason`     | Explain the need for a recomputation                                                                                                                   | YES      |
-`requester_name`     | The name of the person submitting the recomputation                                                                                            | YES      |
-`requester_email`    | The email of the person submitting the recomputation                                                                                           | YES      |
-`report`     | Report for which the recomputation is requested                                                                                                        | YES      |
-`exclude`    | Groups to be excluded from recomputation. If more than one group are to be excluded use the parameter as many times as needed within the same API call | NO       |
+| Parameter                   | Type     | Description                                                                                                                                     | Required |
+|----------------------------|----------|-------------------------------------------------------------------------------------------------------------------------------------------------|----------|
+| `start_time`               | `string` | UTC timestamp in W3C format (e.g., `2025-05-07T12:00:00Z`)                                                                                      | Yes      |
+| `end_time`                 | `string` | UTC timestamp in W3C format (e.g., `2025-05-09T09:00:00Z`)                                                                                      | Yes      |
+| `reason`                   | `string` | Explanation of the need for the recomputation                                                                                                   | Yes      |
+| `requester_name`           | `string` | Name of the person submitting the recomputation                                                                                                 | Yes      |
+| `requester_email`          | `string` | Email of the person submitting the recomputation                                                                                                | Yes      |
+| `report`                   | `string` | Report for which the recomputation is requested                                                                                                 | Yes      |
+| `exclude_monitoring_source` | `array`  | List of monitoring sources to exclude during recomputation, each with `host`, `start_time`, and `end_time`                                     | No       |
+| `exclude`                  | `array`  | List of group names to exclude from recomputation                                                                                               | No       |
+| `exclude_metrics`          | `array`  | List of specific metrics (optionally scoped by hostname, service or group) to exclude from recomputation                                       | No       |
+| `applied_status_changes`   | `array`  | Manual status overrides for specific topology elements (group, service, endpoint, or metric)                                                   | No       |
 
 ### Response
 Headers: `Status: 201 Created`
 
+<a id='4'></a>
 
-## [DELETE]: Delete a specific recomputation {#4}
+#### Request Body
+
+The recomputation request body can include any combination of the following optional elements:
+
+- `"exclude_monitoring_source"` — to exclude data from specified monitoring sources during a time window.
+- `"exclude"` — to exclude specific groups from availability/reliability calculations.
+- `"exclude_metrics"` — to exclude particular metrics, optionally scoped by hostname, service, or group.
+- `"applied_status_changes"` — to manually override statuses of monitored topology items.
+
+All these elements are **optional** and can be included individually or together depending on the recomputation needs.
+
+---
+
+#### Example Request Body
+
+```json
+{
+  "requester_name": "John Doe",
+  "requester_email": "johndoe@foo.gr",
+  "reason": "Recomputation request including all types",
+  "start_time": "2025-05-07T12:00:00Z",
+  "end_time": "2025-05-09T09:00:00Z",
+  "report": "Report-A",
+
+  "exclude_monitoring_source": [
+    {
+      "host": "monitoring_node01.example.foo",
+      "start_time": "2022-01-10T12:00:00Z",
+      "end_time": "2022-01-10T23:00:00Z"
+    }
+  ],
+
+  "exclude": [
+    "Group-1",
+    "Group-2"
+  ],
+
+  "exclude_metrics": [
+    { "metric": "check-1" },
+    { "metric": "check-2", "hostname": "host1.example.com" }
+  ],
+
+  "applied_status_changes": [
+    { "group": "Group-A", "state": "CRITICAL" },
+    { "service": "Service-a", "state": "OK" }
+  ]
+}
+```
+
+
+
+
+## [DELETE]: Delete a specific recomputation
 
 ```
 DELETE /recomputations/{ID}
@@ -313,8 +375,9 @@ Accept: application/json
 ### Response
 `Status 200 OK`
 
+<a id='5'></a>
 
-## [POST]: Change status of recomputation {#5}
+## [POST]: Change status of recomputation
 
 ```
 POST /recomputations/{ID}/status
@@ -360,7 +423,9 @@ Json Response
 ```
 
 
-## [DELETE]: Reset status of a specific recomputation {#6}
+<a id='6'></a>
+
+## [DELETE]: Reset status of a specific recomputation
 
 ```
 DELETE /recomputations/{ID}/status
@@ -388,63 +453,5 @@ Json Response
 }
 ```
 
-# Recomputations that exclude metrics
 
-There is also the ability to run a recomputation and exclude specific metrics. During the recomputation period the metrics that are considered excluded don't take place into any operation or aggregation thus they don't affect their endpoints at all. 
 
-To declare a recomputation that excludes metric you must use the special field "exclude_metrics" in the recomputation and add an array of metrics to be excluded (You can limit the scope also by "group", "service" and "hostname")
-
-For example:
-
-```json
-{
-   "id": "6ac7d684-1f8e-4a02-a502-720e8f11e777",
-   "requester_name": "John Doe",
-   "requester_email": "johndoe@example.com",
-   "reason": "issue with metric checks",
-   "start_time": "2022-01-10T12:00:00Z",
-   "end_time": "2022-01-10T23:00:00Z",
-   "report": "Default",
-   "exclude_metrics": [
-    {
-     "metric": "check-1"
-    },
-    {
-     "metric": "check-2",
-     "hostname": "host1.example.com"
-    },
-    {
-     "metric": "check-3",
-     "group": "Affected-Site"
-    }
-   ]
-  }
-  ```
-
-  If you specify a rule that includes only a `metric` then this type of metric will be excluded globally from all endpoints and groups
-  If you specify a rule that includes a `metric` and another field such as `hostname`, `service` or `group` then the rule is scoped accordingly to a specific group or service type or hostname and the metric that belongs there. The field `metric` is mandatory.
-
-  # Recomputations that exclude monitoring sources
-
-There is also the ability to run a recomputation and exclude a monitoring source (e.g. specific monitoring box). This is especially usefull in HA situations where one of the available monitoring sources might have issues for a specific period of time.
-
-For example:
-
-```json
-{
-   "id": "6ac7d684-1f8e-4a02-a502-720e8f11e777",
-   "requester_name": "John Doe",
-   "requester_email": "johndoe@example.com",
-   "reason": "issue with metric checks",
-   "start_time": "2022-01-10T12:00:00Z",
-   "end_time": "2022-01-10T23:00:00Z",
-   "report": "Default",
-   "exclude_monitoring_source": [
-    {
-        "host":"monitoring_node01.example.foo",
-        "start_time": "2022-01-10T12:00:00Z",
-        "end_time": "2022-01-10T23:00:00Z"
-    }
-   ]
-}
-```


### PR DESCRIPTION
This pr introduces changes to the description of recomputaton requests on API . 
Added the body structure of the POST recomputations to describe how to define the different recomputation types. 
Removed the excluded metrics and monitoring sources description as this part is added to the documentaton of Argo Monitoriring Service along with the rest types of recomputations. We try to keep here only the description on the api structure and not concepts