### PR TITLE
ARGO-5323 Allow component admins to refresh access keys for their int…

### DIFF
--- a/app/tenants/controller.go
+++ b/app/tenants/controller.go
@@ -206,7 +206,7 @@ func Create(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 		}
 	}
 
-	if errMsg, errCode := validateTenantUsers(incoming, tenantCol); errMsg != "" && errCode != 0 {
+	if errMsg, errCode := ValidateTenantUsers(incoming, tenantCol); errMsg != "" && errCode != 0 {
 		output, _ = respond.MarshalContent(respond.ErrConflict(errMsg), contentType, "", " ")
 		code = errCode
 		return code, h, output, err
@@ -529,7 +529,7 @@ func Update(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 		return code, h, output, err
 	}
 
-	if errMsg, errCode := validateTenantUsers(incoming, tenantCol); errMsg != "" && errCode != 0 {
+	if errMsg, errCode := ValidateTenantUsers(incoming, tenantCol); errMsg != "" && errCode != 0 {
 		output, _ = respond.MarshalContent(respond.ErrConflict(errMsg), contentType, "", " ")
 		code = errCode
 		return code, h, output, err
@@ -656,7 +656,7 @@ func UpdateInfo(r *http.Request, cfg config.Config) (int, http.Header, []byte, e
 		return code, h, output, err
 	}
 
-	if errMsg, errCode := validateTenantUsers(incoming, tenantCol); errMsg != "" && errCode != 0 {
+	if errMsg, errCode := ValidateTenantUsers(incoming, tenantCol); errMsg != "" && errCode != 0 {
 		output, _ = respond.MarshalContent(respond.ErrConflict(errMsg), contentType, "", " ")
 		code = errCode
 		return code, h, output, err
@@ -768,7 +768,7 @@ func UpdateDbConf(r *http.Request, cfg config.Config) (int, http.Header, []byte,
 		return code, h, output, err
 	}
 
-	if errMsg, errCode := validateTenantUsers(incoming, tenantCol); errMsg != "" && errCode != 0 {
+	if errMsg, errCode := ValidateTenantUsers(incoming, tenantCol); errMsg != "" && errCode != 0 {
 		output, _ = respond.MarshalContent(respond.ErrConflict(errMsg), contentType, "", " ")
 		code = errCode
 		return code, h, output, err
@@ -881,7 +881,7 @@ func UpdateTopology(r *http.Request, cfg config.Config) (int, http.Header, []byt
 		return code, h, output, err
 	}
 
-	if errMsg, errCode := validateTenantUsers(incoming, tenantCol); errMsg != "" && errCode != 0 {
+	if errMsg, errCode := ValidateTenantUsers(incoming, tenantCol); errMsg != "" && errCode != 0 {
 		output, _ = respond.MarshalContent(respond.ErrConflict(errMsg), contentType, "", " ")
 		code = errCode
 		return code, h, output, err
@@ -1040,7 +1040,7 @@ func GetUserByID(r *http.Request, cfg config.Config) (int, http.Header, []byte, 
 }
 
 // validateTenantUsers validates the uniqueness of the tenant's users' keys
-func validateTenantUsers(tenant Tenant, tenantCol *mongo.Collection) (string, int) {
+func ValidateTenantUsers(tenant Tenant, tenantCol *mongo.Collection) (string, int) {
 
 	usersKeys := make(map[string]bool)
 	errMsg := ""
@@ -1167,7 +1167,7 @@ func CreateUser(r *http.Request, cfg config.Config) (int, http.Header, []byte, e
 
 	tenant.Users = append(tenant.Users, incoming)
 
-	if errMsg, errCode := validateTenantUsers(tenant, tenantCol); errMsg != "" && errCode != 0 {
+	if errMsg, errCode := ValidateTenantUsers(tenant, tenantCol); errMsg != "" && errCode != 0 {
 		output, _ = respond.MarshalContent(respond.ErrConflict(errMsg), contentType, "", " ")
 		code = errCode
 		return code, h, output, err
@@ -1286,7 +1286,7 @@ func UpdateUser(r *http.Request, cfg config.Config) (int, http.Header, []byte, e
 		return code, h, output, err
 	}
 
-	if errMsg, errCode := validateTenantUsers(tenant, tenantCol); errMsg != "" && errCode != 0 {
+	if errMsg, errCode := ValidateTenantUsers(tenant, tenantCol); errMsg != "" && errCode != 0 {
 		output, _ = respond.MarshalContent(respond.ErrConflict(errMsg), contentType, "", " ")
 		code = errCode
 		return code, h, output, err
@@ -1372,7 +1372,7 @@ func DeleteUser(r *http.Request, cfg config.Config) (int, http.Header, []byte, e
 		return code, h, output, err
 	}
 
-	if errMsg, errCode := validateTenantUsers(tenant, tenantCol); errMsg != "" && errCode != 0 {
+	if errMsg, errCode := ValidateTenantUsers(tenant, tenantCol); errMsg != "" && errCode != 0 {
 		output, _ = respond.MarshalContent(respond.ErrConflict(errMsg), contentType, "", " ")
 		code = errCode
 		return code, h, output, err
@@ -1580,7 +1580,7 @@ func RefreshToken(r *http.Request, cfg config.Config) (int, http.Header, []byte,
 		return code, h, output, err
 	}
 
-	if errMsg, errCode := validateTenantUsers(tenant, tenantCol); errMsg != "" && errCode != 0 {
+	if errMsg, errCode := ValidateTenantUsers(tenant, tenantCol); errMsg != "" && errCode != 0 {
 		output, _ = respond.MarshalContent(respond.ErrConflict(errMsg), contentType, "", " ")
 		code = errCode
 		return code, h, output, err
@@ -1604,7 +1604,7 @@ func RefreshToken(r *http.Request, cfg config.Config) (int, http.Header, []byte,
 	}
 
 	// Create view for response message
-	output, err = createRenewedToken(token, "User api key succesfully renewed", 200) //Render the results into JSON
+	output, err = CreateRenewedToken(token, "User api key succesfully renewed", 200) //Render the results into JSON
 
 	code = http.StatusOK
 	return code, h, output, err

--- a/app/tenants/model.go
+++ b/app/tenants/model.go
@@ -110,11 +110,12 @@ type TenantDbConf struct {
 // TenantUser structure holds information about tenant's
 // user
 type TenantUser struct {
-	ID     string   `bson:"id" json:"id"`
-	Name   string   `bson:"name"       json:"name"`
-	Email  string   `bson:"email"      json:"email"`
-	APIkey string   `bson:"api_key"    json:"api_key"`
-	Roles  []string `bson:"roles,omitempty"      json:"roles,omitempty"`
+	ID        string   `bson:"id" json:"id"`
+	Name      string   `bson:"name"       json:"name"`
+	Email     string   `bson:"email"      json:"email"`
+	APIkey    string   `bson:"api_key"    json:"api_key"`
+	Roles     []string `bson:"roles,omitempty"      json:"roles,omitempty"`
+	Component string   `bson:"component,omitempty" json:"component,omitempty"`
 }
 
 // SelfReference to hold links and id

--- a/app/tenants/view.go
+++ b/app/tenants/view.go
@@ -155,7 +155,7 @@ func createMsgView(msg string, code int) ([]byte, error) {
 }
 
 // CreateRenewedToken constructs a message resposne with the renewed token
-func createRenewedToken(apiKey string, msg string, code int) ([]byte, error) {
+func CreateRenewedToken(apiKey string, msg string, code int) ([]byte, error) {
 	docRoot := &respond.ResponseMessage{
 		Status: respond.StatusResponse{
 			Message: msg,

--- a/default.conf
+++ b/default.conf
@@ -5,8 +5,8 @@ maxprocs = 4
 cache = false
 lrucache = 700000000
 gzip = true
-cert = /etc/pki/tls/certs/localhost.crt
-privkey = /etc/pki/tls/private/localhost.key
+cert = /etc/certs/localhost.crt
+privkey = /etc/certs/localhost.key
 reqsizelimit = 1073741824
 enablecors = false
 

--- a/respond/respond.go
+++ b/respond/respond.go
@@ -282,6 +282,18 @@ type SelfLinks struct {
 	Self string `xml:"self" json:"self"`
 }
 
+func QuickResponse(msg string, code int) ([]byte, error) {
+	docRoot := &ResponseMessage{
+		Status: StatusResponse{
+			Message: msg,
+			Code:    strconv.Itoa(code),
+		},
+	}
+
+	output, err := json.MarshalIndent(docRoot, "", " ")
+	return output, err
+}
+
 // CreateResponseMessage creates an output using the parameters given and the correct marshaller
 // according to the contetnType
 func CreateResponseMessage(message string, code string, contentType string) ([]byte, error) {

--- a/respond/wrappers.go
+++ b/respond/wrappers.go
@@ -20,6 +20,10 @@ import (
 // 	return handler
 // }
 
+func isComponentRoute(routeName string) bool {
+	return strings.HasPrefix(routeName, "v3.components")
+}
+
 func needsAPIAdmin(routeName string) bool {
 
 	routePart := strings.Split(routeName, ".")[0]
@@ -35,10 +39,23 @@ func WrapAuthenticate(hfn http.Handler, cfg config.Config, routeName string) htt
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 
 		var errs []ErrorResponse
+		// check if component route
 
-		// check if api admin authentication is needed (for tenants etc...)
-		if needsAPIAdmin(routeName) {
+		if isComponentRoute(routeName) {
 
+			compRole := authentication.GetComponentRole(r.Header, cfg)
+			// check if user has a component role
+			if compRole != "" {
+				gcontext.Set(r, "roles", []string{compRole})
+			} else {
+				// Because user has no component role
+				Error(w, r, ErrAuthen, cfg, errs)
+				return
+			}
+			hfn.ServeHTTP(w, r)
+
+		} else if needsAPIAdmin(routeName) {
+			// check if api admin authentication is needed (for tenants etc...)
 			if !(authentication.AuthenticateAdmin(r.Header, cfg)) {
 				// Because not authenticated respond with error
 				Error(w, r, ErrAuthen, cfg, errs)
@@ -48,8 +65,6 @@ func WrapAuthenticate(hfn http.Handler, cfg config.Config, routeName string) htt
 			// admin api authenticated so continue serving
 			gcontext.Set(r, "authen", true)
 			// Add admin restricted or not information -- used in get tenants
-
-			// Check if admin is restricted
 			if authentication.IsAdminRestricted(r.Header, cfg) {
 				gcontext.Set(r, "roles", []string{"super_admin_restricted"})
 			} else if authentication.IsSuperAdminUI(r.Header, cfg) {

--- a/routing/routes.go
+++ b/routing/routes.go
@@ -50,12 +50,14 @@ import (
 	"github.com/ARGOeu/argo-web-api/consistency"
 	"github.com/ARGOeu/argo-web-api/health"
 	"github.com/ARGOeu/argo-web-api/v3/ar"
+	"github.com/ARGOeu/argo-web-api/v3/integrations"
 	"github.com/ARGOeu/argo-web-api/v3/status"
 	"github.com/ARGOeu/argo-web-api/version"
 )
 
 // Here we declare the v3 routes
 var routesV3 = []RouteV3{
+	{"Integrations", "/integrations", integrations.HandleSubrouter},
 	{"AR", "/results", ar.HandleSubrouter},
 	{"Status", "/status", status.HandleSubrouter},
 	{"Consistency", "", consistency.HandleSubrouter},

--- a/utils/authentication/authenticate.go
+++ b/utils/authentication/authenticate.go
@@ -41,6 +41,7 @@ type Auth struct {
 	ApiKey       string `bson:"api_key"`
 	Restricted   bool   `bson:"restricted"`
 	SuperAdminUI bool   `bson:"super_admin_ui"`
+	Component    string `bson:"component"`
 }
 
 type Tenant struct {
@@ -131,6 +132,11 @@ func IsAdminRestricted(h http.Header, cfg config.Config) bool {
 func IsSuperAdminUI(h http.Header, cfg config.Config) bool {
 	auth := queryAdminRoles(h, cfg)
 	return auth.SuperAdminUI
+}
+
+// GetComponentRole returns a component role if exists
+func GetComponentRole(h http.Header, cfg config.Config) string {
+	return queryAdminRoles(h, cfg).Component
 }
 
 // AuthenticateTenant is used to find which tenant the user making the requests

--- a/v3/integrations/handlers.go
+++ b/v3/integrations/handlers.go
@@ -1,0 +1,135 @@
+package integrations
+
+import (
+	"context"
+	"crypto/rand"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/ARGOeu/argo-web-api/app/tenants"
+	"github.com/ARGOeu/argo-web-api/respond"
+	"github.com/ARGOeu/argo-web-api/utils/config"
+	gcontext "github.com/gorilla/context"
+	"github.com/gorilla/mux"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+var ROLE_DICT = map[string]string{
+	"engine":      "component_engine",
+	"monbox":      "component_monbox",
+	"probe":       "component_monbox",
+	"poem-admin":  "component_poem",
+	"poem-viewer": "component_poem",
+}
+
+func ComponentRefreshKey(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
+	//STANDARD DECLARATIONS START
+	code := http.StatusOK
+	h := http.Header{}
+	output := []byte("")
+	err := error(nil)
+	charset := "utf-8"
+	//STANDARD DECLARATIONS END
+
+	// Set Content-Type response Header value
+	contentType := r.Header.Get("Accept")
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+
+	vars := mux.Vars(r)
+	roles := gcontext.Get(r, "roles").([]string)
+
+	// check if the user has the role for the component
+	compRole, exists := ROLE_DICT[vars["COMPONENT"]]
+	if !exists || !hasRole(roles, compRole) {
+		output, _ = respond.MarshalContent(respond.Forbidden, contentType, "", " ")
+		code = http.StatusNotFound
+		return code, h, output, err
+	}
+
+	// Create structure to hold query results
+	result := tenants.Tenant{}
+
+	// Try to get mongo client and target tenant collection
+	tenantCol := cfg.MongoClient.Database(cfg.MongoDB.Db).Collection("tenants")
+
+	// Create a simple query object to query tenant by name
+	query := bson.M{"info.name": vars["TENANT"]}
+
+	// Query collection tenants for the specific tenant name
+	err = tenantCol.FindOne(context.TODO(), query).Decode(&result)
+
+	if err != nil {
+		if err == mongo.ErrNoDocuments {
+			output, _ = respond.QuickResponse(fmt.Sprintf("tenant %s not found", vars["TENANT"]), 404)
+			code = http.StatusNotFound
+			return code, h, output, err
+		}
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	tenant := result
+
+	token, err := genAccessKey(32)
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	found := false
+	for indx, user := range tenant.Users {
+		if user.Component != "" && user.Component == vars["COMPONENT"] {
+			found = true
+			tenant.Users[indx].APIkey = token
+		}
+	}
+
+	if !found {
+		output, _ = respond.QuickResponse(fmt.Sprintf("Component %s not configured for tenant %s", vars["COMPONENT"], vars["TENANT"]), 404)
+		code = http.StatusNotFound
+		return code, h, output, err
+	}
+
+	if errMsg, errCode := tenants.ValidateTenantUsers(tenant, tenantCol); errMsg != "" && errCode != 0 {
+		output, _ = respond.MarshalContent(respond.ErrConflict(errMsg), contentType, "", " ")
+		code = errCode
+		return code, h, output, err
+	}
+
+	// run the update query
+
+	tenant.Info.Updated = time.Now().Format("2006-01-02 15:04:05")
+	query = bson.M{"info.name": vars["TENANT"]}
+	replaceResult, err := tenantCol.ReplaceOne(context.TODO(), query, tenant)
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	if replaceResult.MatchedCount == 0 {
+		output, _ = respond.QuickResponse(fmt.Sprintf("Component %s not configured for tenant %s", vars["COMPONENT"], vars["TENANT"]), 400)
+		code = http.StatusNotFound
+		return code, h, output, err
+	}
+
+	// Create view for response message
+	output, err = tenants.CreateRenewedToken(token, "component api key succesfully renewed", 200) //Render the results into JSON
+
+	code = http.StatusOK
+	return code, h, output, err
+}
+
+func hasRole(roles []string, checkRole string) bool {
+	return len(roles) > 0 && roles[0] == checkRole
+}
+
+func genAccessKey(length int) (string, error) {
+	b := make([]byte, length)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%x", b), nil
+}

--- a/v3/integrations/routing.go
+++ b/v3/integrations/routing.go
@@ -1,0 +1,21 @@
+package integrations
+
+import (
+	"github.com/ARGOeu/argo-web-api/respond"
+	"github.com/gorilla/mux"
+)
+
+// HandleSubrouter uses the subrouter for a specific calls and creates a tree of sorts
+// handling each route with a different subrouter
+func HandleSubrouter(s *mux.Router, confhandler *respond.ConfHandler) {
+	respond.PrepAppRoutes(s, confhandler, intRoutes)
+}
+
+var intRoutes = []respond.AppRoutes{
+	{
+		Name:             "v3.components.access_refresh",
+		Verb:             "POST",
+		Path:             "/components/{COMPONENT}/by-tenant-name/{TENANT}/refresh",
+		SubrouterHandler: ComponentRefreshKey,
+	},
+}

--- a/website/docs/integrations.md
+++ b/website/docs/integrations.md
@@ -1,0 +1,88 @@
+---
+id: integrations
+title: Integrations - Components
+---
+
+Calls for  components that integrate with argo-web-api and access tenant data.
+
+
+
+## Refresh Access Token for a Component Integration
+
+Component administrators can request to refresh access keys for their assigned components within a specific tenant.
+
+```
+POST /api/v3/integrations/components/{COMPONENT}/by-tenant-name/{TENANT}/refresh
+```
+
+Where {COMPONENT} the name of the component account supported (one of the following):
+- engine
+- poem-admin
+- poem-viewer
+- monbox
+- probe
+
+Where {TENANT} the name of the tenant
+
+### Request headers
+
+```
+Accept: application/json
+x-api-key: component-admin-s3cr3t
+```
+
+### Response
+Headers: `Status: 200 OK`
+
+### Response Body
+
+Json Response example:
+```json
+{
+    "status": {
+        "message": "component api key succesfully renewed",
+        "code": "200"
+    },
+    "data": {
+        "api_key": "..."
+    }
+}
+```
+
+## Errors
+
+Component administrators have access only to their assigned component type. For example, a `component_poem` admin can only access `poem` components.
+
+Attempting to access an unauthorized component type returns:
+
+```json
+{
+    "status": {
+        "message": "Access to the resource is Forbidden",
+        "code": "403"
+    }
+}
+```
+
+If a component access account has not yet been set up for a specific tenant, then the response will be:
+
+```json
+{
+    "status": {
+        "message": "Component poem-viewer not configured for tenant FOO",
+        "code": "404"
+    }
+}
+
+```
+
+### Types of components
+
+Types of component accounts supported:
+
+- engine
+- poem-admin
+- poem-viewer
+- monbox
+- probe
+

--- a/website/docs/tenants_and_feeds/tenants.md
+++ b/website/docs/tenants_and_feeds/tenants.md
@@ -951,6 +951,20 @@ Json Response
 }
 ```
 
+__Note__: If a user account is meant for a specific component integration then an optional field `"component"` can be specified when creating the user account such as in the following example:
+
+```json
+{
+    "name":"poem_viwer_account",
+    "email":"ops@email.foo",
+    "roles": [
+        "viewer"
+    ],
+    "component": "poem-viewer"
+ }`
+
+```
+
 
 ## [PUT]: Update user {#9}
 
@@ -997,6 +1011,21 @@ Json Response
  }
 }
 ```
+
+__Note__: If a user account is meant for a specific component integration then an optional field `"component"` can be specified when updating the user account such as in the following example:
+
+```json
+{
+    "name":"poem_viwer_account",
+    "email":"ops@email.foo",
+    "roles": [
+        "viewer"
+    ],
+    "component": "poem-viewer"
+ }`
+
+```
+
 
 
 ## [POST]: Renew User API key {#10}

--- a/website/static/openapi/argo-web-api.yml
+++ b/website/static/openapi/argo-web-api.yml
@@ -9994,6 +9994,70 @@ paths:
             application/json:
               schema:
                 type: string
+  /v3/integrations/components/{COMPONENT}/by-tenant-name/{TENANT}/refresh:
+    post:
+      tags:
+      - Integrations
+      summary: Renew an account access key for a component that integrates with a specific tenant
+      description: For a specific tenant, renew the access key of a specific integration component
+      operationId: integrations.components.refresh
+      parameters:
+      - name: x-api-key
+        in: header
+        description: the x-api-key
+        required: true
+        schema:
+          type: string
+          default: SecretKey123
+      - name: TENANT
+        in: path
+        description: name of the tenant
+        required: true
+        schema:
+          type: string
+      - name: COMPONENT
+        in: path
+        description: name of the component
+        required: true
+        schema:
+          type: string
+      responses:
+        200:
+          description: User key renewed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RenewedToken'
+        400:
+          description: Bad request due to malformed JSON in post body
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status_error'
+        401:
+          description: Unauthorized user
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status_error'
+        406:
+          description: Content Not acceptable
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status_error'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status_error'
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status_error'
                 
   /v3/results/{report_name}/id/{resource_id}:
     get:


### PR DESCRIPTION
…egrated components

## Goal

Allow component administrators for service like poem, to be able to refresh the access keys for their components that integrate with argo-web-api. 

### Implementation

```
HTTP POST /api/v3/integrations/components/{COMPONENT}/by-tenant-name/{TENANT}/refresh
```
response:
```
{
    "status": {
        "message": "component api key succesfully renewed",
        "code": "200"
    },
    "data": {
        "api_key": "..."
    }
}
```

Types of component accounts supported: 
- engine
- poem-admin
- poem-viewer
- monbox
- probe
