### PR TITLE
ARGO-5476 Support force parameter to overwright existing topology ite…

### DIFF
--- a/app/topology/controller.go
+++ b/app/topology/controller.go
@@ -361,7 +361,6 @@ func getEndpointResults(client *mongo.Client, dbConfig config.MongoConfig, dateI
 	return subResults, expDate, err
 }
 
-// CreateEndpoints Creates a list of endpoints for a specific date
 func CreateEndpoints(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
 
 	//STANDARD DECLARATIONS START
@@ -399,25 +398,6 @@ func CreateEndpoints(r *http.Request, cfg config.Config) (int, http.Header, []by
 		panic(err)
 	}
 
-	// check if topology already exists for current day
-
-	existing := Endpoint{}
-	endpointCol := cfg.MongoClient.Database(tenantDbConfig.Db).Collection(endpointColName)
-	err = endpointCol.FindOne(context.TODO(), bson.M{"date_integer": dt}).Decode(&existing)
-	if err != nil {
-		// Stop at any error except not found. We want to have not found
-		if err != mongo.ErrNoDocuments {
-			code = http.StatusInternalServerError
-			return code, h, output, err
-		}
-		// else continue correctly -
-	} else {
-		// If found we need to inform user that the topology is already created for this date
-		output, err = createMessageOUT(fmt.Sprintf("Topology already exists for date: %s, please either update it or delete it first!", dateStr), 409, "json")
-		code = 409
-		return code, h, output, err
-	}
-
 	// Parse body json
 	if err := json.Unmarshal(body, &incoming); err != nil {
 		output, _ = respond.MarshalContent(respond.BadRequestInvalidJSON, contentType, "", " ")
@@ -435,15 +415,67 @@ func CreateEndpoints(r *http.Request, cfg config.Config) (int, http.Header, []by
 		incomingInf[i] = value
 	}
 
-	_, err = endpointCol.InsertMany(context.TODO(), incomingInf)
+	endpointCol := cfg.MongoClient.Database(tenantDbConfig.Db).Collection(endpointColName)
+	force := urlValues.Get("force") != ""
 
-	if err != nil {
-		code = http.StatusInternalServerError
-		return code, h, output, err
+	if force {
+		// If user selects force then the old topology is removed and replaced by the new
+		// If mongo is in replica set we enable transactions
+		if store.IsReplicaSet(cfg.MongoClient) {
+			session, err := cfg.MongoClient.StartSession()
+			if err != nil {
+				code = http.StatusInternalServerError
+				return code, h, output, err
+			}
+			defer session.EndSession(context.TODO())
+
+			_, err = session.WithTransaction(context.TODO(), func(ctx mongo.SessionContext) (interface{}, error) {
+				if _, err := endpointCol.DeleteMany(ctx, bson.M{"date_integer": dt}); err != nil {
+					return nil, err
+				}
+				_, err := endpointCol.InsertMany(ctx, incomingInf)
+				return nil, err
+			})
+			if err != nil {
+				code = http.StatusInternalServerError
+				return code, h, output, err
+			}
+		} else {
+			// Without transaction
+			_, err = endpointCol.DeleteMany(context.TODO(), bson.M{"date_integer": dt})
+			if err != nil {
+				code = http.StatusInternalServerError
+				return code, h, output, err
+			}
+			_, err = endpointCol.InsertMany(context.TODO(), incomingInf)
+			if err != nil {
+				code = http.StatusInternalServerError
+				return code, h, output, err
+			}
+		}
+	} else {
+		// Check if topology already exists
+		existing := Endpoint{}
+		err = endpointCol.FindOne(context.TODO(), bson.M{"date_integer": dt}).Decode(&existing)
+		if err != nil {
+			if err != mongo.ErrNoDocuments {
+				code = http.StatusInternalServerError
+				return code, h, output, err
+			}
+		} else {
+			output, err = createMessageOUT(fmt.Sprintf("Topology already exists for date: %s, please either update it or delete it first!", dateStr), 409, "json")
+			code = 409
+			return code, h, output, err
+		}
+
+		_, err = endpointCol.InsertMany(context.TODO(), incomingInf)
+		if err != nil {
+			code = http.StatusInternalServerError
+			return code, h, output, err
+		}
 	}
 
-	// Create view of the results
-	output, err = createMessageOUT(fmt.Sprintf("Topology of %d endpoints created for date: %s", len(incoming), dateStr), 201, "json") //Render the results into JSON
+	output, err = createMessageOUT(fmt.Sprintf("Topology of %d endpoints created for date: %s", len(incoming), dateStr), 201, "json")
 	code = 201
 	return code, h, output, err
 }
@@ -530,24 +562,8 @@ func CreateGroups(r *http.Request, cfg config.Config) (int, http.Header, []byte,
 		panic(err)
 	}
 
-	// check if topology already exists for current day
-
-	existing := Group{}
 	groupCol := cfg.MongoClient.Database(tenantDbConfig.Db).Collection(groupColName)
-	err = groupCol.FindOne(context.TODO(), bson.M{"date_integer": dt}).Decode(&existing)
-	if err != nil {
-		// Stop at any error except not found. We want to have not found
-		if err != mongo.ErrNoDocuments {
-			code = http.StatusInternalServerError
-			return code, h, output, err
-		}
-		// else continue correctly -
-	} else {
-		// If found we need to inform user that the topology is already created for this date
-		output, err = createMessageOUT(fmt.Sprintf("Topology already exists for date: %s, please either update it or delete it first!", dateStr), 409, "json")
-		code = 409
-		return code, h, output, err
-	}
+	force := urlValues.Get("force") != ""
 
 	// Parse body json
 	if err := json.Unmarshal(body, &incoming); err != nil {
@@ -566,10 +582,61 @@ func CreateGroups(r *http.Request, cfg config.Config) (int, http.Header, []byte,
 		incomingInf[i] = value
 	}
 
-	_, err = groupCol.InsertMany(context.TODO(), incomingInf)
+	if force {
+		// If user selects force then the old topology is removed and replaced by the new
+		// If mongo is in replica set we enable transactions
+		if store.IsReplicaSet(cfg.MongoClient) {
+			session, err := cfg.MongoClient.StartSession()
+			if err != nil {
+				code = http.StatusInternalServerError
+				return code, h, output, err
+			}
+			defer session.EndSession(context.TODO())
 
-	if err != nil {
-		panic(err)
+			_, err = session.WithTransaction(context.TODO(), func(ctx mongo.SessionContext) (interface{}, error) {
+				if _, err := groupCol.DeleteMany(ctx, bson.M{"date_integer": dt}); err != nil {
+					return nil, err
+				}
+				_, err := groupCol.InsertMany(ctx, incomingInf)
+				return nil, err
+			})
+			if err != nil {
+				code = http.StatusInternalServerError
+				return code, h, output, err
+			}
+		} else {
+			// Without transaction
+			_, err = groupCol.DeleteMany(context.TODO(), bson.M{"date_integer": dt})
+			if err != nil {
+				code = http.StatusInternalServerError
+				return code, h, output, err
+			}
+			_, err = groupCol.InsertMany(context.TODO(), incomingInf)
+			if err != nil {
+				code = http.StatusInternalServerError
+				return code, h, output, err
+			}
+		}
+	} else {
+		// Check if topology already exists
+		existing := Endpoint{}
+		err = groupCol.FindOne(context.TODO(), bson.M{"date_integer": dt}).Decode(&existing)
+		if err != nil {
+			if err != mongo.ErrNoDocuments {
+				code = http.StatusInternalServerError
+				return code, h, output, err
+			}
+		} else {
+			output, err = createMessageOUT(fmt.Sprintf("Topology already exists for date: %s, please either update it or delete it first!", dateStr), 409, "json")
+			code = 409
+			return code, h, output, err
+		}
+
+		_, err = groupCol.InsertMany(context.TODO(), incomingInf)
+		if err != nil {
+			code = http.StatusInternalServerError
+			return code, h, output, err
+		}
 	}
 
 	// Create view of the results
@@ -1399,24 +1466,9 @@ func CreateServiceTypes(r *http.Request, cfg config.Config) (int, http.Header, [
 		panic(err)
 	}
 
-	// check if topology already exists for current day
-
-	existing := ServiceType{}
 	serviceTypeCol := cfg.MongoClient.Database(tenantDbConfig.Db).Collection(serviceTypeColName)
-	err = serviceTypeCol.FindOne(context.TODO(), bson.M{"date_integer": dt}).Decode(&existing)
-	if err != nil {
-		// Stop at any error except not found. We want to have not found
-		if err != mongo.ErrNoDocuments {
-			code = http.StatusInternalServerError
-			return code, h, output, err
-		}
-		// else continue correctly -
-	} else {
-		// If found we need to inform user that the topology is already created for this date
-		output, err = createMessageOUT(fmt.Sprintf("Topology list of service types already exists for date: %s, please either update it or delete it first!", dateStr), 409, "json")
-		code = 409
-		return code, h, output, err
-	}
+
+	force := urlValues.Get("force") != ""
 
 	// Parse body json
 	if err := json.Unmarshal(body, &incoming); err != nil {
@@ -1435,11 +1487,61 @@ func CreateServiceTypes(r *http.Request, cfg config.Config) (int, http.Header, [
 		incomingInf[i] = value
 	}
 
-	_, err = serviceTypeCol.InsertMany(context.TODO(), incomingInf)
+	if force {
+		// If user selects force then the old topology is removed and replaced by the new
+		// If mongo is in replica set we enable transactions
+		if store.IsReplicaSet(cfg.MongoClient) {
+			session, err := cfg.MongoClient.StartSession()
+			if err != nil {
+				code = http.StatusInternalServerError
+				return code, h, output, err
+			}
+			defer session.EndSession(context.TODO())
 
-	if err != nil {
-		code = http.StatusInternalServerError
-		return code, h, output, err
+			_, err = session.WithTransaction(context.TODO(), func(ctx mongo.SessionContext) (interface{}, error) {
+				if _, err := serviceTypeCol.DeleteMany(ctx, bson.M{"date_integer": dt}); err != nil {
+					return nil, err
+				}
+				_, err := serviceTypeCol.InsertMany(ctx, incomingInf)
+				return nil, err
+			})
+			if err != nil {
+				code = http.StatusInternalServerError
+				return code, h, output, err
+			}
+		} else {
+			// Without transaction
+			_, err = serviceTypeCol.DeleteMany(context.TODO(), bson.M{"date_integer": dt})
+			if err != nil {
+				code = http.StatusInternalServerError
+				return code, h, output, err
+			}
+			_, err = serviceTypeCol.InsertMany(context.TODO(), incomingInf)
+			if err != nil {
+				code = http.StatusInternalServerError
+				return code, h, output, err
+			}
+		}
+	} else {
+		// Check if topology already exists
+		existing := Endpoint{}
+		err = serviceTypeCol.FindOne(context.TODO(), bson.M{"date_integer": dt}).Decode(&existing)
+		if err != nil {
+			if err != mongo.ErrNoDocuments {
+				code = http.StatusInternalServerError
+				return code, h, output, err
+			}
+		} else {
+			output, err = createMessageOUT(fmt.Sprintf("Topology list of service types already exists for date: %s, please either update it or delete it first!", dateStr), 409, "json")
+			code = 409
+			return code, h, output, err
+		}
+
+		_, err = serviceTypeCol.InsertMany(context.TODO(), incomingInf)
+		if err != nil {
+			code = http.StatusInternalServerError
+			return code, h, output, err
+		}
 	}
 
 	// Create view of the results

--- a/app/topology/topology_test.go
+++ b/app/topology/topology_test.go
@@ -1696,6 +1696,22 @@ func (suite *topologyTestSuite) TestCreateEndpointGroupTopology() {
 	// Compare the expected and actual json response
 	suite.Equal(expJSON2, output2, "Creation failed")
 
+	// Now test inserting again with force
+
+	request3, _ := http.NewRequest("POST", "/api/v2/topology/endpoints?date=2019-03-03&force=true", strings.NewReader(jsonInput))
+	request3.Header.Set("x-api-key", suite.clientkey)
+	request3.Header.Set("Accept", "application/json")
+	response3 := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response3, request3)
+	code3 := response3.Code
+	output3 := response3.Body.String()
+
+	// Check that we must have a 409 conflict code
+	suite.Equal(201, code3, "Internal Server Error")
+	// Compare the expected and actual json response
+	suite.Equal(expJSON, output3, "Creation failed")
+
 }
 
 func (suite *topologyTestSuite) TestCreateGroupTopology() {
@@ -1744,6 +1760,22 @@ func (suite *topologyTestSuite) TestCreateGroupTopology() {
 	suite.Equal(409, code2, "Internal Server Error")
 	// Compare the expected and actual json response
 	suite.Equal(expJSON2, output2, "Creation failed")
+
+	// Now test inserting again witch force
+
+	request3, _ := http.NewRequest("POST", "/api/v2/topology/groups?date=2019-03-03&force=true", strings.NewReader(jsonInput))
+	request3.Header.Set("x-api-key", suite.clientkey)
+	request3.Header.Set("Accept", "application/json")
+	response3 := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response3, request3)
+	code3 := response3.Code
+	output3 := response3.Body.String()
+
+	// Check that we must have a 409 conflict code
+	suite.Equal(201, code3, "Internal Server Error")
+	// Compare the expected and actual json response
+	suite.Equal(expJSON, output3, "Creation ok")
 
 }
 
@@ -1848,6 +1880,22 @@ func (suite *topologyTestSuite) TestCreateServiceTypeTopology() {
 	suite.Equal(200, code3, "Internal Server Error")
 	// Compare the expected and actual json response
 	suite.Equal(expJSON3, output3, "Creation failed")
+
+	// Now test again with force
+
+	request4, _ := http.NewRequest("POST", "/api/v2/topology/service-types?date=2019-03-03&force=true", strings.NewReader(jsonInput))
+	request4.Header.Set("x-api-key", suite.clientkey)
+	request4.Header.Set("Accept", "application/json")
+	response4 := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response4, request4)
+	code4 := response4.Code
+	output4 := response4.Body.String()
+
+	// Check that we must have a 409 conflict code
+	suite.Equal(201, code4, "Internal Server Error")
+	// Compare the expected and actual json response
+	suite.Equal(expJSON, output4, "Creation failed")
 
 }
 

--- a/utils/store/mongo.go
+++ b/utils/store/mongo.go
@@ -59,3 +59,14 @@ func GetReportID(col *mongo.Collection, report string) (string, error) {
 	return "", err
 
 }
+
+// check if a replica set is enabled
+func IsReplicaSet(client *mongo.Client) bool {
+	result := client.Database("admin").RunCommand(context.TODO(), bson.D{{Key: "isMaster", Value: 1}})
+	resRaw, err := result.Raw()
+	if err != nil {
+		return false
+	}
+	_, err = resRaw.LookupErr("setName")
+	return err == nil
+}

--- a/website/docs/topology/topology_service_types.md
+++ b/website/docs/topology/topology_service_types.md
@@ -29,6 +29,7 @@ POST /topology/service-types?date=YYYY-MM-DD
 | Type   | Description            | Required | Default value |
 | ------ | ---------------------- | -------- | ------------- |
 | `date` | target a specific date | NO       | today's date  |
+| `force` | force overwriting topology for a specific date | NO | false |
 
 #### Headers
 

--- a/website/static/openapi/argo-web-api.yml
+++ b/website/static/openapi/argo-web-api.yml
@@ -3510,6 +3510,12 @@ paths:
         schema:
           type: string
           default: todays_date in YYYY-MM-DD format
+      - name: force
+        in: query
+        description: force overwight of existing topology for specific date
+        schema:
+          type: boolean
+          default: false
       requestBody:
         description: Json description of group topology items to be created
         content:
@@ -3736,6 +3742,12 @@ paths:
         schema:
           type: string
           default: todays_date in YYYY-MM-DD format
+      - name: force
+        in: query
+        description: force overwight of existing topology for specific date
+        schema:
+          type: boolean
+          default: false
       requestBody:
         description: Json description of service type items to be created
         content:
@@ -3930,6 +3942,12 @@ paths:
         schema:
           type: string
           default: todays_date in YYYY-MM-DD format
+      - name: force
+        in: query
+        description: force overwight of existing topology for specific date
+        schema:
+          type: boolean
+          default: false
       requestBody:
         description: Json description of endpoint topology items to be created
         content:


### PR DESCRIPTION
…ms during creation

For the following topology calls:
- POST /api/v2/topology/endpoints
- POST /api/v2/topology/groups
- POST /api/v2/topology/service-types

Support the use of optional `?force=true` parameter to allow overwriting existing topology