### PR TITLE
ARGO-5434 Handle tenants that don't have db configuration yet

### DIFF
--- a/respond/respond.go
+++ b/respond/respond.go
@@ -68,6 +68,8 @@ const (
 	ErrValidHead ErrEnum = iota
 	//ErrValidQuery is Error during validation
 	ErrValidQuery ErrEnum = iota
+	//ErrNoTenantDB is error during validation
+	ErrNoTenantDB = iota
 )
 
 // ConfHandler Keeps all the configuration/variables required by all the requests
@@ -149,6 +151,11 @@ func Error(w http.ResponseWriter, r *http.Request, errType ErrEnum, cfg config.C
 		code = http.StatusBadRequest
 		contentType = r.Header.Get("Accept")
 		output = CreateFailureResponseMessage("Bad Request", strconv.Itoa(code), errs).MarshalTo(contentType)
+	case ErrNoTenantDB:
+		msg = ConflictTenantNoDB
+		code = http.StatusConflict
+		contentType = r.Header.Get("Accept")
+		output, _ = MarshalContent(msg, contentType, "", " ")
 	default:
 		msg = InternalServerErrorMessage
 		code = http.StatusInternalServerError
@@ -366,6 +373,16 @@ var BadRequestInvalidJSON = ResponseMessage{
 	},
 	Errors: []StatusResponse{
 		{Message: "Bad Request", Code: "400", Details: "Request Body contains malformed JSON, thus rendering the Request Bad"},
+	},
+}
+
+var ConflictTenantNoDB = ResponseMessage{
+	Status: StatusResponse{
+		Message: "Conflict",
+		Code:    "409",
+	},
+	Errors: []StatusResponse{
+		{Message: "Conflict", Code: "409", Details: "Tenant database configuration has not been completed yet"},
 	},
 }
 

--- a/respond/wrappers.go
+++ b/respond/wrappers.go
@@ -95,6 +95,12 @@ func WrapAuthenticate(hfn http.Handler, cfg config.Config, routeName string) htt
 				return
 			}
 
+			// if not tenant database configured response with message
+			if tenantConf.Db == "" {
+				Error(w, r, ErrNoTenantDB, cfg, errs)
+				return
+			}
+
 			tenantConf.User = username
 			tenantConf.Email = email
 			if authentication.IsAdminRestricted(r.Header, cfg) {
@@ -121,6 +127,11 @@ func WrapAuthenticate(hfn http.Handler, cfg config.Config, routeName string) htt
 			// If tenant user not authenticated respond with  error
 			if tErr != nil {
 				Error(w, r, ErrAuthen, cfg, errs)
+				return
+			}
+
+			if tenantConf.Db == "" {
+				Error(w, r, ErrNoTenantDB, cfg, errs)
 				return
 			}
 

--- a/utils/authentication/authenticate.go
+++ b/utils/authentication/authenticate.go
@@ -215,7 +215,9 @@ func AuthenticateAdminTenant(h http.Header, cfg config.Config) (config.MongoConf
 	if err == nil {
 
 		mongoConf := config.MongoConfig{}
-		mongoConf.Db = result.DbConf[0].Database
+		if len(result.DbConf) > 0 {
+			mongoConf.Db = result.DbConf[0].Database
+		}
 		return mongoConf, result.Info.Name, nil
 
 	}


### PR DESCRIPTION
# Issue

When a new tenant has been created in argo-web-api but has no db configuration makes accessing the tenant's resources unfeasible. Argo-web-api didn't handle this case gracefully and abruptly terminated the connection with no clear response

## Fix
When someone tries to access tenant's resources (such as profiles, reports, etc) and the tenant db configuration has been completed yet it will receive the following message from web-api:

```json
{
 "status": {
  "message": "Conflict",
  "code": "409"
 },
 "errors": [
  {
   "message": "Conflict",
   "code": "409",
   "details": "Tenant database configuration has not been completed yet"
  }
 ]
}
```

and http request status code `409` `Conflict`