### PR TITLE
ARGO-5073 Add support for consistency check

### DIFF
--- a/consistency/consistency_test.go
+++ b/consistency/consistency_test.go
@@ -1,0 +1,396 @@
+/*
+ * Copyright (c) 2015 GRNET S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS
+ * IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ *
+ * The views and conclusions contained in the software and
+ * documentation are those of the authors and should not be
+ * interpreted as representing official policies, either expressed
+ * or implied, of GRNET S.A.
+ *
+ */
+
+package consistency
+
+import (
+	"context"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/ARGOeu/argo-web-api/respond"
+	"github.com/ARGOeu/argo-web-api/utils/config"
+	"github.com/ARGOeu/argo-web-api/utils/store"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/suite"
+	"go.mongodb.org/mongo-driver/bson"
+	"gopkg.in/gcfg.v1"
+)
+
+type consistencyTestSuite struct {
+	suite.Suite
+	cfg          config.Config
+	router       *mux.Router
+	confHandler  respond.ConfHandler
+	tenantDbConf config.MongoConfig
+	clientkey    string
+	tenant1key   string
+	tenant2key   string
+	tenant1db    string
+	tenant2db    string
+}
+
+// Setup the Test Environment
+func (suite *consistencyTestSuite) SetupSuite() {
+
+	const testConfig = `
+	[server]
+    bindip = ""
+    port = 8080
+    maxprocs = 4
+    cache = false
+    lrucache = 700000000
+    gzip = true
+	reqsizelimit = 1073741824
+	[mongodb]
+	host = "127.0.0.1"
+	port = 27017
+	db = "ARGO_test_topology_test"
+	`
+
+	_ = gcfg.ReadStringInto(&suite.cfg, testConfig)
+
+	client := store.GetMongoClient(suite.cfg.MongoDB)
+	suite.cfg.MongoClient = client
+
+	suite.tenantDbConf.Db = "ARGO_consistency_check"
+	suite.tenantDbConf.Password = "h4shp4ss"
+	suite.tenantDbConf.Username = "dbuser"
+	suite.tenantDbConf.Store = "ar"
+	suite.clientkey = "viewerkey"
+	suite.tenant1key = "tenant1key"
+	suite.tenant2key = "tenant2key"
+	suite.tenant1db = "argo_tenant1"
+	suite.tenant2db = "argo_tenant2"
+
+	// Create router and confhandler for test
+	suite.confHandler = respond.ConfHandler{Config: suite.cfg}
+	suite.router = mux.NewRouter().StrictSlash(false).PathPrefix("/api/v2").Subrouter()
+	HandleSubrouter(suite.router, &suite.confHandler)
+}
+
+// This function runs before any test and setups the environment
+func (suite *consistencyTestSuite) SetupTest() {
+
+	log.SetOutput(io.Discard)
+
+	// Seed database with tenants
+	//TODO: move tests to
+	c := suite.cfg.MongoClient.Database(suite.cfg.MongoDB.Db).Collection("tenants")
+	c.InsertOne(context.TODO(),
+		bson.M{"name": "TestTenant",
+			"db_conf": []bson.M{
+
+				{
+					"server":   "localhost",
+					"port":     27017,
+					"database": suite.tenant1db,
+				},
+			},
+			"users": []bson.M{
+
+				{
+					"name":    "Viewer",
+					"email":   "viewer@example.com",
+					"api_key": "viewerkey",
+					"roles":   []string{"viewer"},
+				},
+				{
+					"name":    "auto check service",
+					"email":   "check@example.com",
+					"api_key": "checkkey",
+					"roles":   []string{"consistency-check"},
+				},
+				{
+					"name":    "ack admin",
+					"email":   "ack@example.com",
+					"api_key": "ackkey",
+					"roles":   []string{"consistency-ack"},
+				},
+			}})
+	c = suite.cfg.MongoClient.Database(suite.cfg.MongoDB.Db).Collection("roles")
+	c.InsertOne(context.TODO(),
+		bson.M{
+			"resource": "consistency.result",
+			"roles":    []string{"editor", "viewer"},
+		})
+	c.InsertOne(context.TODO(),
+		bson.M{
+			"resource": "consistency.auto-check",
+			"roles":    []string{"consistency-check"},
+		})
+	c.InsertOne(context.TODO(),
+		bson.M{
+			"resource": "consistency.ack",
+			"roles":    []string{"consistency-ack"},
+		})
+
+}
+
+func (suite *consistencyTestSuite) TestCheckConsistency() {
+
+	expJSON := `{
+   "message": "Constistency information is not yet available",
+   "code": 404
+ }`
+
+	request, _ := http.NewRequest("GET", "/api/v2/consistency", strings.NewReader(""))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code := response.Code
+	output := response.Body.String()
+	// Check that we must have a 404 not found code
+	suite.Equal(404, code, "Not Found")
+	// Compare the expected and actual json response
+	suite.Equal(expJSON, output, "Event Not Found")
+
+	// Try an ack without having an auto-check event
+
+	inputAck := `{
+	"status": "OK",
+	"message": "This is not a fault of monitoring"
+	}`
+
+	expNotAck := `{
+   "message": "There is no auto check event yet to acknowledge",
+   "code": 404
+ }`
+
+	request, _ = http.NewRequest("POST", "/api/v2/consistency/ack", strings.NewReader(inputAck))
+	request.Header.Set("x-api-key", "ackkey")
+	request.Header.Set("Accept", "application/json")
+	response = httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code = response.Code
+	output = response.Body.String()
+	// Check that we must have a 404 not foudn code
+	suite.Equal(404, code, "not found")
+	// Compare the expected and actual json response
+	suite.Equal(expNotAck, output, "Ack event should not submit")
+
+	// Post an auto check
+
+	inputJSON := `{
+	"status": "OK",
+	"message": "Flapping items are lower"
+	}`
+
+	expJSON = `{
+   "message": "The Auto Check event was posted succesfully",
+   "code": 200
+ }`
+
+	request, _ = http.NewRequest("POST", "/api/v2/consistency/auto-check", strings.NewReader(inputJSON))
+	request.Header.Set("x-api-key", "checkkey")
+	request.Header.Set("Accept", "application/json")
+	response = httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code = response.Code
+	output = response.Body.String()
+	// Check that we must have a 404 not found code
+	suite.Equal(200, code, "Not Found")
+	// Compare the expected and actual json response
+	suite.Equal(expJSON, output, "Event Not Found")
+
+	// Get the check result
+
+	expJSON2 := `{
+ "status": "OK",
+ "timestamp": ".*",
+ "message": "Flapping items are lower"
+}`
+
+	request, _ = http.NewRequest("GET", "/api/v2/consistency", strings.NewReader(""))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+	response = httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code = response.Code
+	output = response.Body.String()
+	// Check that we must have a 404 not found code
+	suite.Equal(200, code, "ok")
+	// Compare the expected and actual json response
+	suite.Regexp(expJSON2, output, "Get consistency check result")
+
+	// Adding another auto check event that is critical
+
+	inputCritical := `{
+	"status": "CRITICAL",
+	"message": "Flapping items are over 50 percent"
+	}`
+
+	request, _ = http.NewRequest("POST", "/api/v2/consistency/auto-check", strings.NewReader(inputCritical))
+	request.Header.Set("x-api-key", "checkkey")
+	request.Header.Set("Accept", "application/json")
+	response = httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code = response.Code
+	output = response.Body.String()
+	// Check that we must have a 404 not found code
+	suite.Equal(200, code, "Not Found")
+	// Compare the expected and actual json response
+	suite.Equal(expJSON, output, "Event Not Found")
+
+	// get the new consistency check result with verbosity
+
+	expJSON3 := `{
+ "status": "CRITICAL",
+ "timestamp": ".*",
+ "message": "Flapping items are over 50 percent",
+ "auto_check_status": "CRITICAL",
+ "auto_check_mesage": "Flapping items are over 50 percent",
+ "auto_check_timestamp": ".*"
+}`
+
+	request, _ = http.NewRequest("GET", "/api/v2/consistency?verbose", strings.NewReader(""))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+	response = httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code = response.Code
+	output = response.Body.String()
+	// Check that we must have a 200 creation code
+	suite.Equal(200, code, "ok")
+	// Compare the expected and actual json response
+	suite.Regexp(expJSON3, output, "Get consistency check result")
+
+	// add an ack result
+
+	// Adding another auto check event that is critical
+
+	inputAck2 := `{
+	"status": "OK",
+	"message": "This is not a fault of monitoring",
+	"timeout_hours": 1
+	}`
+
+	expJSON4 := `{
+   "message": "The Ack event was posted succesfully",
+   "code": 200
+ }`
+
+	request, _ = http.NewRequest("POST", "/api/v2/consistency/ack", strings.NewReader(inputAck2))
+	request.Header.Set("x-api-key", "ackkey")
+	request.Header.Set("Accept", "application/json")
+	response = httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code = response.Code
+	output = response.Body.String()
+	// Check that we must have a 200 creation code
+	suite.Equal(200, code, "ok")
+	// Compare the expected and actual json response
+	suite.Equal(expJSON4, output, "Ack Event created")
+
+	// get the new consistency check result with verbosity
+
+	expJSON5 := `{
+ "status": "OK",
+ "timestamp": ".*",
+ "message": "This is not a fault of monitoring",
+ "auto_check_status": "CRITICAL",
+ "auto_check_mesage": "Flapping items are over 50 percent",
+ "auto_check_timestamp": ".*",
+ "ack_status": "OK",
+ "ack_message": "This is not a fault of monitoring",
+ "ack_timestamp": ".*",
+ "ack_timeout_hours": 1
+}`
+
+	request, _ = http.NewRequest("GET", "/api/v2/consistency?verbose", strings.NewReader(""))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+	response = httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code = response.Code
+	output = response.Body.String()
+	// Check that we must have a 200 creation code
+	suite.Equal(200, code, "ok")
+	// Compare the expected and actual json response
+	suite.Regexp(expJSON5, output, "Get consistency check result")
+
+	// add old date to timestamp and ack
+	conCol := suite.cfg.MongoClient.Database(suite.cfg.MongoDB.Db).Collection(conColName)
+	conCol.UpdateOne(context.TODO(), bson.M{"_id": conID},
+		bson.M{"$set": bson.M{"ack_timestamp": "2010-01-01T00:02:00Z"}})
+
+	// get the new consistency check result with verbosity
+
+	expJSON6 := `{
+ "status": "CRITICAL",
+ "timestamp": ".*",
+ "message": "Flapping items are over 50 percent",
+ "auto_check_status": "CRITICAL",
+ "auto_check_mesage": "Flapping items are over 50 percent",
+ "auto_check_timestamp": ".*"
+}`
+
+	request, _ = http.NewRequest("GET", "/api/v2/consistency?verbose", strings.NewReader(""))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+	response = httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code = response.Code
+	output = response.Body.String()
+	// Check that we must have a 200 creation code
+	suite.Equal(200, code, "ok")
+	// Compare the expected and actual json response
+	suite.Regexp(expJSON6, output, "Get consistency check result")
+}
+
+// TearDownTest to tear down every test
+func (suite *consistencyTestSuite) TearDownSuite() {
+
+	suite.cfg.MongoClient.Database(suite.cfg.MongoDB.Db).Drop(context.TODO())
+	suite.cfg.MongoClient.Database(suite.tenantDbConf.Db).Drop(context.TODO())
+	suite.cfg.MongoClient.Database(suite.tenant1db).Drop(context.TODO())
+	suite.cfg.MongoClient.Database(suite.tenant2db).Drop(context.TODO())
+
+}
+
+// TestTopologyTestSuite is responsible for calling the tests
+func TestSuiteTopology(t *testing.T) {
+	suite.Run(t, new(consistencyTestSuite))
+}

