### PR TITLE
ARGO-5532 Introduce summary capability. Add ability to target specifi…

### DIFF
--- a/docker/files/init_mongo.js
+++ b/docker/files/init_mongo.js
@@ -693,15 +693,35 @@ db.roles.insertMany([
     roles: ['super_admin', 'admin', 'editor']
   },
   {
+    resource: 'v4.nodes.summary',
+    roles: [ 'super_admin', 'admin', 'editor', 'viewer' ]
+  },
+  {
+    resource: 'v4.nodes.summary.item',
+    roles: [ 'super_admin', 'admin', 'editor', 'viewer' ]
+  },
+  {
     resource: 'v4.nodes.availability',
     roles: [ 'super_admin', 'admin', 'editor', 'viewer' ]
   },
   {
-    resource: 'v4.nodes.reliability',
+    resource: 'v4.nodes.availability.item',
+    roles: [ 'super_admin', 'admin', 'editor', 'viewer' ]
+  },
+  {
+    resource: 'v4.nodes.uptime',
+    roles: [ 'super_admin', 'admin', 'editor', 'viewer' ]
+  },
+  {
+    resource: 'v4.nodes.uptime.item',
     roles: [ 'super_admin', 'admin', 'editor', 'viewer' ]
   },
   {
     resource: 'v4.nodes.status',
+    roles: [ 'super_admin', 'admin', 'editor', 'viewer' ]
+  },
+  {
+    resource: 'v4.nodes.status.item',
     roles: [ 'super_admin', 'admin', 'editor', 'viewer' ]
   }
 ])

--- a/respond/wrappers.go
+++ b/respond/wrappers.go
@@ -50,6 +50,7 @@ func WrapAuthenticate(hfn http.Handler, cfg config.Config, routeName string) htt
 		// check if has x-tenant-id header
 		adminTenantId := r.Header.Get("x-tenant-id")
 		if isNodeRoute(routeName) {
+
 			vars := mux.Vars(r)
 			nodeName := vars["node_name"]
 			isAdmin := authentication.AuthenticateAdmin(r.Header, cfg)
@@ -64,6 +65,7 @@ func WrapAuthenticate(hfn http.Handler, cfg config.Config, routeName string) htt
 				}
 			}
 			tenantConf, name, tErr := authentication.AuthenticateNode(r.Header, cfg, nodeName, isAdmin)
+
 			if tErr != nil {
 				Error(w, r, ErrAuthen, cfg, errs)
 				return

--- a/scripts/mongodb/populate_default_roles.js
+++ b/scripts/mongodb/populate_default_roles.js
@@ -349,15 +349,35 @@ function populate_default_roles() {
              roles: ['super_admin', 'admin', 'editor']
         },
         {
+             resource: 'v4.nodes.summary',
+             roles: [ 'super_admin', 'admin', 'editor', 'viewer' ]
+        },
+        {
+             resource: 'v4.nodes.summary.item',
+             roles: [ 'super_admin', 'admin', 'editor', 'viewer' ]
+        },
+        {
              resource: 'v4.nodes.availability',
              roles: [ 'super_admin', 'admin', 'editor', 'viewer' ]
         },
         {
-             resource: 'v4.nodes.reliability',
+             resource: 'v4.nodes.availability.item',
+             roles: [ 'super_admin', 'admin', 'editor', 'viewer' ]
+        },
+        {
+             resource: 'v4.nodes.uptime',
+             roles: [ 'super_admin', 'admin', 'editor', 'viewer' ]
+        },
+        {
+             resource: 'v4.nodes.uptime.item',
              roles: [ 'super_admin', 'admin', 'editor', 'viewer' ]
         },
         {
              resource: 'v4.nodes.status',
+             roles: [ 'super_admin', 'admin', 'editor', 'viewer' ]
+        },
+        {
+             resource: 'v4.nodes.status.item',
              roles: [ 'super_admin', 'admin', 'editor', 'viewer' ]
         }
     ]);

