### PR TITLE
ARGO-5548 add v4 endpoints to serve group results and statuses

### DIFF
--- a/docker/files/init_mongo.js
+++ b/docker/files/init_mongo.js
@@ -144,7 +144,7 @@ db.tenants.insertMany([
       },
     ]
   }
-])
+]);
 
 
 db.roles.insertMany([
@@ -732,17 +732,33 @@ db.roles.insertMany([
   {
     resource: 'v4.nodes.status.item',
     roles: [ 'super_admin', 'admin', 'editor', 'viewer' ]
+  },
+  {
+    resource: 'v4.results.groups',
+    roles: [ 'super_admin', 'admin', 'editor', 'viewer' ]
+  },
+  {
+    resource: 'v4.results.groups.item',
+    roles: [ 'super_admin', 'admin', 'editor', 'viewer' ]
+  },
+  {
+    resource: 'v4.status.groups',
+    roles: [ 'super_admin', 'admin', 'editor', 'viewer' ]
+  },
+  {
+    resource: 'v4.status.groups.item',
+    roles: [ 'super_admin', 'admin', 'editor', 'viewer' ]
   }
-])
+]);
 
 db = db.getSiblingDB('argo_TENANT-TEST');
 
-db.topology_endpoints.ensureIndex({ "date_integer": -1, "id": 1 })
-db.topology_groups.ensureIndex({ "date_integer": -1, "id": 1 })
-db.topology_service_types.ensureIndex({ "date_integer": -1, "id": 1 })
-db.metric_profiles.ensureIndex({ "date_integer": -1, "id": 1 })
-db.operations_profiles.ensureIndex({ "date_integer": -1, "id": 1 })
-db.aggregation_profiles.ensureIndex({ "date_integer": -1, "id": 1 })
+db.topology_endpoints.ensureIndex({ "date_integer": -1, "id": 1 });
+db.topology_groups.ensureIndex({ "date_integer": -1, "id": 1 });
+db.topology_service_types.ensureIndex({ "date_integer": -1, "id": 1 });
+db.metric_profiles.ensureIndex({ "date_integer": -1, "id": 1 });
+db.operations_profiles.ensureIndex({ "date_integer": -1, "id": 1 });
+db.aggregation_profiles.ensureIndex({ "date_integer": -1, "id": 1 });
 
 db.topology_service_types.insertMany(
   [
@@ -784,7 +800,7 @@ db.topology_service_types.insertMany(
       ]
     }
   ]
-)
+);
 
 db.topology_endpoints.insertMany(
   [
@@ -987,7 +1003,7 @@ db.topology_endpoints.insertMany(
       }
     }
   ]
-)
+);
 
 db.topology_groups.insertMany(
   [
@@ -1104,7 +1120,7 @@ db.topology_groups.insertMany(
       }, 
     }
   ]
-)
+);
 
 db.operations_profiles.insertMany([
   {
@@ -1348,7 +1364,7 @@ db.operations_profiles.insertMany([
       }
     ]
   }
-])
+]);
 
 db.metric_profiles.insertMany(
   [
@@ -1418,7 +1434,7 @@ db.metric_profiles.insertMany(
       ]
     }
   ]
-)
+);
 
 db.aggregation_profiles.insertMany(
   [
@@ -1457,7 +1473,7 @@ db.aggregation_profiles.insertMany(
       ]
     }
   ]
-)
+);
 
 db.reports.insertMany(
   [
@@ -1576,7 +1592,7 @@ db.reports.insertMany(
       "node_report": true
     }
   ]
-)
+);
 
 
 db.status_endpoint_groups.insertMany(
@@ -1694,17 +1710,190 @@ db.status_endpoint_groups.insertMany(
       has_threshold_rule: false
     }
   ]
-)
+);
+
+
+const baseRecords = [
+    {
+      report: 'cf010255-cda3-49d8-92d1-926c2c6cf9eb',
+      name: 'ESHOP',
+      supergroup: 'PROJECTA',
+      weight: 0,
+      availability: 100,
+      reliability: 100,
+      up: 1,
+      unknown: 0,
+      down: 0
+    },
+    {
+      report: 'cf010255-cda3-49d8-92d1-926c2c6cf9eb',
+      name: 'HELPDESK',
+      supergroup: 'PROJECTA',
+      weight: 0,
+      availability: 100,
+      reliability: 100,
+      up: 1,
+      unknown: 0,
+      down: 0
+    },
+    {
+      report: 'cf010255-cda3-49d8-92d1-926c2c6cf9eb',
+      name: 'WIKI',
+      supergroup: 'PROJECTA',
+      weight: 0,
+      availability: 100,
+      reliability: 100,
+      up: 1,
+      unknown: 0,
+      down: 0
+    },
+    {
+      report: 'cf010255-cda3-49d8-92d1-926c2c6cf9eb',
+      name: 'FORUM',
+      supergroup: 'PROJECTA',
+      weight: 0,
+      availability: 100,
+      reliability: 100,
+      up: 1,
+      unknown: 0,
+      down: 0
+    },
+    {
+      report: 'cf010255-cda3-49d8-92d1-926c2c6cf9eb',
+      name: 'GLOBAL-PORTAL',
+      supergroup: 'PROJECTA',
+      weight: 0,
+      availability: 100,
+      reliability: 100,
+      up: 1,
+      unknown: 0,
+      down: 0
+    },
+    {
+      report: 'cf010255-cda3-49d8-92d1-926c2c6cf9eb',
+      name: 'LOCAL-PORTAL',
+      supergroup: 'PROJECTA',
+      weight: 0,
+      availability: 100,
+      reliability: 100,
+      up: 1,
+      unknown: 0,
+      down: 0
+    },
+    {
+      report: 'cf010255-cda3-49d8-92d1-926c2c6cf9eb',
+      name: 'ARCHIVE',
+      supergroup: 'PROJECTA',
+      weight: 0,
+      availability: 100,
+      reliability: 100,
+      up: 1,
+      unknown: 0,
+      down: 0
+    },
+    {
+      report: 'c7a6b0d4-4885-46da-9dd1-1f91d0e9142e',
+      name: 'ESHOP',
+      supergroup: 'PROJECTA',
+      weight: 0,
+      availability: 80,
+      reliability: 80,
+      up: 1,
+      unknown: 0,
+      down: 0
+    },
+    {
+      report: 'c7a6b0d4-4885-46da-9dd1-1f91d0e9142e',
+      name: 'HELPDESK',
+      supergroup: 'PROJECTA',
+      weight: 0,
+      availability: 80,
+      reliability: 80,
+      up: 1,
+      unknown: 0,
+      down: 0
+    },
+    {
+      report: 'c7a6b0d4-4885-46da-9dd1-1f91d0e9142e',
+      name: 'WIKI',
+      supergroup: 'PROJECTA',
+      weight: 0,
+      availability: 80,
+      reliability: 80,
+      up: 1,
+      unknown: 0,
+      down: 0
+    },
+    {
+      report: 'c7a6b0d4-4885-46da-9dd1-1f91d0e9142e',
+      name: 'FORUM',
+      supergroup: 'PROJECTA',
+      weight: 0,
+      availability: 100,
+      reliability: 100,
+      up: 1,
+      unknown: 0,
+      down: 0
+    },
+    {
+      report: 'c7a6b0d4-4885-46da-9dd1-1f91d0e9142e',
+      name: 'GLOBAL-PORTAL',
+      supergroup: 'PROJECTA',
+      weight: 0,
+      availability: 80,
+      reliability: 80,
+      up: 1,
+      unknown: 0,
+      down: 0
+    },
+    {
+      report: 'c7a6b0d4-4885-46da-9dd1-1f91d0e9142e', 
+      name: 'LOCAL-PORTAL',
+      supergroup: 'PROJECTA',
+      weight: 0,
+      availability: 80,
+      reliability: 80,
+      up: 1,
+      unknown: 0,
+      down: 0
+    },
+    {
+      report: 'c7a6b0d4-4885-46da-9dd1-1f91d0e9142e',
+      name: 'ARCHIVE',
+      supergroup: 'PROJECTA',
+      weight: 0,
+      availability: 80,
+      reliability: 80,
+      up: 1,
+      unknown: 0,
+      down: 0
+    }
+];
+
+
+for (let i = 0; i < 7; i++) {
+  const day = new Date(now);
+  day.setUTCDate(now.getUTCDate() - i);   
+  const putDate = day.getUTCFullYear() * 10000
+                + (day.getUTCMonth() + 1) * 100
+                + day.getUTCDate();
+
+  const docs = baseRecords.map(r => ({ ...r, date: putDate }));
+
+  db.endpoint_group_ar.insertMany(docs);
+
+};
+
 
 
 db = db.getSiblingDB('argo_TENANTB');
 
-db.topology_endpoints.ensureIndex({ "date_integer": -1, "id": 1 })
-db.topology_groups.ensureIndex({ "date_integer": -1, "id": 1 })
-db.topology_service_types.ensureIndex({ "date_integer": -1, "id": 1 })
-db.metric_profiles.ensureIndex({ "date_integer": -1, "id": 1 })
-db.operations_profiles.ensureIndex({ "date_integer": -1, "id": 1 })
-db.aggregation_profiles.ensureIndex({ "date_integer": -1, "id": 1 })
+db.topology_endpoints.ensureIndex({ "date_integer": -1, "id": 1 });
+db.topology_groups.ensureIndex({ "date_integer": -1, "id": 1 });
+db.topology_service_types.ensureIndex({ "date_integer": -1, "id": 1 });
+db.metric_profiles.ensureIndex({ "date_integer": -1, "id": 1 });
+db.operations_profiles.ensureIndex({ "date_integer": -1, "id": 1 });
+db.aggregation_profiles.ensureIndex({ "date_integer": -1, "id": 1 });
 
 
 db.topology_service_types.insertMany(
@@ -1759,7 +1948,7 @@ db.topology_service_types.insertMany(
       ]
     }
   ]
-)
+);
 
 db.topology_endpoints.insertMany(
   [
@@ -1931,7 +2120,7 @@ db.topology_endpoints.insertMany(
       }
     }
   ]
-)
+);
 
 db.topology_groups.insertMany(
   [
@@ -2016,7 +2205,7 @@ db.topology_groups.insertMany(
       }
     },
   ]
-)
+);
 
 db.operations_profiles.insertMany([
   {
@@ -2260,7 +2449,7 @@ db.operations_profiles.insertMany([
       }
     ]
   }
-])
+]);
 
 db.metric_profiles.insertMany(
   [
@@ -2344,7 +2533,7 @@ db.metric_profiles.insertMany(
       ]
     }
   ]
-)
+);
 
 db.aggregation_profiles.insertMany(
   [
@@ -2387,7 +2576,7 @@ db.aggregation_profiles.insertMany(
       ]
     }
   ]
