### PR TITLE
ARGO-5579 Support public reports

### DIFF
--- a/app/reports/controller.go
+++ b/app/reports/controller.go
@@ -199,6 +199,15 @@ func List(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) 
 		query["id"] = nodeReport.Report_id
 	}
 
+	if urlValues.Has("public") {
+		query["public"] = true
+
+	}
+
+	if urlValues.Has("private") {
+		query["public"] = bson.M{"$exists": false}
+	}
+
 	// Create structure for storing query results
 	results := []MongoInterface{}
 	// Query tenant collection for all available documents.
@@ -456,6 +465,109 @@ func Update(r *http.Request, cfg config.Config) (int, http.Header, []byte, error
 
 }
 
+// SetPublic function is used to set a specific report as public
+func SetPublic(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
+
+	//STANDARD DECLARATIONS START
+	code := http.StatusOK
+	h := http.Header{}
+	output := []byte("")
+	err := error(nil)
+	charset := "utf-8"
+	//STANDARD DECLARATIONS END
+
+	// Set Content-Type response Header value
+	contentType := r.Header.Get("Accept")
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+
+	// Grab Tenant DB configuration from context
+	tenantDbConfig := gcontext.Get(r, "tenant_conf").(config.MongoConfig)
+
+	//Extracting report id from url
+	id := mux.Vars(r)["id"]
+
+	// before updating, check if the report exists and the name is unique
+	rCol := cfg.MongoClient.Database(tenantDbConfig.Db).Collection(reportsColl)
+
+	filter := bson.M{"id": id}
+	update := bson.M{"$set": bson.M{"public": true}}
+
+	updateChange, err := rCol.UpdateOne(context.TODO(), filter, update)
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	if updateChange.MatchedCount == 0 && updateChange.UpsertedCount == 0 {
+		output, _ = respond.MarshalContent(respond.ErrNotFound, contentType, "", " ")
+		code = 404
+		return code, h, output, err
+	}
+	//Render the response into XML
+	output, err = respond.CreateResponseMessage("Report is set as public", "200", contentType)
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	code = http.StatusOK
+	return code, h, output, err
+
+}
+
+// SetPrivate function is used to set a specific report as private
+func SetPrivate(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
+
+	//STANDARD DECLARATIONS START
+	code := http.StatusOK
+	h := http.Header{}
+	output := []byte("")
+	err := error(nil)
+	charset := "utf-8"
+	//STANDARD DECLARATIONS END
+
+	// Set Content-Type response Header value
+	contentType := r.Header.Get("Accept")
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+
+	// Grab Tenant DB configuration from context
+	tenantDbConfig := gcontext.Get(r, "tenant_conf").(config.MongoConfig)
+
+	//Extracting report id from url
+	id := mux.Vars(r)["id"]
+
+	rCol := cfg.MongoClient.Database(tenantDbConfig.Db).Collection(reportsColl)
+
+	filter := bson.M{"id": id}
+	update := bson.M{"$unset": bson.M{"public": ""}}
+
+	updateChange, err := rCol.UpdateOne(context.TODO(), filter, update)
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	if updateChange.MatchedCount == 0 && updateChange.UpsertedCount == 0 {
+		output, _ = respond.MarshalContent(respond.ErrNotFound, contentType, "", " ")
+		code = 404
+		return code, h, output, err
+	}
+	//Render the response into XML
+	output, err = respond.CreateResponseMessage("Report is set as private", "200", contentType)
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	code = http.StatusOK
+	return code, h, output, err
+
+}
+
 // SetNodeReport function is used to set a specific report as node report
 func SetNodeReport(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
 
@@ -506,8 +618,6 @@ func SetNodeReport(r *http.Request, cfg config.Config) (int, http.Header, []byte
 		code = http.StatusInternalServerError
 		return code, h, output, err
 	}
-
-	fmt.Printf("%+v \n", updateChange)
 
 	if updateChange.MatchedCount == 0 && updateChange.UpsertedCount == 0 {
 		output, _ = respond.MarshalContent(respond.ErrNotFound, contentType, "", " ")

--- a/app/reports/model.go
+++ b/app/reports/model.go
@@ -51,6 +51,7 @@ type MongoInterface struct {
 	Profiles     []Profile     `bson:"profiles" json:"profiles" xml:"profiles"`
 	Tags         []Tag         `bson:"filter_tags" json:"filter_tags" xml:"filter_tags"`
 	NodeReport   bool          `bson:"node_report" json:"node_report,omitempty"`
+	Public       bool          `bson:"public" json:"public,omitempty"`
 }
 
 // Info contains info about a report and is used inside the main MongoInterface struct

--- a/app/reports/reports_test.go
+++ b/app/reports/reports_test.go
@@ -248,6 +248,16 @@ func (suite *ReportTestSuite) SetupTest() {
 		})
 	c.InsertOne(context.TODO(),
 		bson.M{
+			"resource": "reports.set_public",
+			"roles":    []string{"admin", "editor"},
+		})
+	c.InsertOne(context.TODO(),
+		bson.M{
+			"resource": "reports.set_private",
+			"roles":    []string{"admin", "editor"},
+		})
+	c.InsertOne(context.TODO(),
+		bson.M{
 			"resource": "reports.delete",
 			"roles":    []string{"admin", "editor"},
 		})
@@ -1356,6 +1366,400 @@ func (suite *ReportTestSuite) TestSetReportNode() {
 	suite.Equal(200, code, "Incorrect error code")
 	// Compare the expected and actual xml response
 	suite.Equal(respReportJSON, output, "Response body mismatch")
+}
+
+func (suite *ReportTestSuite) TestSetReportPublic() {
+
+	respJSON := `{
+ "status": {
+  "message": "Report is set as public",
+  "code": "200"
+ }
+}`
+
+	respPrivateJSON := `{
+ "status": {
+  "message": "Report is set as private",
+  "code": "200"
+ }
+}`
+
+	respReportJSON := `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "id": "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+   "tenant": "GUARDIANS",
+   "disabled": false,
+   "info": {
+    "name": "Report_A",
+    "description": "report aaaaa",
+    "created": "2015-9-10 13:43:00",
+    "updated": "2015-10-11 13:43:00"
+   },
+   "computations": {
+    "ar": true,
+    "status": true,
+    "trends": [
+     "flapping",
+     "status",
+     "tags"
+    ]
+   },
+   "topology_schema": {
+    "group": {
+     "type": "NGI",
+     "group": {
+      "type": "SITE"
+     }
+    }
+   },
+   "profiles": [
+    {
+     "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50b",
+     "name": "profile1",
+     "type": "metric"
+    },
+    {
+     "id": "6ac7d684-1f8e-4a02-a502-720e8f11e523",
+     "name": "profile2",
+     "type": "operations"
+    },
+    {
+     "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50q",
+     "name": "profile3",
+     "type": "aggregation"
+    }
+   ],
+   "filter_tags": [
+    {
+     "name": "name1",
+     "value": "value1",
+     "context": ""
+    },
+    {
+     "name": "name2",
+     "value": "value2",
+     "context": ""
+    }
+   ]
+  }
+ ]
+}`
+
+	respReportPublicJSON := `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "id": "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+   "tenant": "GUARDIANS",
+   "disabled": false,
+   "info": {
+    "name": "Report_A",
+    "description": "report aaaaa",
+    "created": "2015-9-10 13:43:00",
+    "updated": "2015-10-11 13:43:00"
+   },
+   "computations": {
+    "ar": true,
+    "status": true,
+    "trends": [
+     "flapping",
+     "status",
+     "tags"
+    ]
+   },
+   "topology_schema": {
+    "group": {
+     "type": "NGI",
+     "group": {
+      "type": "SITE"
+     }
+    }
+   },
+   "profiles": [
+    {
+     "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50b",
+     "name": "profile1",
+     "type": "metric"
+    },
+    {
+     "id": "6ac7d684-1f8e-4a02-a502-720e8f11e523",
+     "name": "profile2",
+     "type": "operations"
+    },
+    {
+     "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50q",
+     "name": "profile3",
+     "type": "aggregation"
+    }
+   ],
+   "filter_tags": [
+    {
+     "name": "name1",
+     "value": "value1",
+     "context": ""
+    },
+    {
+     "name": "name2",
+     "value": "value2",
+     "context": ""
+    }
+   ],
+   "public": true
+  }
+ ]
+}`
+
+	respReport2JSON := `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "id": "eba61a9e-22e9-4521-9e47-ecaa4a494360",
+   "tenant": "GUARDIANS",
+   "disabled": false,
+   "info": {
+    "name": "Report_B",
+    "description": "report bbb",
+    "created": "2015-10-08 13:43:00",
+    "updated": "2015-10-09 13:43:00"
+   },
+   "computations": {
+    "ar": true,
+    "status": true,
+    "trends": [
+     "flapping",
+     "status",
+     "tags"
+    ]
+   },
+   "topology_schema": {
+    "group": {
+     "type": "ARCHIPELAGO",
+     "group": {
+      "type": "ISLAND"
+     }
+    }
+   },
+   "profiles": [
+    {
+     "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50b",
+     "name": "profile1",
+     "type": "metric"
+    },
+    {
+     "id": "6ac7d684-1f8e-4a02-a502-720e8f11e523",
+     "name": "profile2",
+     "type": "operations"
+    },
+    {
+     "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50q",
+     "name": "profile3",
+     "type": "aggregation"
+    }
+   ],
+   "filter_tags": [
+    {
+     "name": "name1",
+     "value": "value1",
+     "context": ""
+    },
+    {
+     "name": "name2",
+     "value": "value2",
+     "context": ""
+    }
+   ]
+  }
+ ]
+}`
+
+	respReport2PublicJSON := `{
+ "status": {
+  "message": "Success",
+  "code": "200"
+ },
+ "data": [
+  {
+   "id": "eba61a9e-22e9-4521-9e47-ecaa4a494360",
+   "tenant": "GUARDIANS",
+   "disabled": false,
+   "info": {
+    "name": "Report_B",
+    "description": "report bbb",
+    "created": "2015-10-08 13:43:00",
+    "updated": "2015-10-09 13:43:00"
+   },
+   "computations": {
+    "ar": true,
+    "status": true,
+    "trends": [
+     "flapping",
+     "status",
+     "tags"
+    ]
+   },
+   "topology_schema": {
+    "group": {
+     "type": "ARCHIPELAGO",
+     "group": {
+      "type": "ISLAND"
+     }
+    }
+   },
+   "profiles": [
+    {
+     "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50b",
+     "name": "profile1",
+     "type": "metric"
+    },
+    {
+     "id": "6ac7d684-1f8e-4a02-a502-720e8f11e523",
+     "name": "profile2",
+     "type": "operations"
+    },
+    {
+     "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50q",
+     "name": "profile3",
+     "type": "aggregation"
+    }
+   ],
+   "filter_tags": [
+    {
+     "name": "name1",
+     "value": "value1",
+     "context": ""
+    },
+    {
+     "name": "name2",
+     "value": "value2",
+     "context": ""
+    }
+   ],
+   "public": true
+  }
+ ]
+}`
+
+	request, _ := http.NewRequest("POST", "/api/v2/reports/eba61a9e-22e9-4521-9e47-ecaa4a494364/set-public", strings.NewReader(""))
+	request.Header.Set("Accept", "application/json")
+	request.Header.Set("x-api-key", "C4PK3Y")
+
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code := response.Code
+	output := response.Body.String()
+
+	suite.Equal(200, code, "Incorrect Error Code")
+	suite.Equal(respJSON, output, "Response body mismatch")
+
+	request, _ = http.NewRequest("GET", "/api/v2/reports/eba61a9e-22e9-4521-9e47-ecaa4a494364", strings.NewReader(""))
+	request.Header.Set("Accept", "application/json")
+	request.Header.Set("x-api-key", "C4PK3Y")
+	response = httptest.NewRecorder()
+	suite.router.ServeHTTP(response, request)
+
+	code = response.Code
+	output = response.Body.String()
+
+	suite.Equal(200, code, "Incorrect error code")
+	suite.Equal(respReportPublicJSON, output, "Response body mismatch")
+
+	request, _ = http.NewRequest("GET", "/api/v2/reports?public", strings.NewReader(""))
+
+	request.Header.Set("Accept", "application/json")
+	request.Header.Set("x-api-key", "C4PK3Y")
+	response = httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code = response.Code
+	output = response.Body.String()
+
+	suite.Equal(200, code, "Incorrect error code")
+	suite.Equal(respReportPublicJSON, output, "Response body mismatch")
+
+	request, _ = http.NewRequest("GET", "/api/v2/reports?private", strings.NewReader(""))
+
+	request.Header.Set("Accept", "application/json")
+	request.Header.Set("x-api-key", "C4PK3Y")
+	response = httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code = response.Code
+	output = response.Body.String()
+
+	suite.Equal(200, code, "Incorrect error code")
+	suite.Equal(respReport2JSON, output, "Response body mismatch")
+
+	request, _ = http.NewRequest("POST", "/api/v2/reports/eba61a9e-22e9-4521-9e47-ecaa4a494364/set-private", strings.NewReader(""))
+	request.Header.Set("Accept", "application/json")
+	request.Header.Set("x-api-key", "C4PK3Y")
+
+	response = httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code = response.Code
+	output = response.Body.String()
+
+	suite.Equal(200, code, "Incorrect Error Code")
+	suite.Equal(respPrivateJSON, output, "Response body mismatch")
+
+	request, _ = http.NewRequest("POST", "/api/v2/reports/eba61a9e-22e9-4521-9e47-ecaa4a494360/set-public", strings.NewReader(""))
+	request.Header.Set("Accept", "application/json")
+	request.Header.Set("x-api-key", "C4PK3Y")
+
+	response = httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code = response.Code
+	output = response.Body.String()
+
+	suite.Equal(200, code, "Incorrect Error Code")
+	suite.Equal(respJSON, output, "Response body mismatch")
+
+	request, _ = http.NewRequest("GET", "/api/v2/reports?private", strings.NewReader(""))
+
+	request.Header.Set("Accept", "application/json")
+	request.Header.Set("x-api-key", "C4PK3Y")
+	response = httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code = response.Code
+	output = response.Body.String()
+
+	suite.Equal(200, code, "Incorrect error code")
+	suite.Equal(respReportJSON, output, "Response body mismatch")
+
+	request, _ = http.NewRequest("GET", "/api/v2/reports?public", strings.NewReader(""))
+
+	request.Header.Set("Accept", "application/json")
+	request.Header.Set("x-api-key", "C4PK3Y")
+	response = httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code = response.Code
+	output = response.Body.String()
+
+	suite.Equal(200, code, "Incorrect error code")
+	suite.Equal(respReport2PublicJSON, output, "Response body mismatch")
+
 }
 
 // TestReadOneReport function implements the testing

--- a/app/reports/routing.go
+++ b/app/reports/routing.go
@@ -45,6 +45,8 @@ var appRoutesV2 = []respond.AppRoutes{
 	{Name: "reports.create", Verb: "POST", Path: "/reports", SubrouterHandler: Create},
 	{Name: "reports.update", Verb: "PUT", Path: "/reports/{id}", SubrouterHandler: Update},
 	{Name: "reports.delete", Verb: "DELETE", Path: "/reports/{id}", SubrouterHandler: Delete},
+	{Name: "reports.set_public", Verb: "POST", Path: "/reports/{id}/set-public", SubrouterHandler: SetPublic},
+	{Name: "reports.set_private", Verb: "POST", Path: "/reports/{id}/set-private", SubrouterHandler: SetPrivate},
 	{Name: "reports.set_node_report", Verb: "POST", Path: "/reports/{id}/set-node-report", SubrouterHandler: SetNodeReport},
 	{Name: "reports.options", Verb: "OPTIONS", Path: "/reports", SubrouterHandler: Options},
 	{Name: "reports.options", Verb: "OPTIONS", Path: "/reports/{id}", SubrouterHandler: Options},

--- a/docker/files/init_mongo.js
+++ b/docker/files/init_mongo.js
@@ -165,6 +165,14 @@ db.roles.insertMany([
     roles: ['admin', 'editor']
   },
   {
+    resource: 'reports.set_public',
+    roles: ['admin', 'editor']
+  },
+  {
+    resource: 'reports.set_private',
+    roles: ['admin', 'editor']
+  },
+  {
     resource: 'metric_profiles.get',
     roles: ['admin', 'editor', 'viewer', 'admin_ui']
   },

--- a/scripts/mongodb/populate_default_roles.js
+++ b/scripts/mongodb/populate_default_roles.js
@@ -42,6 +42,8 @@ function populate_default_roles() {
         { resource: "reports.delete", roles: ["admin", "editor"] },
         { resource: "reports.update", roles: ["admin", "editor"] },
         { resource: "reports.set_node_report", roles: ["admin", "editor"] },
+        { resource: "reports.set_public", roles: ["admin", "editor"] },
+        { resource: "reports.set_private", roles: ["admin", "editor"] },
         {
             resource: "metricProfiles.get",
             roles: ["admin", "editor", "viewer", "admin_ui"]

--- a/website/docs/profiles_and_reports/reports.md
+++ b/website/docs/profiles_and_reports/reports.md
@@ -12,6 +12,8 @@ sidebar_position: 5
 | POST: Create a new report          | This method can be used to create a new report.                | [ Description](#2) |
 | PUT: Update an existing report     | This method can be used to update an existing report.          | [ Description](#3) |
 | POST: Set report as node report     | This method can be used to set an existing report as node report.          | [ Description](#3B) |
+| POST: Set report as public     | This method can be used to set an existing report as public.          | [ Description](#3C) |
+| POST: Set report as private     | This method can be used to set an existing report as private.          | [ Description](#3D) |
 | DELETE: Delete an existing Report  | This method can be used to delete an existing report.          | [ Description](#4) |
 
 
@@ -35,6 +37,8 @@ or
 When using `/reports` to list the available reports you have the following filters that you can use as url values
 - `?name=<report_name>` to search for an exact report name
 - `?node` to show only the default node report
+- `?public` to show only the public reports
+- `?private` to show only the private reports
 #### Request headers
 
 ```
@@ -348,6 +352,165 @@ Headers: `Status: 200 OK`
 {
   "status": {
     "message": "Report was set as the default node report",
+    "code": "200"
+  }
+}
+```
+
+
+## [POST]: Set a report as public {#3C}
+
+All reports are by default created as private. This method can be used to set an existing report as public
+
+### Input
+
+#### URL
+
+```
+POST /reports/{id}/set-public
+```
+
+#### Request headers
+
+```
+x-api-key: shared_key_value
+Accept: application/json
+```
+
+
+### Response
+
+Headers: `Status: 200 OK`
+
+#### Response Body
+
+```json
+{
+  "status": {
+    "message": "Report is set as public",
+    "code": "200"
+  }
+}
+```
+
+An existing public report will have the `"public": true` boolean field appear on its body and we can quickly list the public reports by using the url parameter `?public` as show below:
+
+### Request:
+
+```
+GET /reports?public
+```
+
+### Response:
+
+
+```json
+{
+    "status": {
+        "message": "Success",
+        "code": "200"
+    },
+    "data": [
+        {
+            "id": "eba61a9e-22e9-4521-9e47-ecaa4a494364",
+            "tenant": "TenantA",
+            "disabled": false,
+            "info": {
+                "name": "Report_A",
+                "description": "report aaaaa",
+                "created": "2015-9-10 13:43:00",
+                "updated": "2015-10-11 13:43:00"
+            },
+            "computations": {
+                "ar": true,
+                "status": true,
+                "trends": [
+                              "flapping",
+                              "status",
+                              "tags"
+                          ]
+            },
+            "topology_schema": {
+                "group": {
+                    "type": "NGI",
+                    "group": {
+                        "type": "SITE"
+                    }
+                }
+            },
+            "thresholds": {
+                "availability": 80.0,
+                "reliability": 85.0,
+                "uptime": 80.0,
+                "unknown": 10.0,
+                "downtime": 10.0
+            },
+            "profiles": [
+                {
+                    "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50b",
+                    "name": "profile1",
+                    "type": "metric"
+                },
+                {
+                    "id": "6ac7d684-1f8e-4a02-a502-720e8f11e523",
+                    "name": "profile2",
+                    "type": "operations"
+                },
+                {
+                    "id": "6ac7d684-1f8e-4a02-a502-720e8f11e50q",
+                    "name": "profile3",
+                    "type": "aggregation"
+                }
+            ],
+            "filter_tags": [
+                {
+                    "name": "name1",
+                    "value": "value1",
+                    "context": ""
+                },
+                {
+                    "name": "name2",
+                    "value": "value2",
+                    "context": ""
+                }
+            ],
+            "public": true
+        }
+    ]
+}
+```
+
+
+## [POST]: Set a report as private {#3D}
+
+This method can be used to set an existing report as private
+
+### Input
+
+#### URL
+
+```
+POST /reports/{id}/set-private
+```
+
+#### Request headers
+
+```
+x-api-key: shared_key_value
+Accept: application/json
+```
+
+
+### Response
+
+Headers: `Status: 200 OK`
+
+#### Response Body
+
+```json
+{
+  "status": {
+    "message": "Report is set as private",
     "code": "200"
   }
 }

--- a/website/static/openapi/argo-web-api.yml
+++ b/website/static/openapi/argo-web-api.yml
@@ -1514,6 +1514,16 @@ paths:
         description: show only active default node report
         schema:
           type: string
+      - name: public
+        in: query
+        description: show only public reports
+        schema:
+          type: string
+      - name: private
+        in: query
+        description: show only private reports
+        schema:
+          type: string
       responses:
         "200":
           description: A list of all available Reports
@@ -1629,6 +1639,108 @@ paths:
               example:
                 status:
                   message: "Report was set as the default node report"
+                  code: "200"
+        "401":
+          description: Unauthorized user
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status_error'
+        "404":
+          description: Item not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status_error'
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status_error'
+      x-codegen-request-body-name: report
+  /v2/reports/{REPORT_ID}/set-public:
+    post:
+      tags:
+      - Reports
+      summary: Set a report as public
+      description: Set an existing report as public
+      operationId: report.SetPublic
+      parameters:
+      - name: REPORT_ID
+        in: path
+        description: id of the report
+        required: true
+        schema:
+          type: string
+      - name: x-api-key
+        in: header
+        description: the x-api-key
+        required: true
+        schema:
+          type: string
+          default: SecretKey123
+      responses:
+        "200":
+          description: Report is set as public
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
+              example:
+                status:
+                  message: "Report is set as public"
+                  code: "200"
+        "401":
+          description: Unauthorized user
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status_error'
+        "404":
+          description: Item not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status_error'
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status_error'
+      x-codegen-request-body-name: report
+  /v2/reports/{REPORT_ID}/set-private:
+    post:
+      tags:
+      - Reports
+      summary: Set a report as private
+      description: Set an existing report as private
+      operationId: report.SetPrivate
+      parameters:
+      - name: REPORT_ID
+        in: path
+        description: id of the report
+        required: true
+        schema:
+          type: string
+      - name: x-api-key
+        in: header
+        description: the x-api-key
+        required: true
+        schema:
+          type: string
+          default: SecretKey123
+      responses:
+        "200":
+          description: Report is set as private
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
+              example:
+                status:
+                  message: "Report is set as private"
                   code: "200"
         "401":
           description: Unauthorized user
@@ -13612,6 +13724,8 @@ components:
                 type: string
               context:
                 type: string
+        public:
+          type: boolean
     FeedsData:
       type: object
       properties:


### PR DESCRIPTION
## Goal
Allow reports to be public or private. If a report is public it will have an optional boolean field `"public": true` designating that it is public. If not it is considered private.  By default all reports are created private.

## Implementation
Add optional field `"public": true` in each report. Add a method to set a report as public. Add another method to set a report as private. Add filters to show only public or private reports in the List Reports method

API method to set a report public:
```
HTTP POST /api/v2/reports/{report-id}/set-public
```
response:
```json
{
  "status": {
    "message": "Report is set as public",
    "code": "200"
  }
}
```

API method to set a report private:
```
HTTP POST /api/v2/reports/{report-id}/set-private
```
response:
```json
{
  "status": {
    "message": "Report is set as private",
    "code": "200"
  }
}
```

See docs here: https://github.com/kaggis/argo-web-api/blob/7765dfa304342ed5345fc9465f9ce1be61d66ba1/website/docs/profiles_and_reports/reports.md

### Implementation tasks
- [x] Update report model to receive optional boolean field `public`
- [x] Add api method set report public
- [x] Add api method set report private
- [x] Update routing
- [x] Add tests
- [x] Update db roles in docker/scripts
- [x] Add docs
- [x] Add openapi definitions
