### PR TITLE
ARGO-5347 Allow super admins to access tenant results by selecting te…

### DIFF
--- a/app/reports/controller.go
+++ b/app/reports/controller.go
@@ -173,7 +173,6 @@ func List(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) 
 	//STANDARD DECLARATIONS END
 
 	urlValues := r.URL.Query()
-
 	// Set Content-Type response Header value
 	contentType := r.Header.Get("Accept")
 	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))

--- a/app/reports/reports_test.go
+++ b/app/reports/reports_test.go
@@ -183,7 +183,7 @@ func (suite *ReportTestSuite) SetupTest() {
 
 	authCol := suite.cfg.MongoClient.Database(suite.cfg.MongoDB.Db).Collection("authentication")
 	// Add authentication token to mongo testdb
-	seedAuth := bson.M{"api_key": "S3CR3T"}
+	seedAuth := bson.M{"api_key": "S3CR3T", "name": "defult_admin", "email": "admin@example.foo"}
 	authCol.InsertOne(context.TODO(), seedAuth)
 
 	// seed a tenant to use
@@ -229,27 +229,27 @@ func (suite *ReportTestSuite) SetupTest() {
 	c.InsertOne(context.TODO(),
 		bson.M{
 			"resource": "reports.list",
-			"roles":    []string{"editor", "viewer"},
+			"roles":    []string{"admin", "editor", "viewer"},
 		})
 	c.InsertOne(context.TODO(),
 		bson.M{
 			"resource": "reports.get",
-			"roles":    []string{"editor", "viewer"},
+			"roles":    []string{"admin", "editor", "viewer"},
 		})
 	c.InsertOne(context.TODO(),
 		bson.M{
 			"resource": "reports.create",
-			"roles":    []string{"editor"},
+			"roles":    []string{"admin", "editor"},
 		})
 	c.InsertOne(context.TODO(),
 		bson.M{
 			"resource": "reports.delete",
-			"roles":    []string{"editor"},
+			"roles":    []string{"admin", "editor"},
 		})
 	c.InsertOne(context.TODO(),
 		bson.M{
 			"resource": "reports.update",
-			"roles":    []string{"editor"},
+			"roles":    []string{"admin", "editor"},
 		})
 
 	// get dbconfiguration based on the tenant
@@ -1297,6 +1297,127 @@ func (suite *ReportTestSuite) TestReadOneReport() {
 
 	code := response.Code
 	output := response.Body.String()
+
+	// Check that we must have a 200 ok code
+	suite.Equal(200, code, "Incorrect Error Code")
+
+	// Compare the expected and actual xml response
+	suite.Equal(respondJSON, output, "Response body mismatch")
+
+}
+
+func (suite *ReportTestSuite) TestAdminGetReport() {
+
+	// Create a string literal of the expected xml Response
+	respondJSON := `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "id": "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+   "tenant": "GUARDIANS",
+   "disabled": false,
+   "info": {
+    "name": "Report_A",
+    "description": "report aaaaa",
+    "created": "2015-9-10 13:43:00",
+    "updated": "2015-10-11 13:43:00"
+   },
+   "computations": {
+    "ar": true,
+    "status": true,
+    "trends": [
+     "flapping",
+     "status",
+     "tags"
+    ]
+   },
+   "topology_schema": {
+    "group": {
+     "type": "NGI",
+     "group": {
+      "type": "SITE"
+     }
+    }
+   },
+   "profiles": [
+    {
+     "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50b",
+     "name": "profile1",
+     "type": "metric"
+    },
+    {
+     "id": "6ac7d684-1f8e-4a02-a502-720e8f11e523",
+     "name": "profile2",
+     "type": "operations"
+    },
+    {
+     "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50q",
+     "name": "profile3",
+     "type": "aggregation"
+    }
+   ],
+   "filter_tags": [
+    {
+     "name": "name1",
+     "value": "value1",
+     "context": ""
+    },
+    {
+     "name": "name2",
+     "value": "value2",
+     "context": ""
+    }
+   ]
+  }
+ ]
+}`
+
+	jsonUnAuth := `{
+ "status": {
+  "message": "Unauthorized",
+  "code": "401",
+  "details": "You need to provide a correct authentication token using the header 'x-api-key'"
+ }
+}`
+
+	// Prepare the request object using report name as urlvar in url path
+	request, _ := http.NewRequest("GET", "/api/v2/reports/eba61a9e-22e9-4521-9e47-ecaa4a494364", strings.NewReader(""))
+	// add the content-type header to application/json
+	request.Header.Set("Accept", "application/json")
+	// add the authentication token which is seeded in testdb
+	request.Header.Set("x-api-key", "S3CR3T")
+	response := httptest.NewRecorder()
+
+	// Execute the request in the controller
+	suite.router.ServeHTTP(response, request)
+
+	code := response.Code
+	output := response.Body.String()
+
+	// Check that we must have a 200 ok code
+	suite.Equal(401, code, "Incorrect Error Code")
+
+	// Compare the expected and actual xml response
+	suite.Equal(jsonUnAuth, output, "Response body mismatch")
+
+	// now do the request with admin credentials but by providing x-tenant-id
+	// Prepare the request object using report name as urlvar in url path
+	request, _ = http.NewRequest("GET", "/api/v2/reports/eba61a9e-22e9-4521-9e47-ecaa4a494364", strings.NewReader(""))
+	// add the content-type header to application/json
+	request.Header.Set("Accept", "application/json")
+	// add the authentication token which is seeded in testdb
+	request.Header.Set("x-api-key", "S3CR3T")
+	request.Header.Set("x-tenant-id", "6ac7d684-1f8e-4a02-a502-720e8f11e50c")
+	response = httptest.NewRecorder()
+
+	// Execute the request in the controller
+	suite.router.ServeHTTP(response, request)
+
+	code = response.Code
+	output = response.Body.String()
 
 	// Check that we must have a 200 ok code
 	suite.Equal(200, code, "Incorrect Error Code")

--- a/respond/wrappers.go
+++ b/respond/wrappers.go
@@ -1,6 +1,7 @@
 package respond
 
 import (
+	"log"
 	"net/http"
 	"strings"
 
@@ -41,6 +42,9 @@ func WrapAuthenticate(hfn http.Handler, cfg config.Config, routeName string) htt
 		var errs []ErrorResponse
 		// check if component route
 
+		// check if has x-tenant-id header
+		adminTenantId := r.Header.Get("x-tenant-id")
+
 		if isComponentRoute(routeName) {
 
 			compRole := authentication.GetComponentRole(r.Header, cfg)
@@ -75,6 +79,41 @@ func WrapAuthenticate(hfn http.Handler, cfg config.Config, routeName string) htt
 
 			hfn.ServeHTTP(w, r)
 
+		} else if adminTenantId != "" {
+			// check if it is an admin trying to access a tenant route
+			authen, username, email := authentication.AuthenticateAdminName(r.Header, cfg)
+			if !(authen) {
+				// Because not authenticated respond with error
+				Error(w, r, ErrAuthen, cfg, errs)
+				return
+			}
+
+			tenantConf, tenantName, tErr := authentication.AuthenticateAdminTenant(r.Header, cfg)
+			// If error respond with error
+			if tErr != nil {
+				Error(w, r, ErrAuthen, cfg, errs)
+				return
+			}
+
+			tenantConf.User = username
+			tenantConf.Email = email
+			if authentication.IsAdminRestricted(r.Header, cfg) {
+				gcontext.Set(r, "roles", []string{"super_admin_restricted", "viewer"})
+				tenantConf.Roles = []string{"viewer"}
+			} else if authentication.IsSuperAdminUI(r.Header, cfg) {
+				gcontext.Set(r, "roles", []string{"super_admin_ui", "admin_ui"})
+				tenantConf.Roles = []string{"viewer"}
+			} else {
+				gcontext.Set(r, "roles", []string{"super_admin", "admin"})
+				tenantConf.Roles = []string{"admin"}
+			}
+
+			gcontext.Set(r, "tenant_conf", tenantConf)
+			gcontext.Set(r, "tenant_name", tenantName)
+			gcontext.Set(r, "authen", authen)
+			log.Printf("Admin User: %s Accessing Tenant: %s", username, tenantName)
+			hfn.ServeHTTP(w, r)
+
 		} else {
 
 			// authenticate tenant user
@@ -107,7 +146,6 @@ func WrapAuthorize(hfn http.Handler, cfg config.Config, routeName string) http.H
 		if roles != nil {
 
 			author := authorization.HasResourceRoles(cfg, routeName, roles)
-
 			if author {
 				hfn.ServeHTTP(w, r)
 				return

--- a/utils/authentication/authenticate.go
+++ b/utils/authentication/authenticate.go
@@ -38,6 +38,8 @@ import (
 )
 
 type Auth struct {
+	Name         string `bson:"name"`
+	Email        string `bson:"email"`
 	ApiKey       string `bson:"api_key"`
 	Restricted   bool   `bson:"restricted"`
 	SuperAdminUI bool   `bson:"super_admin_ui"`
@@ -94,6 +96,23 @@ func Authenticate(h http.Header, cfg config.Config) bool {
 		}
 	}
 	return false
+}
+
+func AuthenticateAdminName(h http.Header, cfg config.Config) (bool, string, string) {
+
+	authCol := cfg.MongoClient.Database(cfg.MongoDB.Db).Collection("authentication")
+	apiKey := h.Get("x-api-key")
+	query := bson.M{
+		"api_key": apiKey,
+	}
+	result := Auth{}
+	err := authCol.FindOne(context.TODO(), query).Decode(&result)
+	if err == nil {
+		if result.ApiKey == apiKey {
+			return true, result.Name, result.Email
+		}
+	}
+	return false, "", ""
 }
 
 // AuthenticateAdmin is used to authenticate and administrator of ARGO
@@ -171,6 +190,32 @@ func AuthenticateTenant(h http.Header, cfg config.Config) (config.MongoConfig, s
 
 		log.Printf("ACCESS User: %s", mongoConf.User)
 		log.Printf("ACESSS Tenant: %s", result.Info.Name)
+		return mongoConf, result.Info.Name, nil
+
+	}
+
+	return config.MongoConfig{}, "", errors.New("Unauthorized")
+
+}
+
+// AuthenticateAdminTenant is used to authenticate access to a super admin trying to access
+// a tenant's user route
+func AuthenticateAdminTenant(h http.Header, cfg config.Config) (config.MongoConfig, string, error) {
+
+	tenantsCol := cfg.MongoClient.Database(cfg.MongoDB.Db).Collection("tenants")
+
+	tenantId := h.Get("x-tenant-id")
+	query := bson.M{"id": tenantId}
+	projection := bson.M{"_id": 0, "info.name": 1, "db_conf": 1}
+
+	var result DbInfoUsers
+
+	err := tenantsCol.FindOne(context.TODO(), query, options.FindOne().SetProjection(projection)).Decode(&result)
+
+	if err == nil {
+
+		mongoConf := config.MongoConfig{}
+		mongoConf.Db = result.DbConf[0].Database
 		return mongoConf, result.Info.Name, nil
 
 	}

--- a/utils/authorization/authorize.go
+++ b/utils/authorization/authorize.go
@@ -17,7 +17,6 @@ type QRole struct {
 func HasResourceRoles(cfg config.Config, resource string, roles []string) bool {
 
 	rolesCol := cfg.MongoClient.Database(cfg.MongoDB.Db).Collection("roles")
-
 	query := bson.M{"resource": resource, "roles": bson.M{"$in": roles}}
 	queryResult := rolesCol.FindOne(context.TODO(), query)
 	return (queryResult.Err() == nil)

--- a/website/docs/accessing_as_admin.md
+++ b/website/docs/accessing_as_admin.md
@@ -1,0 +1,37 @@
+---
+id: adminaccess
+title: Accessing Tenant Results as Admin
+---
+
+## Tenant User Endpoints
+
+Tenant users can access tenant-specific endpoints using their credentials via the `x-api-key` header.
+
+Some tenant-related routes include the following:
+- `/api/v2/operations_profiles`
+- `/api/v2/metric_profiles`
+- `/api/v2/aggregations_profiles`
+- `/api/v2/reports`
+- `/api/v2/topology`
+- `/api/v2/status`
+- `/api/v2/results`
+- `/api/v2/issues`
+- `/api/v2/trends`
+
+### Authentication behavior
+When you authenticate as a tenant user (with `admin`, `editor`, or `viewer` role), your `x-api-key` automatically determines your tenant context. The system selects your tenant during authentication.
+
+To access a different tenant, you must obtain separate credentials for that tenant and use them in your requests.
+
+## Super Admin Access
+
+Super admins can access administrative endpoints under the `/api/v2/admin` path using their super-admin `x-api-key`.
+
+Some super-admin related routes include the following:
+- `/api/v2/tenants`
+- `/api/v2/tenants/{tenant-id}/users`
+
+These endpoints enable management of tenants, users, and related resources.
+
+### Accessing tenant data as super admin
+To view a specific tenant's results, profiles, and other data, use your super-admin credentials with the additional header `x-tenant-id: <tenant-uuid>` (replace `<tenant-uuid>` with the actual tenant ID).


### PR DESCRIPTION
…nant

## Goal
Allow super admin users to access api calls that relate to a specific tenant such as:
- `/api/v2/operations_profiles`
- `/api/v2/metric_profiles`
- `/api/v2/aggregations_profiles`
- `/api/v2/reports`
- `/api/v2/topology`
- `/api/v2/status`
- `/api/v2/results`
- `/api/v2/issues`
- `/api/v2/trends`

In order to be able a super admin tenant to access those it needs to additionaly specify the tenant by using the following header: `x-tenant-id: <tenant-id>` (replace `<tenant-id>` with the actual id of the tenant) on those requests.

## Implementation
Extend auth wrappers to take notice if `x-tenant-id` header is used by an admin and forwarding him to actual tenant calls by selecting the correct tenant context and corresponding roles