-)
+);
 
 db.reports.insertMany(
   [
@@ -2506,7 +2695,103 @@ db.reports.insertMany(
       "node_report": true
     }
   ]
-)
+);
+
+
+
+const baseRecords2 = [
+    {
+      report: '16b2b932-1cf6-42dc-8ce2-1e29bc6879b',
+      name: 'CLOUD-A',
+      supergroup: 'CLOUDINFRA',
+      weight: 0,
+      availability: 100,
+      reliability: 100,
+      up: 1,
+      unknown: 0,
+      down: 0
+    },
+    {
+      report: '16b2b932-1cf6-42dc-8ce2-1e29bc6879b8',
+      name: 'CLOUD-B',
+      supergroup: 'CLOUDINFRA',
+      weight: 0,
+      availability: 100,
+      reliability: 100,
+      up: 1,
+      unknown: 0,
+      down: 0
+    },
+    {
+      report: '16b2b932-1cf6-42dc-8ce2-1e29bc6879b8',
+      name: 'CLOUD-C',
+      supergroup: 'CLOUDINFRA',
+      weight: 0,
+      availability: 100,
+      reliability: 100,
+      up: 1,
+      unknown: 0,
+      down: 0
+    },
+    {
+      report: '16b2b932-1cf6-42dc-8ce2-1e29bc6879b8',
+      name: 'CLOUD-D',
+      supergroup: 'CLOUDINFRA',
+      weight: 0,
+      availability: 100,
+      reliability: 100,
+      up: 1,
+      unknown: 0,
+      down: 0
+    },
+    {
+      report: '16b2b932-1cf6-42dc-8ce2-1e29bc6879b8',
+      name: 'CLOUD-E',
+      supergroup: 'CLOUDINFRA',
+      weight: 0,
+      availability: 100,
+      reliability: 100,
+      up: 1,
+      unknown: 0,
+      down: 0
+    },
+    {
+      report: 'c7a6b0d4-4885-46da-9dd1-1f91d0e9142e',
+      name: 'CLOUD-A',
+      supergroup: 'CLOUDINFRA',
+      weight: 0,
+      availability: 100,
+      reliability: 100,
+      up: 1,
+      unknown: 0,
+      down: 0
+    },
+    {
+      report: 'c7a6b0d4-4885-46da-9dd1-1f91d0e9142e',
+      name: 'CLOUD-B',
+      supergroup: 'CLOUDINFRA',
+      weight: 0,
+      availability: 100,
+      reliability: 100,
+      up: 1,
+      unknown: 0,
+      down: 0
+    }
+];
+
+
+for (let i = 0; i < 7; i++) {
+  const day = new Date(now);
+  day.setUTCDate(now.getUTCDate() - i);   
+  const putDate = day.getUTCFullYear() * 10000
+                + (day.getUTCMonth() + 1) * 100
+                + day.getUTCDate();
+
+  const docs = baseRecords2.map(r => ({ ...r, date: putDate }));
+
+  db.endpoint_group_ar.insertMany(docs);
+
+};
 
 
 db.status_endpoint_groups.insertMany(
@@ -2568,4 +2853,4 @@ db.status_endpoint_groups.insertMany(
       has_threshold_rule: false
     },
   ]
-)
+);

--- a/scripts/mongodb/populate_default_roles.js
+++ b/scripts/mongodb/populate_default_roles.js
@@ -379,6 +379,22 @@ function populate_default_roles() {
         {
              resource: 'v4.nodes.status.item',
              roles: [ 'super_admin', 'admin', 'editor', 'viewer' ]
+        },
+        {
+             resource: 'v4.results.groups.item',
+             roles: [ 'super_admin', 'admin', 'editor', 'viewer' ]
+        },
+        {
+             resource: 'v4.results.groups',
+             roles: [ 'super_admin', 'admin', 'editor', 'viewer' ]
+        },
+        {
+             resource: 'v4.status.groups',
+             roles: [ 'super_admin', 'admin', 'editor', 'viewer' ]
+        },
+        {
+             resource: 'v4.status.groups.item',
+             roles: [ 'super_admin', 'admin', 'editor', 'viewer' ]
         }
     ]);
     print("INFO\tPolulated default roles in 'roles' collection");

--- a/v4/nodes/cap_ar_test.go
+++ b/v4/nodes/cap_ar_test.go
@@ -18,7 +18,7 @@ import (
 	"gopkg.in/gcfg.v1"
 )
 
