### PR TITLE
ARGO-5519 Support eosc-service-catalog connector in feeds topology

### DIFF
--- a/app/feeds/feeds_test.go
+++ b/app/feeds/feeds_test.go
@@ -440,6 +440,49 @@ func (suite *FeedsTestSuite) TestUpdateFeedTopo() {
 
 }
 
+func (suite *FeedsTestSuite) TestUpdateFeedTopo2() {
+
+	jsonInput := `
+  {
+   "type": "eosc-service-catalog",
+   "feed_service_groups": "https://somewhere2.foo.bar/service_groups",
+   "feed_service_endpoints": "https://somewhere2.foo.bar/service_endpoints",
+   "feed_service_endpoints_extensions": "https://somewhere2.foo.bar/service_endpoints_extensions"
+  }
+`
+
+	jsonOutput := `{
+ "status": {
+  "message": "Feeds resource succesfully updated",
+  "code": "200"
+ },
+ "data": [
+  {
+   "type": "eosc-service-catalog",
+   "feed_service_groups": "https://somewhere2.foo.bar/service_groups",
+   "feed_service_endpoints": "https://somewhere2.foo.bar/service_endpoints",
+   "feed_service_endpoints_extensions": "https://somewhere2.foo.bar/service_endpoints_extensions"
+  }
+ ]
+}`
+
+	request, _ := http.NewRequest("PUT", "/api/v2/feeds/topology", strings.NewReader(jsonInput))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code := response.Code
+	output := response.Body.String()
+
+	// Check that we must have a 200 ok code
+	suite.Equal(200, code, "Internal Server Error")
+	// Compare the expected and actual json response
+	suite.Equal(jsonOutput, output, "Response body mismatch")
+
+}
+
 func (suite *FeedsTestSuite) TestListTopo() {
 
 	request, _ := http.NewRequest("GET", "/api/v2/feeds/topology", strings.NewReader(""))

--- a/app/feeds/model.go
+++ b/app/feeds/model.go
@@ -1,12 +1,16 @@
 package feeds
 
-//Topo holds a list of topology feed parameters
+// Topo holds a list of topology feed parameters
 type Topo struct {
-	TopoType     string   `bson:"type" json:"type"`
-	FeedURL      string   `bson:"feed_url" json:"feed_url"`
-	Paginated    string   `bson:"paginated" json:"paginated"`
-	FetchType    []string `bson:"fetch_type" json:"fetch_type"`
-	UIDendpoints string   `bson:"uid_endpoints" json:"uid_endpoints"`
+	TopoType                       string `bson:"type" json:"type"`
+	FeedURL                        string `bson:"feed_url" json:"feed_url,omitempty"`
+	FeedServiceGroups              string `bson:"feed_service_groups" json:"feed_service_groups,omitempty"`
+	FeedServiceEndpoints           string `bson:"feed_service_endpoints" json:"feed_service_endpoints,omitempty"`
+	FeedServiceEndpointsExtensions string `bson:"feed_service_endpoints_extensions" json:"feed_service_endpoints_extensions,omitempty"`
+
+	Paginated    string    `bson:"paginated" json:"paginated,omitempty"`
+	FetchType    *[]string `bson:"fetch_type" json:"fetch_type,omitempty"`
+	UIDendpoints string    `bson:"uid_endpoints" json:"uid_endpoints,omitempty"`
 }
 
 // Weights holds a list of weight feed parameters

--- a/website/docs/tenants_and_feeds/feeds.md
+++ b/website/docs/tenants_and_feeds/feeds.md
@@ -63,6 +63,29 @@ Json Response
 }
 ```
 
+## Example retrieving feed of eosc-service-catalog type
+
+When user selects a feed of `eosc-service-catalog` type then the following fields are supported:
+- `feed_service_groups`
+- `feed_service_endpoints`
+- `feed_service_endpoints_extensions`
+
+```json
+{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "type": "eosc-service-catalog",
+   "feed_service_groups": "https://example.foo/service_groups",
+   "feed_service_endpoints": "https://example.foo/service_endpoints",
+   "feed_service_endpoints_extensions": "https://example.foo/service_endpoints_extensions",
+  }
+ ]
+}
+```
 
 ## [PUT]: Update topology feed parameters {#2}
 This method is used to update topology feed parameters

--- a/website/static/openapi/argo-web-api.yml
+++ b/website/static/openapi/argo-web-api.yml
@@ -12576,6 +12576,8 @@ components:
             type: string
     FeedsTopo:
       type: object
+      required:
+        - type
       properties:
         type:
           type: string
@@ -12589,6 +12591,12 @@ components:
             type: string
         uid_endpoints:
           type: string
+        feed_service_groups:
+           type: string
+        feed_service_endpoints:
+           type: string
+        feed_service_endpoints_extensions:
+           type: string
     TopologyResponse:
       type: object
       properties:


### PR DESCRIPTION
Support the following fields for eosc-service-catalog feed type

```
{
  "type": "eosc-service-catalog",
  "feed_service_groups": "https://example.foo/service_groups",
  "feed_service_endpoints": "https://example.foo/service_endpoints",
  "feed_service_endpoints_extensions": "https://example.foo/service_endpoints_extensions"
}
```