### PR TITLE
ARGO-5403 Support nodes in tenants and node reports

### DIFF
--- a/app/reports/controller.go
+++ b/app/reports/controller.go
@@ -46,6 +46,8 @@ import (
 )
 
 var reportsColl = "reports"
+var nodeReportColl = "node_report"
+var nodeReportId = "node-report"
 
 // Create function is used to implement the create report request.
 // The request is an http POST request with the report description
@@ -183,8 +185,18 @@ func List(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) 
 
 	query := bson.M{}
 
+	// check node report
+	nodeReport := NodeReport{}
+
+	nrCol := cfg.MongoClient.Database(tenantDbConfig.Db).Collection(nodeReportColl)
+	err = nrCol.FindOne(context.TODO(), query).Decode(&nodeReport)
+
 	if urlValues.Get("name") != "" {
 		query["info.name"] = urlValues["name"]
+	}
+
+	if urlValues.Has("node") {
+		query["id"] = nodeReport.Report_id
 	}
 
 	// Create structure for storing query results
@@ -193,7 +205,7 @@ func List(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) 
 	// nil query param == match everything
 	rCol := cfg.MongoClient.Database(tenantDbConfig.Db).Collection(reportsColl)
 	findOptions := options.Find().SetSort(bson.D{{Key: "id", Value: 1}})