--- a/consistency/handlers.go
+++ b/consistency/handlers.go
@@ -1,0 +1,257 @@
+package consistency
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/ARGOeu/argo-web-api/respond"
+	"github.com/ARGOeu/argo-web-api/utils/config"
+	"github.com/gorilla/mux"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+const conColName = "consistency"
+const conID = "consistency-status"
+
+// HandleSubrouter for api access to consistency information
+func HandleSubrouter(s *mux.Router, confhandler *respond.ConfHandler) {
+	respond.PrepAppRoutes(s, confhandler, appRoutes)
+}
+
+var appRoutes = []respond.AppRoutes{
+	{"consistency.result", "GET", "/consistency", GetStatus},
+	{"consistency.options", "OPTIONS", "/consistency", Options},
+	{"consistency.ack", "POST", "/consistency/ack", PostAck},
+	{"consistency.ack.options", "OPTIONS", "/consistency/ack", Options},
+	{"consistency.auto-check", "POST", "/consistency/auto-check", PostAutoCheck},
+	{"consistency.auto-check.options", "OPTIONS", "/consistency/auto-check", Options},
+}
+
+// GetStatus gets consistency status
+func GetStatus(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
+
+	//STANDARD DECLARATIONS START
+	code := http.StatusOK
+	h := http.Header{}
+	var output []byte
+	err := error(nil)
+	charset := "utf-8"
+	//STANDARD DECLARATIONS END
+
+	// Set Content-Type response Header value
+	contentType := r.Header.Get("Accept")
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+
+	// Try to get mongo client and target consistency collection
+	conCol := cfg.MongoClient.Database(cfg.MongoDB.Db).Collection(conColName)
+
+	urlValues := r.URL.Query()
+	verbose := urlValues.Has("verbose")
+
+	var data DataMongo
+	var result Result
+	filter := bson.M{"_id": conID}
+
+	err = conCol.FindOne(context.TODO(), filter).Decode(&data)
+	if err != nil {
+		if err == mongo.ErrNoDocuments {
+			code = 404
+			output, _ = createMessage("Constistency information is not yet available", code, contentType)
+			return code, h, output, err
+		}
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+	now := time.Now().UTC()
+
+	// by default result equals to the result of the auto check
+	result.Status = data.AutoCheckStatus
+	result.Message = data.AutoCheckMsg
+	result.Timestamp = now.Format(time.RFC3339)
+
+	// add auto-check details
+	if verbose {
+		result.AutoCheckMsg = data.AutoCheckMsg
+		result.AutoCheckStatus = data.AutoCheckStatus
+		result.AutoCheckTimestamp = data.AutoCheckTimestamp
+	}
+	// check if ack exists and applies still
+	if data.AckStatus != "" && data.AckMsg != "" && data.AckTimeoutHours > 0 {
+		ackTime, err := time.Parse(time.RFC3339, data.AckTimestamp)
+		if err == nil {
+			ackDur := time.Duration(data.AckTimeoutHours) * time.Hour
+			if now.Sub(ackTime.UTC()) < ackDur {
+				// make status get the ack result
+				result.Status = data.AckStatus
+				result.Message = data.AckMsg
+				if verbose {
+					result.AckStatus = data.AckStatus
+					result.AckMsg = data.AckMsg
+					result.AckTimeoutHours = data.AckTimeoutHours
+					result.AckTimestamp = data.AckTimestamp
+				}
+			}
+
+		}
+
+	}
+
+	output, err = respond.MarshalContent(result, contentType, "", " ")
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	return code, h, output, err
+}
+
+// PostAutoCheck posts results about an auto check
+func PostAutoCheck(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
+
+	//STANDARD DECLARATIONS START
+	code := http.StatusOK
+	h := http.Header{}
+	var output []byte
+	err := error(nil)
+	charset := "utf-8"
+	//STANDARD DECLARATIONS END
+
+	// Set Content-Type response Header value
+	contentType := r.Header.Get("Accept")
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+
+	// Try to get mongo client and target consistency collection
+	conCol := cfg.MongoClient.Database(cfg.MongoDB.Db).Collection(conColName)
+
+	var autoCheckInput AutoCheckMongo
+
+	body, err := io.ReadAll(io.LimitReader(r.Body, cfg.Server.ReqSizeLimit))
+	if err != nil {
+		panic(err)
+	}
+	if err := r.Body.Close(); err != nil {
+		panic(err)
+	}
+	if err := json.Unmarshal(body, &autoCheckInput); err != nil {
+		output, _ = respond.MarshalContent(respond.BadRequestInvalidJSON, contentType, "", " ")
+		code = http.StatusBadRequest
+		return code, h, output, err
+	}
+
+	autoCheckInput.AutoCheckTimestamp = time.Now().UTC().Format(time.RFC3339)
+
+	filter := bson.M{"_id": conID}
+	update := bson.M{"$set": autoCheckInput}
+	opts := options.Update().SetUpsert(true)
+
+	_, err = conCol.UpdateOne(context.TODO(), filter, update, opts)
+	if err != nil {
+		log.Fatal("MongoDB update failed:", err)
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	message := "The Auto Check event was posted succesfully"
+	output, err = createMessage(message, code, contentType)
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	return code, h, output, err
+}
+
+// PostAck posts an acknowledgement
+func PostAck(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
+
+	//STANDARD DECLARATIONS START
+	code := http.StatusOK
+	h := http.Header{}
+	var output []byte
+	err := error(nil)
+	charset := "utf-8"
+	//STANDARD DECLARATIONS END
+
+	// Set Content-Type response Header value
+	contentType := r.Header.Get("Accept")
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+
+	// Try to get mongo client and target consistency collection
+	conCol := cfg.MongoClient.Database(cfg.MongoDB.Db).Collection(conColName)
+
+	var ackInput AckMongo
+
+	body, err := io.ReadAll(io.LimitReader(r.Body, cfg.Server.ReqSizeLimit))
+	if err != nil {
+		panic(err)
+	}
+	if err := r.Body.Close(); err != nil {
+		panic(err)
+	}
+	if err := json.Unmarshal(body, &ackInput); err != nil {
+		output, _ = respond.MarshalContent(respond.BadRequestInvalidJSON, contentType, "", " ")
+		code = http.StatusBadRequest
+		return code, h, output, err
+	}
+
+	ackInput.AckTimestamp = time.Now().UTC().Format(time.RFC3339)
+	if ackInput.AckTimeoutHours == 0 {
+		// default is 6 hours - TODO: to be configurable
+		ackInput.AckTimeoutHours = 6
+	}
+
+	filter := bson.M{"_id": conID}
+	update := bson.M{"$set": ackInput}
+	opts := options.Update().SetUpsert(false)
+
+	updateResult, err := conCol.UpdateOne(context.TODO(), filter, update, opts)
+	if err != nil {
+		log.Fatal("MongoDB update failed:", err)
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	if updateResult.MatchedCount == 0 {
+		message := "There is no auto check event yet to acknowledge"
+		output, err = createMessage(message, http.StatusNotFound, contentType)
+		return http.StatusNotFound, h, output, err
+	}
+
+	message := "The Ack event was posted succesfully"
+	output, err = createMessage(message, code, contentType)
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	return code, h, output, err
+}
+
+func Options(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
+
+	//STANDARD DECLARATIONS START
+
+	code := http.StatusOK
+	h := http.Header{}
+	output := []byte("")
+	err := error(nil)
+	contentType := "text/plain"
+	charset := "utf-8"
+
+	//STANDARD DECLARATIONS END
+
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+	h.Set("Allow", "GET, OPTIONS")
+	return code, h, output, err
+
+}

--- a/consistency/models.go
+++ b/consistency/models.go
@@ -1,0 +1,43 @@
+package consistency
+
+type Result struct {
+	Status             string `json:"status"`
+	Timestamp          string `json:"timestamp"`
+	Message            string `json:"message"`
+	AutoCheckStatus    string `json:"auto_check_status,omitempty"`
+	AutoCheckMsg       string `json:"auto_check_mesage,omitempty"`
+	AutoCheckTimestamp string `json:"auto_check_timestamp,omitempty"`
+	AckStatus          string `json:"ack_status,omitempty"`
+	AckMsg             string `json:"ack_message,omitempty"`
+	AckTimestamp       string `json:"ack_timestamp,omitempty"`
+	AckTimeoutHours    int    `json:"ack_timeout_hours,omitempty"`
+}
+
+type DataMongo struct {
+	AutoCheckStatus    string `bson:"auto_check_status"`
+	AutoCheckMsg       string `bson:"auto_check_message"`
+	AutoCheckTimestamp string `bson:"auto_check_timestamp"`
+	AckStatus          string `bson:"ack_status"`
+	AckMsg             string `bson:"ack_message"`
+	AckTimestamp       string `bson:"ack_timestamp"`
+	AckTimeoutHours    int    `bson:"ack_timeout_hours"`
+}
+
+type AckMongo struct {
+	AckStatus       string `bson:"ack_status" json:"status"`
+	AckMsg          string `bson:"ack_message" json:"message"`
+	AckTimestamp    string `bson:"ack_timestamp" json:"timestamp"`
+	AckTimeoutHours int    `bson:"ack_timeout_hours" json:"timeout_hours"`
+}
+
+type AutoCheckMongo struct {
+	AutoCheckStatus    string `bson:"auto_check_status" json:"status"`
+	AutoCheckMsg       string `bson:"auto_check_message" json:"message"`
+	AutoCheckTimestamp string `bson:"auto_check_timestamp" json:"timestamp"`
+}
+
+// errorMessage struct to hold the json error response
+type errorMessage struct {
+	Message string `json:"message"`
+	Code    int    `json:"code"`
+}

--- a/consistency/views.go
+++ b/consistency/views.go
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2022 GRNET S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS
+ * IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ *
+ * The views and conclusions contained in the software and
+ * documentation are those of the authors and should not be
+ * interpreted as representing official policies, either expressed
+ * or implied, of GRNET S.A.
+ *
+ */
+
+package consistency
+
+import (
+	"encoding/json"
+	"encoding/xml"
+	"strings"
+)
+
+func createMessage(message string, code int, format string) ([]byte, error) {
+
+	var output []byte
+	err := error(nil)
+	docRoot := &errorMessage{}
+
+	docRoot.Message = message
+	docRoot.Code = code
+	if strings.EqualFold(format, "application/json") {
+		output, err = json.MarshalIndent(docRoot, " ", "  ")
+	} else {
+		output, err = xml.MarshalIndent(docRoot, " ", "  ")
+	}
+	return output, err
+}

--- a/health/handlers.go
+++ b/health/handlers.go
@@ -1,0 +1,110 @@
+package health
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/ARGOeu/argo-web-api/respond"
+	"github.com/ARGOeu/argo-web-api/utils/config"
+	"github.com/gorilla/mux"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+const conColName = "consistency"
+const conID = "consistency-status"
+
+// HandleSubrouter for api access to health status
+func HandleSubrouter(s *mux.Router, confhandler *respond.ConfHandler) {
+	respond.PrepAppRoutes(s, confhandler, appRoutes)
+}
+
+var appRoutes = []respond.AppRoutes{
+	{"health", "GET", "/health", GetStatus},
+	{"health", "OPTIONS", "/health", Options},
+}
+
+// GetStatus gets health status
+func GetStatus(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
+
+	//STANDARD DECLARATIONS START
+	code := http.StatusOK
+	h := http.Header{}
+	var output []byte
+	err := error(nil)
+	charset := "utf-8"
+	//STANDARD DECLARATIONS END
+
+	// Set Content-Type response Header value
+	contentType := r.Header.Get("Accept")
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+
+	// Try to get mongo client and target consistency collection
+	conCol := cfg.MongoClient.Database(cfg.MongoDB.Db).Collection(conColName)
+
+	var data DataMongo
+	var result Result
+	filter := bson.M{"_id": conID}
+
+	err = conCol.FindOne(context.TODO(), filter).Decode(&data)
+	if err != nil {
+		if err == mongo.ErrNoDocuments {
+			code = 404
+			output, _ = createMessage("Health status not yet available", code, contentType)
+			return code, h, output, err
+		}
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+	now := time.Now().UTC()
+
+	// by default result equals to the result of the auto check
+	result.Status = data.AutoCheckStatus
+	result.Message = data.AutoCheckMsg
+	result.Timestamp = now.Format(time.RFC3339)
+
+	// check if ack exists and applies still
+	if data.AckStatus != "" && data.AckMsg != "" && data.AckTimeoutHours > 0 {
+		ackTime, err := time.Parse(time.RFC3339, data.AckTimestamp)
+		if err == nil {
+			ackDur := time.Duration(data.AckTimeoutHours) * time.Hour
+			if now.Sub(ackTime.UTC()) < ackDur {
+				// make status get the ack result
+				result.Status = data.AckStatus
+				result.Message = data.AckMsg
+			}
+
+		}
+
+	}
+
+	output, err = respond.MarshalContent(result, contentType, "", " ")
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	return code, h, output, err
+}
+
+func Options(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
+
+	//STANDARD DECLARATIONS START
+
+	code := http.StatusOK
+	h := http.Header{}
+	output := []byte("")
+	err := error(nil)
+	contentType := "text/plain"
+	charset := "utf-8"
+
+	//STANDARD DECLARATIONS END
+
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+	h.Set("Allow", "GET, OPTIONS")
+	return code, h, output, err
+
+}

--- a/health/health_test.go
+++ b/health/health_test.go
@@ -1,0 +1,188 @@
+/*
+ * Copyright (c) 2015 GRNET S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS
+ * IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ *
+ * The views and conclusions contained in the software and
+ * documentation are those of the authors and should not be
+ * interpreted as representing official policies, either expressed
+ * or implied, of GRNET S.A.
+ *
+ */
+
+package health
+
+import (
+	"context"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/ARGOeu/argo-web-api/respond"
+	"github.com/ARGOeu/argo-web-api/utils/config"
+	"github.com/ARGOeu/argo-web-api/utils/store"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/suite"
+	"go.mongodb.org/mongo-driver/bson"
+	"gopkg.in/gcfg.v1"
+)
+
+type consistencyTestSuite struct {
+	suite.Suite
+	cfg          config.Config
+	router       *mux.Router
+	confHandler  respond.ConfHandler
+	tenantDbConf config.MongoConfig
+	clientkey    string
+	tenant1key   string
+	tenant2key   string
+	tenant1db    string
+	tenant2db    string
+}
+
+// Setup the Test Environment
+func (suite *consistencyTestSuite) SetupSuite() {
+
+	const testConfig = `
+	[server]
+    bindip = ""
+    port = 8080
+    maxprocs = 4
+    cache = false
+    lrucache = 700000000
+    gzip = true
+	reqsizelimit = 1073741824
+	[mongodb]
+	host = "127.0.0.1"
+	port = 27017
+	db = "ARGO_test_topology_test"
+	`
+
+	_ = gcfg.ReadStringInto(&suite.cfg, testConfig)
+
+	client := store.GetMongoClient(suite.cfg.MongoDB)
+	suite.cfg.MongoClient = client
+
+	suite.tenantDbConf.Db = "ARGO_consistency_check"
+	suite.tenantDbConf.Password = "h4shp4ss"
+	suite.tenantDbConf.Username = "dbuser"
+	suite.tenantDbConf.Store = "ar"
+	suite.clientkey = "viewerkey"
+	suite.tenant1key = "tenant1key"
+	suite.tenant2key = "tenant2key"
+	suite.tenant1db = "argo_tenant1"
+	suite.tenant2db = "argo_tenant2"
+
+	// Create router and confhandler for test
+	suite.confHandler = respond.ConfHandler{Config: suite.cfg}
+	suite.router = mux.NewRouter().StrictSlash(false).PathPrefix("/api/v2").Subrouter()
+	HandleSubrouter(suite.router, &suite.confHandler)
+}
+
+// This function runs before any test and setups the environment
+func (suite *consistencyTestSuite) SetupTest() {
+
+	log.SetOutput(io.Discard)
+
+	// Seed database with tenants
+	//TODO: move tests to
+	c := suite.cfg.MongoClient.Database(suite.cfg.MongoDB.Db).Collection("tenants")
+	c.InsertOne(context.TODO(),
+		bson.M{"name": "TestTenant",
+			"db_conf": []bson.M{
+
+				{
+					"server":   "localhost",
+					"port":     27017,
+					"database": suite.tenant1db,
+				},
+			},
+			"users": []bson.M{
+
+				{
+					"name":    "Viewer",
+					"email":   "viewer@example.com",
+					"api_key": "viewerkey",
+					"roles":   []string{"viewer"},
+				},
+				{
+					"name":    "auto check service",
+					"email":   "check@example.com",
+					"api_key": "checkkey",
+					"roles":   []string{"consistency-check"},
+				},
+				{
+					"name":    "ack admin",
+					"email":   "ack@example.com",
+					"api_key": "ackkey",
+					"roles":   []string{"consistency-ack"},
+				},
+			}})
+	c = suite.cfg.MongoClient.Database(suite.cfg.MongoDB.Db).Collection("roles")
+	c.InsertOne(context.TODO(),
+		bson.M{
+			"resource": "health",
+			"roles":    []string{"editor", "viewer"},
+		})
+	c = suite.cfg.MongoClient.Database(suite.cfg.MongoDB.Db).Collection("consistency")
+	c.InsertOne(context.TODO(),
+		bson.M{
+			"_id":                  conID,
+			"auto_check_status":    "OK",
+			"auto_check_timestamp": "2025-07-01T00:00:00Z",
+			"auto_check_message":   "No flapping items",
+		})
+
+}
+
+func (suite *consistencyTestSuite) TestCheckConsistency() {
+
+	expJSON := `{
+ "status": "OK",
+ "timestamp": ".*",
+ "message": "No flapping items"
+}`
+
+	request, _ := http.NewRequest("GET", "/api/v2/health", strings.NewReader(""))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code := response.Code
+	output := response.Body.String()
+	// Check that we must have a 200 ok code
+	suite.Equal(200, code, "all ok")
+	// Compare the expected and actual json response
+	suite.Regexp(expJSON, output, "Health event")
+
+}
+
+// TearDownTest to tear down every test
+func (suite *consistencyTestSuite) TearDownSuite() {
+
+	suite.cfg.MongoClient.Database(suite.cfg.MongoDB.Db).Drop(context.TODO())
+	suite.cfg.MongoClient.Database(suite.tenantDbConf.Db).Drop(context.TODO())
+	suite.cfg.MongoClient.Database(suite.tenant1db).Drop(context.TODO())
+	suite.cfg.MongoClient.Database(suite.tenant2db).Drop(context.TODO())
+
+}
+
+// TestTopologyTestSuite is responsible for calling the tests
+func TestSuiteTopology(t *testing.T) {
+	suite.Run(t, new(consistencyTestSuite))
+}

--- a/health/models.go
+++ b/health/models.go
@@ -1,0 +1,23 @@
+package health
+
+type Result struct {
+	Status    string `json:"status"`
+	Timestamp string `json:"timestamp"`
+	Message   string `json:"message"`
+}
+
+type DataMongo struct {
+	AutoCheckStatus    string `bson:"auto_check_status"`
+	AutoCheckMsg       string `bson:"auto_check_message"`
+	AutoCheckTimestamp string `bson:"auto_check_timestamp"`
+	AckStatus          string `bson:"ack_status"`
+	AckMsg             string `bson:"ack_message"`
+	AckTimestamp       string `bson:"ack_timestamp"`
+	AckTimeoutHours    int    `bson:"ack_timeout_hours"`
+}
+
+// errorMessage struct to hold the json error response
+type errorMessage struct {
+	Message string `json:"message"`
+	Code    int    `json:"code"`
+}

--- a/health/views.go
+++ b/health/views.go
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2022 GRNET S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS
+ * IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ *
+ * The views and conclusions contained in the software and
+ * documentation are those of the authors and should not be
+ * interpreted as representing official policies, either expressed
+ * or implied, of GRNET S.A.
+ *
+ */
+
+package health
+
+import (
+	"encoding/json"
+	"encoding/xml"
+	"strings"
+)
+
+func createMessage(message string, code int, format string) ([]byte, error) {
+
+	var output []byte
+	err := error(nil)
+	docRoot := &errorMessage{}
+
+	docRoot.Message = message
+	docRoot.Code = code
+	if strings.EqualFold(format, "application/json") {
+		output, err = json.MarshalIndent(docRoot, " ", "  ")
+	} else {
+		output, err = xml.MarshalIndent(docRoot, " ", "  ")
+	}
+	return output, err
+}

--- a/routing/routes.go
+++ b/routing/routes.go
@@ -47,6 +47,8 @@ import (
 	"github.com/ARGOeu/argo-web-api/app/topology"
 	"github.com/ARGOeu/argo-web-api/app/trends"
 	"github.com/ARGOeu/argo-web-api/app/weights"
+	"github.com/ARGOeu/argo-web-api/consistency"
+	"github.com/ARGOeu/argo-web-api/health"
 	"github.com/ARGOeu/argo-web-api/v3/ar"
 	"github.com/ARGOeu/argo-web-api/v3/status"
 	"github.com/ARGOeu/argo-web-api/version"
@@ -56,6 +58,8 @@ import (
 var routesV3 = []RouteV3{
 	{"AR", "/results", ar.HandleSubrouter},
 	{"Status", "/status", status.HandleSubrouter},
+	{"Consistency", "", consistency.HandleSubrouter},
+	{"Health", "", health.HandleSubrouter},
 }
 
 var routesV2 = []RouteV2{
@@ -84,6 +88,8 @@ var routesV2 = []RouteV2{
 	{"Metrics_Admin", "/admin", metrics.HandleAdminSubrouter},
 	{"Factors", "", factors.HandleSubrouter},
 	{"Version", "", version.HandleSubrouter},
+	{"Consistency", "", consistency.HandleSubrouter},
+	{"Health", "", health.HandleSubrouter},
 	{"Downtimes", "", downtimes.HandleSubrouter},
 	{"Weights", "", weights.HandleSubrouter},
 }

--- a/scripts/consistency/config.yml
+++ b/scripts/consistency/config.yml
@@ -1,0 +1,15 @@
+api: 
+  endpoint: "localhost"
+  access_token: "secret1"
+  verify: false
+  timeout: 10
+
+check_threshold: 50
+
+check_tenants:
+ - name: "TENANTA"
+   access_token: "secret2"
+   reports: ["Default"]
+ - name: "TENANTB"
+   access_token: "secret3"
+   reports: ["CORE"]

--- a/scripts/consistency/consistency-check.py
+++ b/scripts/consistency/consistency-check.py
@@ -1,0 +1,158 @@
+import argparse
+import requests
+import yaml
+from datetime import datetime, timezone
+
+
+def load_config(path):
+    """Load configuration options from a yaml file
+
+    Args:
+        path (string): path to the config.yml file
+
+    Returns:
+        dict: A dictionary with all configuration options
+    """
+    with open(path, "r", encoding="utf-8") as f:
+        return yaml.safe_load(f) or {}
+
+
+def publish_results(status: str, message: str, api: dict):
+    """Publish check results to a remote argo-web-api endpoint
+
+    Args:
+        status (str): status value of the check - OK or CRITICAL
+        message (str): message containing details about the check performed
+        api (dict): a subset of the configuration dictionary containing all the api-related config options
+    """
+    timeout = api.get("timeout", 10)
+    resp = requests.post(
+        f"https://{api['endpoint']}/api/v3/consistency/auto-check",
+        headers={"Accept": "application/json", "x-api-key": api["access_token"]},
+        json={"status": status, "message": message},
+        verify=api.get("verify", True),
+        timeout=timeout,
+    )
+    resp.raise_for_status()
+
+
+def get_num_of_endpoints(report: str, tenant: dict, api: dict) -> int:
+    """Get the number of endpoints for a specific tenant and a specific report from a remote argo-web-api instance
+
+    Args:
+        report (str): name of the report
+        tenant (dict): a subset of the configuration dictionary containing all config options for a specific tenant
+        api (dict): a subset of the configuration dictionary containing all the api-related config options
+
+    Returns:
+        int: number of endpoints found
+    """
+    today = datetime.now(timezone.utc).date().isoformat()
+    headers = {"Accept": "application/json", "x-api-key": tenant["access_token"]}
+    timeout = api.get("timeout", 10)
+    resp = requests.get(
+        f"https://{api['endpoint']}/api/v2/results/{report}/endpoints?start_time={today}T00:00:00Z&end_time={today}T23:59:59Z",
+        headers=headers,
+        verify=api.get("verify", True),
+        timeout=timeout,
+    )
+    resp.raise_for_status()
+    return len(resp.json()["results"])
+
+
+def get_num_of_flapping_endpoints(report: str, tenant: dict, api: dict) -> int:
+    """Get the number of flapping endpoints for a specific tenant and a specific report from a remote argo-web-api instance
+
+    Args:
+        report (str): name of the report
+        tenant (dict): a subset of the configuration dictionary containing all config options for a specific tenant
+        api (dict): a subset of the configuration dictionary containing all the api-related config options
+
+    Returns:
+        int: number of flapping endpoints found
+    """
+    today = datetime.now(timezone.utc).date().isoformat()
+    headers = {"Accept": "application/json", "x-api-key": tenant["access_token"]}
+    timeout = api.get("timeout", 10)
+    resp = requests.get(
+        f"https://{api['endpoint']}/api/v2/trends/{report}/flapping/endpoints?date={today}",
+        headers=headers,
+        verify=api.get("verify", True),
+        timeout=timeout,
+    )
+    resp.raise_for_status()
+    return len(resp.json()["data"])
+
+
+def check_tenant(threshold: int, tenant: dict, api: dict) -> tuple[bool, str]:
+    """Check data for a specific tenant in an argo-web-api instance and compare flapping endpoints found against a specific threshold
+
+    Args:
+        threshold (int): threshold percentage to compare against
+        tenant (dict): a subset of the configuration dictionary containing all config options for a specific tenant
+        api (dict): a subset of the configuration dictionary containing all the api-related config options
+
+    Returns:
+        tuple[bool, str]: a tuple with a boolean that designates if check is ok and a message string containing details
+    """
+    ok = True
+    messages = []
+    for report in tenant["reports"]:
+        endpoint_num = get_num_of_endpoints(report, tenant, api)
+        flapping_num = get_num_of_flapping_endpoints(report, tenant, api)
+        if flapping_num == 0:
+            messages.append(f"{tenant['name']}-{report}: No flapping endpoints.\n")
+        elif endpoint_num > 0:
+            # find flapping percentage
+            perc = flapping_num * 100 / endpoint_num
+            comp = "<="
+            if perc > threshold:
+                comp = ">"
+                ok = False
+            messages.append(
+                f"{tenant['name']}-{report}: Flapping percent {int(perc)}% {comp} 50% ({flapping_num} of {endpoint_num})."
+            )
+    return (ok, "\n".join(messages))
+
+
+def check_instance(config: dict) -> tuple[bool, str]:
+    """Check a remote instance of argo-web-api for consistency
+
+    Args:
+        config (dict): the configuration dictionary
+
+    Returns:
+        tuple[bool, str]: a tuple with a boolean that designates if check is ok and a message string containing details
+    """
+    ok = True
+    messages = []
+    # for each tenant
+    for tenant_config in config["check_tenants"]:
+        tenant_ok, tenant_message = check_tenant(
+            config["check_threshold"], tenant_config, config["api"]
+        )
+        ok = ok and tenant_ok
+        messages.append(tenant_message)
+    return ok, "".join(messages)
+
+
+def main(args):
+
+    config = load_config(args.config)
+    # Use configuration to check designated instance - return if everything is ok (boolean) and message
+    ok, message = check_instance(config)
+
+    status = "OK" if ok else "CRITICAL"
+
+    publish_results(status, message, config["api"])
+
+    return 0
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-c", "--config", required=True, help="path to .yml configuration file"
+    )
+    args = parser.parse_args()
+    exit(main(args))

--- a/scripts/consistency/requirements.txt
+++ b/scripts/consistency/requirements.txt
@@ -1,0 +1,2 @@
+requests
+pyyaml

--- a/scripts/mongodb/populate_default_roles.js
+++ b/scripts/mongodb/populate_default_roles.js
@@ -298,6 +298,22 @@ function populate_default_roles() {
         {
             resource: "v3.status.list-by-id",
             roles: ["admin", "editor", "viewer", "admin_ui"]
+        },
+        {
+            resource: "consistency.result",
+            roles: ["editor", "consitency-viewer"]
+        },
+        {
+            resource: "consistency.ack",
+            roles: ["consistency-ack"]
+        },
+        {
+            resource: "constistency.auto-check",
+            roles: ["consistency-check"]
+        },
+        {
+            resource: "health",
+            roles: ["editor", "viewer"]
         }
     ]);
     print("INFO\tPolulated default roles in 'roles' collection");

--- a/website/docs/consistency.md
+++ b/website/docs/consistency.md
@@ -1,0 +1,170 @@
+---
+id: consistency
+title: API Data Consistency Check
+---
+
+Argo Monitoring uses automated checks that run at specific intervals and analyse the consistency of the monitorig data. If for example most of the monitored items appear to be problematic (flapping through states or appear as CRITICAL) that might indicate a network issue affecting Argo Monitoring. The automated checking mechanism will update the argo-web-api with the status of it's findings.There is also a manual mechanism where an argo-monitoring administrator can check the automated consistency warning and respond with an acknowledgement: either by maintaining the problematic state and confirming that there is an issue with the monitoring platform or - in the case that most of the monitoring items are truly experiecing issues idepedent from the state of the monitoring platform - revert the consistency warning and inform the users accordingly.
+
+
+
+## GET Consistency information
+
+__note: consistency information is both accessible from `/api/v2` and `/api/v3` paths. In the examples we are going to maintin the `/api/v3`__
+
+A user can get consistency information by issuing the following call:
+
+```
+GET /api/v3/consistency
+```
+
+### Request headers
+
+```
+Accept: application/json
+```
+
+### Response
+Headers: `Status: 200 OK`
+
+### Response Body
+
+Json Response example:
+```json
+{
+  "status": "OK",
+  "timestamp": "2025-07-10T12:30:00Z",
+  "message": "Flapping items percentage 2% (2/100)"
+}
+```
+
+## GET Consistency information with verbosity
+
+A user can get consistency information with more details (verbose) by using the url parameter `?verbose` in the previous call:
+
+```
+GET /api/v3/consistency?verbose
+```
+
+### Request headers
+
+```
+Accept: application/json
+```
+
+### Response
+Headers: `Status: 200 OK`
+
+### Response Body
+
+User can be informed with details about the automated check (when did it run recently, it's status and it's message)
+
+Json Response example:
+```json
+{
+  "status": "CRITICAL",
+  "timestamp": "2025-07-10T05:44:00Z",
+  "message": "Flapping items percentage 65% (65/100)",
+  "auto_check_status": "CRITICAL",
+  "auto_check_message": "Flapping items percentage 65% (65/100)",
+  "auto_check_timestamp": "2025-07-10T02:30:00Z",
+}
+```
+
+If there is an admin acknowledgement the user can be informed about it also (in verbose mode)
+
+Json Response example:
+```json
+{
+  "status": "OK",
+  "timestamp": "2025-07-10T12:44:00Z",
+  "message": "Monitoring is ok - most items are flapping due to issues of their own",
+  "auto_check_status": "CRITICAL",
+  "auto_check_message": "Flapping items percentage 65% (65/100)",
+  "auto_check_timestamp": "2025-07-10T12:30:00Z",
+  "ack_check_status": "OK",
+  "ack_check_message": "Monitoring is ok - most items are flapping due to issues of their own",
+  "ack_check_timestamp": "2025-07-10T06:30:00Z",
+  "ack_timeout_hours":6
+}
+```
+
+So with verbose mode the user can have fully awareness of the consistency status and how it is affected both by the automated check and from the admin acknowledgements. 
+
+## POST Consistency results as automated check
+
+An automated consistency check can post results by having the correct token (with the correct role of `consistency-check`) and by issuing the following request:
+
+```
+POST /api/v3/consistency/auto-check
+```
+
+### Request headers
+
+```
+Accept: application/json
+```
+
+### Post body
+```json
+{
+    "status": "OK",
+    "message": "All items are ok"
+}
+
+```
+
+### Response
+
+The automated check needs only to specify a state (`OK`, `CRITICAL`) and an accompanying message. If the request is succesfull the web-api will respond:
+
+Json Response:
+```json
+{
+  "message": "The Auto Check event was posted succesfully",
+  "code": 200
+}
+```
+
+## POST Acknlowledgement of consistency issue
+
+An user with the correct role (`consistency-ack`) can acknowledge consistency issues raised by the automated mechanism and respond accordingly by issuing the following request:
+
+```
+POST /api/v3/consistency/ack
+```
+
+### Request headers
+
+```
+Accept: application/json
+```
+
+### Post body
+```json
+{
+    "status": "OK",
+    "message": "False alarm! Monitoring platform is ok"
+}
+```
+
+Optionally the user can specify an ack timeout in hours (default: `6`) as such:
+
+```json
+{
+    "status": "OK",
+    "message": "False alarm! Monitoring platform is ok",
+    "timeout_hours": 2
+}
+```
+
+### Response
+
+If the request is succesfull the web-api will respond:
+
+Json Response:
+```json
+{
+  "message": "The Ack event was posted succesfully",
+  "code": 200
+}
+```

--- a/website/docs/health.md
+++ b/website/docs/health.md
@@ -1,0 +1,38 @@
+---
+id: health
+title: API Health Information
+---
+
+The users can receive information about the health of the argo-web-api service
+
+
+
+## GET Health information
+
+__note: Health information is both accessible from `/api/v2` and `/api/v3` paths. In the examples we are going to maintin the `/api/v3`__
+
+A user can get health information about the argo-web-api instance by issuing the following call:
+
+```
+GET /api/v3/health
+```
+
+### Request headers
+
+```
+Accept: application/json
+```
+
+### Response
+Headers: `Status: 200 OK`
+
+### Response Body
+
+Json Response example:
+```json
+{
+  "status": "OK",
+  "timestamp": "2025-07-10T12:30:00Z",
+  "message": "No flapping items"
+}
+```

--- a/website/static/openapi/argo-web-api.yml
+++ b/website/static/openapi/argo-web-api.yml
@@ -9557,6 +9557,140 @@ paths:
             application/xml:
               schema:
                 $ref: '#/components/schemas/Version'
+                
+  /v3/health:
+    get:
+      tags:
+      - Health
+      summary: Get health info
+      description: Get health info regarding this api instance
+      parameters:
+      - name: x-api-key
+        in: header
+        description: the x-api-key
+        required: true
+        schema:
+          type: string
+          default: SecretKey123
+      responses:
+        200:
+          description: Successful retrieval of health result
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Health'
+  /v3/consistency:
+    get:
+      tags:
+      - Consistency
+      summary: Get data consistency status information
+      description: Check if argo-monitoring platform data are consistent
+      parameters:
+      - name: x-api-key
+        in: header
+        description: the x-api-key
+        required: true
+        schema:
+          type: string
+          default: SecretKey123
+      - name: verbose
+        in: query
+        description: get verbose results regarding consistency
+        required: true
+        schema:
+          type: boolean
+          default: false
+      responses:
+        200:
+          description: Successful retrieval consistency results
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Consistency'
+                
+  /v3/consistency/auto-check:
+    post:
+      tags:
+      - Consistency
+      summary: Post auto check results into argo-web-api
+      description: Post consistency status results and message to argo-web-api
+      parameters:
+      - name: x-api-key
+        in: header
+        description: the x-api-key
+        required: true
+        schema:
+          type: string
+          default: SecretKey123
+      requestBody:
+        description: Json description of the recomputation to be created
+        content:
+          'application/json':
+            schema:
+              type: object
+              properties:
+                status:
+                  type: string
+                message:
+                  type: string
+              
+        required: true
+      responses:
+        200:
+          description: Post consistency status results
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                  code:
+                    type: number
+                    
+  /v3/consistency/ack:
+    post:
+      tags:
+      - Consistency
+      summary: Post ack event into argo-web-api
+      description: Post acknowledgement that either confirms the monitoring issue or overrides it with another status
+      parameters:
+      - name: x-api-key
+        in: header
+        description: the x-api-key
+        required: true
+        schema:
+          type: string
+          default: SecretKey123
+      requestBody:
+        description: Json description of the recomputation to be created
+        content:
+          'application/json':
+            schema:
+              type: object
+              properties:
+                status:
+                  type: string
+                message:
+                  type: string
+                timeout_hours:
+                  type: number
+                  default: 6
+              
+        required: true
+      responses:
+        200:
+          description: Post consistency status results
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                  code:
+                    type: number
+            
   /v3/results/{report_name}:
     get:
       tags:
@@ -11721,6 +11855,39 @@ components:
           type: string
         architecture:
           type: string
+    Consistency:
+      type: object
+      properties:
+        status:
+          type: string
+        message:
+          type: string
+        timestamp:
+          type: string
+        auto_check_status:
+          type: string
+        auto_check_message:
+          type: string
+        auto_check_timestamp:
+          type: string
+        ack_status:
+          type: string
+        ack_message:
+          type: string
+        ack_timestamp:
+          type: string
+        ack_timeout_hours:
+          type: number
+    Health:
+      type: object
+      properties:
+        status:
+          type: string
+        message:
+          type: string
+        timestamp:
+          type: string
+  
   responses:
     404:
       description: Item not found


### PR DESCRIPTION
### Goal
Give to the end user a health endpoint to get informed about the health status of argo web api 
```
GET /api/v2/health 
````
```json
{
 "status" : "OK",
 "timestamp": "2025-05-10T00:05:00Z",
 "message": "No flapping endpoints"
}
```

### Consistency Check for admin users

Give the ability to have a consistency check endpoint to get quickly information about the status of the consistency of data in argo-web-api. The response is something like this:

```
GET /api/v2/consistency
```

```json
{
 "status" : "OK",
 "timestamp": "2025-05-10T00:05:00Z",
 "message": "Flapping items under 50% (3 in 100)"
}
```

An automated check running at intervals (outside the api) check the api and various tenants/reports for issues in trends and posts the consistency results using the following endpoint

```
POST /api/v2/consistency/auto-check
```

```json
{
 "status" : "CRITICAL",
 "message": "Flapping items over 50% (65 in 100)"
}
```

We can get the verbose version of the consistency results by issuing:
```
GET /api/v2/consistency?verbose
```
```json
{
 "status" : "CRITICAL",
 "timestamp": "2025-05-10T00:08:00Z",
 "message": "Flapping items over 50% (65 in 100)"
 "auto_check_status": "CRITICAL",
 "auto_check_message": "Flapping items over 50% (65 in 100)"
 "auto_check_timestamp": "2025-05-10T00:07:00Z"
}
```

A user with the appropriate role can also ack consistency issues by issuing: 
```
POST /api/v2/consistency/ack
```
```json
{
 "status" : "OK",
 "message": "Indeed most items are flapping but this is not due to monitoring."
 "timeout_hours": 2
}
```

And then we can view the new consistency result overridden by the ack action :
```
GET /api/v2/consistency?verbose
```
```json
{
 "status" : "OK",
 "timestamp": "2025-05-10T00:13:00Z",
 "message": "Indeed most items are flapping but this is not due to monitoring."
 "auto_check_status": "CRITICAL",
 "auto_check_message": "Flapping items over 50% (65 in 100)"
 "auto_check_timestamp": "2025-05-10T00:07:00Z",
 "ack_status" : "OK",
 "ack_message": "Indeed most items are flapping but this is not due to monitoring.",
 "ack_timestamp": "2025-05-10T00:12:00Z"
 "ack_timeout_hours": 2
}
```
 
 ### Implementations
- [x] Implement Health package, handlers, views and routing
- [x] Add Consistency package 
- [x] Implement Consistency models
- [x] Implement Consistency handlers
- [x] Add routing
- [x] Add unit tests
- [x] Update swagger
- [x] Add docs
- [x] Add `./scripts/consistency/consistency-check.py` script that is configurable (through `config.yml`)