-type AvailabilityTestSuite struct {
+type CapAvailabilityTestSuite struct {
 	suite.Suite
 	cfg             config.Config
 	router          *mux.Router
@@ -31,7 +31,7 @@ type AvailabilityTestSuite struct {
 }
 
 // Setup the Test Environment
-func (suite *AvailabilityTestSuite) SetupSuite() {
+func (suite *CapAvailabilityTestSuite) SetupSuite() {
 
 	const testConfig = `
 		 [server]
@@ -65,7 +65,7 @@ func (suite *AvailabilityTestSuite) SetupSuite() {
 }
 
 // This function runs before any test and setups the environment
-func (suite *AvailabilityTestSuite) SetupTest() {
+func (suite *CapAvailabilityTestSuite) SetupTest() {
 
 	log.SetOutput(io.Discard)
 
@@ -138,17 +138,32 @@ func (suite *AvailabilityTestSuite) SetupTest() {
 	c = suite.cfg.MongoClient.Database(suite.cfg.MongoDB.Db).Collection("roles")
 	c.InsertOne(context.TODO(),
 		bson.M{
+			"resource": "v4.nodes.summary.item",
+			"roles":    []string{"super_admin", "admin", "editor", "viewer"},
+		})
+	c.InsertOne(context.TODO(),
+		bson.M{
+			"resource": "v4.nodes.summary",
+			"roles":    []string{"super_admin", "admin", "editor", "viewer"},
+		})
+	c.InsertOne(context.TODO(),
+		bson.M{
+			"resource": "v4.nodes.availability.item",
+			"roles":    []string{"super_admin", "admin", "editor", "viewer"},
+		})
+	c.InsertOne(context.TODO(),
+		bson.M{
 			"resource": "v4.nodes.availability",
 			"roles":    []string{"super_admin", "admin", "editor", "viewer"},
 		})
 	c.InsertOne(context.TODO(),
 		bson.M{
-			"resource": "v4.nodes.uptime",
+			"resource": "v4.nodes.uptime.item",
 			"roles":    []string{"super_admin", "admin", "editor", "viewer"},
 		})
 	c.InsertOne(context.TODO(),
 		bson.M{
-			"resource": "v4.nodes.status",
+			"resource": "v4.nodes.uptime",
 			"roles":    []string{"super_admin", "admin", "editor", "viewer"},
 		})
 
@@ -318,7 +333,200 @@ func (suite *AvailabilityTestSuite) SetupTest() {
 
 }
 
-func (suite *AvailabilityTestSuite) TestAvailability() {
+func (suite *CapAvailabilityTestSuite) TestSummary() {
+
+	request, _ := http.NewRequest("GET", "/api/v4/nodes/NODEB/capabilities/summary?start_time=2015-06-20T12:00:00Z&end_time=2015-06-23T23:00:00Z", strings.NewReader(""))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	endpointGroupAvailabilityA := `{
+   "data": [
+     {
+       "name": "ST01",
+       "results": [
+         {
+           "date": "2015-06-22",
+           "availability": "66.7",
+           "uptime": "1"
+         },
+         {
+           "date": "2015-06-23",
+           "availability": "100",
+           "uptime": "1"
+         }
+       ]
+     },
+     {
+       "name": "ST02",
+       "results": [
+         {
+           "date": "2015-06-22",
+           "availability": "70",
+           "uptime": "1"
+         },
+         {
+           "date": "2015-06-23",
+           "availability": "43.5",
+           "uptime": "1"
+         }
+       ]
+     }
+   ]
+ }`
+
+	// Check that we must have a 200 ok code
+	suite.Equal(200, response.Code, "Incorrect HTTP response code")
+	// Compare the expected and actual xml response
+	suite.Equal(endpointGroupAvailabilityA, response.Body.String(), "Response body mismatch")
+
+	request, _ = http.NewRequest("GET", "/api/v4/nodes/NODEB/capabilities/summary?start_time=2015-06-20T12:00:00Z&end_time=2015-06-23T23:00:00Z&granularity=monthly", strings.NewReader(""))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+
+	response = httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	monthlyAvailJSON := `{
+   "data": [
+     {
+       "name": "ST01",
+       "results": [
+         {
+           "date": "2015-06",
+           "availability": "99.99999900000002",
+           "uptime": "1"
+         }
+       ]
+     },
+     {
+       "name": "ST02",
+       "results": [
+         {
+           "date": "2015-06",
+           "availability": "99.99999900000002",
+           "uptime": "1"
+         }
+       ]
+     }
+   ]
+ }`
+
+	// Check that we must have a 200 ok code
+	suite.Equal(200, response.Code, "Incorrect HTTP response code")
+	// Compare the expected and actual xml response
+	suite.Equal(monthlyAvailJSON, response.Body.String(), "Response body mismatch")
+
+	// check by start and end date
+	request, _ = http.NewRequest("GET", "/api/v4/nodes/NODEB/capabilities/summary?start_date=2015-06-20&end_date=2015-06-23", strings.NewReader(""))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+
+	response = httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	// Check that we must have a 200 ok code
+	suite.Equal(200, response.Code, "Incorrect HTTP response code")
+	// Compare the expected and actual xml response
+	suite.Equal(endpointGroupAvailabilityA, response.Body.String(), "Response body mismatch")
+
+	oneItemJSON := `{
+   "data": [
+     {
+       "name": "ST01",
+       "results": [
+         {
+           "date": "2015-06-22",
+           "availability": "66.7",
+           "uptime": "1"
+         }
+       ]
+     }
+   ]
+ }`
+
+	// check by date
+	request, _ = http.NewRequest("GET", "/api/v4/nodes/NODEB/capabilities/summary/ST01?date=2015-06-22", strings.NewReader(""))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+
+	response = httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	// Check that we must have a 200 ok code
+	suite.Equal(200, response.Code, "Incorrect HTTP response code")
+	// Compare the expected and actual xml response
+	suite.Equal(oneItemJSON, response.Body.String(), "Response body mismatch")
+
+	oneDateJSON := `{
+   "data": [
+     {
+       "name": "ST01",
+       "results": [
+         {
+           "date": "2015-06-22",
+           "availability": "66.7",
+           "uptime": "1"
+         }
+       ]
+     },
+     {
+       "name": "ST02",
+       "results": [
+         {
+           "date": "2015-06-22",
+           "availability": "70",
+           "uptime": "1"
+         }
+       ]
+     }
+   ]
+ }`
+
+	// check by date
+	request, _ = http.NewRequest("GET", "/api/v4/nodes/NODEB/capabilities/summary?date=2015-06-22", strings.NewReader(""))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+
+	response = httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	// Check that we must have a 200 ok code
+	suite.Equal(200, response.Code, "Incorrect HTTP response code")
+	// Compare the expected and actual xml response
+	suite.Equal(oneDateJSON, response.Body.String(), "Response body mismatch")
+
+	request, _ = http.NewRequest("GET", "/api/v4/nodes/NODEB/capabilities/summary?start_time=2015-06-20T12:00:00Z&end_time=2015-06-23T23:00:00Z&granularity=monthly", strings.NewReader(""))
+	request.Header.Set("x-api-key", "AWRONGKEY")
+	request.Header.Set("Accept", "application/json")
+
+	response = httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	unauthorizedresponse := `{
+ "status": {
+  "message": "Unauthorized",
+  "code": "401",
+  "details": "You need to provide a correct authentication token using the header 'x-api-key'"
+ }
+}`
+
+	// Check that we must have a 401 Unauthorized code
+	suite.Equal(401, response.Code, "Incorrect HTTP response code")
+	// Compare the expected and actual xml response
+	suite.Equal(unauthorizedresponse, response.Body.String(), "Response body mismatch")
+
+}
+
+func (suite *CapAvailabilityTestSuite) TestAvailability() {
 
 	request, _ := http.NewRequest("GET", "/api/v4/nodes/NODEB/capabilities/availability?start_time=2015-06-20T12:00:00Z&end_time=2015-06-23T23:00:00Z", strings.NewReader(""))
 	request.Header.Set("x-api-key", suite.clientkey)
@@ -414,6 +622,34 @@ func (suite *AvailabilityTestSuite) TestAvailability() {
 	// Compare the expected and actual xml response
 	suite.Equal(endpointGroupAvailabilityA, response.Body.String(), "Response body mismatch")
 
+	oneItemJSON := `{
+   "data": [
+     {
+       "name": "ST02",
+       "results": [
+         {
+           "date": "2015-06-22",
+           "availability": "70"
+         }
+       ]
+     }
+   ]
+ }`
+
+	// check by date
+	request, _ = http.NewRequest("GET", "/api/v4/nodes/NODEB/capabilities/availability/ST02?date=2015-06-22", strings.NewReader(""))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+
+	response = httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	// Check that we must have a 200 ok code
+	suite.Equal(200, response.Code, "Incorrect HTTP response code")
+	// Compare the expected and actual xml response
+	suite.Equal(oneItemJSON, response.Body.String(), "Response body mismatch")
+
 	oneDateJSON := `{
    "data": [
      {
@@ -474,7 +710,7 @@ func (suite *AvailabilityTestSuite) TestAvailability() {
 
 }
 
-func (suite *AvailabilityTestSuite) TestAvailabilityOptions() {
+func (suite *CapAvailabilityTestSuite) TestAvailabilityOptions() {
 
 	request, _ := http.NewRequest("OPTIONS", "/api/v4/nodes/NODEB/capabilities/availability", strings.NewReader(""))
 
@@ -493,7 +729,26 @@ func (suite *AvailabilityTestSuite) TestAvailabilityOptions() {
 
 }
 
-func (suite *AvailabilityTestSuite) TestUptime() {
+func (suite *CapAvailabilityTestSuite) TestAvailabilityItemOptions() {
+
+	request, _ := http.NewRequest("OPTIONS", "/api/v4/nodes/NODEB/capabilities/availability/ST01", strings.NewReader(""))
+
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code := response.Code
+	output := response.Body.String()
+	headers := response.HeaderMap
+
+	suite.Equal(200, code, "Error in response code")
+	suite.Equal("", output, "Expected empty response body")
+	suite.Equal("GET, OPTIONS", headers.Get("Allow"), "Error in Allow header response (supported resource verbs of resource)")
+	suite.Equal("text/plain; charset=utf-8", headers.Get("Content-Type"), "Error in Content-Type header response")
+
+}
+
+func (suite *CapAvailabilityTestSuite) TestUptime() {
 
 	request, _ := http.NewRequest("GET", "/api/v4/nodes/NODEB/capabilities/uptime?start_time=2015-06-20T12:00:00Z&end_time=2015-06-23T23:00:00Z", strings.NewReader(""))
 	request.Header.Set("x-api-key", suite.clientkey)
@@ -589,6 +844,34 @@ func (suite *AvailabilityTestSuite) TestUptime() {
 	// Compare the expected and actual xml response
 	suite.Equal(endpointGroupUptimeA, response.Body.String(), "Response body mismatch")
 
+	oneItemJSON := `{
+   "data": [
+     {
+       "name": "ST01",
+       "results": [
+         {
+           "date": "2015-06-22",
+           "uptime": "1"
+         }
+       ]
+     }
+   ]
+ }`
+
+	// check by date
+	request, _ = http.NewRequest("GET", "/api/v4/nodes/NODEB/capabilities/uptime/ST01?date=2015-06-22", strings.NewReader(""))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+
+	response = httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	// Check that we must have a 200 ok code
+	suite.Equal(200, response.Code, "Incorrect HTTP response code")
+	// Compare the expected and actual xml response
+	suite.Equal(oneItemJSON, response.Body.String(), "Response body mismatch")
+
 	oneDateJSON := `{
    "data": [
      {
@@ -649,7 +932,7 @@ func (suite *AvailabilityTestSuite) TestUptime() {
 
 }
 
-func (suite *AvailabilityTestSuite) TestUptimeOptions() {
+func (suite *CapAvailabilityTestSuite) TestUptimeOptions() {
 
 	request, _ := http.NewRequest("OPTIONS", "/api/v4/nodes/NODEB/capabilities/uptime", strings.NewReader(""))
 
@@ -668,8 +951,27 @@ func (suite *AvailabilityTestSuite) TestUptimeOptions() {
 
 }
 
+func (suite *CapAvailabilityTestSuite) TestUptimeItemOptions() {
+
+	request, _ := http.NewRequest("OPTIONS", "/api/v4/nodes/NODEB/capabilities/uptime/ST01", strings.NewReader(""))
+
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code := response.Code
+	output := response.Body.String()
+	headers := response.HeaderMap
+
+	suite.Equal(200, code, "Error in response code")
+	suite.Equal("", output, "Expected empty response body")
+	suite.Equal("GET, OPTIONS", headers.Get("Allow"), "Error in Allow header response (supported resource verbs of resource)")
+	suite.Equal("text/plain; charset=utf-8", headers.Get("Content-Type"), "Error in Content-Type header response")
+
+}
+
 // TearDownTest to tear down every test
-func (suite *AvailabilityTestSuite) TearDownTest() {
+func (suite *CapAvailabilityTestSuite) TearDownTest() {
 
 	mainDB := suite.cfg.MongoClient.Database(suite.cfg.MongoDB.Db)
 	cols, err := mainDB.ListCollectionNames(context.TODO(), bson.M{})
@@ -694,13 +996,13 @@ func (suite *AvailabilityTestSuite) TearDownTest() {
 }
 
 // TearDownTest to tear down every test
-func (suite *AvailabilityTestSuite) TearDownSuite() {
+func (suite *CapAvailabilityTestSuite) TearDownSuite() {
 
 	suite.cfg.MongoClient.Database(suite.cfg.MongoDB.Db).Drop(context.TODO())
 	suite.cfg.MongoClient.Database(suite.tenantDbConf.Db).Drop(context.TODO())
 }
 
-// TestEndpointGroupsTestSuite is responsible for calling the tests
-func TestSuiteAR(t *testing.T) {
-	suite.Run(t, new(AvailabilityTestSuite))
+// CapTestSuiteAR is responsible for calling the tests
+func CapTestSuiteAR(t *testing.T) {
+	suite.Run(t, new(CapAvailabilityTestSuite))
 }

--- a/v4/nodes/cap_status_test.go
+++ b/v4/nodes/cap_status_test.go
@@ -40,7 +40,7 @@ import (
 	"gopkg.in/gcfg.v1"
 )
 
-type StatusTestSuite struct {
+type CapStatusTestSuite struct {
 	suite.Suite
 	cfg          config.Config
 	router       *mux.Router
@@ -51,7 +51,7 @@ type StatusTestSuite struct {
 }
 
 // Setup the Test Environment
-func (suite *StatusTestSuite) SetupSuite() {
+func (suite *CapStatusTestSuite) SetupSuite() {
 
 	const testConfig = `
 		   [server]
@@ -85,7 +85,7 @@ func (suite *StatusTestSuite) SetupSuite() {
 }
 
 // This function runs before any test and setups the environment
-func (suite *StatusTestSuite) SetupTest() {
+func (suite *CapStatusTestSuite) SetupTest() {
 
 	log.SetOutput(io.Discard)
 
@@ -159,12 +159,12 @@ func (suite *StatusTestSuite) SetupTest() {
 
 	c.InsertOne(context.TODO(),
 		bson.M{
-			"resource": "v4.status.groups",
+			"resource": "v4.nodes.status",
 			"roles":    []string{"super_admin", "admin", "editor", "viewer"},
 		})
 	c.InsertOne(context.TODO(),
 		bson.M{
-			"resource": "v4.status.groups.item",
+			"resource": "v4.nodes.status.item",
 			"roles":    []string{"super_admin", "admin", "editor", "viewer"},
 		})
 
@@ -252,10 +252,10 @@ func (suite *StatusTestSuite) SetupTest() {
 
 }
 
-// TestListGroupStatus test the status results
-func (suite *StatusTestSuite) TestListGroupStatus() {
+// TestListStatus test the status results
+func (suite *CapStatusTestSuite) TestListStatus() {
 
-	request, _ := http.NewRequest("GET", "/api/v4/status/groups?start_time=2015-05-01T00:00:00Z&end_time=2015-05-01T23:59:00Z", strings.NewReader(""))
+	request, _ := http.NewRequest("GET", "/api/v4/nodes/NODEB/capabilities/status?start_time=2015-05-01T00:00:00Z&end_time=2015-05-01T23:59:00Z", strings.NewReader(""))
 	request.Header.Set("x-api-key", suite.clientkey)
 	request.Header.Set("Accept", "application/json")
 
@@ -315,7 +315,7 @@ func (suite *StatusTestSuite) TestListGroupStatus() {
 	// Compare the expected and actual json response
 	suite.Equal(expResponse, response.Body.String(), "Response body mismatch")
 
-	request, _ = http.NewRequest("GET", "/api/v4/status/groups/SITEB?start_time=2015-05-01T00:00:00Z&end_time=2015-05-01T23:59:00Z", strings.NewReader(""))
+	request, _ = http.NewRequest("GET", "/api/v4/nodes/NODEB/capabilities/status/SITEB?start_time=2015-05-01T00:00:00Z&end_time=2015-05-01T23:59:00Z", strings.NewReader(""))
 	request.Header.Set("x-api-key", suite.clientkey)
 	request.Header.Set("Accept", "application/json")
 
@@ -354,7 +354,7 @@ func (suite *StatusTestSuite) TestListGroupStatus() {
 	// Compare the expected and actual json response
 	suite.Equal(expItemResp, response.Body.String(), "Response body mismatch")
 
-	request, _ = http.NewRequest("GET", "/api/v4/status/groups?start_time=2015-06-20T12:00:00Z&end_time=2015-06-23T23:00:00Z", strings.NewReader(""))
+	request, _ = http.NewRequest("GET", "/api/v4/nodes/NODEB/capabilities/status?start_time=2015-06-20T12:00:00Z&end_time=2015-06-23T23:00:00Z", strings.NewReader(""))
 	request.Header.Set("x-api-key", "AWRONGKEY")
 	request.Header.Set("Accept", "application/json")
 
@@ -376,7 +376,7 @@ func (suite *StatusTestSuite) TestListGroupStatus() {
 	suite.Equal(unauthorizedresponse, response.Body.String(), "Response body mismatch")
 
 	// Case of bad start_time input
-	request, _ = http.NewRequest("GET", "/api/v4/status/groups?start_time=2015-06-20AT12:00:00Z&end_time=2015-06-23T23:00:00Z", strings.NewReader(""))
+	request, _ = http.NewRequest("GET", "/api/v4/nodes/NODEB/capabilities/status?start_time=2015-06-20AT12:00:00Z&end_time=2015-06-23T23:00:00Z", strings.NewReader(""))
 	request.Header.Set("x-api-key", suite.clientkey)
 	request.Header.Set("Accept", "application/json")
 
@@ -403,7 +403,7 @@ func (suite *StatusTestSuite) TestListGroupStatus() {
 	suite.Equal(badRequestResponse, response.Body.String(), "Response body mismatch")
 
 	// Case of bad end_time input
-	request, _ = http.NewRequest("GET", "/api/v4/status/groups?start_time=2015-06-20T12:00:00Z&end_time=2015-06T23:00:00Z", strings.NewReader(""))
+	request, _ = http.NewRequest("GET", "/api/v4/nodes/NODEB/capabilities/status?start_time=2015-06-20T12:00:00Z&end_time=2015-06T23:00:00Z", strings.NewReader(""))
 	request.Header.Set("x-api-key", suite.clientkey)
 	request.Header.Set("Accept", "application/json")
 
@@ -432,9 +432,9 @@ func (suite *StatusTestSuite) TestListGroupStatus() {
 }
 
 // TestOptions tests responses in case the OPTIONS http verb is used
-func (suite *StatusTestSuite) TestOptions() {
+func (suite *CapStatusTestSuite) TestOptions() {
 
-	request, _ := http.NewRequest("OPTIONS", "/api/v4/status/groups", strings.NewReader(""))
+	request, _ := http.NewRequest("OPTIONS", "/api/v4/nodes/NODEB/capabilities/status", strings.NewReader(""))
 
 	response := httptest.NewRecorder()
 
@@ -451,9 +451,9 @@ func (suite *StatusTestSuite) TestOptions() {
 
 }
 
-func (suite *StatusTestSuite) TestItemOptions() {
+func (suite *CapStatusTestSuite) TestItemOptions() {
 
-	request, _ := http.NewRequest("OPTIONS", "/api/v4/status/groups/ST01", strings.NewReader(""))
+	request, _ := http.NewRequest("OPTIONS", "/api/v4/nodes/NODEB/capabilities/status/ST01", strings.NewReader(""))
 
 	response := httptest.NewRecorder()
 
@@ -471,7 +471,7 @@ func (suite *StatusTestSuite) TestItemOptions() {
 }
 
 // TearDownTest to tear down every test
-func (suite *StatusTestSuite) TearDownTest() {
+func (suite *CapStatusTestSuite) TearDownTest() {
 
 	mainDB := suite.cfg.MongoClient.Database(suite.cfg.MongoDB.Db)
 	cols, err := mainDB.ListCollectionNames(context.TODO(), bson.M{})
@@ -496,13 +496,13 @@ func (suite *StatusTestSuite) TearDownTest() {
 }
 
 // TearDownTest to tear down every test
-func (suite *StatusTestSuite) TearDownSuite() {
+func (suite *CapStatusTestSuite) TearDownSuite() {
 
 	suite.cfg.MongoClient.Database(suite.cfg.MongoDB.Db).Drop(context.TODO())
 	suite.cfg.MongoClient.Database(suite.tenantDbConf.Db).Drop(context.TODO())
 }
 
-// TestEndpointGroupsTestSuite is responsible for calling the tests
-func TestSuiteStatus(t *testing.T) {
-	suite.Run(t, new(StatusTestSuite))
+// TestSuiteCap is responsible for calling the tests
+func TestSuiteCapStatus(t *testing.T) {
+	suite.Run(t, new(CapStatusTestSuite))
 }

--- a/v4/nodes/handlers.go
+++ b/v4/nodes/handlers.go
@@ -379,6 +379,298 @@ func GetUptime(r *http.Request, cfg config.Config) (int, http.Header, []byte, er
 	return code, h, output, err
 }
 
+// GetGroupResults lists availability, reliability and uptime for a specific group
+func GetGroupResults(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
+
+	//STANDARD DECLARATIONS START
+	code := http.StatusOK
+	h := http.Header{}
+	output := []byte("")
+	err := error(nil)
+	charset := "utf-8"
+	//STANDARD DECLARATIONS END
+
+	// Set Content-Type response Header value
+	contentType := r.Header.Get("Accept")
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+
+	// Parse the request into the input
+	urlValues := r.URL.Query()
+	vars := mux.Vars(r)
+	reportItem := urlValues.Get("report")
+	period := urlValues.Get("period")
+
+	item := vars["item"]
+
+	// Grab Tenant DB configuration from context
+	tenantDbConfig := gcontext.Get(r, "tenant_conf").(config.MongoConfig)
+
+	report := reports.MongoInterface{}
+
+	rCol := cfg.MongoClient.Database(tenantDbConfig.Db).Collection(reportsColName)
+
+	// if report param is given
+	if reportItem != "" {
+		err = rCol.FindOne(context.TODO(), bson.M{"$or": bson.A{bson.M{"id": reportItem}, bson.M{"info.name": reportItem}}}).Decode(&report)
+
+		if err != nil {
+			code = http.StatusNotFound
+			message := "The report: " + reportItem + " does not exist"
+			output, err := createErrorMessage(message, code, contentType)
+			h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+			return code, h, output, err
+		}
+	} else {
+		count, err := rCol.CountDocuments(context.TODO(), bson.M{})
+		if err != nil {
+			code = http.StatusInternalServerError
+			message := "Could not access reports"
+			output, err := createErrorMessage(message, code, contentType)
+			h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+			return code, h, output, err
+		}
+		switch {
+		case count == 0:
+			code = http.StatusNotFound
+			message := "No reports found"
+			output, err := createErrorMessage(message, code, contentType)
+			h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+			return code, h, output, err
+		case count > 1:
+			code = http.StatusBadRequest
+			message := "Multiple reports found please specify one by using report url param"
+			output, err := createErrorMessage(message, code, contentType)
+			h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+			return code, h, output, err
+		}
+		err = rCol.FindOne(context.TODO(), bson.M{}).Decode(&report)
+	}
+
+	input :=
+		basicQuery{
+			Name:        item,
+			Granularity: urlValues.Get("granularity"),
+			Format:      contentType,
+			StartTime:   urlValues.Get("start_time"),
+			EndTime:     urlValues.Get("end_time"),
+			Report:      report,
+			Vars:        vars,
+			Date:        urlValues.Get("date"),
+			StartDate:   urlValues.Get("start_date"),
+			EndDate:     urlValues.Get("end_date"),
+		}
+
+	// check if period declared
+	if period != "" {
+		days, err := periodToDays(period)
+		if err != nil {
+			code = http.StatusBadRequest
+			output, _ = respond.MarshalContent(respond.ErrBadRequestDetails(err.Error()), contentType, "", " ")
+			h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+			return code, h, output, err
+		}
+		input.EndTime = time.Now().UTC().Format(time.RFC3339)
+		input.StartTime = time.Now().UTC().AddDate(0, 0, -(days - 1)).Format(time.RFC3339)
+
+	}
+
+	errs := input.Validate()
+	if len(errs) > 0 {
+		out := respond.BadRequestSimple
+		out.Errors = errs
+		output = out.MarshalTo(contentType)
+		code = 400
+		return code, h, output, err
+	}
+
+	resultsGroups := []GroupInterface{}
+
+	filter := bson.M{
+		"date":   bson.M{"$gte": input.StartTimeInt, "$lte": input.EndTimeInt},
+		"report": report.ID,
+	}
+
+	var query []primitive.M
+
+	if input.Name != "" {
+		filter["name"] = input.Name
+	}
+
+	// Prepare the group results
+	// Select the granularity of the search daily/monthly
+
+	if input.Granularity == "daily" {
+		customForm[0] = "20060102"
+		customForm[1] = "2006-01-02"
+		query = DailyEndpoint(filter)
+
+	} else if input.Granularity == "monthly" {
+		customForm[0] = "200601"
+		customForm[1] = "2006-01"
+		query = MonthlyGroup(filter)
+
+	}
+
+	arCol := cfg.MongoClient.Database(tenantDbConfig.Db).Collection(groupColName)
+	cursor, err := arCol.Aggregate(context.TODO(), query)
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	defer cursor.Close(context.TODO())
+	cursor.All(context.TODO(), &resultsGroups)
+
+	output, err = createSummaryView(resultsGroups)
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	return code, h, output, err
+}
+
+// GetGroupStatus lists group timelines per report
+func GetGroupStatus(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
+
+	//STANDARD DECLARATIONS START
+
+	code := http.StatusOK
+	h := http.Header{}
+	output := []byte("List Metric Timelines")
+	err := error(nil)
+	charset := "utf-8"
+
+	//STANDARD DECLARATIONS END
+
+	// Set Content-Type response Header value
+	contentType := r.Header.Get("Accept")
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+
+	// Parse the request into the input
+	urlValues := r.URL.Query()
+	vars := mux.Vars(r)
+	item := vars["item"]
+	reportItem := urlValues.Get("report")
+
+	// This is going to be used to determine a detailed/latest view of the results
+	view := urlValues.Get("view")
+	history := urlValues.Get("history")
+	details := false
+	if view == "details" {
+		details = true
+	}
+
+	var parsedStart, parsedEnd int
+
+	// check if user provided start and end time correctly
+	urlStartTime := urlValues.Get("start_time")
+	urlEndTime := urlValues.Get("end_time")
+
+	endDate := ""
+
+	if urlStartTime == "" && urlEndTime == "" {
+		isoTimeNow := time.Now().UTC().Format(time.RFC3339)
+		startDate := strings.Split(isoTimeNow, "T")[0]
+		startTime := startDate + "T00:00:00Z"
+		endDate = startDate
+		parsedStart, _ = parseZuluDate(startTime)
+		parsedEnd, _ = parseZuluDate(isoTimeNow)
+	} else {
+		if parsedStart, err = parseZuluDate(urlStartTime); err != nil {
+			code = http.StatusBadRequest
+			message := fmt.Sprintf("Error parsing start_time=%s - please use zulu format like %s", urlStartTime, zuluForm)
+			output, _ = respond.MarshalContent(respond.ErrBadRequestDetails(message), contentType, "", " ")
+			h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+			return code, h, output, err
+		}
+
+		if parsedEnd, err = parseZuluDate(urlEndTime); err != nil {
+			code = http.StatusBadRequest
+			message := fmt.Sprintf("Error parsing end_time=%s - please use zulu format like %s", urlEndTime, zuluForm)
+			output, _ = respond.MarshalContent(respond.ErrBadRequestDetails(message), contentType, "", " ")
+			h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+			return code, h, output, err
+		}
+
+		endDate = strings.Split(urlEndTime, "T")[0]
+		history = "true"
+	}
+
+	input := InputStatus{
+		parsedStart,
+		parsedEnd,
+		urlValues.Get("report_name"),
+		urlValues.Get("group_type"),
+		item,
+		contentType,
+		"",
+	}
+
+	// Grab Tenant DB configuration from context
+	tenantDbConfig := gcontext.Get(r, "tenant_conf").(config.MongoConfig)
+
+	report := reports.MongoInterface{}
+	rCol := cfg.MongoClient.Database(tenantDbConfig.Db).Collection(reportsColName)
+
+	// if report param is given
+	if reportItem != "" {
+		err = rCol.FindOne(context.TODO(), bson.M{"$or": bson.A{bson.M{"id": reportItem}, bson.M{"info.name": reportItem}}}).Decode(&report)
+
+		if err != nil {
+			code = http.StatusNotFound
+			message := "The report: " + reportItem + " does not exist"
+			output, err := createErrorMessage(message, code, contentType)
+			h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+			return code, h, output, err
+		}
+	} else {
+		count, err := rCol.CountDocuments(context.TODO(), bson.M{})
+		if err != nil {
+			code = http.StatusInternalServerError
+			message := "Could not access reports"
+			output, err := createErrorMessage(message, code, contentType)
+			h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+			return code, h, output, err
+		}
+		switch {
+		case count == 0:
+			code = http.StatusNotFound
+			message := "No reports found"
+			output, err := createErrorMessage(message, code, contentType)
+			h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+			return code, h, output, err
+		case count > 1:
+			code = http.StatusBadRequest
+			message := "Multiple reports found please specify one by using report url param"
+			output, err := createErrorMessage(message, code, contentType)
+			h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+			return code, h, output, err
+		}
+		err = rCol.FindOne(context.TODO(), bson.M{}).Decode(&report)
+	}
+
+	input.groupType = report.Topology.Group.Group.Type
+
+	groupCol := cfg.MongoClient.Database(tenantDbConfig.Db).Collection(statusGroupColName)
+	groupResults := []GroupStatusData{}
+
+	cursor, err := groupCol.Find(context.TODO(), queryStatusGroups(input, report.ID))
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	defer cursor.Close(context.TODO())
+	cursor.All(context.TODO(), &groupResults)
+
+	output, err = createStatusView(groupResults, input, endDate, details, history == "") //Render the results into JSON
+
+	return code, h, output, err
+}
+
 // GetStatus lists group timelines
 func GetStatus(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
 

--- a/v4/nodes/helpers.go
+++ b/v4/nodes/helpers.go
@@ -1,7 +1,9 @@
 package nodes
 
 import (
+	"fmt"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -12,4 +14,34 @@ func parseZuluDate(dateStr string) (int, error) {
 		return -1, err
 	}
 	return strconv.Atoi(parsedTime.Format(ymdForm))
+}
+
+// periodToDays parses '7d' or '1w' strings and returns total days
+func periodToDays(period string) (int, error) {
+	period = strings.TrimSpace(period)
+	if len(period) < 2 {
+		return 0, fmt.Errorf("invalid period: %q", period)
+	}
+
+	value, err := strconv.Atoi(period[:len(period)-1])
+	if err != nil {
+		return 0, fmt.Errorf("wrong period defined %q", period)
+	}
+	if value < 0 {
+		return 0, fmt.Errorf("don't specify negative period %q", period)
+	}
+	unit := period[len(period)-1]
+
+	switch unit {
+	case 'd':
+		return value, nil
+	case 'w':
+		return value * 7, nil
+	default:
+		return 0, fmt.Errorf("unsupported unit: %q", unit)
+	}
+}
+
+func dateInt(t time.Time) int {
+	return t.Year()*10000 + int(t.Month())*100 + t.Day()
 }

--- a/v4/nodes/results_test.go
+++ b/v4/nodes/results_test.go
@@ -1,0 +1,800 @@
+package nodes
+
+import (
+	"context"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ARGOeu/argo-web-api/respond"
+	"github.com/ARGOeu/argo-web-api/utils/config"
+	"github.com/ARGOeu/argo-web-api/utils/store"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/suite"
+	"go.mongodb.org/mongo-driver/bson"
+	"gopkg.in/gcfg.v1"
+)
+
+type ResultsTestSuite struct {
+	suite.Suite
+	cfg             config.Config
+	router          *mux.Router
+	confHandler     respond.ConfHandler
+	tenantDbConf    config.MongoConfig
+	tenantpassword  string
+	tenantusername  string
+	tenantstorename string
+	clientkey       string
+}
+
+// Setup the Test Environment
+func (suite *ResultsTestSuite) SetupSuite() {
+
+	const testConfig = `
+		 [server]
+		 bindip = ""
+		 port = 8080
+		 maxprocs = 4
+		 cache = false
+		 lrucache = 700000000
+		 gzip = true
+		 [mongodb]
+		 host = "127.0.0.1"
+		 port = 27017
+		 db = "ARGO_test_node_ar"
+		 `
+
+	_ = gcfg.ReadStringInto(&suite.cfg, testConfig)
+
+	client := store.GetMongoClient(suite.cfg.MongoDB)
+	suite.cfg.MongoClient = client
+
+	suite.tenantDbConf.Db = "ARGO_test_arV3_tenant"
+	suite.tenantDbConf.Password = "h4shp4ss"
+	suite.tenantDbConf.Username = "dbuser"
+	suite.tenantDbConf.Store = "ar"
+	suite.clientkey = "secretkey"
+
+	// Create router and confhandler for test
+	suite.confHandler = respond.ConfHandler{Config: suite.cfg}
+	suite.router = mux.NewRouter().StrictSlash(false).PathPrefix("/api/v4").Subrouter()
+	HandleSubrouter(suite.router, &suite.confHandler)
+}
+
+// This function runs before any test and setups the environment
+func (suite *ResultsTestSuite) SetupTest() {
+
+	log.SetOutput(io.Discard)
+
+	// Seed database with tenants
+	//TODO: move tests to
+	c := suite.cfg.MongoClient.Database(suite.cfg.MongoDB.Db).Collection("tenants")
+	c.InsertOne(context.TODO(),
+		bson.M{"id": "NODEA-id",
+			"info": bson.M{"name": "NODEA"},
+			"db_conf": []bson.M{
+				{
+					"server":   "localhost",
+					"port":     27017,
+					"database": "argo_Tenant1",
+				},
+				{
+					"server":   "localhost",
+					"port":     27017,
+					"database": "argo_Tenant2",
+				},
+			},
+			"node": true,
+			"users": []bson.M{
+				{
+					"name":    "bob",
+					"email":   "bob@foo",
+					"api_key": "random-1",
+					"roles":   []string{"viewer"},
+				},
+				{
+					"name":    "alice",
+					"email":   "alice@foo",
+					"api_key": "random-2",
+					"roles":   []string{"viewer"},
+				},
+			}})
+	c.InsertOne(context.TODO(),
+		bson.M{"id": "NODEB-id",
+			"info": bson.M{"name": "NODEB"},
+			"db_conf": []bson.M{
+				{
+					"server":   "localhost",
+					"port":     27017,
+					"database": suite.tenantDbConf.Db,
+					"username": suite.tenantDbConf.Username,
+					"password": suite.tenantDbConf.Password,
+				},
+				{
+					"server":   "localhost",
+					"port":     27017,
+					"database": "argo_wrong_db_endpointgrouavailability",
+				},
+			},
+			"node": true,
+			"users": []bson.M{
+				{
+					"name":    "john",
+					"email":   "john@foo",
+					"api_key": suite.clientkey,
+					"roles":   []string{"viewer"},
+				},
+				{
+					"name":    "george",
+					"email":   "george@foo",
+					"api_key": "random-2",
+					"roles":   []string{"viewer"},
+				},
+			}})
+
+	c = suite.cfg.MongoClient.Database(suite.cfg.MongoDB.Db).Collection("roles")
+	c.InsertOne(context.TODO(),
+		bson.M{
+			"resource": "v4.results.groups.item",
+			"roles":    []string{"super_admin", "admin", "editor", "viewer"},
+		})
+	c.InsertOne(context.TODO(),
+		bson.M{
+			"resource": "v4.results.groups",
+			"roles":    []string{"super_admin", "admin", "editor", "viewer"},
+		})
+
+	c = suite.cfg.MongoClient.Database(suite.tenantDbConf.Db).Collection(nodeReportColName)
+	c.InsertOne(context.TODO(), bson.M{
+		"_id":       "node-report",
+		"report_id": "eba61a9e-22e9-4521-9e47-ecaa4a49436",
+	})
+
+	// Seed tenant database with data
+	c = suite.cfg.MongoClient.Database(suite.tenantDbConf.Db).Collection("endpoint_group_ar")
+
+	// Insert seed data
+	c.InsertOne(context.TODO(),
+		bson.M{
+			"report":       "eba61a9e-22e9-4521-9e47-ecaa4a49436",
+			"date":         20150622,
+			"name":         "ST01",
+			"supergroup":   "GROUP_A",
+			"up":           1,
+			"down":         0,
+			"unknown":      0,
+			"availability": 66.7,
+			"reliability":  54.6,
+			"weight":       5634,
+			"tags": []bson.M{
+				{
+					"name":  "",
+					"value": "",
+				},
+			},
+		})
+	c.InsertOne(context.TODO(),
+		bson.M{
+			"report":       "eba61a9e-22e9-4521-9e47-ecaa4a49436",
+			"date":         20150622,
+			"name":         "ST02",
+			"supergroup":   "GROUP_A",
+			"up":           1,
+			"down":         0,
+			"unknown":      0,
+			"availability": 70,
+			"reliability":  45,
+			"weight":       4356,
+			"tags": []bson.M{
+				bson.M{
+					"name":  "",
+					"value": "",
+				},
+			},
+		})
+	c.InsertOne(context.TODO(),
+		bson.M{
+			"report":       "eba61a9e-22e9-4521-9e47-ecaa4a49436",
+			"date":         20150623,
+			"name":         "ST01",
+			"supergroup":   "GROUP_A",
+			"up":           1,
+			"down":         0,
+			"unknown":      0,
+			"availability": 100,
+			"reliability":  100,
+			"weight":       5634,
+			"tags": []bson.M{
+				{
+					"name":  "",
+					"value": "",
+				},
+			},
+		})
+	c.InsertOne(context.TODO(),
+		bson.M{
+			"report":       "eba61a9e-22e9-4521-9e47-ecaa4a49436",
+			"date":         20150623,
+			"name":         "ST02",
+			"supergroup":   "GROUP_A",
+			"up":           1,
+			"down":         0,
+			"unknown":      0,
+			"availability": 43.5,
+			"reliability":  56,
+			"weight":       4356,
+			"tags": []bson.M{
+				{
+					"name":  "",
+					"value": "",
+				},
+			},
+		})
+
+	// add latest
+	today := time.Now().UTC()
+	for d := 0; d < 20; d++ {
+		past := today.AddDate(0, 0, -d)
+		c.InsertOne(context.TODO(),
+			bson.M{
+				"report":       "eba61a9e-22e9-4521-9e47-ecaa4a49436",
+				"date":         dateInt(past),
+				"name":         "ST01",
+				"supergroup":   "GROUP_A",
+				"up":           1,
+				"down":         0,
+				"unknown":      0,
+				"availability": 98.9,
+				"reliability":  100,
+				"weight":       5634,
+				"tags": []bson.M{
+					{
+						"name":  "",
+						"value": "",
+					},
+				},
+			})
+		c.InsertOne(context.TODO(),
+			bson.M{
+				"report":       "eba61a9e-22e9-4521-9e47-ecaa4a49436",
+				"date":         dateInt(past),
+				"name":         "ST02",
+				"supergroup":   "GROUP_A",
+				"up":           1,
+				"down":         0,
+				"unknown":      0,
+				"availability": 99.9,
+				"reliability":  98.9,
+				"weight":       4356,
+				"tags": []bson.M{
+					{
+						"name":  "",
+						"value": "",
+					},
+				},
+			})
+	}
+
+	// Seed endpoint data
+	c = suite.cfg.MongoClient.Database(suite.tenantDbConf.Db).Collection("endpoint_ar")
+
+	// Insert seed data
+	c.InsertOne(context.TODO(),
+		bson.M{
+			"report":       "eba61a9e-22e9-4521-9e47-ecaa4a49436",
+			"date":         20150622,
+			"name":         "host01",
+			"service":      "service01",
+			"supergroup":   "GROUP_A",
+			"up":           1,
+			"down":         0,
+			"unknown":      0,
+			"availability": 66.7,
+			"reliability":  54.6,
+			"weight":       5634,
+			"tags": []bson.M{
+				{
+					"name":  "",
+					"value": "",
+				},
+			},
+			"info": bson.M{"ID": "special-queue"},
+		})
+	c.InsertOne(context.TODO(),
+		bson.M{
+			"report":       "eba61a9e-22e9-4521-9e47-ecaa4a49436",
+			"date":         20150623,
+			"name":         "host01",
+			"service":      "service01",
+			"supergroup":   "GROUP_A",
+			"up":           1,
+			"down":         0,
+			"unknown":      0,
+			"availability": 100,
+			"reliability":  100,
+			"weight":       5634,
+			"tags": []bson.M{
+				{
+					"name":  "",
+					"value": "",
+				},
+			},
+			"info": bson.M{"ID": "special-queue"},
+		})
+
+	c = suite.cfg.MongoClient.Database(suite.tenantDbConf.Db).Collection("reports")
+
+	c.InsertOne(context.TODO(), bson.M{
+		"id": "eba61a9e-22e9-4521-9e47-ecaa4a49436",
+		"info": bson.M{
+			"name":        "Report_A",
+			"description": "lalalallala",
+		},
+		"topology_schema": bson.M{
+			"group": bson.M{
+				"type": "GROUP",
+				"group": bson.M{
+					"type": "SITES",
+				},
+			},
+		},
+		"profiles": []bson.M{
+			{
+				"type": "metric",
+				"name": "ch.cern.SAM.ROC_CRITICAL"},
+		},
+		"filter_tags": []bson.M{
+			{
+				"name":  "name1",
+				"value": "value1"},
+			{
+				"name":  "name2",
+				"value": "value2"},
+		}})
+
+}
+
+func (suite *ResultsTestSuite) TestResultsGroups() {
+
+	request, _ := http.NewRequest("GET", "/api/v4/results/groups?start_time=2015-06-20T12:00:00Z&end_time=2015-06-23T23:00:00Z", strings.NewReader(""))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	endpointGroupAvailabilityA := `{
+   "data": [
+     {
+       "name": "ST01",
+       "results": [
+         {
+           "date": "2015-06-22",
+           "availability": "66.7",
+           "uptime": "1"
+         },
+         {
+           "date": "2015-06-23",
+           "availability": "100",
+           "uptime": "1"
+         }
+       ]
+     },
+     {
+       "name": "ST02",
+       "results": [
+         {
+           "date": "2015-06-22",
+           "availability": "70",
+           "uptime": "1"
+         },
+         {
+           "date": "2015-06-23",
+           "availability": "43.5",
+           "uptime": "1"
+         }
+       ]
+     }
+   ]
+ }`
+
+	// Check that we must have a 200 ok code
+	suite.Equal(200, response.Code, "Incorrect HTTP response code")
+	// Compare the expected and actual xml response
+	suite.Equal(endpointGroupAvailabilityA, response.Body.String(), "Response body mismatch")
+
+	request, _ = http.NewRequest("GET", "/api/v4/results/groups?start_time=2015-06-20T12:00:00Z&end_time=2015-06-23T23:00:00Z&granularity=monthly", strings.NewReader(""))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+
+	response = httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	monthlyAvailJSON := `{
+   "data": [
+     {
+       "name": "ST01",
+       "results": [
+         {
+           "date": "2015-06",
+           "availability": "99.99999900000002",
+           "uptime": "1"
+         }
+       ]
+     },
+     {
+       "name": "ST02",
+       "results": [
+         {
+           "date": "2015-06",
+           "availability": "99.99999900000002",
+           "uptime": "1"
+         }
+       ]
+     }
+   ]
+ }`
+
+	// Check that we must have a 200 ok code
+	suite.Equal(200, response.Code, "Incorrect HTTP response code")
+	// Compare the expected and actual xml response
+	suite.Equal(monthlyAvailJSON, response.Body.String(), "Response body mismatch")
+
+	// check by start and end date
+	request, _ = http.NewRequest("GET", "/api/v4/results/groups?start_date=2015-06-20&end_date=2015-06-23", strings.NewReader(""))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+
+	response = httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	// Check that we must have a 200 ok code
+	suite.Equal(200, response.Code, "Incorrect HTTP response code")
+	// Compare the expected and actual xml response
+	suite.Equal(endpointGroupAvailabilityA, response.Body.String(), "Response body mismatch")
+
+	oneItemJSON := `{
+   "data": [
+     {
+       "name": "ST01",
+       "results": [
+         {
+           "date": "2015-06-22",
+           "availability": "66.7",
+           "uptime": "1"
+         }
+       ]
+     }
+   ]
+ }`
+
+	// check by date
+	request, _ = http.NewRequest("GET", "/api/v4/results/groups/ST01?date=2015-06-22", strings.NewReader(""))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+
+	response = httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	// Check that we must have a 200 ok code
+	suite.Equal(200, response.Code, "Incorrect HTTP response code")
+	// Compare the expected and actual xml response
+	suite.Equal(oneItemJSON, response.Body.String(), "Response body mismatch")
+
+	// check by period
+	period3dJSON := `{
+   "data": [
+     {
+       "name": "ST01",
+       "results": [
+         {
+           "date": "{{-2days}}",
+           "availability": "98.9",
+           "uptime": "1"
+         },
+         {
+           "date": "{{-1days}}",
+           "availability": "98.9",
+           "uptime": "1"
+         },
+         {
+           "date": "{{today}}",
+           "availability": "98.9",
+           "uptime": "1"
+         }
+       ]
+     },
+     {
+       "name": "ST02",
+       "results": [
+         {
+           "date": "{{-2days}}",
+           "availability": "99.9",
+           "uptime": "1"
+         },
+         {
+           "date": "{{-1days}}",
+           "availability": "99.9",
+           "uptime": "1"
+         },
+         {
+           "date": "{{today}}",
+           "availability": "99.9",
+           "uptime": "1"
+         }
+       ]
+     }
+   ]
+ }`
+
+	today := time.Now().UTC()
+
+	period3dJSON = strings.ReplaceAll(period3dJSON, "{{-2days}}", today.AddDate(0, 0, -2).Format("2006-01-02"))
+	period3dJSON = strings.ReplaceAll(period3dJSON, "{{-1days}}", today.AddDate(0, 0, -1).Format("2006-01-02"))
+	period3dJSON = strings.ReplaceAll(period3dJSON, "{{today}}", today.Format("2006-01-02"))
+
+	request, _ = http.NewRequest("GET", "/api/v4/results/groups?period=3d", strings.NewReader(""))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+
+	response = httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	// Check that we must have a 200 ok code
+	suite.Equal(200, response.Code, "Incorrect HTTP response code")
+	// Compare the expected and actual xml response
+	suite.Equal(period3dJSON, response.Body.String(), "Response body mismatch")
+
+	// check by period
+	period1wJSON := `{
+   "data": [
+     {
+       "name": "ST01",
+       "results": [
+         {
+           "date": "{{-6days}}",
+           "availability": "98.9",
+           "uptime": "1"
+         },
+         {
+           "date": "{{-5days}}",
+           "availability": "98.9",
+           "uptime": "1"
+         },
+         {
+           "date": "{{-4days}}",
+           "availability": "98.9",
+           "uptime": "1"
+         },
+         {
+           "date": "{{-3days}}",
+           "availability": "98.9",
+           "uptime": "1"
+         },
+         {
+           "date": "{{-2days}}",
+           "availability": "98.9",
+           "uptime": "1"
+         },
+         {
+           "date": "{{-1days}}",
+           "availability": "98.9",
+           "uptime": "1"
+         },
+         {
+           "date": "{{today}}",
+           "availability": "98.9",
+           "uptime": "1"
+         }
+       ]
+     },
+     {
+       "name": "ST02",
+       "results": [
+         {
+           "date": "{{-6days}}",
+           "availability": "99.9",
+           "uptime": "1"
+         },
+         {
+           "date": "{{-5days}}",
+           "availability": "99.9",
+           "uptime": "1"
+         },
+         {
+           "date": "{{-4days}}",
+           "availability": "99.9",
+           "uptime": "1"
+         },
+         {
+           "date": "{{-3days}}",
+           "availability": "99.9",
+           "uptime": "1"
+         },
+         {
+           "date": "{{-2days}}",
+           "availability": "99.9",
+           "uptime": "1"
+         },
+         {
+           "date": "{{-1days}}",
+           "availability": "99.9",
+           "uptime": "1"
+         },
+         {
+           "date": "{{today}}",
+           "availability": "99.9",
+           "uptime": "1"
+         }
+       ]
+     }
+   ]
+ }`
+
+	period1wJSON = strings.ReplaceAll(period1wJSON, "{{-7days}}", today.AddDate(0, 0, -7).Format("2006-01-02"))
+	period1wJSON = strings.ReplaceAll(period1wJSON, "{{-6days}}", today.AddDate(0, 0, -6).Format("2006-01-02"))
+	period1wJSON = strings.ReplaceAll(period1wJSON, "{{-5days}}", today.AddDate(0, 0, -5).Format("2006-01-02"))
+	period1wJSON = strings.ReplaceAll(period1wJSON, "{{-4days}}", today.AddDate(0, 0, -4).Format("2006-01-02"))
+	period1wJSON = strings.ReplaceAll(period1wJSON, "{{-3days}}", today.AddDate(0, 0, -3).Format("2006-01-02"))
+	period1wJSON = strings.ReplaceAll(period1wJSON, "{{-2days}}", today.AddDate(0, 0, -2).Format("2006-01-02"))
+	period1wJSON = strings.ReplaceAll(period1wJSON, "{{-1days}}", today.AddDate(0, 0, -1).Format("2006-01-02"))
+	period1wJSON = strings.ReplaceAll(period1wJSON, "{{today}}", today.Format("2006-01-02"))
+
+	request, _ = http.NewRequest("GET", "/api/v4/results/groups?period=1w", strings.NewReader(""))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+
+	response = httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	// Check that we must have a 200 ok code
+	suite.Equal(200, response.Code, "Incorrect HTTP response code")
+	// Compare the expected and actual xml response
+	suite.Equal(period1wJSON, response.Body.String(), "Response body mismatch")
+
+	oneDateJSON := `{
+   "data": [
+     {
+       "name": "ST01",
+       "results": [
+         {
+           "date": "2015-06-22",
+           "availability": "66.7",
+           "uptime": "1"
+         }
+       ]
+     },
+     {
+       "name": "ST02",
+       "results": [
+         {
+           "date": "2015-06-22",
+           "availability": "70",
+           "uptime": "1"
+         }
+       ]
+     }
+   ]
+ }`
+
+	// check by date
+	request, _ = http.NewRequest("GET", "/api/v4/results/groups?date=2015-06-22", strings.NewReader(""))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+
+	response = httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	// Check that we must have a 200 ok code
+	suite.Equal(200, response.Code, "Incorrect HTTP response code")
+	// Compare the expected and actual xml response
+	suite.Equal(oneDateJSON, response.Body.String(), "Response body mismatch")
+
+	request, _ = http.NewRequest("GET", "/api/v4/results/groups?start_time=2015-06-20T12:00:00Z&end_time=2015-06-23T23:00:00Z&granularity=monthly", strings.NewReader(""))
+	request.Header.Set("x-api-key", "AWRONGKEY")
+	request.Header.Set("Accept", "application/json")
+
+	response = httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	unauthorizedresponse := `{
+ "status": {
+  "message": "Unauthorized",
+  "code": "401",
+  "details": "You need to provide a correct authentication token using the header 'x-api-key'"
+ }
+}`
+
+	// Check that we must have a 401 Unauthorized code
+	suite.Equal(401, response.Code, "Incorrect HTTP response code")
+	// Compare the expected and actual xml response
+	suite.Equal(unauthorizedresponse, response.Body.String(), "Response body mismatch")
+
+}
+
+func (suite *ResultsTestSuite) TestGroupsResultsOptions() {
+
+	request, _ := http.NewRequest("OPTIONS", "/api/v4/results/groups", strings.NewReader(""))
+
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code := response.Code
+	output := response.Body.String()
+	headers := response.HeaderMap
+
+	suite.Equal(200, code, "Error in response code")
+	suite.Equal("", output, "Expected empty response body")
+	suite.Equal("GET, OPTIONS", headers.Get("Allow"), "Error in Allow header response (supported resource verbs of resource)")
+	suite.Equal("text/plain; charset=utf-8", headers.Get("Content-Type"), "Error in Content-Type header response")
+
+}
+
+func (suite *ResultsTestSuite) TestGroupsResultsItemOptions() {
+
+	request, _ := http.NewRequest("OPTIONS", "/api/v4/results/groups/ST01", strings.NewReader(""))
+
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code := response.Code
+	output := response.Body.String()
+	headers := response.HeaderMap
+
+	suite.Equal(200, code, "Error in response code")
+	suite.Equal("", output, "Expected empty response body")
+	suite.Equal("GET, OPTIONS", headers.Get("Allow"), "Error in Allow header response (supported resource verbs of resource)")
+	suite.Equal("text/plain; charset=utf-8", headers.Get("Content-Type"), "Error in Content-Type header response")
+
+}
+
+// TearDownTest to tear down every test
+func (suite *ResultsTestSuite) TearDownTest() {
+
+	mainDB := suite.cfg.MongoClient.Database(suite.cfg.MongoDB.Db)
+	cols, err := mainDB.ListCollectionNames(context.TODO(), bson.M{})
+	if err != nil {
+		panic(err)
+	}
+
+	for _, col := range cols {
+		mainDB.Collection(col).Drop(context.TODO())
+	}
+
+	tenantDB := suite.cfg.MongoClient.Database(suite.tenantDbConf.Db)
+	cols, err = tenantDB.ListCollectionNames(context.TODO(), bson.M{})
+	if err != nil {
+		panic(err)
+	}
+
+	for _, col := range cols {
+		tenantDB.Collection(col).Drop(context.TODO())
+	}
+
+}
+
+// TearDownTest to tear down every test
+func (suite *ResultsTestSuite) TearDownSuite() {
+
+	suite.cfg.MongoClient.Database(suite.cfg.MongoDB.Db).Drop(context.TODO())
+	suite.cfg.MongoClient.Database(suite.tenantDbConf.Db).Drop(context.TODO())
+}
+
+// TestEndpointGroupsTestSuite is responsible for calling the tests
+func TestSuiteAR(t *testing.T) {
+	suite.Run(t, new(ResultsTestSuite))
+}

--- a/v4/nodes/routing.go
+++ b/v4/nodes/routing.go
@@ -13,6 +13,54 @@ func HandleSubrouter(s *mux.Router, confhandler *respond.ConfHandler) {
 
 var arRoutes = []respond.AppRoutes{
 	{
+		Name:             "v4.results.groups.item",
+		Verb:             "GET",
+		Path:             "/results/groups/{item}",
+		SubrouterHandler: GetGroupResults,
+	},
+	{
+		Name:             "v4.results.groups",
+		Verb:             "GET",
+		Path:             "/results/groups",
+		SubrouterHandler: GetGroupResults,
+	},
+	{
+		Name:             "v4.results.groups.options",
+		Verb:             "OPTIONS",
+		Path:             "/results/groups",
+		SubrouterHandler: Options,
+	},
+	{
+		Name:             "v4.results.groups.item.options",
+		Verb:             "OPTIONS",
+		Path:             "/results/groups/{item}",
+		SubrouterHandler: Options,
+	},
+	{
+		Name:             "v4.status.groups.item",
+		Verb:             "GET",
+		Path:             "/status/groups/{item}",
+		SubrouterHandler: GetGroupStatus,
+	},
+	{
+		Name:             "v4.status.groups",
+		Verb:             "GET",
+		Path:             "/status/groups",
+		SubrouterHandler: GetGroupStatus,
+	},
+	{
+		Name:             "v4.status.groups.options",
+		Verb:             "OPTIONS",
+		Path:             "/status/groups",
+		SubrouterHandler: Options,
+	},
+	{
+		Name:             "v4.status.groups.item.options",
+		Verb:             "OPTIONS",
+		Path:             "/status/groups/{item}",
+		SubrouterHandler: Options,
+	},
+	{
 		Name:             "v4.nodes.summary.item",
 		Verb:             "GET",
 		Path:             "/nodes/{node_name}/capabilities/summary/{item}",
@@ -46,7 +94,7 @@ var arRoutes = []respond.AppRoutes{
 		Name:             "v4.nodes.uptime.item",
 		Verb:             "GET",
 		Path:             "/nodes/{node_name}/capabilities/uptime/{item}",
-		SubrouterHandler: GetAvailability,
+		SubrouterHandler: GetUptime,
 	},
 	{
 		Name:             "v4.nodes.status",

--- a/website/docs/apiv4/v4groups.md
+++ b/website/docs/apiv4/v4groups.md
@@ -1,0 +1,454 @@
+---
+id: v4_groups
+title: Group Resoults and Statuses
+sidebar_position: 1
+---
+
+## Group Results and Statuses
+
+A user can quickly retrive latest results and statuses about the groups of a tenant by using the following calls. If the tenant has one only report this will be selected automatically otherwise the user must specifiy the report by using the `?report=` url parameter. User can query for all groups or a specific one.
+
+
+## API Calls
+
+
+
+| Name                                                                          | Description                                                                                                                                                                                                                              | Shortcut          |
+| ----------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
+| GET: Group Results | This method retrieves by default the latest daily availability and uptime for all tenant groups or a specific one | [Description](#1) |
+| GET: Group Statuses | This method retrieves by default the latest statuses for all tenant groups or a specific one | [Description](#2) |
+
+
+
+## [GET]: Group Results {#A}
+
+The following methods can be used to obtain availability and uptime results for a tenant's groups. The api authenticates the tenant using the api-key within the x-api-key header. User can specify time granularity (`monthly`, `daily`) for retrieved results and also format using the `Accept` header. 
+
+The period can be set by either:
+- `date` parameter for a specific date
+- `start_date` & `end_date` parameters for specific days
+- `period` parameter that accept values such as `7d` to go 7 days back or `2w` to go two weeks back or `1m` to go one month back
+
+The report can be specified by using the `report` parameter
+
+### Input
+
+```
+/api/v4/results/groups/{group_name}?([start_time]&[end_time]|[start_date]&[end_date]|[date]|[period])&[granularity]&[report]
+```
+
+#### Query Parameters
+
+| Type            | Description                                                                                     | Required | Default value |
+| --------------- | ----------------------------------------------------------------------------------------------- | -------- | ------------- |
+| `[date]`        | UTC date in YYYY-MM-DD format                                                                   | NO       |               |
+| `[start_time]`  | UTC time in W3C format                                                                          | NO       |               |
+| `[end_time]`    | UTC time in W3C format                                                                          | NO       |               |
+| `[start_date]`  | UTC date in YYYY-MM-DD format                                                                   | NO       |               |
+| `[start_date]`  | UTC date in YYYY-MM-DD format                                                                   | NO       |               |
+| `[report]`      | Name of the report                                                                              | Only if multiple reports exists       |               |    
+| `[granularity]` | Granularity of time that will be used to present data. Possible values are `monthly`,  `daily`  | NO       | `daily`       |
+
+- If a user doesn't specify any query parameter the api returns the latest daily results.
+- If a user specifies the date parameter the api returns the daily  results for that date
+- A user can specify the period of results by using start_date and end_date instead of start_time and end_time
+- A user can specify the latest period of results by using the period parameter with example values such as 7d (7 days), 3w (3 weeks)
+
+#### Path Parameters
+
+| Name            | Description                                                                                           | Required | Default value |
+| --------------- | ----------------------------------------------------------------------------------------------------- | -------- | ------------- |
+| `{group_name}`| Target a specific group. If omitted you get a result list for all the groups                | NO       |               |
+
+
+
+### Example Request 1: Get default daily results for group ST101
+
+```
+/api/v4/results/groups/ST101`
+```
+
+##### Headers
+
+```
+x-api-key: "tenant_key_value"
+Accept: "application/json"
+```
+
+#### Response
+
+##### Code
+
+```
+Status: 200 OK
+```
+
+##### Body
+
+```json
+{
+  "data": [
+    {
+      "name": "ST101",
+      "results": [
+        {
+          "date": "2015-06-26",
+          "availability": "99",
+          "uptime": "1"
+        }
+      ]
+    }
+  ]
+}
+```
+
+
+### Example Request 2: daily results over a period
+
+#### Request
+
+##### Method
+`HTTP GET`
+
+##### Path
+
+```
+/api/v4/results/groups/ST101?start_date=2015-06-20Z&end_date=2015-06-22T&granularity=daily&report=CORE`
+```
+
+or
+
+```
+/api/v4/results/groups/ST101?start_time=2015-06-20T12:00:00Z&end_time=2015-06-22T23:00:00Z&granularity=daily&report=CORE`
+```
+
+or 
+
+```
+/api/v4/results/groups/ST101?period=3d&report=CORE`
+```
+
+##### Headers
+
+```
+x-api-key: "tenant_key_value"
+Accept: "application/json"
+```
+
+#### Response
+
+##### Code
+
+```
+Status: 200 OK
+```
+
+##### Body
+
+```json
+{
+   "data": [
+     {
+       "name": "SERVICE101",
+       "results": [
+         {
+           "date": "2015-06-20",
+           "availability": "100",
+           "uptime": "1"
+         },
+         {
+           "date": "2015-06-21",
+           "availability": "100",
+           "uptime": "1"
+         },
+         {
+           "date": "2015-06-22",
+           "availability": "100",
+           "uptime": "1"
+         }
+       ]
+     }
+   ]
+ }
+```
+
+### Example Request 3: monthly granularity
+
+#### Request
+
+##### Method
+`HTTP GET`
+
+##### Path
+
+```
+/api/v4/results/groups/ST101?start_time=2015-07-01T12:00:00Z&end_time=2015-07-31T23:00:00Z&granularity=monthly&report=CORE
+```
+##### Headers
+
+```
+x-api-key: "tenant_key_value"
+Accept: "application/json"
+```
+
+#### Response
+
+##### Code
+
+```
+Status: 200 OK
+```
+
+##### Body
+
+```json
+{
+  "data": [
+    {
+      "name": "ST101",
+      "results": [
+        {
+          "date": "2015-06",
+          "availability": "99.99999900000002",
+          "uptime": "1"
+        }
+      ]
+    }
+  ]
+}  
+```
+
+### Example Request 4: Get default daily availability for all the tenant's groups
+
+```
+/api/v4/results/groups`
+```
+
+##### Headers
+
+```
+x-api-key: "tenant_key_value"
+Accept: "application/json"
+```
+
+#### Response
+
+##### Code
+
+```
+Status: 200 OK
+```
+
+##### Body
+
+```json
+{
+  "data": [
+    {
+      "name": "ST101",
+      "results": [
+        {
+          "date": "2015-06-26",
+          "availability": "99",
+          "uptime": "0.99"
+        }
+      ]
+    },
+    {
+      "name": "ST202",
+      "results": [
+        {
+          "date": "2015-06-26",
+          "availability": "98",
+          "uptime": "0.98"
+        }
+      ]
+    }
+  ]
+}
+```
+
+
+
+## [GET]: Status results for the tenant's groups {#2}
+
+The following methods can be used to obtain status results for a tenant's groups. The api authenticates the tenant using the api-key within the x-api-key header. for retrieved results and also format using the `Accept` header. 
+
+
+The report can be specified by using the `report` parameter
+
+### Input
+
+```
+/api/v4/status/groups/{group_name}?[start_time]&[end_time]&[history]
+```
+
+#### Query Parameters
+
+| Type            | Description                                                                                     | Required | Default value |
+| --------------- | ----------------------------------------------------------------------------------------------- | -------- | ------------- |
+| `[start_time]`  | UTC time in W3C format                                                                          | NO       |               |
+| `[end_time]`    | UTC time in W3C format                                                                          | NO       |               |
+| `[history]`     | Show full history of status timelines                                                           | NO       |               |        
+| `[report]`      | Name of the report                                                                              | Only if multiple reports exists       |               |  
+- If a user doesn't specify any query parameter the api returns the status of the services
+
+#### Path Parameters
+
+| Name            | Description                                                                                           | Required | Default value |
+| --------------- | ----------------------------------------------------------------------------------------------------- | -------- | ------------- |
+| `{group_name}`| Target a specific group. If omitted you get a result list for all the groups                | NO       |               |
+
+
+### Example Request 1: Get latest status of a specific group
+
+```
+/api/v4/status/groups/SERVICE101?report=CORE`
+```
+
+##### Headers
+
+```
+x-api-key: "tenant_key_value"
+Accept: "application/json"
+```
+
+#### Response
+
+##### Code
+
+```
+Status: 200 OK
+```
+
+##### Body
+
+```json
+{
+ "data": [
+  {
+   "name": "ST101",
+   "results": [
+    {
+     "timestamp": "2015-05-01T17:53:00Z",
+     "value": "OK"
+    }
+   ]
+  }
+ ]
+}
+```
+
+
+### Example Request 2: get status timelines period
+
+#### Request
+
+##### Method
+`HTTP GET`
+
+##### Path
+
+```
+/api/v4/status/groups/ST101?report=CORE&start_date=2015-05-01Z&end_date=2015-05-01T&granularity=daily`
+```
+
+or
+
+```
+/api/v4/status/groups/ST101?report=CORE&start_time=2015-05-01T12:00:00Z&end_time=2015-05-01T23:00:00Z`
+```
+
+##### Headers
+
+```
+x-api-key: "tenant_key_value"
+Accept: "application/json"
+```
+
+#### Response
+
+##### Code
+
+```
+Status: 200 OK
+```
+
+##### Body
+
+```json
+{
+ "data": [
+  {
+   "name": "ST101",
+   "results": [
+    {
+     "timestamp": "2015-05-01T00:00:00Z",
+     "value": "OK"
+    },
+    {
+     "timestamp": "2015-05-01T01:00:00Z",
+     "value": "CRITICAL"
+    },
+    {
+     "timestamp": "2015-05-01T05:00:00Z",
+     "value": "OK"
+    },
+    {
+     "timestamp": "2015-05-01T23:59:59Z",
+     "value": "OK"
+    }
+   ]
+  }
+ ]
+}
+```
+
+### Example Request 3: Get latest status for all tenant's groups
+
+```
+/api/v4/status/groups?report=CORE
+```
+
+##### Headers
+
+```
+x-api-key: "tenant_key_value"
+Accept: "application/json"
+```
+
+#### Response
+
+##### Code
+
+```
+Status: 200 OK
+```
+
+##### Body
+
+```json
+{
+ "data": [
+  {
+   "name": "ST101",
+   "results": [
+    {
+     "timestamp": "2015-05-01T17:53:00Z",
+     "value": "OK"
+    }
+   ]
+  },
+  {
+   "name": "ST202",
+   "results": [
+    {
+     "timestamp": "2015-05-01T17:53:00Z",
+     "value": "CRITICAL"
+    }
+   ]
+  }
+ ]
+}
+```
+

--- a/website/docs/apiv4/v4nodes.md
+++ b/website/docs/apiv4/v4nodes.md
@@ -1,7 +1,7 @@
 ---
 id: v4_nodes
 title: Node Capabilities
-sidebar_position: 1
+sidebar_position: 2
 ---
 
 ## Node capabilities

--- a/website/static/openapi/argo-web-api.yml
+++ b/website/static/openapi/argo-web-api.yml
@@ -10739,6 +10739,485 @@ paths:
               schema:
                 type: string
 
+  
+
+  /v4/results/groups:
+    get:
+      tags:
+      - Group Results (v4)
+      summary: List service summary of availability and uptime scores for groups
+      description: this method retrieves the latest daily availability and uptime scores for groups
+      operationId: group.results
+      parameters:
+      - name: x-api-key
+        in: header
+        description: the x-api-key
+        required: true
+        schema:
+          type: string
+          default: SecretKey123
+      - name: report
+        in: query
+        description: the name of the report to be used for providing the results
+        required: false
+        schema:
+          type: string
+      - name: date
+        in: query
+        description: a specific date to retrieve results (YYYY-MM-DD)
+        required: false
+        schema:
+          type: string
+      - name: start_date
+        in: query
+        description: start date of query in YYYY-MM-DD format
+        required: false
+        schema:
+          type: string
+      - name: end_date
+        in: query
+        description: end date of query in YYYY-MM-DD format
+        required: false
+        schema:
+          type: string
+      - name: start_time
+        in: query
+        description: start date of query in zulu format
+        schema:
+          type: string
+          default: 2006-01-01T00:04:05Z
+      - name: end_time
+        in: query
+        description: end date of query in zulu format
+        schema:
+          type: string
+          default: 2006-01-03T15:04:05Z
+      responses:
+        "200":
+          description: Successful retrieval of latest availability and uptime results
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        results:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              date:
+                                type: string
+                                format: date
+                                example: "2015-06-22"
+                              availability:
+                                type: string
+                                example: "100"
+                              uptime:
+                                type: string
+                                example: "1"
+
+        "400":
+          description: Item not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status_error'
+        "401":
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                  code:
+                    type: string
+                  details:
+                    type: string
+        "406":
+          description: Content Not acceptable
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status_error'
+        "422":
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status_error'
+        "500":
+          description: internal server error
+          content:
+            application/json:
+              schema:
+                type: string
+
+  /v4/results/groups/{group_name}:
+    get:
+      tags:
+      - Group Results (v4)
+      summary: List summary of availability and uptime scores for a specific group
+      description: this method retrieves retrieves the latest daily availability and uptime scores for a specific group
+      operationId: group.results.item
+      parameters:
+      - name: x-api-key
+        in: header
+        description: the x-api-key
+        required: true
+        schema:
+          type: string
+          default: SecretKey123
+      - name: report
+        in: query
+        description: the name of the report to be used for providing the results
+        required: false
+        schema:
+          type: string
+      - name: group_name
+        in: path
+        description: name of the group
+        required: true
+        schema:
+          type: string
+      - name: period
+        in: query
+        description: A period expressed in days like 7d or in weeks like 4w or in months like 24m
+        required: false
+        schema:
+          type: string
+      - name: date
+        in: query
+        description: a specific date to retrieve results (YYYY-MM-DD)
+        required: false
+        schema:
+          type: string
+      - name: start_date
+        in: query
+        description: start date of query in YYYY-MM-DD format
+        required: false
+        schema:
+          type: string
+      - name: end_date
+        in: query
+        description: end date of query in YYYY-MM-DD format
+        required: false
+        schema:
+          type: string
+      - name: start_time
+        in: query
+        description: start date of query in zulu format
+        schema:
+          type: string
+          default: 2006-01-01T00:04:05Z
+      - name: end_time
+        in: query
+        description: end date of query in zulu format
+        schema:
+          type: string
+          default: 2006-01-03T15:04:05Z
+      responses:
+        "200":
+          description: Successful retrieval of latest availability and uptime results
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        results:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              date:
+                                type: string
+                                format: date
+                                example: "2015-06-22"
+                              availability:
+                                type: string
+                                example: "100"
+                              uptime:
+                                type: string
+                                example: "1"
+
+        "400":
+          description: Item not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status_error'
+        "401":
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                  code:
+                    type: string
+                  details:
+                    type: string
+        "406":
+          description: Content Not acceptable
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status_error'
+        "422":
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status_error'
+        "500":
+          description: internal server error
+          content:
+            application/json:
+              schema:
+                type: string
+
+
+
+  /v4/status/groups:
+    get:
+      tags:
+      - Group Status (v4)
+      summary: List service status for a specific group
+      description: this method retrieves retrieves the latest status of a specific group
+      operationId: group.status
+      parameters:
+      - name: x-api-key
+        in: header
+        description: the x-api-key
+        required: true
+        schema:
+          type: string
+          default: SecretKey123
+      - name: report
+        in: query
+        description: name of the report used
+        required: true
+        schema:
+          type: string
+      - name: period
+        in: query
+        description: A period expressed in days like 7d or in weeks like 4w or in months like 24m
+        required: false
+        schema:
+          type: string
+      - name: start_time
+        in: query
+        description: start date of query in zulu format
+        schema:
+          type: string
+          default: 2006-01-01T00:04:05Z
+      - name: end_time
+        in: query
+        description: end date of query in zulu format
+        schema:
+          type: string
+          default: 2006-01-03T15:04:05Z
+      - name: history
+        in: query
+        description: enable or disable history
+        required: false
+        schema:
+          type: boolean
+      responses:
+        "200":
+          description: Successful retrieval of latest status results
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        results:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              timestamp:
+                                type: string
+                                format: date
+                                example: "2015-06-22T00:00:00Z"
+                              status:
+                                type: string
+                                example: "CRITICAL"
+
+        "400":
+          description: Item not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status_error'
+        "401":
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                  code:
+                    type: string
+                  details:
+                    type: string
+        "406":
+          description: Content Not acceptable
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status_error'
+        "422":
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status_error'
+        "500":
+          description: internal server error
+          content:
+            application/json:
+              schema:
+                type: string
+
+  /v4/status/groups/{group_name}:
+    get:
+      tags:
+      - Group Status (v4)
+      summary: List service status for a specific group
+      description: this method retrieves the latest status of a specific group
+      operationId: group.status.item
+      parameters:
+      - name: x-api-key
+        in: header
+        description: the x-api-key
+        required: true
+        schema:
+          type: string
+          default: SecretKey123
+      - name: report
+        in: query
+        description: name of the report used for status results
+        required: true
+        schema:
+          type: string
+      - name: group_name
+        in: path
+        description: name of the specific group
+        required: true
+        schema:
+          type: string
+      - name: start_time
+        in: query
+        description: start date of query in zulu format
+        schema:
+          type: string
+          default: 2006-01-01T00:04:05Z
+      - name: end_time
+        in: query
+        description: end date of query in zulu format
+        schema:
+          type: string
+          default: 2006-01-03T15:04:05Z
+      - name: history
+        in: query
+        description: enable or disable history
+        required: false
+        schema:
+          type: boolean
+      responses:
+        "200":
+          description: Successful retrieval of latest status results
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        results:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              timestamp:
+                                type: string
+                                format: date
+                                example: "2015-06-22T00:00:00Z"
+                              status:
+                                type: string
+                                example: "CRITICAL"
+
+        "400":
+          description: Item not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status_error'
+        "401":
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                  code:
+                    type: string
+                  details:
+                    type: string
+        "406":
+          description: Content Not acceptable
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status_error'
+        "422":
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status_error'
+        "500":
+          description: internal server error
+          content:
+            application/json:
+              schema:
+                type: string
+  
+
   /v4/nodes/{node_name}/capabilities/summary/{service_name}:
     get:
       tags:
@@ -11394,7 +11873,7 @@ paths:
       tags:
       - Node Capabilities (v4)
       summary: List service status for a specific node
-      description: this method retrieves retrieves the latest daily uptime scores for a node's specific service
+      description: this method retrieves retrieves the latest status result for a node's specific service
       operationId: nodeStatus.Services
       parameters:
       - name: x-api-key
@@ -11505,7 +11984,7 @@ paths:
       tags:
       - Node Capabilities (v4)
       summary: List service status for a specific node
-      description: this method retrieves retrieves the latest daily uptime scores for the node's services
+      description: this method retrieves retrieves the latest status results for the node's services
       operationId: nodeStatus
       parameters:
       - name: x-api-key


### PR DESCRIPTION
## Goal 
Add two endpoints (similar to capabilities style) to quickly serve group results (availability etc) and statuses per report. If tenant has only one report it is selected automatically

## Endpoints to get availability results
```
HTTP GET /api/v4/results/groups?report={report-name}
HTTP GET /api/v4/results/groups{group-name}?report={report-name}
```
style of response:
```
{
  "data": [
    {
      "name": "ST101",
      "results": [
        {
          "date": "2015-06-26",
          "availability": "99",
          "uptime": "0.99"
        }
      ]
    },
    {
      "name": "ST202",
      "results": [
        {
          "date": "2015-06-26",
          "availability": "98",
          "uptime": "0.98"
        }
      ]
    }
  ]
}
```

## Endpoints to get status results
```
HTTP GET /api/v4/status/groups?report={report-name}
HTTP GET /api/v4/status/groups{group-name}?report={report-name}
```

style of response:
```

 "data": [
  {
   "name": "ST101",
   "results": [
    {
     "timestamp": "2015-05-01T17:53:00Z",
     "value": "OK"
    }
   ]
  },
  {
   "name": "ST202",
   "results": [
    {
     "timestamp": "2015-05-01T17:53:00Z",
     "value": "CRITICAL"
    }
   ]
  }
 ]
}
```