-	cursor, err := rCol.Find(context.TODO(), bson.M{}, findOptions)
+	cursor, err := rCol.Find(context.TODO(), query, findOptions)
 	if err != nil {
 		code = http.StatusInternalServerError
 		return code, h, output, err
@@ -203,6 +215,9 @@ func List(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) 
 	cursor.All(context.TODO(), &results)
 
 	for indx := range results {
+		if nodeReport.Report_id == results[indx].ID {
+			results[indx].NodeReport = true
+		}
 		results[indx].Tenant = tenantName
 
 		// check if computations field is not set and return the default value
@@ -244,9 +259,13 @@ func ListOne(r *http.Request, cfg config.Config) (int, http.Header, []byte, erro
 	tenantDbConfig := gcontext.Get(r, "tenant_conf").(config.MongoConfig)
 	tenantName := gcontext.Get(r, "tenant_name").(string)
 
-	//Extracting urlvar "name" from url path
-
 	id := mux.Vars(r)["id"]
+
+	// check node report
+	nodeReport := NodeReport{}
+
+	nrCol := cfg.MongoClient.Database(tenantDbConfig.Db).Collection(nodeReportColl)
+	err = nrCol.FindOne(context.TODO(), bson.M{}).Decode(&nodeReport)
 
 	// Create structure for storing query results
 	result := MongoInterface{}
@@ -267,6 +286,11 @@ func ListOne(r *http.Request, cfg config.Config) (int, http.Header, []byte, erro
 		}
 		code = http.StatusInternalServerError
 		return code, h, output, err
+	}
+
+	// if report is set as a node report enrich the report information with node: true
+	if nodeReport.Report_id == result.ID {
+		result.NodeReport = true
 	}
 
 	// Enrich report with tenant name -- used in argo engine
@@ -421,6 +445,77 @@ func Update(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 	}
 	//Render the response into XML
 	output, err = respond.CreateResponseMessage("Report was successfully updated", "200", contentType)
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	code = http.StatusOK
+	return code, h, output, err
+
+}
+
+// SetNodeReport function is used to set a specific report as node report
+func SetNodeReport(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
+
+	//STANDARD DECLARATIONS START
+	code := http.StatusOK
+	h := http.Header{}
+	output := []byte("")
+	err := error(nil)
+	charset := "utf-8"
+	//STANDARD DECLARATIONS END
+
+	// Set Content-Type response Header value
+	contentType := r.Header.Get("Accept")
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+
+	// Grab Tenant DB configuration from context
+	tenantDbConfig := gcontext.Get(r, "tenant_conf").(config.MongoConfig)
+
+	//Extracting report id from url
+	id := mux.Vars(r)["id"]
+
+	queryById := bson.M{"id": id}
+
+	// before updating, check if the report exists and the name is unique
+	rCol := cfg.MongoClient.Database(tenantDbConfig.Db).Collection(reportsColl)
+	nrCol := cfg.MongoClient.Database((tenantDbConfig.Db)).Collection(nodeReportColl)
+	result := MongoInterface{}
+
+	err = rCol.FindOne(context.TODO(), queryById).Decode(&result)
+
+	if err != nil {
+		if err == mongo.ErrNoDocuments {
+			output, _ = respond.MarshalContent(respond.ErrNotFound, contentType, "", " ")
+			code = http.StatusNotFound
+			return code, h, output, err
+		}
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	filter := bson.M{"_id": nodeReportId}
+	update := bson.M{"$set": NodeReport{Report_id: id}}
+	opts := options.Update().SetUpsert(true)
+
+	updateChange, err := nrCol.UpdateOne(context.TODO(), filter, update, opts)
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	fmt.Printf("%+v \n", updateChange)
+
+	if updateChange.MatchedCount == 0 && updateChange.UpsertedCount == 0 {
+		output, _ = respond.MarshalContent(respond.ErrNotFound, contentType, "", " ")
+		code = 404
+		return code, h, output, err
+	}
+	//Render the response into XML
+	output, err = respond.CreateResponseMessage("Node report information was successfully updated", "200", contentType)
 
 	if err != nil {
 		code = http.StatusInternalServerError

--- a/app/reports/model.go
+++ b/app/reports/model.go
@@ -50,6 +50,7 @@ type MongoInterface struct {
 	Topology     Topology      `bson:"topology_schema" json:"topology_schema" xml:"topology_schema"`
 	Profiles     []Profile     `bson:"profiles" json:"profiles" xml:"profiles"`
 	Tags         []Tag         `bson:"filter_tags" json:"filter_tags" xml:"filter_tags"`
+	NodeReport   bool          `bson:"node_report" json:"node_report,omitempty"`
 }
 
 // Info contains info about a report and is used inside the main MongoInterface struct
@@ -115,6 +116,11 @@ type Message struct {
 type RootXML struct {
 	XMLName xml.Name `xml:"root" json:"-"`
 	Reports interface{}
+}
+
+// NodeReport holds information about which report will be used for the Node (optional)
+type NodeReport struct {
+	Report_id string `bson:"report_id" json:"report_id"`
 }
 
 // GetEndpointGroupType retrieves the deepest type nested inside the group hierarchy

--- a/app/reports/reports_test.go
+++ b/app/reports/reports_test.go
@@ -243,6 +243,11 @@ func (suite *ReportTestSuite) SetupTest() {
 		})
 	c.InsertOne(context.TODO(),
 		bson.M{
+			"resource": "reports.set_node_report",
+			"roles":    []string{"admin", "editor"},
+		})
+	c.InsertOne(context.TODO(),
+		bson.M{
 			"resource": "reports.delete",
 			"roles":    []string{"admin", "editor"},
 		})
@@ -1210,6 +1215,147 @@ func (suite *ReportTestSuite) TestDeleteReport() {
 	suite.Equal(404, code, "Incorrect error code")
 	// Compare the expected and actual xml response
 	suite.Equal(suite.respReportNotFound, output, "Response body mismatch")
+}
+
+// Set a report as the default node report
+func (suite *ReportTestSuite) TestSetReportNode() {
+
+	respJSON := `{
+ "status": {
+  "message": "Node report information was successfully updated",
+  "code": "200"
+ }
+}`
+
+	respReportJSON := `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "id": "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+   "tenant": "GUARDIANS",
+   "disabled": false,
+   "info": {
+    "name": "Report_A",
+    "description": "report aaaaa",
+    "created": "2015-9-10 13:43:00",
+    "updated": "2015-10-11 13:43:00"
+   },
+   "computations": {
+    "ar": true,
+    "status": true,
+    "trends": [
+     "flapping",
+     "status",
+     "tags"
+    ]
+   },
+   "topology_schema": {
+    "group": {
+     "type": "NGI",
+     "group": {
+      "type": "SITE"
+     }
+    }
+   },
+   "profiles": [
+    {
+     "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50b",
+     "name": "profile1",
+     "type": "metric"
+    },
+    {
+     "id": "6ac7d684-1f8e-4a02-a502-720e8f11e523",
+     "name": "profile2",
+     "type": "operations"
+    },
+    {
+     "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50q",
+     "name": "profile3",
+     "type": "aggregation"
+    }
+   ],
+   "filter_tags": [
+    {
+     "name": "name1",
+     "value": "value1",
+     "context": ""
+    },
+    {
+     "name": "name2",
+     "value": "value2",
+     "context": ""
+    }
+   ],
+   "node_report": true
+  }
+ ]
+}`
+
+	// Prepare the request object
+	request, _ := http.NewRequest("POST", "/api/v2/reports/eba61a9e-22e9-4521-9e47-ecaa4a494364/set-node-report", strings.NewReader(""))
+	// add the content-type header to application/json
+	request.Header.Set("Accept", "application/json")
+	// add the authentication token which is seeded in testdb
+	request.Header.Set("x-api-key", "C4PK3Y")
+
+	// Execute the request in the controller
+	response := httptest.NewRecorder()
+
+	// Execute the request in the controller
+	suite.router.ServeHTTP(response, request)
+
+	code := response.Code
+	output := response.Body.String()
+
+	suite.Equal(200, code, "Incorrect Error Code")
+	suite.Equal(respJSON, output, "Response body mismatch")
+
+	// Double check that the report is actually removed when you try
+	// to retrieve it's information by name
+	// Prepare the request object using report name as urlvar in url path
+	request, _ = http.NewRequest("GET", "/api/v2/reports/eba61a9e-22e9-4521-9e47-ecaa4a494364", strings.NewReader(""))
+	// add the content-type header to application/json
+	request.Header.Set("Accept", "application/json")
+	// add the authentication token which is seeded in testdb
+	request.Header.Set("x-api-key", "C4PK3Y")
+	// Pass request to controller calling List() handler method
+	response = httptest.NewRecorder()
+
+	// Execute the request in the controller
+	suite.router.ServeHTTP(response, request)
+
+	code = response.Code
+	output = response.Body.String()
+
+	// Check that we must have a 200 ok code
+	suite.Equal(200, code, "Incorrect error code")
+	// Compare the expected and actual xml response
+	suite.Equal(respReportJSON, output, "Response body mismatch")
+
+	// Double check that the report is actually removed when you try
+	// to retrieve it's information by name
+	// Prepare the request object using report name as urlvar in url path
+	request, _ = http.NewRequest("GET", "/api/v2/reports?node", strings.NewReader(""))
+	// add the content-type header to application/json
+	request.Header.Set("Accept", "application/json")
+	// add the authentication token which is seeded in testdb
+	request.Header.Set("x-api-key", "C4PK3Y")
+	// Pass request to controller calling List() handler method
+	response = httptest.NewRecorder()
+
+	// Execute the request in the controller
+	suite.router.ServeHTTP(response, request)
+
+	code = response.Code
+	output = response.Body.String()
+
+	// Check that we must have a 200 ok code
+	suite.Equal(200, code, "Incorrect error code")
+	// Compare the expected and actual xml response
+	suite.Equal(respReportJSON, output, "Response body mismatch")
 }
 
 // TestReadOneReport function implements the testing

--- a/app/reports/routing.go
+++ b/app/reports/routing.go
@@ -45,6 +45,7 @@ var appRoutesV2 = []respond.AppRoutes{
 	{Name: "reports.create", Verb: "POST", Path: "/reports", SubrouterHandler: Create},
 	{Name: "reports.update", Verb: "PUT", Path: "/reports/{id}", SubrouterHandler: Update},
 	{Name: "reports.delete", Verb: "DELETE", Path: "/reports/{id}", SubrouterHandler: Delete},
+	{Name: "reports.set_node_report", Verb: "POST", Path: "/reports/{id}/set-node-report", SubrouterHandler: SetNodeReport},
 	{Name: "reports.options", Verb: "OPTIONS", Path: "/reports", SubrouterHandler: Options},
 	{Name: "reports.options", Verb: "OPTIONS", Path: "/reports/{id}", SubrouterHandler: Options},
 }

--- a/app/tenants/controller.go
+++ b/app/tenants/controller.go
@@ -829,6 +829,101 @@ func UpdateInfo(r *http.Request, cfg config.Config) (int, http.Header, []byte, e
 
 }
 
+// UpdateNode function used to update only the node info part of a tenant
+func UpdateNode(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
+
+	//STANDARD DECLARATIONS START
+	code := http.StatusOK
+	h := http.Header{}
+	var output []byte
+	err := error(nil)
+	charset := "utf-8"
+
+	//STANDARD DECLARATIONS END
+
+	// Set Content-Type response Header value
+	contentType := r.Header.Get("Accept")
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+
+	vars := mux.Vars(r)
+
+	incoming := Tenant{}
+
+	// ingest body data
+	body, err := io.ReadAll(io.LimitReader(r.Body, cfg.Server.ReqSizeLimit))
+	if err != nil {
+		panic(err)
+	}
+	if err := r.Body.Close(); err != nil {
+		panic(err)
+	}
+	// parse body json
+	if err := json.Unmarshal(body, &incoming); err != nil {
+		output, _ = respond.MarshalContent(respond.BadRequestInvalidJSON, contentType, "", " ")
+		code = http.StatusBadRequest
+		return code, h, output, err
+	}
+
+	// Try to get mongo client and target tenant collection
+	tenantCol := cfg.MongoClient.Database(cfg.MongoDB.Db).Collection("tenants")
+
+	// create query to retrieve specific profile with id
+	query := bson.M{"id": vars["ID"]}
+
+	incoming.ID = vars["ID"]
+
+	// Retrieve Results from database
+	result := Tenant{}
+	err = tenantCol.FindOne(context.TODO(), query).Decode(&result)
+
+	if err != nil {
+		if err == mongo.ErrNoDocuments {
+			output, _ = respond.MarshalContent(respond.ErrNotFound, contentType, "", " ")
+			code = http.StatusNotFound
+			return code, h, output, err
+		}
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	if errMsg, errCode := ValidateTenantUsers(incoming, tenantCol); errMsg != "" && errCode != 0 {
+		output, _ = respond.MarshalContent(respond.ErrConflict(errMsg), contentType, "", " ")
+		code = errCode
+		return code, h, output, err
+	}
+
+	// run the update query
+	incoming.Info.Created = result.Info.Created
+
+	incoming.Info.Updated = time.Now().Format("2006-01-02 15:04:05")
+	query = bson.M{"id": vars["ID"]}
+	update := bson.M{
+		"$set": bson.M{
+			"node":         incoming.Node,
+			"info.updated": incoming.Info.Updated,
+		},
+	}
+
+	updateResult, err := tenantCol.UpdateOne(context.TODO(), query, update)
+
+	if updateResult.MatchedCount == 0 {
+		output, _ = respond.MarshalContent(respond.ErrNotFound, contentType, "", " ")
+		code = http.StatusNotFound
+		return code, h, output, err
+	}
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	// Create view for response message
+	output, err = createMsgView("Tenant node information updated", 200) //Render the results into JSON
+	code = http.StatusOK
+	return code, h, output, err
+
+}
+
 // Update Db conf function used to update only the db_conf part of a tenant
 func UpdateDbConf(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
 

--- a/app/tenants/model.go
+++ b/app/tenants/model.go
@@ -34,12 +34,18 @@ type Tenant struct {
 	DbConf   []TenantDbConf `bson:"db_conf" json:"db_conf,omitempty"`
 	Topology TopologyInfo   `bson:"topology" json:"topology"`
 	Users    []TenantUser   `bson:"users" json:"users,omitempty"`
+	Node     *NodeInfo      `bson:"node" json:"node,omitempty"`
 }
 
 // TopologyInfo contains topology feed information
 type TopologyInfo struct {
 	TopoType string `bson:"type" json:"type"`
 	Feed     string `bson:"feed" json:"feed"`
+}
+
+type NodeInfo struct {
+	Id   string `bson:"id" json:"id"`
+	Name string `bson:"name" json:"name"`
 }
 
 type TenantReadyOut struct {

--- a/app/tenants/routing.go
+++ b/app/tenants/routing.go
@@ -40,6 +40,7 @@ var appRoutesV2 = []respond.AppRoutes{
 	{Name: "tenants.get_status", Verb: "GET", Path: "/tenants/{ID}/status", SubrouterHandler: ListStatus},
 	{Name: "tenants.get", Verb: "GET", Path: "/tenants/{ID}", SubrouterHandler: ListOne},
 	{Name: "tenants.create", Verb: "POST", Path: "/tenants", SubrouterHandler: Create},
+	{Name: "tenants.update_node", Verb: "PUT", Path: "/tenants/{ID}/node", SubrouterHandler: UpdateNode},
 	{Name: "tenants.update_status", Verb: "PUT", Path: "/tenants/{ID}/status", SubrouterHandler: UpdateStatus},
 	{Name: "tenants.update_ready", Verb: "PUT", Path: "/tenants/{ID}/ready", SubrouterHandler: UpdateReady},
 	{Name: "tenants.create_user", Verb: "POST", Path: "/tenants/{ID}/users", SubrouterHandler: CreateUser},

--- a/app/tenants/tenants_test.go
+++ b/app/tenants/tenants_test.go
@@ -220,6 +220,11 @@ func (suite *TenantTestSuite) SetupTest() {
 		})
 	c.InsertOne(context.TODO(),
 		bson.M{
+			"resource": "tenants.update_node",
+			"roles":    []string{"super_admin"},
+		})
+	c.InsertOne(context.TODO(),
+		bson.M{
 			"resource": "tenants.update_topology",
 			"roles":    []string{"super_admin"},
 		})
@@ -1058,6 +1063,81 @@ func (suite *TenantTestSuite) TestUpdateTenantDbConf() {
 	suite.NotEqual("TENANT_INFO_UPDATED", result.Info.Name)
 	suite.Equal("test-ar", result.DbConf[0].Store)
 	suite.Equal("mongo.remote", result.DbConf[0].Server)
+	suite.Equal("starlord", result.Users[1].Name)
+
+	// now do the normal update that will replace the users
+
+	request, _ = http.NewRequest("PUT", "/api/v2/admin/tenants/6ac7d684-1f8e-4a02-a502-720e8f11e50c", strings.NewReader(putData))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+	response = httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code = response.Code
+	output = response.Body.String()
+
+	suite.Equal(200, code, "Internal Server Error")
+	suite.Equal(jsonOutput2, output, "Response body mismatch")
+
+	c.FindOne(context.TODO(), bson.M{"id": "6ac7d684-1f8e-4a02-a502-720e8f11e50c"}).Decode(&result)
+	suite.Equal("TENANT_INFO_UPDATED", result.Info.Name)
+	suite.Empty(result.Users)
+
+}
+
+func (suite *TenantTestSuite) TestUpdateTenantNode() {
+
+	// create json input data for the request
+	putData := `
+  {
+      "info":{
+				"name":"TENANT_INFO_UPDATED",
+				"email":"bar@example.foo",
+				"website":"updated_info_website"
+			},
+      "node": {
+	 	"id": "node_id",
+		"name": "node_name"
+	  },
+      "users": []
+  }`
+
+	jsonOutput := `{
+ "status": {
+  "message": "Tenant node information updated",
+  "code": "200"
+ }
+}`
+
+	jsonOutput2 := `{
+ "status": {
+  "message": "Tenant successfully updated",
+  "code": "200"
+ }
+}`
+
+	request, _ := http.NewRequest("PUT", "/api/v2/admin/tenants/6ac7d684-1f8e-4a02-a502-720e8f11e50c/node", strings.NewReader(putData))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code := response.Code
+	output := response.Body.String()
+
+	suite.Equal(200, code, "Internal Server Error")
+	suite.Equal(jsonOutput, output, "Response body mismatch")
+
+	// try to retrieve item
+	var result Tenant
+	c := suite.cfg.MongoClient.Database(suite.cfg.MongoDB.Db).Collection("tenants")
+	c.FindOne(context.TODO(), bson.M{"id": "6ac7d684-1f8e-4a02-a502-720e8f11e50c"}).Decode(&result)
+
+	suite.NotEqual("TENANT_INFO_UPDATED", result.Info.Name)
+	suite.Equal("node_id", result.Node.Id)
+	suite.Equal("node_name", result.Node.Name)
 	suite.Equal("starlord", result.Users[1].Name)
 
 	// now do the normal update that will replace the users

--- a/docker/files/init_mongo.js
+++ b/docker/files/init_mongo.js
@@ -42,6 +42,10 @@ db.roles.insertMany([
     roles: [ 'admin', 'editor' ]
   },
   {
+    resource: 'reports.set_node_report',
+    roles: [ 'admin', 'editor' ]
+  },
+  {
     resource: 'metric_profiles.get',
     roles: [ 'admin', 'editor', 'viewer', 'admin_ui' ]
   },

--- a/scripts/mongodb/populate_default_roles.js
+++ b/scripts/mongodb/populate_default_roles.js
@@ -41,6 +41,7 @@ function populate_default_roles() {
         { resource: "reports.create", roles: ["admin", "editor"] },
         { resource: "reports.delete", roles: ["admin", "editor"] },
         { resource: "reports.update", roles: ["admin", "editor"] },
+        { resource: "reports.set_node_report", roles: ["admin", "editor"] },
         {
             resource: "metricProfiles.get",
             roles: ["admin", "editor", "viewer", "admin_ui"]

--- a/website/docs/profiles_and_reports/reports.md
+++ b/website/docs/profiles_and_reports/reports.md
@@ -11,6 +11,7 @@ sidebar_position: 5
 | GET: List reports or single report | This method can be used to retrieve a list of existing reports | [ Description](#1) |
 | POST: Create a new report          | This method can be used to create a new report.                | [ Description](#2) |
 | PUT: Update an existing report     | This method can be used to update an existing report.          | [ Description](#3) |
+| POST: Set report as node report     | This method can be used to set an existing report as node report.          | [ Description](#3B) |
 | DELETE: Delete an existing Report  | This method can be used to delete an existing report.          | [ Description](#4) |
 
 
@@ -29,6 +30,11 @@ or
 /reports/{id}
 ```
 
+#### Filters on `/reports` list
+
+When using `/reports` to list the available reports you have the following filters that you can use as url values
+- `?name=<report_name>` to search for an exact report name
+- `?node` to show only the default node report
 #### Request headers
 
 ```
@@ -309,6 +315,41 @@ Headers: `Status: 200 OK`
         "message": "Report was successfully updated",
         "code": "200"
     }
+}
+```
+
+## [POST]: Set a report as node report {#3B}
+
+This method can be used to set an existing report as a node report. Node reports are used as default sources for results when requesting node capabilities
+
+### Input
+
+#### URL
+
+```
+/reports/{id}/set-node-report
+```
+
+#### Request headers
+
+```
+x-api-key: shared_key_value
+Accept: application/json
+```
+
+
+### Response
+
+Headers: `Status: 200 OK`
+
+#### Response Body
+
+```json
+{
+  "status": {
+    "message": "Node report information was successfully updated",
+    "code": "200"
+  }
 }
 ```
 

--- a/website/docs/tenants_and_feeds/tenants.md
+++ b/website/docs/tenants_and_feeds/tenants.md
@@ -13,9 +13,10 @@ sidebar_position: 1
 | GET: List a specific tenant           | This method can be used to retrieve a specific metric tenant based on its id.          | [ Description](#2) |
 | POST: Create a new tenant             | This method can be used to create a new tenant                                         | [ Description](#3) |
 | PUT: Update a tenant                  | This method can be used to update information on an existing tenant                    | [ Description](#4) |
-| PUT: Update a tenant's info                  | This method can be used to update just the info part on an existing tenant                    | [ Description](#4B) |
-| PUT: Update a tenant's db conf                  | This method can be used to update just the db conf part on an existing tenant                    | [ Description](#4C) |
-| PUT: Update a tenant's topology                  | This method can be used to update just the topology part on an existing tenant                    | [ Description](#4D) |
+| PUT: Update a tenant's info           | This method can be used to update just the info part on an existing tenant             | [ Description](#4B) |
+| PUT: Update a tenant's db conf        | This method can be used to update just the db conf part on an existing tenant          | [ Description](#4C) |
+| PUT: Update a tenant's topology       | This method can be used to update just the topology part on an existing tenant         | [ Description](#4D) |
+| PUT: Update a tenant's node info      | This method can be used to update just the node info part on an existing tenant        | [ Description](#4E) |
 | DELETE: Delete a tenant               | This method can be used to delete an existing tenant                                   | [ Description](#5) |
 | GET: Get a tenant's arg engine status | This method can be used to get status for a specific tenant                            | [ Description](#6) |
 | PUT: Update a tenant's engine status  | This method can be used to update argo engine status information for a specific tenant | [ Description](#7) |
@@ -138,10 +139,7 @@ Json Response
      "username": "admin",
      "password": "3NCRYPT3D"
     },
-    "topology": {
-    "type": "GOCDB",
-    "feed": "gocdb2.example.foo"
-   },
+   
     {
      "store": "status",
      "server": "b.mongodb.org",
@@ -151,6 +149,10 @@ Json Response
      "password": "3NCRYPT3D"
     }
    ],
+   "topology": {
+    "type": "GOCDB",
+    "feed": "gocdb2.example.foo"
+   },
    "users": [
     {
     "id": "acb74194-553a-11e9-8647-d663bd873d95",
@@ -719,6 +721,52 @@ Json Response
 {
     "status": {
         "message": "Tenant database configuration successfully updated",
+        "code": "200"
+    }
+}
+```
+
+## [PUT]: Update only the node info part of an existing tenant {#4C}
+
+Some tenants can represent Nodes and hold optional node information in the nested json object named "node".
+This method can be used to update only the node info part of an existing tenant
+
+### Input
+
+```
+PUT /admin/tenants/{ID}/node
+```
+
+#### Request headers
+
+```
+x-api-key: shared_key_value
+Accept: application/json
+```
+
+#### PUT BODY
+
+```json
+{
+    "node": {
+        "id": "node-id",
+        "name": "node-namke",
+    }
+}
+```
+
+### Response
+
+Headers: `Status: 200 OK`
+
+#### Response body
+
+Json Response
+
+```json
+{
+    "status": {
+        "message": "Tenant node information successfully updated",
         "code": "200"
     }
 }

--- a/website/static/openapi/argo-web-api.yml
+++ b/website/static/openapi/argo-web-api.yml
@@ -1403,6 +1403,16 @@ paths:
         schema:
           type: string
           default: SecretKey123
+      - name: name
+        in: query
+        description: search by report name
+        schema:
+          type: string
+      - name: node
+        in: query
+        scription: show only active default node report
+        schema:
+          type: boolean
       responses:
         200:
           description: A list of all available Reports
@@ -12013,6 +12023,8 @@ components:
           type: string
         disabled:
           type: string
+        node:
+          type: boolean
         weight:
           type: string
         info:
@@ -12226,6 +12238,13 @@ components:
             created:
               type: string
             updated:
+              type: string
+        node:
+          type: object
+          properties:
+            id: 
+              type: string
+            name:
               type: string
         db_conf:
           type: array


### PR DESCRIPTION
# Goal

Configure a tenant with node information such as `node_id` and `node_name`

Give the ability to the user to configure a tenant report as the default node report supporting the results of capabilities

# Implementation

### Tenant supports now node information

Tenant has now an extra **optional** field called `node` which holds node information such as
```json
...
"node" : {
  "id": "node-id",
  "name": "node-name"
}
...
```

And you can update just this information by using the following request:
```bash
HTTP PUT /api/v2/admin/tenants/{tenant-id}/node
```
with PUT body:
```json
{
  "node" : {
   "id": "node-id",
   "name": "node-name"
 }
}
```

### Reports support now setting one report as default node report

User can set **one** of the reports to be the default node report. This can be done by the following request:

```bash
HTTP PUT /api/v2/reports/{report-id}/set-node-repot
```

The activated report will have an extra field `node: true` in its contents 