--- a/utils/authentication/authenticate.go
+++ b/utils/authentication/authenticate.go
@@ -213,7 +213,6 @@ func AuthenticateNode(h http.Header, cfg config.Config, nodeName string, isAdmin
 	var result DbInfoUsers
 
 	err := tenantsCol.FindOne(context.TODO(), query, options.FindOne().SetProjection(projection)).Decode(&result)
-
 	if err == nil {
 
 		mongoConf := config.MongoConfig{}

--- a/v4/nodes/handlers.go
+++ b/v4/nodes/handlers.go
@@ -16,8 +16,8 @@ import (
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
-// GetAvailability lists group availabilities according to the http request
-func GetAvailability(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
+// GetSummary lists availability, reliability and uptime for a specific group
+func GetSummary(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
 
 	//STANDARD DECLARATIONS START
 	code := http.StatusOK
@@ -34,6 +34,8 @@ func GetAvailability(r *http.Request, cfg config.Config) (int, http.Header, []by
 	// Parse the request into the input
 	urlValues := r.URL.Query()
 	vars := mux.Vars(r)
+
+	item := vars["item"]
 
 	// Grab Tenant DB configuration from context
 	tenantDbConfig := gcontext.Get(r, "tenant_conf").(config.MongoConfig)
@@ -67,7 +69,7 @@ func GetAvailability(r *http.Request, cfg config.Config) (int, http.Header, []by
 
 	input :=
 		basicQuery{
-			Name:        "",
+			Name:        item,
 			Granularity: urlValues.Get("granularity"),
 			Format:      contentType,
 			StartTime:   urlValues.Get("start_time"),
@@ -93,6 +95,132 @@ func GetAvailability(r *http.Request, cfg config.Config) (int, http.Header, []by
 		"date":   bson.M{"$gte": input.StartTimeInt, "$lte": input.EndTimeInt},
 		"report": report.ID,
 	}
+	var query []primitive.M
+
+	if input.Name != "" {
+		filter["name"] = input.Name
+	}
+
+	// Prepare the group results
+	// Select the granularity of the search daily/monthly
+
+	if input.Granularity == "daily" {
+		customForm[0] = "20060102"
+		customForm[1] = "2006-01-02"
+		query = DailyEndpoint(filter)
+
+	} else if input.Granularity == "monthly" {
+		customForm[0] = "200601"
+		customForm[1] = "2006-01"
+		query = MonthlyGroup(filter)
+
+	}
+
+	arCol := cfg.MongoClient.Database(tenantDbConfig.Db).Collection(groupColName)
+	cursor, err := arCol.Aggregate(context.TODO(), query)
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	defer cursor.Close(context.TODO())
+	cursor.All(context.TODO(), &resultsGroups)
+
+	output, err = createSummaryView(resultsGroups)
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	return code, h, output, err
+}
+
+// GetAvailability lists group availabilities according to the http request
+func GetAvailability(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
+
+	//STANDARD DECLARATIONS START
+	code := http.StatusOK
+	h := http.Header{}
+	output := []byte("")
+	err := error(nil)
+	charset := "utf-8"
+	//STANDARD DECLARATIONS END
+
+	// Set Content-Type response Header value
+	contentType := r.Header.Get("Accept")
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+
+	// Parse the request into the input
+	urlValues := r.URL.Query()
+	vars := mux.Vars(r)
+
+	item := vars["item"]
+
+	// Grab Tenant DB configuration from context
+	tenantDbConfig := gcontext.Get(r, "tenant_conf").(config.MongoConfig)
+
+	// get node report id
+	nodeReport := NodeReport{}
+
+	report := reports.MongoInterface{}
+	nrCol := cfg.MongoClient.Database(tenantDbConfig.Db).Collection(nodeReportColName)
+	rCol := cfg.MongoClient.Database(tenantDbConfig.Db).Collection(reportsColName)
+
+	err = nrCol.FindOne(context.TODO(), bson.M{"_id": "node-report"}).Decode(&nodeReport)
+
+	if err != nil {
+		code = http.StatusNotFound
+		message := "Node report not set"
+		output, err := createErrorMessage(message, code, contentType)
+		h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+		return code, h, output, err
+	}
+
+	err = rCol.FindOne(context.TODO(), bson.M{"id": nodeReport.ReportId}).Decode(&report)
+
+	if err != nil {
+		code = http.StatusNotFound
+		message := "The report with the id " + nodeReport.ReportId + " does not exist"
+		output, err := createErrorMessage(message, code, contentType)
+		h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+		return code, h, output, err
+	}
+
+	input :=
+		basicQuery{
+			Name:        item,
+			Granularity: urlValues.Get("granularity"),
+			Format:      contentType,
+			StartTime:   urlValues.Get("start_time"),
+			EndTime:     urlValues.Get("end_time"),
+			Report:      report,
+			Vars:        vars,
+			Date:        urlValues.Get("date"),
+			StartDate:   urlValues.Get("start_date"),
+			EndDate:     urlValues.Get("end_date"),
+		}
+	errs := input.Validate()
+	if len(errs) > 0 {
+		out := respond.BadRequestSimple
+		out.Errors = errs
+		output = out.MarshalTo(contentType)
+		code = 400
+		return code, h, output, err
+	}
+
+	resultsGroups := []GroupInterface{}
+
+	filter := bson.M{
+		"date":   bson.M{"$gte": input.StartTimeInt, "$lte": input.EndTimeInt},
+		"report": report.ID,
+	}
+
+	if input.Name != "" {
+		filter["name"] = item
+	}
+
 	var query []primitive.M
 
 	// Prepare the group results
@@ -149,6 +277,7 @@ func GetUptime(r *http.Request, cfg config.Config) (int, http.Header, []byte, er
 	// Parse the request into the input
 	urlValues := r.URL.Query()
 	vars := mux.Vars(r)
+	item := vars["item"]
 
 	// Grab Tenant DB configuration from context
 	tenantDbConfig := gcontext.Get(r, "tenant_conf").(config.MongoConfig)
@@ -182,7 +311,7 @@ func GetUptime(r *http.Request, cfg config.Config) (int, http.Header, []byte, er
 
 	input :=
 		basicQuery{
-			Name:        "",
+			Name:        item,
 			Granularity: urlValues.Get("granularity"),
 			Format:      contentType,
 			StartTime:   urlValues.Get("start_time"),
@@ -209,6 +338,10 @@ func GetUptime(r *http.Request, cfg config.Config) (int, http.Header, []byte, er
 		"report": report.ID,
 	}
 	var query []primitive.M
+
+	if input.Name != "" {
+		filter["name"] = input.Name
+	}
 
 	// Prepare the group results
 	// Select the granularity of the search daily/monthly
@@ -265,6 +398,8 @@ func GetStatus(r *http.Request, cfg config.Config) (int, http.Header, []byte, er
 
 	// Parse the request into the input
 	urlValues := r.URL.Query()
+	vars := mux.Vars(r)
+	item := vars["item"]
 
 	// This is going to be used to determine a detailed/latest view of the results
 	view := urlValues.Get("view")
@@ -315,7 +450,7 @@ func GetStatus(r *http.Request, cfg config.Config) (int, http.Header, []byte, er
 		parsedEnd,
 		urlValues.Get("report_name"),
 		urlValues.Get("group_type"),
-		urlValues.Get("group_name"),
+		item,
 		contentType,
 		"",
 	}

--- a/v4/nodes/models.go
+++ b/v4/nodes/models.go
@@ -69,6 +69,12 @@ type NodeReport struct {
 	ReportId string `bson:"report_id"`
 }
 
+type Summary struct {
+	Date         string `json:"date,omitempty"`
+	Availability string `json:"availability"`
+	Uptime       string `json:"uptime,omitempty"`
+}
+
 type Availability struct {
 	Date         string `json:"date,omitempty"`
 	Availability string `json:"availability"`
@@ -90,12 +96,12 @@ type StatusResult struct {
 	AffectedByThresholdRule bool   `json:"affected_by_threshold_rule,omitempty"`
 }
 
-type Results[T Availability | Uptime] struct {
+type Results[T Availability | Uptime | Summary] struct {
 	Name    string `json:"name"`
 	Results []T    `json:"results"`
 }
 
-type Data[T Availability | Uptime] struct {
+type Data[T Availability | Uptime | Summary] struct {
 	Data []Results[T] `json:"data"`
 }
 

--- a/v4/nodes/queries.go
+++ b/v4/nodes/queries.go
@@ -1,6 +1,8 @@
 package nodes
 
-import "go.mongodb.org/mongo-driver/bson"
+import (
+	"go.mongodb.org/mongo-driver/bson"
+)
 
 // datastore collection name that contains aggregations profile records
 const groupColName = "endpoint_group_ar"

--- a/v4/nodes/routing.go
+++ b/v4/nodes/routing.go
@@ -13,9 +13,27 @@ func HandleSubrouter(s *mux.Router, confhandler *respond.ConfHandler) {
 
 var arRoutes = []respond.AppRoutes{
 	{
+		Name:             "v4.nodes.summary.item",
+		Verb:             "GET",
+		Path:             "/nodes/{node_name}/capabilities/summary/{item}",
+		SubrouterHandler: GetSummary,
+	},
+	{
+		Name:             "v4.nodes.summary",
+		Verb:             "GET",
+		Path:             "/nodes/{node_name}/capabilities/summary",
+		SubrouterHandler: GetSummary,
+	},
+	{
 		Name:             "v4.nodes.availability",
 		Verb:             "GET",
 		Path:             "/nodes/{node_name}/capabilities/availability",
+		SubrouterHandler: GetAvailability,
+	},
+	{
+		Name:             "v4.nodes.availability.item",
+		Verb:             "GET",
+		Path:             "/nodes/{node_name}/capabilities/availability/{item}",
 		SubrouterHandler: GetAvailability,
 	},
 	{
@@ -25,15 +43,39 @@ var arRoutes = []respond.AppRoutes{
 		SubrouterHandler: GetUptime,
 	},
 	{
+		Name:             "v4.nodes.uptime.item",
+		Verb:             "GET",
+		Path:             "/nodes/{node_name}/capabilities/uptime/{item}",
+		SubrouterHandler: GetAvailability,
+	},
+	{
 		Name:             "v4.nodes.status",
 		Verb:             "GET",
 		Path:             "/nodes/{node_name}/capabilities/status",
 		SubrouterHandler: GetStatus,
 	},
 	{
+		Name:             "v4.nodes.status.item",
+		Verb:             "GET",
+		Path:             "/nodes/{node_name}/capabilities/status/{item}",
+		SubrouterHandler: GetStatus,
+	},
+	{
 		Name:             "v4.nodes.status.options",
 		Verb:             "OPTIONS",
 		Path:             "/nodes/{node_name}/capabilities/status",
+		SubrouterHandler: Options,
+	},
+	{
+		Name:             "v4.nodes.status.item.options",
+		Verb:             "OPTIONS",
+		Path:             "/nodes/{node_name}/capabilities/status/{item}",
+		SubrouterHandler: Options,
+	},
+	{
+		Name:             "v4.nodes.availability.item.options",
+		Verb:             "OPTIONS",
+		Path:             "/nodes/{node_name}/capabilities/availability/{item}",
 		SubrouterHandler: Options,
 	},
 	{
@@ -46,6 +88,12 @@ var arRoutes = []respond.AppRoutes{
 		Name:             "v4.nodes.uptime.options",
 		Verb:             "OPTIONS",
 		Path:             "/nodes/{node_name}/capabilities/uptime",
+		SubrouterHandler: Options,
+	},
+	{
+		Name:             "v4.nodes.uptime.item.options",
+		Verb:             "OPTIONS",
+		Path:             "/nodes/{node_name}/capabilities/uptime/{item}",
 		SubrouterHandler: Options,
 	},
 }

--- a/v4/nodes/views.go
+++ b/v4/nodes/views.go
@@ -26,6 +26,40 @@ func createErrorMessage(message string, code int, format string) ([]byte, error)
 	return output, err
 }
 
+func createSummaryView(results []GroupInterface) ([]byte, error) {
+
+	docRoot := Data[Summary]{
+		Data: []Results[Summary]{},
+	}
+
+	prevEndpoint := ""
+
+	for i := 0; i < len(results); i++ {
+		row := results[i]
+		timestamp, _ := time.Parse(customForm[0], fmt.Sprint(row.Date))
+
+		if prevEndpoint != row.Name {
+			prevEndpoint = row.Name
+			docRoot.Data = append(docRoot.Data, Results[Summary]{
+				Name:    row.Name,
+				Results: []Summary{},
+			})
+		}
+
+		currIdx := len(docRoot.Data) - 1
+		prepDate := timestamp.Format(customForm[1])
+
+		docRoot.Data[currIdx].Results = append(docRoot.Data[currIdx].Results,
+			Summary{
+				Date:         prepDate,
+				Availability: fmt.Sprintf("%g", row.Availability),
+				Uptime:       fmt.Sprintf("%g", row.Up),
+			})
+	}
+	return json.MarshalIndent(docRoot, " ", "  ")
+
+}
+
 func createAvailabilityView(results []GroupInterface) ([]byte, error) {
 
 	docRoot := Data[Availability]{

--- a/website/docs/apiv4/v4nodes.md
+++ b/website/docs/apiv4/v4nodes.md
@@ -16,6 +16,7 @@ A tenant can be defined to represent a specific node by adding the following ext
 
 When a tenant has been configured with node information the node's capabilities become available through the `/api/v4/nodes` calls.
 Capabilities include the following:
+- summary (get both availability and uptime results for the nod'es services)
 - availability (get availability results for the node's services)
 - uptime (get uptime results for the node's services)
 - status (get status results for the node's services)
@@ -26,19 +27,20 @@ _Note_: The following calls implement the node capabilities
 
 | Name                                                                          | Description                                                                                                                                                                                                                              | Shortcut          |
 | ----------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
-| GET: Availability results for the node's services | This method retrieves by default the latest daily availability for all node's services | [Description](#1) |
-| GET: Uptime results for the node's services | This method retrieves by default the latest daily availability for all node's services | [Description](#2) |
-| GET: Status results for the node's services | This method retrieves by default the latest daily availability for all node's services | [Description](#3) |
+| GET: Summary results for the node's services | This method retrieves by default the latest daily availability and uptime for a node's service | [Description](#1A) |
+| GET: Availability results for the node's services | This method retrieves by default the latest daily availability for a node's service | [Description](#1) |
+| GET: Uptime results for the node's services | This method retrieves by default the latest daily availability for a node's service | [Description](#2) |
+| GET: Status results for the node's services | This method retrieves by default the latest daily availability for a node's service | [Description](#3) |
 
 
-## [GET]: Availability results for the node's services {#1}
+## [GET]: Availability results for the node's services {#1A}
 
-The following methods can be used to obtain availability results for a node's services. The api authenticates the tenant using the api-key within the x-api-key header. User can specify time granularity (`monthly`, `daily`) for retrieved results and also format using the `Accept` header. 
+The following methods can be used to obtain availability and uptime results for a node's services. The api authenticates the tenant using the api-key within the x-api-key header. User can specify time granularity (`monthly`, `daily`) for retrieved results and also format using the `Accept` header. 
 
 ### Input
 
 ```
-/nodes/{node_name}/capabilities/availability?([start_time]&[end_time]|[start_date]&[end_date]|[date])&[granularity]
+/nodes/{node_name}/capabilities/summary/{service-name}?([start_time]&[end_time]|[start_date]&[end_date]|[date])&[granularity]
 ```
 
 #### Query Parameters
@@ -60,10 +62,161 @@ The following methods can be used to obtain availability results for a node's se
 
 | Name            | Description                                                                                           | Required | Default value |
 | --------------- | ----------------------------------------------------------------------------------------------------- | -------- | ------------- |
+| `{service-name}`| Target a specific service. If omitted you get a result list for all the services                | NO       |               |
 | `{node_name}` | Name of the node | YES      |
 
 
-### Example Request 1: Get default daily availability
+### Example Request 1: Get default daily availability for service ST01
+
+```
+/api/v4/nodes/NODE_A/capabilities/summary/SERVICE101`
+```
+
+##### Headers
+
+```
+x-api-key: "tenant_key_value"
+Accept: "application/json"
+```
+
+#### Response
+
+##### Code
+
+```
+Status: 200 OK
+```
+
+##### Body
+
+```json
+{
+  "data": [
+    {
+      "name": "SERVICE101",
+      "results": [
+        {
+          "date": "2015-06-26",
+          "availability": "99",
+          "uptime": "1"
+        }
+      ]
+    }
+  ]
+}
+```
+
+
+### Example Request 2: daily summary over a period
+
+#### Request
+
+##### Method
+`HTTP GET`
+
+##### Path
+
+```
+/api/v4/nodes/NODE_A/capabilities/summary/SERVICE101?start_date=2015-06-20Z&end_date=2015-06-22T&granularity=daily`
+```
+
+or
+
+```
+/api/v4/nodes/NODE_A/capabilities/summary/SERVICE101?start_time=2015-06-20T12:00:00Z&end_time=2015-06-22T23:00:00Z&granularity=daily`
+```
+
+##### Headers
+
+```
+x-api-key: "tenant_key_value"
+Accept: "application/json"
+```
+
+#### Response
+
+##### Code
+
+```
+Status: 200 OK
+```
+
+##### Body
+
+```json
+{
+   "data": [
+     {
+       "name": "SERVICE101",
+       "results": [
+         {
+           "date": "2015-06-20",
+           "availability": "100",
+           "uptime": "1"
+         },
+         {
+           "date": "2015-06-21",
+           "availability": "100",
+           "uptime": "1"
+         },
+         {
+           "date": "2015-06-22",
+           "availability": "100",
+           "uptime": "1"
+         }
+       ]
+     }
+   ]
+ }
+```
+
+### Example Request 3: monthly granularity
+
+#### Request
+
+##### Method
+`HTTP GET`
+
+##### Path
+
+```
+/api/v4/nodes/NODE_A/capabilities/summary/SERVICE101?start_time=2015-07-01T12:00:00Z&end_time=2015-07-31T23:00:00Z&granularity=monthly
+```
+##### Headers
+
+```
+x-api-key: "tenant_key_value"
+Accept: "application/json"
+```
+
+#### Response
+
+##### Code
+
+```
+Status: 200 OK
+```
+
+##### Body
+
+```json
+{
+  "data": [
+    {
+      "name": "SERVICE101",
+      "results": [
+        {
+          "date": "2015-06",
+          "availability": "99.99999900000002",
+          "uptime": "1"
+        }
+      ]
+    }
+  ]
+}  
+```
+
+### Example Request 4: Get default daily availability for all the node's services
 
 ```
 /api/v4/nodes/NODE_A/capabilities/availability`
@@ -90,20 +243,95 @@ Status: 200 OK
 {
   "data": [
     {
-      "name": "ST01",
+      "name": "SERVICE101",
       "results": [
         {
           "date": "2015-06-26",
-          "availability": "99"
+          "availability": "99",
+          "uptime": "0.99"
         }
       ]
     },
     {
-      "name": "ST02",
+      "name": "SERVICE202",
       "results": [
         {
           "date": "2015-06-26",
-          "availability": "98"
+          "availability": "98",
+          "uptime": "0.98"
+        }
+      ]
+    }
+  ]
+}
+```
+
+
+## [GET]: Availability results for the node's services {#1}
+
+The following methods can be used to obtain availability results for a node's services. The api authenticates the tenant using the api-key within the x-api-key header. User can specify time granularity (`monthly`, `daily`) for retrieved results and also format using the `Accept` header. 
+
+### Input
+
+```
+/nodes/{node_name}/capabilities/availability/{service-name}?([start_time]&[end_time]|[start_date]&[end_date]|[date])&[granularity]
+```
+
+#### Query Parameters
+
+| Type            | Description                                                                                     | Required | Default value |
+| --------------- | ----------------------------------------------------------------------------------------------- | -------- | ------------- |
+| `[date]`        | UTC date in YYYY-MM-DD format                                                                   | NO       |               |
+| `[start_time]`  | UTC time in W3C format                                                                          | NO       |               |
+| `[end_time]`    | UTC time in W3C format                                                                          | NO       |               |
+| `[start_date]`  | UTC date in YYYY-MM-DD format                                                                   | NO       |               |
+| `[start_date]`  | UTC date in YYYY-MM-DD format                                                                   | NO       |               |
+| `[granularity]` | Granularity of time that will be used to present data. Possible values are `monthly`,  `daily`  | NO       | `daily`       |
+
+- If a user doesn't specify any query parameter the api returns the latest daily availability results.
+- If a user specifies the date parameter the api retuerns the daily availability results for that date
+- A user can specify the period of availability results by using start_date and end_date instead of start_time and end_time
+
+#### Path Parameters
+
+| Name            | Description                                                                                           | Required | Default value |
+| --------------- | ----------------------------------------------------------------------------------------------------- | -------- | ------------- |
+| `{service-name}`| Target a specific service. If omitted you get a result list for all the services                | NO       |               |
+| `{node_name}` | Name of the node | YES      |
+
+
+### Example Request 1: Get default daily availability for service ST01
+
+```
+/api/v4/nodes/NODE_A/capabilities/availability/SERVICE101`
+```
+
+##### Headers
+
+```
+x-api-key: "tenant_key_value"
+Accept: "application/json"
+```
+
+#### Response
+
+##### Code
+
+```
+Status: 200 OK
+```
+
+##### Body
+
+```json
+{
+  "data": [
+    {
+      "name": "SERVICE101",
+      "results": [
+        {
+          "date": "2015-06-26",
+          "availability": "99"
         }
       ]
     }
@@ -122,13 +350,13 @@ Status: 200 OK
 ##### Path
 
 ```
-/api/v4/nodes/NODE_A/capabilities/availability?start_date=2015-06-20Z&end_date=2015-06-22T&granularity=daily`
+/api/v4/nodes/NODE_A/capabilities/availability/SERVICE101?start_date=2015-06-20Z&end_date=2015-06-22T&granularity=daily`
 ```
 
 or
 
 ```
-/api/v4/nodes/NODE_A/capabilities/availability?start_time=2015-06-20T12:00:00Z&end_time=2015-06-22T23:00:00Z&granularity=daily`
+/api/v4/nodes/NODE_A/capabilities/availability/SERVICE101?start_time=2015-06-20T12:00:00Z&end_time=2015-06-22T23:00:00Z&granularity=daily`
 ```
 
 ##### Headers
@@ -152,7 +380,7 @@ Status: 200 OK
 {
    "data": [
      {
-       "name": "ST01",
+       "name": "SERVICE101",
        "results": [
          {
            "date": "2015-06-20",
@@ -165,23 +393,6 @@ Status: 200 OK
          {
            "date": "2015-06-22",
            "availability": "100"
-         }
-       ]
-     },
-     {
-       "name": "ST02",
-       "results": [
-         {
-           "date": "2015-06-20",
-           "availability": "100"
-         },
-         {
-           "date": "2015-06-21",
-           "availability": "98"
-         },
-         {
-           "date": "2015-06-22",
-           "availability": "98"
          }
        ]
      }
@@ -189,7 +400,7 @@ Status: 200 OK
  }
 ```
 
-### Example Request 2: monthly granularity
+### Example Request 3: monthly granularity
 
 #### Request
 
@@ -199,7 +410,7 @@ Status: 200 OK
 ##### Path
 
 ```
-/api/v3/results/Report_A?start_time=2015-07-01T12:00:00Z&end_time=2015-07-31T23:00:00Z&granularity=monthly
+/api/v4/nodes/NODE_A/capabilities/availability/SERVICE101?start_time=2015-07-01T12:00:00Z&end_time=2015-07-31T23:00:00Z&granularity=monthly
 ```
 ##### Headers
 
@@ -222,16 +433,7 @@ Status: 200 OK
 {
   "data": [
     {
-      "name": "ST01",
-      "results": [
-        {
-          "date": "2015-06",
-          "availability": "99.99999900000002"
-        }
-      ]
-    },
-    {
-      "name": "ST02",
+      "name": "SERVICE101",
       "results": [
         {
           "date": "2015-06",
@@ -243,6 +445,54 @@ Status: 200 OK
 }  
 ```
 
+### Example Request 4: Get default daily availability for all the node's services
+
+```
+/api/v4/nodes/NODE_A/capabilities/availability`
+```
+
+##### Headers
+
+```
+x-api-key: "tenant_key_value"
+Accept: "application/json"
+```
+
+#### Response
+
+##### Code
+
+```
+Status: 200 OK
+```
+
+##### Body
+
+```json
+{
+  "data": [
+    {
+      "name": "SERVICE101",
+      "results": [
+        {
+          "date": "2015-06-26",
+          "availability": "99"
+        }
+      ]
+    },
+    {
+      "name": "SERVICE202",
+      "results": [
+        {
+          "date": "2015-06-26",
+          "availability": "98"
+        }
+      ]
+    }
+  ]
+}
+```
+
 
 ## [GET]: Uptime results for the node's services {#2}
 
@@ -251,7 +501,7 @@ The following methods can be used to obtain uptime results for a node's services
 ### Input
 
 ```
-/nodes/{node_name}/capabilities/uptime?([start_time]&[end_time]|[start_date]&[end_date]|[date])&[granularity]
+/nodes/{node_name}/capabilities/uptime/{service-name}?([start_time]&[end_time]|[start_date]&[end_date]|[date])&[granularity]
 ```
 
 #### Query Parameters
@@ -274,9 +524,154 @@ The following methods can be used to obtain uptime results for a node's services
 | Name            | Description                                                                                           | Required | Default value |
 | --------------- | ----------------------------------------------------------------------------------------------------- | -------- | ------------- |
 | `{node_name}` | Name of the node | YES      |
-
+| `{service-name}`| Target a specific service. If omitted you get a result list for all the services                | NO       |               |
 
 ### Example Request 1: Get default daily uptime
+
+```
+/api/v4/nodes/NODE_A/capabilities/uptime/SERVICE101`
+```
+
+##### Headers
+
+```
+x-api-key: "tenant_key_value"
+Accept: "application/json"
+```
+
+#### Response
+
+##### Code
+
+```
+Status: 200 OK
+```
+
+##### Body
+
+```json
+{
+  "data": [
+    {
+      "name": "SERVICE101",
+      "results": [
+        {
+          "date": "2015-06-26",
+          "uptime": "0.99"
+        }
+      ]
+    }
+  ]
+}
+```
+
+
+### Example Request 2: daily uptime over a period
+
+#### Request
+
+##### Method
+`HTTP GET`
+
+##### Path
+
+```
+/api/v4/nodes/NODE_A/capabilities/uptime/SERVICE101?start_date=2015-06-20Z&end_date=2015-06-22T&granularity=daily`
+```
+
+or
+
+```
+/api/v4/nodes/NODE_A/capabilities/uptime/SERVICE101?start_time=2015-06-20T12:00:00Z&end_time=2015-06-22T23:00:00Z&granularity=daily`
+```
+
+##### Headers
+
+```
+x-api-key: "tenant_key_value"
+Accept: "application/json"
+```
+
+#### Response
+
+##### Code
+
+```
+Status: 200 OK
+```
+
+##### Body
+
+```json
+{
+   "data": [
+     {
+       "name": "SERVICE101",
+       "results": [
+         {
+           "date": "2015-06-20",
+           "uptime": "1"
+         },
+         {
+           "date": "2015-06-21",
+           "uptime": "1"
+         },
+         {
+           "date": "2015-06-22",
+           "uptime": "1"
+         }
+       ]
+     }
+   ]
+ }
+```
+
+### Example Request 3: monthly granularity
+
+#### Request
+
+##### Method
+`HTTP GET`
+
+##### Path
+
+```
+/api/v4/nodes/NODE_A/capabilities/uptime/SERVICE101?start_time=2015-07-01T12:00:00Z&end_time=2015-07-31T23:00:00Z&granularity=monthly
+```
+##### Headers
+
+```
+x-api-key: "tenant_key_value"
+Accept: "application/json"
+```
+
+#### Response
+
+##### Code
+
+```
+Status: 200 OK
+```
+
+##### Body
+
+```json
+{
+  "data": [
+    {
+      "name": "SERVICE101",
+      "results": [
+        {
+          "date": "2015-06",
+          "uptime": "1"
+        }
+      ]
+    }
+  ]
+}  
+```
+
+### Example Request 4: Get default daily uptime for all node's services
 
 ```
 /api/v4/nodes/NODE_A/capabilities/uptime`
@@ -303,159 +698,26 @@ Status: 200 OK
 {
   "data": [
     {
-      "name": "ST01",
+      "name": "SERVICE101",
       "results": [
         {
           "date": "2015-06-26",
-          "uptime": "99"
+          "uptime": "0.99"
         }
       ]
     },
     {
-      "name": "ST02",
+      "name": "SERVICE202",
       "results": [
         {
           "date": "2015-06-26",
-          "uptime": "98"
+          "uptime": "0.98"
         }
       ]
     }
   ]
 }
 ```
-
-
-### Example Request 2: daily uptime over a period
-
-#### Request
-
-##### Method
-`HTTP GET`
-
-##### Path
-
-```
-/api/v4/nodes/NODE_A/capabilities/uptime?start_date=2015-06-20Z&end_date=2015-06-22T&granularity=daily`
-```
-
-or
-
-```
-/api/v4/nodes/NODE_A/capabilities/uptime?start_time=2015-06-20T12:00:00Z&end_time=2015-06-22T23:00:00Z&granularity=daily`
-```
-
-##### Headers
-
-```
-x-api-key: "tenant_key_value"
-Accept: "application/json"
-```
-
-#### Response
-
-##### Code
-
-```
-Status: 200 OK
-```
-
-##### Body
-
-```json
-{
-   "data": [
-     {
-       "name": "ST01",
-       "results": [
-         {
-           "date": "2015-06-20",
-           "uptime": "1"
-         },
-         {
-           "date": "2015-06-21",
-           "uptime": "1"
-         },
-         {
-           "date": "2015-06-22",
-           "uptime": "1"
-         }
-       ]
-     },
-     {
-       "name": "ST02",
-       "results": [
-         {
-           "date": "2015-06-20",
-           "uptime": "1"
-         },
-         {
-           "date": "2015-06-21",
-           "uptime": "1"
-         },
-         {
-           "date": "2015-06-22",
-           "uptime": "1"
-         }
-       ]
-     }
-   ]
- }
-```
-
-### Example Request 2: monthly granularity
-
-#### Request
-
-##### Method
-`HTTP GET`
-
-##### Path
-
-```
-/api/v3/results/Report_A?start_time=2015-07-01T12:00:00Z&end_time=2015-07-31T23:00:00Z&granularity=monthly
-```
-##### Headers
-
-```
-x-api-key: "tenant_key_value"
-Accept: "application/json"
-```
-
-#### Response
-
-##### Code
-
-```
-Status: 200 OK
-```
-
-##### Body
-
-```json
-{
-  "data": [
-    {
-      "name": "ST01",
-      "results": [
-        {
-          "date": "2015-06",
-          "uptime": "1"
-        }
-      ]
-    },
-    {
-      "name": "ST02",
-      "results": [
-        {
-          "date": "2015-06",
-          "uptime": "1"
-        }
-      ]
-    }
-  ]
-}  
-```
-
 
 
 ## [GET]: Status results for the node's services {#3}
@@ -465,7 +727,7 @@ The following methods can be used to obtain status results for a node's services
 ### Input
 
 ```
-/nodes/{node_name}/capabilities/uptime?[start_time]&[end_time]&[history]
+/nodes/{node_name}/capabilities/uptime/{service-name}?[start_time]&[end_time]&[history]
 ```
 
 #### Query Parameters
@@ -482,10 +744,115 @@ The following methods can be used to obtain status results for a node's services
 
 | Name            | Description                                                                                           | Required | Default value |
 | --------------- | ----------------------------------------------------------------------------------------------------- | -------- | ------------- |
-| `{node_name}` | Name of the node | YES      |
+| `{service-name}`| Target a specific service. If omitted you get a result list for all the services                | NO       |               |
+| `{node_name}` | Name of the node | YES      | |
 
 
 ### Example Request 1: Get latest status
+
+```
+/api/v4/nodes/NODE_A/capabilities/status/SERVICE101`
+```
+
+##### Headers
+
+```
+x-api-key: "tenant_key_value"
+Accept: "application/json"
+```
+
+#### Response
+
+##### Code
+
+```
+Status: 200 OK
+```
+
+##### Body
+
+```json
+{
+ "data": [
+  {
+   "name": "SERVICE101",
+   "results": [
+    {
+     "timestamp": "2015-05-01T17:53:00Z",
+     "value": "OK"
+    }
+   ]
+  }
+ ]
+}
+```
+
+
+### Example Request 2: get status timelines period
+
+#### Request
+
+##### Method
+`HTTP GET`
+
+##### Path
+
+```
+/api/v4/nodes/NODE_A/capabilities/status/SERVICE101?start_date=2015-05-01Z&end_date=2015-05-01T&granularity=daily`
+```
+
+or
+
+```
+/api/v4/nodes/NODE_A/capabilities/status/SERVICE101?start_time=2015-05-01T12:00:00Z&end_time=2015-05-01T23:00:00Z`
+```
+
+##### Headers
+
+```
+x-api-key: "tenant_key_value"
+Accept: "application/json"
+```
+
+#### Response
+
+##### Code
+
+```
+Status: 200 OK
+```
+
+##### Body
+
+```json
+{
+ "data": [
+  {
+   "name": "SERVICE101",
+   "results": [
+    {
+     "timestamp": "2015-05-01T00:00:00Z",
+     "value": "OK"
+    },
+    {
+     "timestamp": "2015-05-01T01:00:00Z",
+     "value": "CRITICAL"
+    },
+    {
+     "timestamp": "2015-05-01T05:00:00Z",
+     "value": "OK"
+    },
+    {
+     "timestamp": "2015-05-01T23:59:59Z",
+     "value": "OK"
+    }
+   ]
+  }
+ ]
+}
+```
+
+### Example Request 3: Get latest status for all node's services
 
 ```
 /api/v4/nodes/NODE_A/capabilities/status`
@@ -512,7 +879,7 @@ Status: 200 OK
 {
  "data": [
   {
-   "name": "SITEA",
+   "name": "SERVICE101",
    "results": [
     {
      "timestamp": "2015-05-01T17:53:00Z",
@@ -521,96 +888,10 @@ Status: 200 OK
    ]
   },
   {
-   "name": "SITEB",
+   "name": "SERVICE202",
    "results": [
     {
      "timestamp": "2015-05-01T17:53:00Z",
-     "value": "CRITICAL"
-    }
-   ]
-  }
- ]
-}
-```
-
-
-### Example Request 2: get status timelines period
-
-#### Request
-
-##### Method
-`HTTP GET`
-
-##### Path
-
-```
-/api/v4/nodes/NODE_A/capabilities/uptime?start_date=2015-05-01Z&end_date=2015-05-01T&granularity=daily`
-```
-
-or
-
-```
-/api/v4/nodes/NODE_A/capabilities/uptime?start_time=2015-05-01T12:00:00Z&end_time=2015-05-01T23:00:00Z&granularity=daily`
-```
-
-##### Headers
-
-```
-x-api-key: "tenant_key_value"
-Accept: "application/json"
-```
-
-#### Response
-
-##### Code
-
-```
-Status: 200 OK
-```
-
-##### Body
-
-```json
-{
- "data": [
-  {
-   "name": "SITEA",
-   "results": [
-    {
-     "timestamp": "2015-05-01T00:00:00Z",
-     "value": "OK"
-    },
-    {
-     "timestamp": "2015-05-01T01:00:00Z",
-     "value": "CRITICAL"
-    },
-    {
-     "timestamp": "2015-05-01T05:00:00Z",
-     "value": "OK"
-    },
-    {
-     "timestamp": "2015-05-01T23:59:59Z",
-     "value": "OK"
-    }
-   ]
-  },
-  {
-   "name": "SITEB",
-   "results": [
-    {
-     "timestamp": "2015-05-01T00:00:00Z",
-     "value": "OK"
-    },
-    {
-     "timestamp": "2015-05-01T03:00:00Z",
-     "value": "WARNING"
-    },
-    {
-     "timestamp": "2015-05-01T17:53:00Z",
-     "value": "CRITICAL"
-    },
-    {
-     "timestamp": "2015-05-01T23:59:59Z",
      "value": "CRITICAL"
     }
    ]

--- a/website/static/openapi/argo-web-api.yml
+++ b/website/static/openapi/argo-web-api.yml
@@ -10739,6 +10739,375 @@ paths:
               schema:
                 type: string
 
+  /v4/nodes/{node_name}/capabilities/summary/{service_name}:
+    get:
+      tags:
+      - Node Capabilities (v4)
+      summary: List summary of availability and uptime scores for a specific node
+      description: this method retrieves retrieves the latest daily availability and uptime scores for a node's specific service
+      operationId: nodeSummary.Service
+      parameters:
+      - name: x-api-key
+        in: header
+        description: the x-api-key
+        required: true
+        schema:
+          type: string
+          default: SecretKey123
+      - name: node_name
+        in: path
+        description: name of the node
+        required: true
+        schema:
+          type: string
+      - name: service_name
+        in: path
+        description: name of the node
+        required: true
+        schema:
+          type: string
+      - name: date
+        in: query
+        description: a specific date to retrieve results (YYYY-MM-DD)
+        required: false
+        schema:
+          type: string
+      - name: start_date
+        in: query
+        description: start date of query in YYYY-MM-DD format
+        required: false
+        schema:
+          type: string
+      - name: end_date
+        in: query
+        description: end date of query in YYYY-MM-DD format
+        required: false
+        schema:
+          type: string
+      - name: start_time
+        in: query
+        description: start date of query in zulu format
+        schema:
+          type: string
+          default: 2006-01-01T00:04:05Z
+      - name: end_time
+        in: query
+        description: end date of query in zulu format
+        schema:
+          type: string
+          default: 2006-01-03T15:04:05Z
+      responses:
+        "200":
+          description: Successful retrieval of latest availability and uptime results
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        results:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              date:
+                                type: string
+                                format: date
+                                example: "2015-06-22"
+                              availability:
+                                type: string
+                                example: "100"
+                              uptime:
+                                type: string
+                                example: "1"
+
+        "400":
+          description: Item not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status_error'
+        "401":
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                  code:
+                    type: string
+                  details:
+                    type: string
+        "406":
+          description: Content Not acceptable
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status_error'
+        "422":
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status_error'
+        "500":
+          description: internal server error
+          content:
+            application/json:
+              schema:
+                type: string
+
+  /v4/nodes/{node_name}/capabilities/summary:
+    get:
+      tags:
+      - Node Capabilities (v4)
+      summary: List service summary of availability and uptime scores for a specific node
+      description: this method retrieves the latest daily availability and uptime scores for the node's services
+      operationId: nodeSummary
+      parameters:
+      - name: x-api-key
+        in: header
+        description: the x-api-key
+        required: true
+        schema:
+          type: string
+          default: SecretKey123
+      - name: node_name
+        in: path
+        description: name of the node
+        required: true
+        schema:
+          type: string
+      - name: date
+        in: query
+        description: a specific date to retrieve results (YYYY-MM-DD)
+        required: false
+        schema:
+          type: string
+      - name: start_date
+        in: query
+        description: start date of query in YYYY-MM-DD format
+        required: false
+        schema:
+          type: string
+      - name: end_date
+        in: query
+        description: end date of query in YYYY-MM-DD format
+        required: false
+        schema:
+          type: string
+      - name: start_time
+        in: query
+        description: start date of query in zulu format
+        schema:
+          type: string
+          default: 2006-01-01T00:04:05Z
+      - name: end_time
+        in: query
+        description: end date of query in zulu format
+        schema:
+          type: string
+          default: 2006-01-03T15:04:05Z
+      responses:
+        "200":
+          description: Successful retrieval of latest availability and uptime results
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        results:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              date:
+                                type: string
+                                format: date
+                                example: "2015-06-22"
+                              availability:
+                                type: string
+                                example: "100"
+                              uptime:
+                                type: string
+                                example: "1"
+
+        "400":
+          description: Item not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status_error'
+        "401":
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                  code:
+                    type: string
+                  details:
+                    type: string
+        "406":
+          description: Content Not acceptable
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status_error'
+        "422":
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status_error'
+        "500":
+          description: internal server error
+          content:
+            application/json:
+              schema:
+                type: string
+
+  /v4/nodes/{node_name}/capabilities/availability/{service_name}:
+    get:
+      tags:
+      - Node Capabilities (v4)
+      summary: List service availability scores for a specific node
+      description: this method retrieves retrieves the latest daily availability and scores for a node's specific service
+      operationId: nodeAvailability.Service
+      parameters:
+      - name: x-api-key
+        in: header
+        description: the x-api-key
+        required: true
+        schema:
+          type: string
+          default: SecretKey123
+      - name: node_name
+        in: path
+        description: name of the node
+        required: true
+        schema:
+          type: string
+      - name: service_name
+        in: path
+        description: name of the node
+        required: true
+        schema:
+          type: string
+      - name: date
+        in: query
+        description: a specific date to retrieve results (YYYY-MM-DD)
+        required: false
+        schema:
+          type: string
+      - name: start_date
+        in: query
+        description: start date of query in YYYY-MM-DD format
+        required: false
+        schema:
+          type: string
+      - name: end_date
+        in: query
+        description: end date of query in YYYY-MM-DD format
+        required: false
+        schema:
+          type: string
+      - name: start_time
+        in: query
+        description: start date of query in zulu format
+        schema:
+          type: string
+          default: 2006-01-01T00:04:05Z
+      - name: end_time
+        in: query
+        description: end date of query in zulu format
+        schema:
+          type: string
+          default: 2006-01-03T15:04:05Z
+      responses:
+        "200":
+          description: Successful retrieval of latest availability results
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        results:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              date:
+                                type: string
+                                format: date
+                                example: "2015-06-22"
+                              availability:
+                                type: string
+                                example: "100"
+
+        "400":
+          description: Item not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status_error'
+        "401":
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                  code:
+                    type: string
+                  details:
+                    type: string
+        "406":
+          description: Content Not acceptable
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status_error'
+        "422":
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status_error'
+        "500":
+          description: internal server error
+          content:
+            application/json:
+              schema:
+                type: string
+
   /v4/nodes/{node_name}/capabilities/availability:
     get:
       tags:
@@ -10855,6 +11224,90 @@ paths:
             application/json:
               schema:
                 type: string
+  /v4/nodes/{node_name}/capabilities/uptime/{service_name}:
+    get:
+      tags:
+      - Node Capabilities (v4)
+      summary: List service uptime score for a specific node
+      description: this method retrieves retrieves the latest daily uptime scores for a node's specific services
+      operationId: nodeUptime.Service
+      parameters:
+      - name: x-api-key
+        in: header
+        description: the x-api-key
+        required: true
+        schema:
+          type: string
+          default: SecretKey123
+      - name: node_name
+        in: path
+        description: name of the node
+        required: true
+        schema:
+          type: string
+      - name: service_name
+        in: path
+        description: name of the node
+        required: true
+        schema:
+          type: string
+      - name: date
+        in: query
+        description: a specific date to retrieve results (YYYY-MM-DD)
+        required: false
+        schema:
+          type: string
+      - name: start_date
+        in: query
+        description: start date of query in YYYY-MM-DD format
+        required: false
+        schema:
+          type: string
+      - name: end_date
+        in: query
+        description: end date of query in YYYY-MM-DD format
+        required: false
+        schema:
+          type: string
+      - name: start_time
+        in: query
+        description: start date of query in zulu format
+        schema:
+          type: string
+          default: 2006-01-01T00:04:05Z
+      - name: end_time
+        in: query
+        description: end date of query in zulu format
+        schema:
+          type: string
+          default: 2006-01-03T15:04:05Z
+      responses:
+        "200":
+          description: Successful retrieval of latest uptime results
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        results:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              date:
+                                type: string
+                                format: date
+                                example: "2015-06-22"
+                              uptime:
+                                type: string
+                                example: "1"
 
   /v4/nodes/{node_name}/capabilities/uptime:
     get:
@@ -10933,7 +11386,120 @@ paths:
                                 example: "2015-06-22"
                               uptime:
                                 type: string
-                                example: "100"
+                                example: "1"
+
+
+  /v4/nodes/{node_name}/capabilities/status/{service_name}:
+    get:
+      tags:
+      - Node Capabilities (v4)
+      summary: List service status for a specific node
+      description: this method retrieves retrieves the latest daily uptime scores for a node's specific service
+      operationId: nodeStatus.Services
+      parameters:
+      - name: x-api-key
+        in: header
+        description: the x-api-key
+        required: true
+        schema:
+          type: string
+          default: SecretKey123
+      - name: node_name
+        in: path
+        description: name of the node
+        required: true
+        schema:
+          type: string
+      - name: service_name
+        in: path
+        description: name of the node
+        required: true
+        schema:
+          type: string
+      - name: start_time
+        in: query
+        description: start date of query in zulu format
+        schema:
+          type: string
+          default: 2006-01-01T00:04:05Z
+      - name: end_time
+        in: query
+        description: end date of query in zulu format
+        schema:
+          type: string
+          default: 2006-01-03T15:04:05Z
+      - name: history
+        in: query
+        description: enable or disable history
+        required: false
+        schema:
+          type: boolean
+      responses:
+        "200":
+          description: Successful retrieval of latest status results
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        results:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              timestamp:
+                                type: string
+                                format: date
+                                example: "2015-06-22T00:00:00Z"
+                              status:
+                                type: string
+                                example: "CRITICAL"
+
+        "400":
+          description: Item not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status_error'
+        "401":
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                  code:
+                    type: string
+                  details:
+                    type: string
+        "406":
+          description: Content Not acceptable
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status_error'
+        "422":
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status_error'
+        "500":
+          description: internal server error
+          content:
+            application/json:
+              schema:
+                type: string
+
   /v4/nodes/{node_name}/capabilities/status:
     get:
       tags:


### PR DESCRIPTION
…c service for all capabilities

## Goal
Give the ability for each capability to target a specific service item. Introduce also a summary capability that groups results from other capabilities such as availability, uptime.

## Implementation
Add optional path parameter {service-name} in existing capabilities:
```
HTTP GET /api/v4/nodes/{node_name}/capabilities/availability/{service-name}
HTTP GET /api/v4/nodes/{node_name}/capabilities/uptime/{service-name}
HTTP GET /api/v4/nodes/{node_name}/capabilities/status/{service-name}
```
Add also additional capability named `summary` that groups results from other capabilities
```
HTTP GET /api/v4/nodes/{node_name}/capabilities/summary/{service-name}
```
example:
```
HTTP GET /api/v4/nodes/MYNODE/capabilities/summary/MY-SERVICE
```
```json
{
    "data": [
        {
            "name": "MY-SERVICE",
            "results": [
                {
                    "date": "2026-05-11",
                    "availability": "100",
                    "uptime": "1"
                }
            ]
        }
    ]
}
```
