### PR TITLE
ARGO-5716 Provide new calls to retrieve a/r results for supergroups a…

### DIFF
--- a/docker/files/init_mongo.js
+++ b/docker/files/init_mongo.js
@@ -1880,6 +1880,8 @@ const baseRecords = [
 ];
 
 
+
+
 for (let i = 0; i < 7; i++) {
   const day = new Date(now);
   day.setUTCDate(now.getUTCDate() - i);   
@@ -1888,6 +1890,21 @@ for (let i = 0; i < 7; i++) {
                 + day.getUTCDate();
 
   const docs = baseRecords.map(r => ({ ...r, date: putDate }));
+
+  db.endpoint_group_ar.insertMany(docs);
+
+};
+
+// add also some random a/r metrics 
+
+for (let i = 7; i < 57; i++) {
+  const day = new Date(now);
+  day.setUTCDate(now.getUTCDate() - i);   
+  const putDate = day.getUTCFullYear() * 10000
+                + (day.getUTCMonth() + 1) * 100
+                + day.getUTCDate();
+
+  const docs = baseRecords.map(r => ({ ...r, date: putDate, availability: Math.floor(Math.random() * (100 - 80 + 1)) + 80 , reliability: Math.floor(Math.random() * (100 - 80 + 1)) + 80}));
 
   db.endpoint_group_ar.insertMany(docs);
 
@@ -2798,6 +2815,21 @@ for (let i = 0; i < 7; i++) {
                 + day.getUTCDate();
 
   const docs = baseRecords2.map(r => ({ ...r, date: putDate }));
+
+  db.endpoint_group_ar.insertMany(docs);
+
+};
+
+// add also some random a/r metrics 
+console.log("add extra data");
+for (let i = 7; i < 57; i++) {
+  const day = new Date(now);
+  day.setUTCDate(now.getUTCDate() - i);   
+  const putDate = day.getUTCFullYear() * 10000
+                + (day.getUTCMonth() + 1) * 100
+                + day.getUTCDate();
+
+  const docs = baseRecords2.map(r => ({ ...r, date: putDate, availability: Math.floor(Math.random() * (100 - 80 + 1)) + 80 , reliability: Math.floor(Math.random() * (100 - 80 + 1)) + 80}));
 
   db.endpoint_group_ar.insertMany(docs);
 

--- a/respond/wrappers.go
+++ b/respond/wrappers.go
@@ -230,13 +230,7 @@ func WrapValidate(hfn http.Handler, cfg config.Config, routeName string) http.Ha
 					return
 				}
 			}
-			if strings.Contains(resource, "results") {
-				errs = ValidateResultsParams(queries)
-				if len(errs) > 0 {
-					Error(w, r, ErrValidQuery, cfg, errs)
-					return
-				}
-			}
+
 			if strings.Contains(resource, "metricResult") {
 				errs = ValidateMetricParams(queries)
 				if len(errs) > 0 {

--- a/routing/router.go
+++ b/routing/router.go
@@ -44,6 +44,7 @@ type RouteV2 struct {
 // Same Route model as V2
 type RouteV3 RouteV2
 type RouteV4 RouteV2
+type RouteV5 RouteV2
 
 // NewRouter creates the main router that will be used by the api (contains both v2 and v3 routes)
 func NewRouter(cfg config.Config) *mux.Router {
@@ -72,12 +73,24 @@ func NewRouter(cfg config.Config) *mux.Router {
 
 	// Add v4 subroutes
 	for _, subroute := range routesV4 {
+
 		subrouter := router.
 			PathPrefix("/api/v4" + subroute.Pattern).
 			Name(subroute.Name).
 			Subrouter()
 		subroute.SubrouterHandler(subrouter, &confhandler)
 	}
+
+	// Add v5 subroutes
+	for _, subroute := range routesV5 {
+
+		subrouter := router.
+			PathPrefix("/api/v5" + subroute.Pattern).
+			Name(subroute.Name).
+			Subrouter()
+		subroute.SubrouterHandler(subrouter, &confhandler)
+	}
+
 	return router
 }
 

--- a/routing/routes.go
+++ b/routing/routes.go
@@ -53,8 +53,13 @@ import (
 	"github.com/ARGOeu/argo-web-api/v3/integrations"
 	"github.com/ARGOeu/argo-web-api/v3/status"
 	"github.com/ARGOeu/argo-web-api/v4/nodes"
+	resultsV5 "github.com/ARGOeu/argo-web-api/v5/results"
 	"github.com/ARGOeu/argo-web-api/version"
 )
+
+var routesV5 = []RouteV5{
+	{"resultsV5", "/results", resultsV5.HandleSubrouter},
+}
 
 // Here we declare the v4 routes
 var routesV4 = []RouteV4{

--- a/v5/results/controller.go
+++ b/v5/results/controller.go
@@ -1,0 +1,269 @@
+package resultsV5
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/ARGOeu/argo-web-api/app/reports"
+	"github.com/ARGOeu/argo-web-api/respond"
+	"github.com/ARGOeu/argo-web-api/utils/config"
+
+	gcontext "github.com/gorilla/context"
+	"github.com/gorilla/mux"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+// ListGroupResults list monitoring results (availability/reliability)
+func GetGroups(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
+
+	//STANDARD DECLARATIONS START
+	code := http.StatusOK
+	h := http.Header{}
+	output := []byte("")
+	err := error(nil)
+	charset := "utf-8"
+	//STANDARD DECLARATIONS END
+
+	// Set Content-Type response Header value
+	contentType := r.Header.Get("Accept")
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+
+	// Parse the request into the input
+	urlValues := r.URL.Query()
+	vars := mux.Vars(r)
+
+	// Grab Tenant DB configuration from context
+	tenantDbConfig := gcontext.Get(r, "tenant_conf").(config.MongoConfig)
+
+	report := reports.MongoInterface{}
+	rCol := cfg.MongoClient.Database(tenantDbConfig.Db).Collection("reports")
+	err = rCol.FindOne(context.TODO(), bson.M{"info.name": vars["report-name"]}).Decode(&report)
+
+	if err != nil {
+		code = http.StatusNotFound
+		message := "The report with the name " + vars["report-name"] + " does not exist"
+		output, err := createErrorMessage(message, code, contentType) //Render the response into XML or JSON
+		h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+		return code, h, output, err
+	}
+
+	input := endpointGroupResultQuery{
+		basicQuery{
+			Name:        vars["group-name"],
+			Granularity: urlValues.Get("granularity"),
+			Format:      contentType,
+			StartTime:   urlValues.Get("start-time"),
+			EndTime:     urlValues.Get("end-time"),
+			Report:      report,
+			Vars:        vars,
+		}, "",
+	}
+
+	errs := input.Validate()
+	if len(errs) > 0 {
+		out := respond.BadRequestSimple
+		out.Errors = errs
+		output = out.MarshalTo(contentType)
+		code = 400
+		return code, h, output, err
+	}
+
+	results := []EndpointGroupInterface{}
+
+	// Construct the query to mongodb based on the input
+	filter := bson.M{
+		"date":   bson.M{"$gte": input.StartTimeInt, "$lte": input.EndTimeInt},
+		"report": report.ID,
+	}
+
+	if input.Name != "" {
+		filter["name"] = input.Name
+	}
+
+	// Select the granularity of the search daily/monthly
+	custom := false
+	arCol := cfg.MongoClient.Database(tenantDbConfig.Db).Collection("endpoint_group_ar")
+	var query []primitive.M
+
+	if input.Granularity == "daily" {
+		customForm[0] = "20060102"
+		customForm[1] = "2006-01-02"
+		query = DailyGroup(filter)
+	} else if input.Granularity == "monthly" {
+		customForm[0] = "200601"
+		customForm[1] = "2006-01"
+		query = MonthlyGroup(filter)
+	} else if input.Granularity == "custom" {
+		customForm[0] = "200601"
+		customForm[1] = "2006-01"
+		query = CustomGroup(filter)
+		custom = true
+	}
+
+	cursor, err := arCol.Aggregate(context.TODO(), query)
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	defer cursor.Close(context.TODO())
+	cursor.All(context.TODO(), &results)
+
+	if len(results) == 0 {
+		code = http.StatusNotFound
+		message := "No results found for given query"
+		output, err = createErrorMessage(message, code, contentType)
+		return code, h, output, err
+	}
+
+	output, err = createGroupResultView(results, report, input.Format, custom)
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	return code, h, output, err
+}
+
+// ListSuperGroupResults supergroup availabilities according to the http request
+func GetSupergroups(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
+
+	//STANDARD DECLARATIONS START
+	code := http.StatusOK
+	h := http.Header{}
+	output := []byte("")
+	err := error(nil)
+	charset := "utf-8"
+	//STANDARD DECLARATIONS END
+
+	// Set Content-Type response Header value
+	contentType := r.Header.Get("Accept")
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+
+	// Parse the request into the input
+	urlValues := r.URL.Query()
+	vars := mux.Vars(r)
+
+	// Grab Tenant DB configuration from context
+	tenantDbConfig := gcontext.Get(r, "tenant_conf").(config.MongoConfig)
+
+	report := reports.MongoInterface{}
+	rCol := cfg.MongoClient.Database(tenantDbConfig.Db).Collection("reports")
+	err = rCol.FindOne(context.TODO(), bson.M{"info.name": vars["report-name"]}).Decode(&report)
+
+	if err != nil {
+		if errors.Is(err, mongo.ErrNoDocuments) {
+			code = http.StatusNotFound
+			message := "The report with the name " + vars["report-name"] + " does not exist"
+			output, err := createErrorMessage(message, code, contentType) //Render the response into XML or JSON
+			h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+			return code, h, output, err
+		} else {
+			code = http.StatusInternalServerError
+			return code, h, output, err
+		}
+	}
+
+	input := endpointGroupResultQuery{
+		basicQuery{
+			Name:        vars["supergroup-name"],
+			Granularity: urlValues.Get("granularity"),
+			Format:      contentType,
+			StartTime:   urlValues.Get("start-time"),
+			EndTime:     urlValues.Get("end-time"),
+			Report:      report,
+			Vars:        vars,
+		}, "",
+	}
+
+	errs := input.Validate()
+	if len(errs) > 0 {
+		out := respond.BadRequestSimple
+		out.Errors = errs
+		output = out.MarshalTo(contentType)
+		code = 400
+		return code, h, output, err
+	}
+
+	results := []SuperGroupInterface{}
+
+	// Construct the query to mongodb based on the input
+	filter := bson.M{
+		"date":   bson.M{"$gte": input.StartTimeInt, "$lte": input.EndTimeInt},
+		"report": report.ID,
+	}
+
+	if input.Name != "" {
+		filter["supergroup"] = input.Name
+	}
+
+	custom := false
+
+	arCol := cfg.MongoClient.Database(tenantDbConfig.Db).Collection("endpoint_group_ar")
+	var query []primitive.M
+	// Select the granularity of the search daily/monthly
+	if input.Granularity == "daily" {
+		customForm[0] = "20060102"
+		customForm[1] = "2006-01-02"
+		query = DailySuperGroup(filter)
+	} else if input.Granularity == "monthly" {
+		customForm[0] = "200601"
+		customForm[1] = "2006-01"
+		query = MonthlySuperGroup(filter)
+	} else if input.Granularity == "custom" {
+		customForm[0] = "200601"
+		customForm[1] = "2006-01"
+		query = CustomSuperGroup(filter)
+		custom = true
+	}
+	cursor, err := arCol.Aggregate(context.TODO(), query)
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	defer cursor.Close(context.TODO())
+	cursor.All(context.TODO(), &results)
+
+	if len(results) == 0 {
+		code = http.StatusNotFound
+		message := "No results found for given query"
+		output, err = createErrorMessage(message, code, contentType)
+		return code, h, output, err
+	}
+
+	output, err = createSuperGroupView(results, report, input.Format, custom)
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	return code, h, output, err
+}
+
+func Options(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
+
+	//STANDARD DECLARATIONS START
+
+	code := http.StatusOK
+	h := http.Header{}
+	output := []byte("")
+	err := error(nil)
+	contentType := "text/plain"
+	charset := "utf-8"
+
+	//STANDARD DECLARATIONS END
+
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+	h.Set("Allow", "GET, OPTIONS")
+	return code, h, output, err
+
+}

--- a/v5/results/group_test.go
+++ b/v5/results/group_test.go
@@ -1,0 +1,534 @@
+package resultsV5
+
+import (
+	"context"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/ARGOeu/argo-web-api/respond"
+	"github.com/ARGOeu/argo-web-api/utils/config"
+	"github.com/ARGOeu/argo-web-api/utils/store"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/suite"
+	"go.mongodb.org/mongo-driver/bson"
+	"gopkg.in/gcfg.v1"
+)
+
+type endpointGroupAvailabilityTestSuite struct {
+	suite.Suite
+	cfg          config.Config
+	router       *mux.Router
+	confHandler  respond.ConfHandler
+	tenantDbConf config.MongoConfig
+	clientkey    string
+}
+
+// Setup the Test Environment
+func (suite *endpointGroupAvailabilityTestSuite) SetupSuite() {
+
+	const testConfig = `
+	    [server]
+	    bindip = ""
+	    port = 8080
+	    maxprocs = 4
+	    cache = false
+	    lrucache = 700000000
+	    gzip = true
+	    [mongodb]
+	    host = "127.0.0.1"
+	    port = 27017
+	    db = "ARGO_test_endpointGroup_availability"
+	    `
+
+	_ = gcfg.ReadStringInto(&suite.cfg, testConfig)
+
+	client := store.GetMongoClient(suite.cfg.MongoDB)
+	suite.cfg.MongoClient = client
+
+	suite.tenantDbConf.Db = "ARGO_test_endpointGroup_availability_tenant"
+	suite.tenantDbConf.Password = "h4shp4ss"
+	suite.tenantDbConf.Username = "dbuser"
+	suite.tenantDbConf.Store = "ar"
+	suite.clientkey = "secretkey"
+
+	// Create router and confhandler for test
+	suite.confHandler = respond.ConfHandler{Config: suite.cfg}
+	suite.router = mux.NewRouter().StrictSlash(false).PathPrefix("/api/v5/results").Subrouter()
+	HandleSubrouter(suite.router, &suite.confHandler)
+}
+
+// This function runs before any test and setups the environment
+func (suite *endpointGroupAvailabilityTestSuite) SetupTest() {
+
+	log.SetOutput(io.Discard)
+
+	// Seed database with tenants
+	//TODO: move tests to
+	c := suite.cfg.MongoClient.Database(suite.cfg.MongoDB.Db).Collection("tenants")
+	c.InsertOne(context.TODO(),
+		bson.M{"name": "TENANT-AA",
+			"db_conf": []bson.M{
+				{
+					"server":   "localhost",
+					"port":     27017,
+					"database": "argo_test1",
+				},
+				{
+					"server":   "localhost",
+					"port":     27017,
+					"database": "argo_test2",
+				},
+			},
+			"users": []bson.M{
+				{
+					"name":    "alice",
+					"email":   "alice@tenant-a.foo",
+					"api_key": "alice_key",
+					"roles":   []string{"viewer"},
+				},
+				{
+					"name":    "bob",
+					"email":   "bob@tenant-a.foo",
+					"api_key": "bob_key",
+					"roles":   []string{"viewer"},
+				},
+			}})
+	c.InsertOne(context.TODO(),
+		bson.M{"name": "TENANT-BB",
+			"db_conf": []bson.M{
+				{
+					"server":   "localhost",
+					"port":     27017,
+					"database": suite.tenantDbConf.Db,
+					"username": suite.tenantDbConf.Username,
+					"password": suite.tenantDbConf.Password,
+				},
+				{
+					"server":   "localhost",
+					"port":     27017,
+					"database": "tenant_b_db",
+				},
+			},
+			"users": []bson.M{
+				{
+					"name":    "alice",
+					"email":   "alice@tenant-b.foo",
+					"api_key": suite.clientkey,
+					"roles":   []string{"viewer"},
+				},
+				{
+					"name":    "bob",
+					"email":   "bob@tenant-b.foo",
+					"api_key": "bob_key",
+					"roles":   []string{"viewer"},
+				},
+			}})
+
+	c = suite.cfg.MongoClient.Database(suite.cfg.MongoDB.Db).Collection("roles")
+	c.InsertOne(context.TODO(),
+		bson.M{
+			"resource": "results.list",
+			"roles":    []string{"editor", "viewer"},
+		})
+	c.InsertOne(context.TODO(),
+		bson.M{
+			"resource": "results.get",
+			"roles":    []string{"editor", "viewer"},
+		})
+	// Seed tenant database with data
+	c = suite.cfg.MongoClient.Database(suite.tenantDbConf.Db).Collection("endpoint_group_ar")
+
+	// Insert seed data
+	c.InsertOne(context.TODO(),
+		bson.M{
+			"report":       "eba61a9e-22e9-4521-9e47-ecaa4a49436",
+			"date":         20150622,
+			"name":         "ST01",
+			"supergroup":   "GROUP_A",
+			"up":           1,
+			"down":         0,
+			"unknown":      0,
+			"availability": 66.7,
+			"reliability":  54.6,
+			"weight":       5634,
+			"tags": []bson.M{
+				{
+					"name":  "",
+					"value": "",
+				},
+			},
+		})
+	c.InsertOne(context.TODO(),
+		bson.M{
+			"report":       "eba61a9e-22e9-4521-9e47-ecaa4a49436",
+			"date":         20150622,
+			"name":         "ST02",
+			"supergroup":   "GROUP_A",
+			"up":           1,
+			"down":         0,
+			"unknown":      0,
+			"availability": 70,
+			"reliability":  45,
+			"weight":       4356,
+			"tags": []bson.M{
+				{
+					"name":  "",
+					"value": "",
+				},
+			},
+		})
+	c.InsertOne(context.TODO(),
+		bson.M{
+			"report":       "eba61a9e-22e9-4521-9e47-ecaa4a49436",
+			"date":         20150623,
+			"name":         "ST01",
+			"supergroup":   "GROUP_A",
+			"up":           1,
+			"down":         0,
+			"unknown":      0,
+			"availability": 100,
+			"reliability":  100,
+			"weight":       5634,
+			"tags": []bson.M{
+				{
+					"name":  "",
+					"value": "",
+				},
+			},
+		})
+	c.InsertOne(context.TODO(),
+		bson.M{
+			"report":       "eba61a9e-22e9-4521-9e47-ecaa4a49436",
+			"date":         20150623,
+			"name":         "ST02",
+			"supergroup":   "GROUP_A",
+			"up":           1,
+			"down":         0,
+			"unknown":      0,
+			"availability": 43.5,
+			"reliability":  56,
+			"weight":       4356,
+			"tags": []bson.M{
+				{
+					"name":  "",
+					"value": "",
+				},
+			},
+		})
+
+	c = suite.cfg.MongoClient.Database(suite.tenantDbConf.Db).Collection("reports")
+
+	c.InsertOne(context.TODO(), bson.M{
+		"id": "eba61a9e-22e9-4521-9e47-ecaa4a49436",
+		"info": bson.M{
+			"name":        "Report_A",
+			"description": "lalalallala",
+		},
+		"topology_schema": bson.M{
+			"group": bson.M{
+				"type": "GROUP",
+				"group": bson.M{
+					"type": "SITES",
+				},
+			},
+		},
+		"profiles": []bson.M{
+			{
+				"type": "metric",
+				"name": "ch.cern.SAM.ROC_CRITICAL"},
+		},
+		"filter_tags": []bson.M{
+			{
+				"name":  "name1",
+				"value": "value1"},
+			{
+				"name":  "name2",
+				"value": "value2"},
+		}})
+
+}
+
+// TestEndpointGroupAvailability test if daily results are returned correctly
+func (suite *endpointGroupAvailabilityTestSuite) TestListGroupAvailability() {
+
+	request, _ := http.NewRequest("GET", "/api/v5/results/Report_A/groups/ST01?start-time=2015-06-20T12:00:00Z&end-time=2015-06-23T23:00:00Z", strings.NewReader(""))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	endpointGroupAvailabilityJSON := `{
+   "results": [
+     {
+       "name": "GROUP_A",
+       "type": "GROUP",
+       "groups": [
+         {
+           "name": "ST01",
+           "type": "SITES",
+           "results": [
+             {
+               "timestamp": "2015-06-22",
+               "availability": 66.7,
+               "reliability": 54.6,
+               "unknown": 0,
+               "uptime": 1,
+               "downtime": 0
+             },
+             {
+               "timestamp": "2015-06-23",
+               "availability": 100,
+               "reliability": 100,
+               "unknown": 0,
+               "uptime": 1,
+               "downtime": 0
+             }
+           ]
+         }
+       ]
+     }
+   ]
+ }`
+
+	// Check that we must have a 200 ok code
+	suite.Equal(200, response.Code, "Incorrect HTTP response code")
+	// Compare the expected and actual xml response
+	suite.Equal(endpointGroupAvailabilityJSON, response.Body.String(), "Response body mismatch")
+
+	request, _ = http.NewRequest("GET", "/api/v5/results/Report_A/groups/ST01?start-time=2015-06-20T12:00:00Z&end-time=2015-06-23T23:00:00Z", strings.NewReader(""))
+	request.Header.Set("x-api-key", "AWRONGKEY")
+	request.Header.Set("Accept", "application/json")
+
+	response = httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	unauthorizedresponseXML := `{
+ "status": {
+  "message": "Unauthorized",
+  "code": "401",
+  "details": "You need to provide a correct authentication token using the header 'x-api-key'"
+ }
+}`
+
+	// Check that we must have a 401 Unauthorized code
+	suite.Equal(401, response.Code, "Incorrect HTTP response code")
+	// Compare the expected and actual xml response
+	suite.Equal(unauthorizedresponseXML, response.Body.String(), "Response body mismatch")
+
+}
+
+// TestListAllEndpointGroupAvailability test if daily results are returned correctly
+func (suite *endpointGroupAvailabilityTestSuite) TestListAllEndpointGroupAvailability() {
+
+	request, _ := http.NewRequest("GET", "/api/v5/results/Report_A/groups?start-time=2015-06-20T12:00:00Z&end-time=2015-06-23T23:00:00Z&granularity=daily", strings.NewReader(""))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	endpointGroupAvailabilityJSON := `{
+   "results": [
+     {
+       "name": "GROUP_A",
+       "type": "GROUP",
+       "groups": [
+         {
+           "name": "ST01",
+           "type": "SITES",
+           "results": [
+             {
+               "timestamp": "2015-06-22",
+               "availability": 66.7,
+               "reliability": 54.6,
+               "unknown": 0,
+               "uptime": 1,
+               "downtime": 0
+             },
+             {
+               "timestamp": "2015-06-23",
+               "availability": 100,
+               "reliability": 100,
+               "unknown": 0,
+               "uptime": 1,
+               "downtime": 0
+             }
+           ]
+         },
+         {
+           "name": "ST02",
+           "type": "SITES",
+           "results": [
+             {
+               "timestamp": "2015-06-22",
+               "availability": 70,
+               "reliability": 45,
+               "unknown": 0,
+               "uptime": 1,
+               "downtime": 0
+             },
+             {
+               "timestamp": "2015-06-23",
+               "availability": 43.5,
+               "reliability": 56,
+               "unknown": 0,
+               "uptime": 1,
+               "downtime": 0
+             }
+           ]
+         }
+       ]
+     }
+   ]
+ }`
+
+	// Check that we must have a 200 ok code
+	suite.Equal(200, response.Code, "Incorrect HTTP response code")
+	// Compare the expected and actual xml response
+	suite.Equal(endpointGroupAvailabilityJSON, response.Body.String(), "Response body mismatch")
+
+}
+
+// TestOptionsEndpointGroup tests responses in case the OPTIONS http verb is used
+func (suite *endpointGroupAvailabilityTestSuite) TestOptionsEndpointGroup() {
+
+	request, _ := http.NewRequest("OPTIONS", "/api/v5/results/Report_A/groups", strings.NewReader(""))
+
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code := response.Code
+	output := response.Body.String()
+	headers := response.Result().Header
+
+	suite.Equal(200, code, "Error in response code")
+	suite.Equal("", output, "Expected empty response body")
+	suite.Equal("GET, OPTIONS", headers.Get("Allow"), "Error in Allow header response (supported resource verbs of resource)")
+	suite.Equal("text/plain; charset=utf-8", headers.Get("Content-Type"), "Error in Content-Type header response")
+
+	request, _ = http.NewRequest("OPTIONS", "/api/v5/results/Report_A/groups/ST01", strings.NewReader(""))
+
+	response = httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code = response.Code
+	output = response.Body.String()
+	headers = response.Result().Header
+
+	suite.Equal(200, code, "Error in response code")
+	suite.Equal("", output, "Expected empty response body")
+	suite.Equal("GET, OPTIONS", headers.Get("Allow"), "Error in Allow header response (supported resource verbs of resource)")
+	suite.Equal("text/plain; charset=utf-8", headers.Get("Content-Type"), "Error in Content-Type header response")
+
+	request, _ = http.NewRequest("OPTIONS", "/api/v5/results/Report_A/groups", strings.NewReader(""))
+
+	response = httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code = response.Code
+	output = response.Body.String()
+	headers = response.Result().Header
+
+}
+
+// TestListAllEndpointGroupAvailabilityCustom tests if a/r results are returned correctly over a custom period
+func (suite *endpointGroupAvailabilityTestSuite) TestListAllEndpointGroupAvailabilityCustom() {
+
+	request, _ := http.NewRequest("GET", "/api/v5/results/Report_A/groups?start-time=2015-06-20T12:00:00Z&end-time=2015-06-23T23:00:00Z&granularity=custom", strings.NewReader(""))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	endpointGroupAvailabilityJSON := `{
+   "results": [
+     {
+       "name": "GROUP_A",
+       "type": "GROUP",
+       "groups": [
+         {
+           "name": "ST01",
+           "type": "SITES",
+           "results": [
+             {
+               "availability": 100,
+               "reliability": 100,
+               "unknown": 0,
+               "uptime": 1,
+               "downtime": 0
+             }
+           ]
+         },
+         {
+           "name": "ST02",
+           "type": "SITES",
+           "results": [
+             {
+               "availability": 100,
+               "reliability": 100,
+               "unknown": 0,
+               "uptime": 1,
+               "downtime": 0
+             }
+           ]
+         }
+       ]
+     }
+   ]
+ }`
+
+	// Check that we must have a 200 ok code
+	suite.Equal(200, response.Code, "Incorrect HTTP response code")
+	// Compare the expected and actual xml response
+	suite.Equal(endpointGroupAvailabilityJSON, response.Body.String(), "Response body mismatch")
+
+}
+
+// TearDownTest to tear down every test
+func (suite *endpointGroupAvailabilityTestSuite) TearDownTest() {
+
+	mainDB := suite.cfg.MongoClient.Database(suite.cfg.MongoDB.Db)
+	cols, err := mainDB.ListCollectionNames(context.TODO(), bson.M{})
+	if err != nil {
+		panic(err)
+	}
+
+	for _, col := range cols {
+		mainDB.Collection(col).Drop(context.TODO())
+	}
+
+	tenantDB := suite.cfg.MongoClient.Database(suite.tenantDbConf.Db)
+	cols, err = tenantDB.ListCollectionNames(context.TODO(), bson.M{})
+	if err != nil {
+		panic(err)
+	}
+
+	for _, col := range cols {
+		tenantDB.Collection(col).Drop(context.TODO())
+	}
+
+}
+
+// TearDownTest to tear down every test
+func (suite *endpointGroupAvailabilityTestSuite) TearDownSuite() {
+	suite.cfg.MongoClient.Database(suite.cfg.MongoDB.Db).Drop(context.TODO())
+	suite.cfg.MongoClient.Database(suite.tenantDbConf.Db).Drop(context.TODO())
+}
+
+// TestSuiteResultsEndpointGroup is responsible for calling the tests
+func TestSuiteResultsEndpointGroup(t *testing.T) {
+	suite.Run(t, new(endpointGroupAvailabilityTestSuite))
+}

--- a/v5/results/model.go
+++ b/v5/results/model.go
@@ -1,0 +1,131 @@
+package resultsV5
+
+import (
+	"encoding/json"
+	"math"
+
+	"github.com/ARGOeu/argo-web-api/app/reports"
+	"github.com/ARGOeu/argo-web-api/respond"
+)
+
+type list []interface{}
+
+var customForm []string
+
+func init() {
+	customForm = []string{"20060102", "2006-01-02T15:04:05Z"} //{"Format that is returned by the database" , "Format that will be used in the generated report"}
+}
+
+const zuluForm = "2006-01-02T15:04:05Z"
+const ymdForm = "20060102"
+
+type basicQuery struct {
+	Name         string                 `bson:"name"`
+	Granularity  string                 `bson:"-"`
+	Format       string                 `bson:"-"`
+	StartTime    string                 `bson:"-"` // UTC time in W3C format
+	EndTime      string                 `bson:"-"` // UTC time in W3C format
+	Report       reports.MongoInterface `bson:"report"`
+	StartTimeInt int                    `bson:"start_time"`
+	EndTimeInt   int                    `bson:"end_time"`
+	Vars         map[string]string      `bson:"-"`
+}
+
+type endpointGroupResultQuery struct {
+	basicQuery
+	Group string `bson:"supergroup"`
+}
+
+// EndpointGroupInterface for mongodb object exchanging
+type EndpointGroupInterface struct {
+	Name         string  `bson:"name"`
+	Report       string  `bson:"report"`
+	Date         string  `bson:"date"`
+	Type         string  `bson:"type"`
+	Up           float64 `bson:"up"`
+	Down         float64 `bson:"down"`
+	Unknown      float64 `bson:"unknown"`
+	Availability float64 `bson:"availability"`
+	Reliability  float64 `bson:"reliability"`
+	Weights      string  `bson:"weights"`
+	SuperGroup   string  `bson:"supergroup"`
+}
+
+// SuperGroupInterface for mongodb object exchanging
+type SuperGroupInterface struct {
+	Report       string  `bson:"report"`
+	Date         string  `bson:"date"`
+	Type         string  `bson:"type"`
+	Up           float64 `bson:"uptime"`
+	Down         float64 `bson:"downtime"`
+	Unknown      float64 `bson:"unknown"`
+	Availability float64 `bson:"availability"`
+	Reliability  float64 `bson:"reliability"`
+	Weights      string  `bson:"weight"`
+	SuperGroup   string  `bson:"supergroup"`
+}
+
+type RoundedFloat float64
+
+func (rf RoundedFloat) MarshalJSON() ([]byte, error) {
+	return json.Marshal(math.Round(float64(rf)*100) / 100)
+}
+
+type ShortResult struct {
+	Timestamp    string       `json:"timestamp,omitempty"`
+	Availability RoundedFloat `json:"availability"`
+	Reliability  RoundedFloat `json:"reliability"`
+}
+
+type Result struct {
+	Timestamp    string       `json:"timestamp,omitempty"`
+	Availability RoundedFloat `json:"availability"`
+	Reliability  RoundedFloat `json:"reliability"`
+	Unknown      RoundedFloat `json:"unknown"`
+	Uptime       RoundedFloat `json:"uptime"`
+	Downtime     RoundedFloat `json:"downtime"`
+}
+
+// Endpoint A/R struct for formating json
+type Endpoint struct {
+	Name       string            `json:"name"`
+	Service    string            `json:"service,omitempty"`
+	SuperGroup string            `json:"supergroup,omitempty"`
+	Type       string            `json:"type"`
+	Info       map[string]string `json:"info,omitempty"`
+	Results    []interface{}     `json:"results"`
+}
+
+// Group struct for formating xml/json
+type Group struct {
+	Name    string        `json:"name"`
+	Type    string        `json:"type"`
+	Results []interface{} `json:"results"`
+}
+
+// SuperGroup struct for formating xml/json
+type SuperGroup struct {
+	Name    string        `xml:"name,attr" json:"name"`
+	Type    string        `xml:"type,attr" json:"type"`
+	Groups  []interface{} `json:"groups,omitempty"`
+	Results []interface{} `json:"results,omitempty"`
+}
+
+type pageRoot struct {
+	Result    []interface{} `json:"results"`
+	PageToken string        `json:"nextPageToken,omitempty"`
+	PageSize  int           `json:"pageSize,omitempty"`
+}
+
+type root struct {
+	Result []interface{} `json:"results"`
+}
+
+// errorMessage struct to hold the json/xml error response
+type errorMessage struct {
+	Message string `json:"message"`
+	Code    int    `json:"code"`
+}
+
+// ErrorResponse shortcut to respond.ErrorResponse
+type ErrorResponse respond.ErrorResponse

--- a/v5/results/queries.go
+++ b/v5/results/queries.go
@@ -1,0 +1,398 @@
+package resultsV5
+
+import (
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+// DailyGroup query to aggregate daily results from mongodb
+func DailyGroup(filter bson.M) []bson.M {
+	// Mongo aggregation pipeline
+	// Select all the records that match q
+	// Project to select just the first 8 digits of the date YYYYMMDD
+	// Sort by profile->supergroup->endpointGroup->datetime
+	query := []bson.M{
+		{"$match": filter},
+		{"$project": bson.M{
+			"date":         bson.M{"$substr": list{"$date", 0, 8}},
+			"availability": 1,
+			"reliability":  1,
+			"unknown":      1,
+			"up":           1,
+			"down":         1,
+			"report":       1,
+			"supergroup":   1,
+			"name":         1}},
+		{"$sort": bson.D{
+			{Key: "report", Value: 1},
+			{Key: "supergroup", Value: 1},
+			{Key: "name", Value: 1},
+			{Key: "date", Value: 1}}}}
+
+	return query
+}
+
+// MonthlyGroup query to aggregate monthly results from mongodb
+func MonthlyGroup(filter bson.M) []bson.M {
+
+	// Mongo aggregation pipeline
+	// Select all the records that match q
+	// Group them by the first six digits of their date (YYYYMM), their supergroup, their endpointGroup, their profile, etc...
+	// from that group find the average of the uptime, u, downtime
+	// Project the result to a better format and do this computation
+	// availability = (avgup/(1.00000001 - avgu))*100
+	// reliability = (avgup/((1.00000001 - avgu)-avgd))*100
+	// Sort the results by namespace->profile->supergroup->endpointGroup->datetime
+
+	query := []bson.M{
+		{"$match": filter},
+		{"$group": bson.M{
+			"_id": bson.M{
+				"date":       bson.M{"$substr": list{"$date", 0, 6}},
+				"name":       "$name",
+				"supergroup": "$supergroup",
+				"report":     "$report"},
+			"avgup":      bson.M{"$avg": "$up"},
+			"avgunknown": bson.M{"$avg": "$unknown"},
+			"avgdown":    bson.M{"$avg": "$down"}}},
+		{"$project": bson.M{
+			"date":       "$_id.date",
+			"name":       "$_id.name",
+			"report":     "$_id.report",
+			"supergroup": "$_id.supergroup",
+			"unknown":    "$avgunknown",
+			"up":         "$avgup",
+			"down":       "$avgdown",
+			"avgup":      1,
+			"avgunknown": 1,
+			"avgdown":    1,
+			"availability": bson.M{
+				"$multiply": list{
+					bson.M{"$divide": list{
+						"$avgup", bson.M{"$subtract": list{1.00000001, "$avgunknown"}}}},
+					100}},
+			"reliability": bson.M{
+				"$multiply": list{
+					bson.M{"$divide": list{
+						"$avgup", bson.M{"$subtract": list{bson.M{"$subtract": list{1.00000001, "$avgunknown"}}, "$avgdown"}}}},
+					100}}}},
+		{"$sort": bson.D{
+			{Key: "report", Value: 1},
+			{Key: "supergroup", Value: 1},
+			{Key: "name", Value: 1},
+			{Key: "date", Value: 1}}}}
+
+	return query
+}
+
+// CustomGroup query to aggregate results over a custom period from mongodb
+func CustomGroup(filter bson.M) []bson.M {
+
+	// Mongo aggregation pipeline
+	// Select all the records that match q
+	// Group them by their supergroup, their endpointGroup, their profile, etc...
+	// from that group find the average of the uptime, u, downtime
+	// Project the result to a better format and do this computation
+	// availability = (avgup/(1.00000001 - avgu))*100
+	// reliability = (avgup/((1.00000001 - avgu)-avgd))*100
+	// Sort the results by namespace->profile->supergroup->endpointGroup
+
+	query := []bson.M{
+		{"$match": filter},
+		{"$group": bson.M{
+			"_id": bson.M{
+				"name":       "$name",
+				"supergroup": "$supergroup",
+				"report":     "$report"},
+			"avgup":      bson.M{"$avg": "$up"},
+			"avgunknown": bson.M{"$avg": "$unknown"},
+			"avgdown":    bson.M{"$avg": "$down"}}},
+		{"$project": bson.M{
+			"name":       "$_id.name",
+			"report":     "$_id.report",
+			"supergroup": "$_id.supergroup",
+			"unknown":    "$avgunknown",
+			"up":         "$avgup",
+			"down":       "$avgdown",
+			"avgup":      1,
+			"avgunknown": 1,
+			"avgdown":    1,
+			"availability": bson.M{
+				"$multiply": list{
+					bson.M{"$divide": list{
+						"$avgup", bson.M{"$subtract": list{1.00000001, "$avgunknown"}}}},
+					100}},
+			"reliability": bson.M{
+				"$multiply": list{
+					bson.M{"$divide": list{
+						"$avgup", bson.M{"$subtract": list{bson.M{"$subtract": list{1.00000001, "$avgunknown"}}, "$avgdown"}}}},
+					100}}}},
+		{"$sort": bson.D{
+			{Key: "report", Value: 1},
+			{Key: "supergroup", Value: 1},
+			{Key: "name", Value: 1}}}}
+
+	return query
+}
+
+// DailySuperGroup function to build the MongoDB aggregation query for daily calculations
+func DailySuperGroup(filter bson.M) []bson.M {
+	// The following aggregation query consists of 5 grand steps
+	// 1. Match   : records for the specific date and report and supergroup(optional)
+	// 2. Project : all necessary fields (date,availability,reliability,report) etc but also
+	//              if avail >= 0 set an availability-weigh = weight + 1, else = 0
+	//							if rel >=0 set a reliability-weight = weight + 1, else = 0
+	//              keep also weight = weight + 1 (to compensate for zero values)
+	//
+	//              Keeping two extra weights (a/r) has the following result:
+	//               - If an item has undef availab. then it will have an weightAv=0 and will not affect sums
+	//                    for eg. avg_daily_supergroup_availability = (av1*w1 + av2*w2 + undefAv3*0) / (w1 + w1 + 0)
+	//               - If an item has undef reliab. then it will have an weightRel=0 and will not affect sums
+	//                    for eg. avg_daily_supergroup_reliability = (rel1*w2 + rel2*w2 + undefRel3*0) / (w1 + w1 + 0)
+	//
+	// 3. Group   : by supergroup and day and calculate the sum of weighted daily availabilites (and reliabilities also)
+	//              - availability(weighted_sum) = av1*w1 + av2*w2 + undefAv3*0 etc...
+	//              - reliability(weighted_sum) = rel1*w1 + rel2*w2 + undefRel3*0 etc...
+	//
+	// 4. Match   : assertion step - keep only items that have a valid weight > 0
+	// 5. Project : the previous results and try to find the weighted average of daily avail. and reliability by:
+	//              - divide the previous sum of weighted availabilities by the total weightAv
+	//                SPECIAL CASE: If total weightAv remains : 0 that means that total daily supergroup avail = undef
+	//                              so instead of a numeric value, add a "nan" string (will not be counted in monthly average)
+	//              - divide the previous sum of weighted availabilities by the total weightAv
+	//								SPECIAL CASE: If total weightRem remains : 0 that means that total daily supergroup rel = undef
+	//                              so instead of a numeric value, add a "nan" string (will not be counted in monthly average)
+	// 6. Project : the relevant fields to form the appropriate final response (date,supergroup,report,avail,rel)
+	// 7. Sort    : the final results by report, supergroup and then date
+	query := []bson.M{
+		{"$match": filter},
+		{"$project": bson.M{
+			"date":         1,
+			"availability": 1,
+			"reliability":  1,
+			"report":       1,
+			"supergroup":   1,
+			"weightAv":     bson.M{"$cond": list{bson.M{"$gte": list{"$availability", 0}}, bson.M{"$add": list{"$weight", 1}}, 0}},
+			"weightRel":    bson.M{"$cond": list{bson.M{"$gte": list{"$reliability", 0}}, bson.M{"$add": list{"$weight", 1}}, 0}},
+			"weight": bson.M{
+				"$add": list{"$weight", 1}}},
+		},
+		{"$group": bson.M{
+			"_id": bson.M{
+				"date":       bson.D{{Key: "$substr", Value: list{"$date", 0, 8}}},
+				"supergroup": "$supergroup",
+				"report":     "$report"},
+			"availability": bson.M{"$sum": bson.M{"$multiply": list{"$availability", "$weightAv"}}},
+			"reliability":  bson.M{"$sum": bson.M{"$multiply": list{"$reliability", "$weightRel"}}},
+			"weightAv":     bson.M{"$sum": "$weightAv"},
+			"weightRel":    bson.M{"$sum": "$weightRel"},
+			"weight":       bson.M{"$sum": "$weight"}},
+		},
+		{"$match": bson.M{
+			"weight": bson.M{"$gt": 0}},
+		},
+		{"$project": bson.M{
+			"date":         "$_id.date",
+			"supergroup":   "$_id.supergroup",
+			"report":       "$_id.report",
+			"availability": bson.M{"$cond": list{bson.M{"$gt": list{"$weightAv", 0}}, bson.M{"$divide": list{"$availability", "$weightAv"}}, 0}},
+			"reliability":  bson.M{"$cond": list{bson.M{"$gt": list{"$weightRel", 0}}, bson.M{"$divide": list{"$reliability", "$weightRel"}}, 0}}},
+		},
+		{"$project": bson.M{
+			"date":         "$_id.date",
+			"supergroup":   "$_id.supergroup",
+			"report":       "$_id.report",
+			"availability": 1,
+			"reliability":  1},
+		},
+		{"$sort": bson.D{
+			{Key: "report", Value: 1},
+			{Key: "supergroup", Value: 1},
+			{Key: "date", Value: 1}},
+		}}
+
+	return query
+}
+
+// MonthlySuperGroup function to build the MongoDB aggregation query for monthly calculations
+func MonthlySuperGroup(filter bson.M) []bson.M {
+
+	// The following aggregation query consists of 5 grand steps
+	// 1. Match   : records for the specific date and report and supergroup(optional)
+	// 2. Project : all necessary fields (date,availability,reliability,report) etc but also
+	//              if avail >= 0 set an availability-weigh = weight + 1, else = 0
+	//							if rel >=0 set a reliability-weight = weight + 1, else = 0
+	//              keep also weight = weight + 1 (to compensate for zero values)
+	//
+	//              Keeping two extra weights (a/r) has the following result:
+	//               - If an item has undef availab. then it will have an weightAv=0 and will not affect sums
+	//                    for eg. avg_daily_supergroup_availability = (av1*w1 + av2*w2 + undefAv3*0) / (w1 + w1 + 0)
+	//               - If an item has undef reliab. then it will have an weightRel=0 and will not affect sums
+	//                    for eg. avg_daily_supergroup_reliability = (rel1*w2 + rel2*w2 + undefRel3*0) / (w1 + w1 + 0)
+	//
+	// 3. Group   : by supergroup and day and calculate the sum of weighted daily availabilites (and reliabilities also)
+	//              - availability(weighted_sum) = av1*w1 + av2*w2 + undefAv3*0 etc...
+	//              - reliability(weighted_sum) = rel1*w1 + rel2*w2 + undefRel3*0 etc...
+	//
+	// 4. Match   : assertion step - keep only items that have a valid weight > 0
+	// 5. Project : the previous results and try to find the weighted average of daily avail. and reliability by:
+	//              - divide the previous sum of weighted availabilities by the total weightAv
+	//                SPECIAL CASE: If total weightAv remains : 0 that means that total daily supergroup avail = undef
+	//                              so instead of a numeric value, add a "nan" string (will not be counted in monthly average)
+	//              - divide the previous sum of weighted availabilities by the total weightAv
+	//								SPECIAL CASE: If total weightRem remains : 0 that means that total daily supergroup rel = undef
+	//                              so instead of a numeric value, add a "nan" string (will not be counted in monthly average)
+	// 6. Group   : by first date part (month, eg: 201608) to calculate monthly average avail and rel.
+	//							- monthly availability avg = avg(daily_availabilities) ~ but items with "nan" values will be neglected
+	//						  - monthly reliability avg = avg(daily_reliabilities) ~ but items with "nan" values will be neglected
+	//
+	// 7. Project : the relevant fields to form the appropriate final response (date,supergroup,report,avail,rel)
+	// 8. Sort    : the final results by report, supergroup and then date
+
+	query := []bson.M{
+		{"$match": filter},
+		{"$project": bson.M{
+			"date":         1,
+			"availability": 1,
+			"reliability":  1,
+			"report":       1,
+			"supergroup":   1,
+			"weightAv":     bson.M{"$cond": list{bson.M{"$gte": list{"$availability", 0}}, bson.M{"$add": list{"$weight", 1}}, 0}},
+			"weightRel":    bson.M{"$cond": list{bson.M{"$gte": list{"$reliability", 0}}, bson.M{"$add": list{"$weight", 1}}, 0}},
+			"weight": bson.M{
+				"$add": list{"$weight", 1}}},
+		},
+		{"$group": bson.M{
+			"_id": bson.M{
+				"date":       bson.D{{Key: "$substr", Value: list{"$date", 0, 8}}},
+				"supergroup": "$supergroup",
+				"report":     "$report"},
+			"availability": bson.M{"$sum": bson.M{"$multiply": list{"$availability", "$weightAv"}}},
+			"reliability":  bson.M{"$sum": bson.M{"$multiply": list{"$reliability", "$weightRel"}}},
+			"weightAv":     bson.M{"$sum": "$weightAv"},
+			"weightRel":    bson.M{"$sum": "$weightRel"},
+			"weight":       bson.M{"$sum": "$weight"}},
+		},
+		{"$match": bson.M{
+			"weight": bson.M{"$gt": 0}},
+		},
+		{"$project": bson.M{
+			"date":         "$_id.date",
+			"supergroup":   "$_id.supergroup",
+			"report":       "$_id.report",
+			"availability": bson.M{"$cond": list{bson.M{"$gt": list{"$weightAv", 0}}, bson.M{"$divide": list{"$availability", "$weightAv"}}, "nan"}},
+			"reliability":  bson.M{"$cond": list{bson.M{"$gt": list{"$weightRel", 0}}, bson.M{"$divide": list{"$reliability", "$weightRel"}}, "nan"}}},
+		},
+		{"$group": bson.M{
+			"_id": bson.M{
+				"date":       bson.D{{Key: "$substr", Value: list{"$date", 0, 6}}},
+				"supergroup": "$supergroup", "report": "$report"},
+			"availability": bson.M{"$avg": "$availability"},
+			"reliability":  bson.M{"$avg": "$reliability"}},
+		},
+		{"$project": bson.M{
+			"date":         "$_id.date",
+			"supergroup":   "$_id.supergroup",
+			"report":       "$_id.report",
+			"availability": 1,
+			"reliability":  1},
+		},
+		{"$sort": bson.D{
+			{Key: "report", Value: 1},
+			{Key: "supergroup", Value: 1},
+			{Key: "date", Value: 1}},
+		}}
+
+	return query
+}
+
+// CustomSuperGroup function to build the MongoDB aggregation query for custom period aggregation
+func CustomSuperGroup(filter bson.M) []bson.M {
+
+	// The following aggregation query consists of 5 grand steps
+	// 1. Match   : records for the specific date and report and supergroup(optional)
+	// 2. Project : all necessary fields (date,availability,reliability,report) etc but also
+	//              if avail >= 0 set an availability-weigh = weight + 1, else = 0
+	//							if rel >=0 set a reliability-weight = weight + 1, else = 0
+	//              keep also weight = weight + 1 (to compensate for zero values)
+	//
+	//              Keeping two extra weights (a/r) has the following result:
+	//               - If an item has undef availab. then it will have an weightAv=0 and will not affect sums
+	//                    for eg. avg_daily_supergroup_availability = (av1*w1 + av2*w2 + undefAv3*0) / (w1 + w1 + 0)
+	//               - If an item has undef reliab. then it will have an weightRel=0 and will not affect sums
+	//                    for eg. avg_daily_supergroup_reliability = (rel1*w2 + rel2*w2 + undefRel3*0) / (w1 + w1 + 0)
+	//
+	// 3. Group   : by supergroup and day and calculate the sum of weighted daily availabilites (and reliabilities also)
+	//              - availability(weighted_sum) = av1*w1 + av2*w2 + undefAv3*0 etc...
+	//              - reliability(weighted_sum) = rel1*w1 + rel2*w2 + undefRel3*0 etc...
+	//
+	// 4. Match   : assertion step - keep only items that have a valid weight > 0
+	// 5. Project : the previous results and try to find the weighted average of daily avail. and reliability by:
+	//              - divide the previous sum of weighted availabilities by the total weightAv
+	//                SPECIAL CASE: If total weightAv remains : 0 that means that total daily supergroup avail = undef
+	//                              so instead of a numeric value, add a "nan" string (will not be counted in monthly average)
+	//              - divide the previous sum of weighted availabilities by the total weightAv
+	//								SPECIAL CASE: If total weightRem remains : 0 that means that total daily supergroup rel = undef
+	//                              so instead of a numeric value, add a "nan" string (will not be counted in monthly average)
+	// 6. Group   : by first date part (month, eg: 201608) to calculate monthly average avail and rel.
+	//							- monthly availability avg = avg(daily_availabilities) ~ but items with "nan" values will be neglected
+	//						  - monthly reliability avg = avg(daily_reliabilities) ~ but items with "nan" values will be neglected
+	//
+	// 7. Project : the relevant fields to form the appropriate final response (date,supergroup,report,avail,rel)
+	// 8. Sort    : the final results by report, supergroup and then date
+
+	query := []bson.M{
+		{"$match": filter},
+		{"$project": bson.M{
+			"date":         1,
+			"availability": 1,
+			"reliability":  1,
+			"report":       1,
+			"supergroup":   1,
+			"weightAv":     bson.M{"$cond": list{bson.M{"$gte": list{"$availability", 0}}, bson.M{"$add": list{"$weight", 1}}, 0}},
+			"weightRel":    bson.M{"$cond": list{bson.M{"$gte": list{"$reliability", 0}}, bson.M{"$add": list{"$weight", 1}}, 0}},
+			"weight": bson.M{
+				"$add": list{"$weight", 1}}},
+		},
+		{"$group": bson.M{
+			"_id": bson.M{
+				"date":       bson.D{{Key: "$substr", Value: list{"$date", 0, 8}}},
+				"supergroup": "$supergroup",
+				"report":     "$report"},
+			"availability": bson.M{"$sum": bson.M{"$multiply": list{"$availability", "$weightAv"}}},
+			"reliability":  bson.M{"$sum": bson.M{"$multiply": list{"$reliability", "$weightRel"}}},
+			"weightAv":     bson.M{"$sum": "$weightAv"},
+			"weightRel":    bson.M{"$sum": "$weightRel"},
+			"weight":       bson.M{"$sum": "$weight"}},
+		},
+		{"$match": bson.M{
+			"weight": bson.M{"$gt": 0}},
+		},
+		{"$project": bson.M{
+			"date":         "$_id.date",
+			"supergroup":   "$_id.supergroup",
+			"report":       "$_id.report",
+			"availability": bson.M{"$cond": list{bson.M{"$gt": list{"$weightAv", 0}}, bson.M{"$divide": list{"$availability", "$weightAv"}}, "nan"}},
+			"reliability":  bson.M{"$cond": list{bson.M{"$gt": list{"$weightRel", 0}}, bson.M{"$divide": list{"$reliability", "$weightRel"}}, "nan"}}},
+		},
+		{"$group": bson.M{
+			"_id": bson.M{
+				"date":       bson.D{{Key: "$substr", Value: list{"$date", 0, 6}}},
+				"supergroup": "$supergroup", "report": "$report"},
+			"availability": bson.M{"$avg": "$availability"},
+			"reliability":  bson.M{"$avg": "$reliability"}},
+		},
+		{"$project": bson.M{
+			"date":         "$_id.date",
+			"supergroup":   "$_id.supergroup",
+			"report":       "$_id.report",
+			"availability": 1,
+			"reliability":  1},
+		},
+		{"$sort": bson.D{
+			{Key: "report", Value: 1},
+			{Key: "supergroup", Value: 1},
+			{Key: "date", Value: 1}},
+		}}
+
+	return query
+}

--- a/v5/results/routing.go
+++ b/v5/results/routing.go
@@ -1,0 +1,22 @@
+package resultsV5
+
+import (
+	"github.com/ARGOeu/argo-web-api/respond"
+	"github.com/gorilla/mux"
+)
+
+func HandleSubrouter(s *mux.Router, confhandler *respond.ConfHandler) {
+	respond.PrepAppRoutes(s, confhandler, resultsV5Routes)
+}
+
+var resultsV5Routes = []respond.AppRoutes{
+	{Name: "results.list", Verb: "GET", Path: "/{report-name}/supergroups", SubrouterHandler: GetSupergroups},
+	{Name: "results.get", Verb: "GET", Path: "/{report-name}/supergroups/{supergroup-name}", SubrouterHandler: GetSupergroups},
+	{Name: "results.list", Verb: "GET", Path: "/{report-name}/groups", SubrouterHandler: GetGroups},
+	{Name: "results.get", Verb: "GET", Path: "/{report-name}/groups/{group-name}", SubrouterHandler: GetGroups},
+
+	{Name: "results.options", Verb: "OPTIONS", Path: "/{report-name}/groups", SubrouterHandler: Options},
+	{Name: "results.options", Verb: "OPTIONS", Path: "/{report-name}/groups/{group-name}", SubrouterHandler: Options},
+	{Name: "results.options", Verb: "OPTIONS", Path: "/{report-name}/supergroups", SubrouterHandler: Options},
+	{Name: "results.options", Verb: "OPTIONS", Path: "/{report-name}/supergroups/{supergroup-name}", SubrouterHandler: Options},
+}

--- a/v5/results/supergroup_test.go
+++ b/v5/results/supergroup_test.go
@@ -1,0 +1,650 @@
+package resultsV5
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/ARGOeu/argo-web-api/respond"
+	"github.com/ARGOeu/argo-web-api/utils/config"
+	"github.com/ARGOeu/argo-web-api/utils/store"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/suite"
+	"go.mongodb.org/mongo-driver/bson"
+	"gopkg.in/gcfg.v1"
+)
+
+type SuperGroupAvailabilityTestSuite struct {
+	suite.Suite
+	cfg          config.Config
+	router       *mux.Router
+	confHandler  respond.ConfHandler
+	tenantDbConf config.MongoConfig
+	clientkey    string
+}
+
+// Setup the Test Environment
+func (suite *SuperGroupAvailabilityTestSuite) SetupSuite() {
+
+	const testConfig = `
+	    [server]
+	    bindip = ""
+	    port = 8080
+	    maxprocs = 4
+	    cache = false
+	    lrucache = 700000000
+	    gzip = true
+	    [mongodb]
+	    host = "127.0.0.1"
+	    port = 27017
+	    db = "ARGO_test_SuperGroup_availability"
+	    `
+
+	_ = gcfg.ReadStringInto(&suite.cfg, testConfig)
+
+	client := store.GetMongoClient(suite.cfg.MongoDB)
+	suite.cfg.MongoClient = client
+
+	suite.tenantDbConf.Db = "ARGO_test_SuperGroup_availability_tenant"
+	suite.tenantDbConf.Password = "h4shp4ss"
+	suite.tenantDbConf.Username = "dbuser"
+	suite.tenantDbConf.Store = "ar"
+	suite.clientkey = "secretkey"
+
+	// Create router and confhandler for test
+	suite.confHandler = respond.ConfHandler{Config: suite.cfg}
+	suite.router = mux.NewRouter().StrictSlash(false).PathPrefix("/api/v5/results").Subrouter()
+	HandleSubrouter(suite.router, &suite.confHandler)
+}
+
+// This function runs before any test and setups the environment
+func (suite *SuperGroupAvailabilityTestSuite) SetupTest() {
+
+	// Seed database with tenants
+	//TODO: move tests to
+	c := suite.cfg.MongoClient.Database(suite.cfg.MongoDB.Db).Collection("tenants")
+	c.InsertOne(context.TODO(),
+		bson.M{"id": "6ac7d684-1f8e-4a02-a502-720e8f11e50c",
+			"info": bson.M{
+				"name":    "TENANT-AA",
+				"email":   "email@tenant-a.foo",
+				"website": "www.tenant-a.foo",
+				"created": "2015-10-20 02:08:04",
+				"updated": "2015-10-20 02:08:04"},
+			"db_conf": []bson.M{
+				{
+					"server":   "localhost",
+					"port":     27017,
+					"database": "argo_Westeros1",
+				},
+				{
+					"server":   "localhost",
+					"port":     27017,
+					"database": "argo_Westeros2",
+				},
+			},
+			"users": []bson.M{
+				{
+					"name":    "Bob",
+					"email":   "bob@tenant-a.foo",
+					"api_key": "bob_key",
+					"roles":   []string{"viewer"},
+				},
+				{
+					"name":    "Alice",
+					"email":   "alice@tenant-a.foo",
+					"api_key": "alice_key",
+					"roles":   []string{"viewer"},
+				},
+			}})
+	c.InsertOne(context.TODO(),
+		bson.M{"id": "6ac7d684-1f8e-4a02-a502-720e8f11e50d",
+			"info": bson.M{
+				"name":    "TENANT-BB",
+				"email":   "email@tenant-b.foo",
+				"website": "www.tenant-b.foo",
+				"created": "2015-10-20 02:08:04",
+				"updated": "2015-10-20 02:08:04"},
+			"db_conf": []bson.M{
+				{
+					"server":   "localhost",
+					"port":     27017,
+					"database": suite.tenantDbConf.Db,
+					"username": suite.tenantDbConf.Username,
+					"password": suite.tenantDbConf.Password,
+				},
+				{
+					"server":   "localhost",
+					"port":     27017,
+					"database": "argo_wrong_db_endpointgrouavailability",
+				},
+			},
+			"users": []bson.M{
+				{
+					"name":    "bob",
+					"email":   "bob@tenant-b.foo",
+					"api_key": suite.clientkey,
+					"roles":   []string{"viewer"},
+				},
+				{
+					"name":    "alice",
+					"email":   "alice@tenant-b.foo",
+					"api_key": "alice_secret_2",
+					"roles":   []string{"viewer"},
+				},
+			}})
+
+	c = suite.cfg.MongoClient.Database(suite.cfg.MongoDB.Db).Collection("roles")
+	c.InsertOne(context.TODO(),
+		bson.M{
+			"resource": "results.list",
+			"roles":    []string{"editor", "viewer"},
+		})
+	c.InsertOne(context.TODO(),
+		bson.M{
+			"resource": "results.get",
+			"roles":    []string{"editor", "viewer"},
+		})
+	// Seed database with recomputations
+	c = suite.cfg.MongoClient.Database(suite.tenantDbConf.Db).Collection("endpoint_group_ar")
+
+	// Insert seed data
+	c.InsertOne(context.TODO(),
+		bson.M{
+			"report":       "eba61a9e-22e9-4521-9e47-ecaa4a49436",
+			"date":         20150622,
+			"name":         "ST01",
+			"supergroup":   "GROUP_A",
+			"up":           1,
+			"down":         0,
+			"unknown":      0,
+			"availability": 66.7,
+			"reliability":  54.6,
+			"weight":       5634,
+			"tags": []bson.M{
+				{
+					"name":  "",
+					"value": "",
+				},
+			},
+		})
+	c.InsertOne(context.TODO(),
+		bson.M{
+			"report":       "eba61a9e-22e9-4521-9e47-ecaa4a49436",
+			"date":         20150622,
+			"name":         "ST02",
+			"supergroup":   "GROUP_A",
+			"up":           1,
+			"down":         0,
+			"unknown":      0,
+			"availability": 70,
+			"reliability":  45,
+			"weight":       4356,
+			"tags": []bson.M{
+				{
+					"name":  "",
+					"value": "",
+				},
+			},
+		})
+	c.InsertOne(context.TODO(),
+		bson.M{
+			"report":       "eba61a9e-22e9-4521-9e47-ecaa4a49436",
+			"date":         20150623,
+			"name":         "ST01",
+			"supergroup":   "GROUP_A",
+			"up":           1,
+			"down":         0,
+			"unknown":      0,
+			"availability": 100,
+			"reliability":  100,
+			"weight":       5634,
+			"tags": []bson.M{
+				{
+					"name":  "",
+					"value": "",
+				},
+			},
+		})
+	c.InsertOne(context.TODO(),
+		bson.M{
+			"report":       "eba61a9e-22e9-4521-9e47-ecaa4a49436",
+			"date":         20150623,
+			"name":         "ST04",
+			"supergroup":   "GROUP_B",
+			"up":           1,
+			"down":         0,
+			"unknown":      0,
+			"availability": 30,
+			"reliability":  100,
+			"weight":       5344,
+			"tags": []bson.M{
+				{
+					"name":  "",
+					"value": "",
+				},
+			},
+		})
+	c.InsertOne(context.TODO(),
+		bson.M{
+			"report":       "eba61a9e-22e9-4521-9e47-ecaa4a49436",
+			"date":         20150623,
+			"name":         "ST05",
+			"supergroup":   "GROUP_B",
+			"up":           0,
+			"down":         0,
+			"unknown":      1,
+			"availability": 90,
+			"reliability":  100,
+			"weight":       5634,
+			"tags": []bson.M{
+				{
+					"name":  "",
+					"value": "",
+				},
+			},
+		})
+	c.InsertOne(context.TODO(),
+		bson.M{
+			"report":       "eba61a9e-22e9-4521-9e47-ecaa4a49436",
+			"date":         20150624,
+			"name":         "ST05",
+			"supergroup":   "GROUP_B",
+			"up":           1,
+			"down":         0,
+			"unknown":      0,
+			"availability": 40,
+			"reliability":  70,
+			"weight":       5634,
+			"tags": []bson.M{
+				{
+					"name":  "",
+					"value": "",
+				},
+			},
+		})
+	c.InsertOne(context.TODO(),
+		bson.M{
+			"report":       "eba61a9e-22e9-4521-9e47-ecaa4a49436",
+			"date":         20150625,
+			"name":         "ST05",
+			"supergroup":   "GROUP_B",
+			"up":           1,
+			"down":         0,
+			"unknown":      0,
+			"availability": 40,
+			"reliability":  70,
+			"weight":       5634,
+			"tags": []bson.M{
+				{
+					"name":  "",
+					"value": "",
+				},
+			},
+		})
+	c.InsertOne(context.TODO(),
+		bson.M{
+			"report":       "eba61a9e-22e9-4521-9e47-ecaa4a49436",
+			"date":         20150623,
+			"name":         "ST02",
+			"supergroup":   "GROUP_A",
+			"up":           1,
+			"down":         0,
+			"unknown":      0,
+			"availability": 43.5,
+			"reliability":  56,
+			"weight":       4356,
+			"tags": []bson.M{
+				{
+					"name":  "",
+					"value": "",
+				},
+			},
+		})
+
+	c = suite.cfg.MongoClient.Database(suite.tenantDbConf.Db).Collection("reports")
+
+	c.InsertOne(context.TODO(), bson.M{
+		"id": "eba61a9e-22e9-4521-9e47-ecaa4a49436",
+		"info": bson.M{
+			"name":        "Report_A",
+			"description": "lalalallala",
+		},
+		"topology_schema": bson.M{
+			"group": bson.M{
+				"type": "GROUP",
+				"group": bson.M{
+					"type": "SITE",
+				},
+			},
+		},
+		"profiles": []bson.M{
+			{
+				"type": "metric",
+				"name": "ch.cern.SAM.ROC_CRITICAL"},
+		},
+		"filter_tags": []bson.M{
+			{
+				"name":  "name1",
+				"value": "value1"},
+			{
+				"name":  "name2",
+				"value": "value2"},
+		}})
+
+}
+
+// TestListSuperGroupAvailability test if daily results are returned correctly
+func (suite *SuperGroupAvailabilityTestSuite) TestListSuperGroupAvailability() {
+
+	request, _ := http.NewRequest("GET", "/api/v5/results/Report_A/supergroups/GROUP_A?start-time=2015-06-20T12:00:00Z&end-time=2015-06-26T23:00:00Z", strings.NewReader(""))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	SuperGrouAvailabilityJSON := `{
+   "results": [
+     {
+       "name": "GROUP_A",
+       "type": "GROUP",
+       "results": [
+         {
+           "timestamp": "2015-06-22",
+           "availability": 68.14,
+           "reliability": 50.41
+         },
+         {
+           "timestamp": "2015-06-23",
+           "availability": 75.36,
+           "reliability": 80.81
+         }
+       ]
+     }
+   ]
+ }`
+
+	// Check that we must have a 200 ok code
+	suite.Equal(200, response.Code, "Incorrect HTTP response code")
+	// Compare the expected and actual xml response
+	suite.Equal(SuperGrouAvailabilityJSON, response.Body.String(), "Response body mismatch")
+
+	request, _ = http.NewRequest("GET", "/api/v5/results/Report_A/supergroups/GROUP_A?start-time=2015-06-20T12:00:00Z&end-time=2015-06-26T23:00:00Z", strings.NewReader(""))
+	request.Header.Set("x-api-key", "AWRONGKEY")
+	request.Header.Set("Accept", "application/xml")
+
+	response = httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	// Check that we must have a 401 Unauthorized code
+	suite.Equal(401, response.Code, "Incorrect HTTP response code")
+
+}
+
+// TestListAllSuperGroupAvailability test if daily results are returned correctly
+func (suite *SuperGroupAvailabilityTestSuite) TestListAllSuperGroupAvailability() {
+
+	request, _ := http.NewRequest("GET", "/api/v5/results/Report_A/supergroups?start-time=2015-06-20T12:00:00Z&end-time=2015-06-26T23:00:00Z&granularity=daily", strings.NewReader(""))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	output := response.Body.String()
+
+	SuperGroupAvailabilityJSON := `{
+   "results": [
+     {
+       "name": "GROUP_A",
+       "type": "GROUP",
+       "results": [
+         {
+           "timestamp": "2015-06-22",
+           "availability": 68.14,
+           "reliability": 50.41
+         },
+         {
+           "timestamp": "2015-06-23",
+           "availability": 75.36,
+           "reliability": 80.81
+         }
+       ]
+     },
+     {
+       "name": "GROUP_B",
+       "type": "GROUP",
+       "results": [
+         {
+           "timestamp": "2015-06-23",
+           "availability": 60.79,
+           "reliability": 100
+         },
+         {
+           "timestamp": "2015-06-24",
+           "availability": 40,
+           "reliability": 70
+         },
+         {
+           "timestamp": "2015-06-25",
+           "availability": 40,
+           "reliability": 70
+         }
+       ]
+     }
+   ]
+ }`
+
+	// Check that we must have a 200 ok code
+	suite.Equal(200, response.Code, "Incorrect HTTP response code")
+	// Compare the expected and actual xml response
+	suite.Equal(SuperGroupAvailabilityJSON, output, "Response body mismatch")
+
+}
+
+// TestListAllSuperGroupAvailabilityMonthly test if results are returned correctly for a monthly period
+func (suite *SuperGroupAvailabilityTestSuite) TestListAllSuperGroupAvailabilityMonthly() {
+
+	request, _ := http.NewRequest("GET", "/api/v5/results/Report_A/supergroups?start-time=2015-06-20T12:00:00Z&end-time=2015-06-26T23:00:00Z&granularity=monthly", strings.NewReader(""))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	SuperGroupAvailabilityJSON := `{
+   "results": [
+     {
+       "name": "GROUP_A",
+       "type": "GROUP",
+       "results": [
+         {
+           "timestamp": "2015-06",
+           "availability": 71.75,
+           "reliability": 65.61
+         }
+       ]
+     },
+     {
+       "name": "GROUP_B",
+       "type": "GROUP",
+       "results": [
+         {
+           "timestamp": "2015-06",
+           "availability": 46.93,
+           "reliability": 80
+         }
+       ]
+     }
+   ]
+ }`
+
+	// Check that we must have a 200 ok code
+	suite.Equal(200, response.Code, "Incorrect HTTP response code")
+	// Compare the expected and actual xml response
+	suite.Equal(SuperGroupAvailabilityJSON, response.Body.String(), "Response body mismatch")
+
+}
+
+// TestListAllSuperGroupAvailabilityCustom test if results are returned correctly for a custom period
+func (suite *SuperGroupAvailabilityTestSuite) TestListAllSuperGroupAvailabilityCustom() {
+
+	request, _ := http.NewRequest("GET", "/api/v5/results/Report_A/supergroups?start-time=2015-06-20T12:00:00Z&end-time=2015-06-26T23:00:00Z&granularity=custom", strings.NewReader(""))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	SuperGroupAvailabilityJSON := `{
+   "results": [
+     {
+       "name": "GROUP_A",
+       "type": "GROUP",
+       "results": [
+         {
+           "availability": 71.75,
+           "reliability": 65.61
+         }
+       ]
+     },
+     {
+       "name": "GROUP_B",
+       "type": "GROUP",
+       "results": [
+         {
+           "availability": 46.93,
+           "reliability": 80
+         }
+       ]
+     }
+   ]
+ }`
+
+	// Check that we must have a 200 ok code
+	suite.Equal(200, response.Code, "Incorrect HTTP response code")
+	// Compare the expected and actual xml response
+	suite.Equal(SuperGroupAvailabilityJSON, response.Body.String(), "Response body mismatch")
+
+}
+
+// TestListSuperGroupAvailabilityErrors tests if errors/exceptions are returned correctly
+func (suite *SuperGroupAvailabilityTestSuite) TestListSuperGroupAvailabilityErrors() {
+
+	typeError1JSON := `{
+   "message": "No results found for given query",
+   "code": 404
+ }`
+
+	request, _ := http.NewRequest("GET", "/api/v5/results/Report_A/supergroups/lala?start-time=2025-06-22T00:00:00Z&end-time=2025-06-23T23:59:59Z", strings.NewReader(""))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/json")
+	//request.Header.Set("Accept", "application/json")
+
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+	output := response.Body.String()
+
+	// Check that we must have a 404 not found code
+	suite.Equal(404, response.Code, "Incorrect HTTP response code")
+	// Compare the expected and actual xml response
+	suite.Equal(typeError1JSON, output, "Response body mismatch")
+
+}
+
+func (suite *SuperGroupAvailabilityTestSuite) TestOptionsSuperGroup() {
+	request, _ := http.NewRequest("OPTIONS", "/api/v5/results/Report_A/supergroups", strings.NewReader(""))
+
+	response := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code := response.Code
+	output := response.Body.String()
+	headers := response.Result().Header
+
+	suite.Equal(200, code, "Error in response code")
+	suite.Equal("", output, "Expected empty response body")
+	suite.Equal("GET, OPTIONS", headers.Get("Allow"), "Error in Allow header response (supported resource verbs of resource)")
+	suite.Equal("text/plain; charset=utf-8", headers.Get("Content-Type"), "Error in Content-Type header response")
+
+	request, _ = http.NewRequest("OPTIONS", "/api/v5/results/Report_A/supergroups/GROUP_A", strings.NewReader(""))
+
+	response = httptest.NewRecorder()
+
+	suite.router.ServeHTTP(response, request)
+
+	code = response.Code
+	output = response.Body.String()
+	headers = response.Result().Header
+
+	suite.Equal(200, code, "Error in response code")
+	suite.Equal("", output, "Expected empty response body")
+	suite.Equal("GET, OPTIONS", headers.Get("Allow"), "Error in Allow header response (supported resource verbs of resource)")
+	suite.Equal("text/plain; charset=utf-8", headers.Get("Content-Type"), "Error in Content-Type header response")
+
+}
+
+// TestStrictSlashSuperGroupResults test if not found responses are returned correctly
+func (suite *SuperGroupAvailabilityTestSuite) TestStrictSlashSuperGroupResults() {
+
+	request, _ := http.NewRequest("GET", "/api/v2/results/Report_A/supergroups/?start-time=2015-06-20T12:00:00Z&end-time=2015-06-26T23:00:00Z&granularity=daily", strings.NewReader(""))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/xml")
+	response := httptest.NewRecorder()
+	suite.router.ServeHTTP(response, request)
+	suite.Equal(404, response.Code, "Incorrect HTTP response code")
+
+	request, _ = http.NewRequest("GET", "/api/v2/results/Report_A/supergroups/GROUP_A/?start-time=2015-06-20T12:00:00Z&end-time=2015-06-26T23:00:00Z&granularity=daily", strings.NewReader(""))
+	request.Header.Set("x-api-key", suite.clientkey)
+	request.Header.Set("Accept", "application/xml")
+	response = httptest.NewRecorder()
+	suite.router.ServeHTTP(response, request)
+	suite.Equal(404, response.Code, "Incorrect HTTP response code")
+
+}
+
+// TearDownTest to tear down every test
+func (suite *SuperGroupAvailabilityTestSuite) TearDownTest() {
+
+	mainDB := suite.cfg.MongoClient.Database(suite.cfg.MongoDB.Db)
+	cols, err := mainDB.ListCollectionNames(context.TODO(), bson.M{})
+	if err != nil {
+		panic(err)
+	}
+
+	for _, col := range cols {
+		mainDB.Collection(col).Drop(context.TODO())
+	}
+
+	tenantDB := suite.cfg.MongoClient.Database(suite.tenantDbConf.Db)
+	cols, err = tenantDB.ListCollectionNames(context.TODO(), bson.M{})
+	if err != nil {
+		panic(err)
+	}
+
+	for _, col := range cols {
+		tenantDB.Collection(col).Drop(context.TODO())
+	}
+
+}
+
+// TearDownTest to tear down every test
+func (suite *SuperGroupAvailabilityTestSuite) TearDownSuite() {
+
+	suite.cfg.MongoClient.Database(suite.cfg.MongoDB.Db).Drop(context.TODO())
+	suite.cfg.MongoClient.Database(suite.tenantDbConf.Db).Drop(context.TODO())
+}
+
+// TestRecompuptationsTestSuite is responsible for calling the tests
+func TestSuperGroupResultsTestSuite(t *testing.T) {
+	suite.Run(t, new(SuperGroupAvailabilityTestSuite))
+}

--- a/v5/results/util.go
+++ b/v5/results/util.go
@@ -1,0 +1,56 @@
+package resultsV5
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func (query *basicQuery) Validate() []ErrorResponse {
+
+	errs := []ErrorResponse{}
+	query.Granularity = strings.ToLower(query.Granularity)
+	if query.Granularity == "" {
+		query.Granularity = "daily"
+	} else if query.Granularity != "daily" && query.Granularity != "monthly" && query.Granularity != "custom" {
+		errs = append(errs, ErrorResponse{
+			Message: "Wrong Granularity",
+			Code:    "400",
+			Details: fmt.Sprintf("%s is not acceptesd as granularity parameter, please provide either daily, monthly or custom", query.Granularity),
+		})
+	}
+
+	if query.StartTime == "" && query.EndTime == "" {
+		errs = append(errs, ErrorResponse{
+			Message: "No time span set",
+			Code:    "400",
+			Details: "Please use start-time and/or end-time url parameters to set the prefered time span",
+		})
+	} else {
+		if query.StartTime != "" {
+			ts, tserr := time.Parse(zuluForm, query.StartTime)
+			if tserr != nil {
+				errs = append(errs, ErrorResponse{
+					Message: "start-time parsing error",
+					Code:    "400",
+					Details: fmt.Sprintf("Error parsing date string %s please use zulu format like %s", query.StartTime, zuluForm),
+				})
+			}
+			query.StartTimeInt, _ = strconv.Atoi(ts.Format(ymdForm))
+		}
+		if query.EndTime != "" {
+			te, teerr := time.Parse(zuluForm, query.EndTime)
+			if teerr != nil {
+				errs = append(errs, ErrorResponse{
+					Message: "end-time parsing error",
+					Code:    "400",
+					Details: fmt.Sprintf("Error parsing date string %s please use zulu format like %s", query.EndTime, zuluForm),
+				})
+			}
+			query.EndTimeInt, _ = strconv.Atoi(te.Format(ymdForm))
+		}
+	}
+
+	return errs
+}

--- a/v5/results/view.go
+++ b/v5/results/view.go
@@ -1,0 +1,120 @@
+package resultsV5
+
+import (
+	"encoding/json"
+	"encoding/xml"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/ARGOeu/argo-web-api/app/reports"
+)
+
+func createGroupResultView(results []EndpointGroupInterface, report reports.MongoInterface, format string, custom bool) ([]byte, error) {
+
+	docRoot := &root{}
+
+	prevSuperGroup := ""
+	prevEndpointGroup := ""
+	endpointGroup := &Group{}
+	superGroup := &SuperGroup{}
+
+	// we iterate through the results struct array
+	// keeping only the value of each row
+
+	for _, row := range results {
+		timestamp, _ := time.Parse(customForm[0], fmt.Sprint(row.Date))
+		//if new superGroup value does not match the previous superGroup value
+		//we create a new superGroup in the xml
+		if prevSuperGroup != row.SuperGroup {
+			prevSuperGroup = row.SuperGroup
+			superGroup = &SuperGroup{
+				Name: row.SuperGroup,
+				Type: report.GetGroupType(),
+			}
+			docRoot.Result = append(docRoot.Result, superGroup)
+			prevEndpointGroup = ""
+		}
+		//if new endpointGroup does not match the previous service value
+		//we create a new endpointGroup entry in the xml
+		if prevEndpointGroup != row.Name {
+			prevEndpointGroup = row.Name
+			endpointGroup = &Group{
+				Name: row.Name,
+				Type: report.GetEndpointGroupType(),
+			}
+			superGroup.Groups = append(superGroup.Groups, endpointGroup)
+		}
+		//we append the new availability values
+		prepDate := timestamp.Format(customForm[1])
+		if custom {
+			prepDate = ""
+		}
+		endpointGroup.Results = append(endpointGroup.Results,
+			&Result{
+				Timestamp:    prepDate,
+				Availability: RoundedFloat(row.Availability),
+				Reliability:  RoundedFloat(row.Reliability),
+				Unknown:      RoundedFloat(row.Unknown),
+				Uptime:       RoundedFloat(row.Up),
+				Downtime:     RoundedFloat(row.Down),
+			})
+	}
+
+	return json.MarshalIndent(docRoot, " ", "  ")
+
+}
+
+func createSuperGroupView(results []SuperGroupInterface, report reports.MongoInterface, format string, custom bool) ([]byte, error) {
+
+	docRoot := &root{}
+
+	prevSuperGroup := ""
+	superGroup := &SuperGroup{}
+
+	// we iterate through the results struct array
+	// keeping only the value of each row
+	for _, row := range results {
+		timestamp, _ := time.Parse(customForm[0], row.Date)
+
+		//if new superGroup does not match the previous superGroup value
+		//we create a new superGroup entry in the xml
+		if prevSuperGroup != row.SuperGroup {
+			prevSuperGroup = row.SuperGroup
+			superGroup = &SuperGroup{
+				Name: row.SuperGroup,
+				Type: report.GetGroupType(),
+			}
+			docRoot.Result = append(docRoot.Result, superGroup)
+		}
+		//we append the new availability values
+		prepDate := timestamp.Format(customForm[1])
+		if custom {
+			prepDate = ""
+		}
+		superGroup.Results = append(superGroup.Results,
+			&ShortResult{
+				Timestamp:    prepDate,
+				Availability: RoundedFloat(row.Availability),
+				Reliability:  RoundedFloat(row.Reliability)})
+	}
+
+	return json.MarshalIndent(docRoot, " ", "  ")
+
+}
+
+func createErrorMessage(message string, code int, format string) ([]byte, error) {
+
+	var output []byte
+	err := error(nil)
+	docRoot := &errorMessage{}
+
+	docRoot.Message = message
+	docRoot.Code = code
+	if strings.EqualFold(format, "application/json") {
+		output, err = json.MarshalIndent(docRoot, " ", "  ")
+	} else {
+		output, err = xml.MarshalIndent(docRoot, " ", "  ")
+	}
+	return output, err
+}

--- a/website/docs/apiv5/_category_.json
+++ b/website/docs/apiv5/_category_.json
@@ -1,0 +1,8 @@
+{
+    "label": "API Version 5",
+    "position": 7,
+    "link": {
+      "type": "generated-index"
+    }
+}
+  

--- a/website/docs/apiv5/v5results.md
+++ b/website/docs/apiv5/v5results.md
@@ -1,0 +1,1001 @@
+---
+id: v5_ar_results
+title: Results (v5)
+sidebar_position: 1
+---
+
+## API Calls
+
+_Note_: These are v5 api calls implementations found under the path `/api/v5`
+
+| Name                                                                          | Description                                                                                                                                                                                                                              | Shortcut          |
+| ----------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
+| Get results for top level supergroups| This method retrieves the a/r results of all top level supergroups | [Description](#1) |
+| Get results for specific supergroup| This method retrieves the a/r results for a specific supergroup | [Description](#2) |
+| Get results for top level groups| This method retrieves the a/r results of all top level groups | [Description](#3) |
+| Get results for specific group| This method retrieves the a/r results for a specific group | [Description](#4) |
+
+
+
+## Get results for top level supergroups {#1}
+
+The following method can be used to obtain a tenant's Availability and Reliability result metrics for all top level supergroups. The api authenticates the tenant using the api-key within the x-api-key header (or using an admin key along with `x-tenant-id` param). User can specify time granularity (`monthly`, `daily` or `custom`) for retrieved results 
+
+### Input
+
+
+```
+HTTP GET /api/v5/results/{report-name}/supergroups?[start-time]&[end-time]&[granularity]
+```
+
+#### Query Parameters
+
+| Type            | Description                                                                                     | Required | Default value |
+| --------------- | ----------------------------------------------------------------------------------------------- | -------- | ------------- |
+| `[start-time]`  | UTC time in W3C format                                                                          | YES      |
+| `[end-time]`    | UTC time in W3C format                                                                          | YES      |
+| `[granularity]` | Granularity of time that will be used to present data. Possible values are `monthly`,  `daily` or `custom` | NO       | `daily`       |
+
+#### Path Parameters
+
+| Name            | Description                                                                                           | Required | Default value |
+| --------------- | ----------------------------------------------------------------------------------------------------- | -------- | ------------- |
+| `{report-name}` | Name of the report that contains the results | YES      |
+
+
+### Example Request 1: default daily granularity
+
+#### Request
+
+##### Method
+`HTTP GET`
+
+##### Path
+
+```
+/api/v5/results/Report_A/supergroups?start_time=2015-06-20T12:00:00Z&end_time=2015-06-26T23:00:00Z 
+```
+or 
+```
+/api/v3/results/Report_A/supergroups?start_time=2015-06-20T12:00:00Z&end_time=2015-06-26T23:00:00Z&granularity=daily`
+```
+
+##### Headers
+
+```
+x-api-key: "tenant_key_value"
+Accept: "application/json"
+```
+
+#### Response
+
+##### Code
+
+```
+Status: 200 OK
+```
+
+##### Body
+
+```json
+{
+  "results": [
+    {
+      "name": "PROJECT_A",
+      "type": "PROJECT",
+      "results": [
+        {
+          "date": "2015-06-22",
+          "availability": 68.14,
+          "reliability": 68.14
+        },
+        {
+          "date": "2015-06-23",
+          "availability": 75.36,
+          "reliability": 75.36
+        }
+      ]
+    },
+    {
+      "name": "PROJECT_B",
+      "type": "PROJECT",
+      "results": [
+        {
+          "date": "2015-06-22",
+          "availability": 33.13,
+          "reliability": 55.13
+        },
+        {
+          "date": "2015-06-23",
+          "availability": 23.36,
+          "reliability": 88.36
+        }
+      ]
+    }
+  ]
+}
+```
+
+### Example Request 2: monthly granularity
+
+#### Request
+
+##### Method
+`HTTP GET`
+
+##### Path
+
+```
+/api/v5/results/Report_A/supergroups?start_time=2015-06-20T12:00:00Z&end_time=2015-06-26T23:00:00Z&granularity=monthly
+```
+##### Headers
+
+```
+x-api-key: "tenant_key_value"
+Accept: "application/json"
+```
+
+#### Response
+
+##### Code
+
+```
+Status: 200 OK
+```
+
+##### Body
+
+```json
+{
+  "results": [
+    {
+      "name": "PROJECT_A",
+      "type": "PROJECT",
+      "results": [
+        {
+          "date": "2015-06",
+          "availability": 99.99,
+          "reliability": 99.98
+        }
+      ]
+    },
+    {
+      "name": "PROJECT_B",
+      "type": "PROJECT",
+      "results": [
+        {
+          "date": "2015-06",
+          "availability": 45.99,
+          "reliability": 33.32
+        }
+      ]
+    }
+  ]
+}
+```
+
+### Example Request 3: Custom granularity
+This request returns availability/reliability score numbers for the whole custom period defined between `start-time` and `end-time`. 
+This means that for each item the user will receive one availability and reliability result concerning the whole period (instead of multiple daily or monthly results)
+
+#### Request
+
+##### Method
+`HTTP GET`
+
+##### Path
+
+```
+/api/v5/results/Report_A/supergroups?start_time=2015-06-20T12:00:00Z&end_time=2015-06-26T23:00:00Z&granularity=custom
+```
+##### Headers
+
+```
+x-api-key: "tenant_key_value"
+Accept: "application/json"
+```
+
+#### Response
+
+##### Code
+
+```
+Status: 200 OK
+```
+
+##### Body
+
+```json
+{
+  "results": [
+    {
+      "name": "PROJECT_A",
+      "type": "PROJECT",
+      "results": [
+        {
+          "date": "2015-06",
+          "availability": 99.99,
+          "reliability": 99.98
+        }
+      ]
+    },
+    {
+      "name": "PROJECT_B",
+      "type": "PROJECT",
+      "results": [
+        {
+          "date": "2015-06",
+          "availability": 33.99,
+          "reliability": 33.98
+        }
+      ]
+    }
+  ]
+}
+```
+
+## Get results for specific top level supergroup {#2}
+
+The following method can be used to obtain a tenant's Availability and Reliability result metrics for a specific top level supergroup. The api authenticates the tenant using the api-key within the x-api-key header (or using an admin key along with `x-tenant-id` param). User can specify time granularity (`monthly`, `daily` or `custom`) for retrieved results 
+
+### Input
+
+```
+HTTP GET /api/v5/results/{report-name}/supergroups/{supergroup-name}?[start-time]&[end-time]&[granularity]
+```
+
+#### Query Parameters
+
+| Type            | Description                                                                                     | Required | Default value |
+| --------------- | ----------------------------------------------------------------------------------------------- | -------- | ------------- |
+| `[start-time]`  | UTC time in W3C format                                                                          | YES      |
+| `[end-time]`    | UTC time in W3C format                                                                          | YES      |
+| `[granularity]` | Granularity of time that will be used to present data. Possible values are `monthly`,  `daily` or `custom` | NO       | `daily`       |
+
+#### Path Parameters
+
+| Name            | Description                                                                                           | Required | Default value |
+| --------------- | ----------------------------------------------------------------------------------------------------- | -------- | ------------- |
+| `{report-name}` | Name of the report that contains the results | YES      |
+| `{supergroup-name}` | Name of the specific supergroup | YES      |
+
+
+### Example Request 1: default daily granularity
+
+#### Request
+
+##### Method
+`HTTP GET`
+
+##### Path
+
+```
+/api/v5/results/Report_A/supergroups/PROJECT-A?start_time=2015-06-20T12:00:00Z&end_time=2015-06-26T23:00:00Z 
+```
+or 
+```
+/api/v3/results/Report_A/supergroups/PROJECT-A?start_time=2015-06-20T12:00:00Z&end_time=2015-06-26T23:00:00Z&granularity=daily`
+```
+
+##### Headers
+
+```
+x-api-key: "tenant_key_value"
+Accept: "application/json"
+```
+
+#### Response
+
+##### Code
+
+```
+Status: 200 OK
+```
+
+##### Body
+
+```json
+{
+  "results": [
+    {
+      "name": "PROJECT_A",
+      "type": "PROJECT",
+      "results": [
+        {
+          "date": "2015-06-22",
+          "availability": 68.14,
+          "reliability": 68.14
+        },
+        {
+          "date": "2015-06-23",
+          "availability": 75.36,
+          "reliability": 75.36
+        }
+      ]
+    }
+  ]
+}
+```
+
+### Example Request 2: monthly granularity
+
+#### Request
+
+##### Method
+`HTTP GET`
+
+##### Path
+
+```
+/api/v5/results/Report_A/supergroups/PROJECT-A?start_time=2015-06-20T12:00:00Z&end_time=2015-06-26T23:00:00Z&granularity=monthly
+```
+##### Headers
+
+```
+x-api-key: "tenant_key_value"
+Accept: "application/json"
+```
+
+#### Response
+
+##### Code
+
+```
+Status: 200 OK
+```
+
+##### Body
+
+```json
+{
+  "results": [
+    {
+      "name": "PROJECT_A",
+      "type": "PROJECT",
+      "results": [
+        {
+          "date": "2015-06",
+          "availability": 99.99,
+          "reliability": 99.98
+        }
+      ]
+    }
+  ]
+}
+```
+
+### Example Request 3: Custom granularity
+This request returns availability/reliability score numbers for the whole custom period defined between `start-time` and `end-time`. 
+This means that for each item the user will receive one availability and reliability result concerning the whole period (instead of multiple daily or monthly results)
+
+#### Request
+
+##### Method
+`HTTP GET`
+
+##### Path
+
+```
+/api/v5/results/Report_A/supergroups/PROJECT-A?start_time=2015-06-20T12:00:00Z&end_time=2015-06-26T23:00:00Z&granularity=custom
+```
+##### Headers
+
+```
+x-api-key: "tenant_key_value"
+Accept: "application/json"
+```
+
+#### Response
+
+##### Code
+
+```
+Status: 200 OK
+```
+
+##### Body
+
+```json
+{
+  "results": [
+    {
+      "name": "PROJECT_A",
+      "type": "PROJECT",
+      "results": [
+        {
+          "date": "2015-06",
+          "availability": 99.99,
+          "reliability": 99.98
+        }
+      ]
+    }
+  ]
+}
+```
+
+
+
+## Get results for groups {#3}
+
+The following method can be used to obtain a tenant's Availability and Reliability result metrics for all groups. The api authenticates the tenant using the api-key within the x-api-key header (or using an admin key along with `x-tenant-id` param). User can specify time granularity (`monthly`, `daily` or `custom`) for retrieved results 
+
+### Input
+
+```
+HTTP GET /api/v5/results/{report-name}/groups?[start-time]&[end-time]&[granularity]
+```
+
+#### Query Parameters
+
+| Type            | Description                                                                                     | Required | Default value |
+| --------------- | ----------------------------------------------------------------------------------------------- | -------- | ------------- |
+| `[start-time]`  | UTC time in W3C format                                                                          | YES      |
+| `[end-time]`    | UTC time in W3C format                                                                          | YES      |
+| `[granularity]` | Granularity of time that will be used to present data. Possible values are `monthly`,  `daily` or `custom` | NO       | `daily`       |
+
+#### Path Parameters
+
+| Name            | Description                                                                                           | Required | Default value |
+| --------------- | ----------------------------------------------------------------------------------------------------- | -------- | ------------- |
+| `{report-name}` | Name of the report that contains the results | YES      |
+
+
+### Example Request 1: default daily granularity
+
+#### Request
+
+##### Method
+`HTTP GET`
+
+##### Path
+
+```
+/api/v5/results/Report_A/groups?start_time=2015-06-20T12:00:00Z&end_time=2015-06-26T23:00:00Z 
+```
+or 
+```
+/api/v3/results/Report_A/groups?start_time=2015-06-20T12:00:00Z&end_time=2015-06-26T23:00:00Z&granularity=daily`
+```
+
+##### Headers
+
+```
+x-api-key: "tenant_key_value"
+Accept: "application/json"
+```
+
+#### Response
+
+##### Code
+
+```
+Status: 200 OK
+```
+
+##### Body
+
+```json
+{
+  "results": [
+    {
+      "name": "PROJECT_A",
+      "type": "PROJECT",
+      "groups": [
+        {
+          "name": "GROUP-A",
+          "type": "SERVICEGROUP",
+          "results": [
+            {
+              "date": "2015-06-22",
+              "availability": 68.14,
+              "reliability": 68.14,
+              "unknown": 0,
+              "downtime": 0,
+              "uptime": 0.68
+            },
+            {
+              "date": "2015-06-23",
+              "availability": 75.36,
+              "reliability": 75.36,
+              "unknown": 0,
+              "downtime": 0,
+              "uptime": 0.75
+            }
+          ]
+        },
+        {
+          "name": "GROUP-B",
+          "type": "SERVICEGROUP",
+          "results": [
+            {
+              "date": "2015-06-22",
+              "availability": 68.14,
+              "reliability": 68.14,
+              "unknown": 0,
+              "downtime": 0,
+              "uptime": 0.68
+            },
+            {
+              "date": "2015-06-23",
+              "availability": 75.36,
+              "reliability": 75.36,
+              "unknown": 0,
+              "downtime": 0,
+              "uptime": 0.75
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "PROJECT_B",
+      "type": "PROJECT",
+      "groups": [
+        {
+          "name": "GROUP-X",
+          "type": "SERVICEGROUP",
+          "results": [
+            {
+              "date": "2015-06-22",
+              "availability": 68.14,
+              "reliability": 68.14,
+              "unknown": 0,
+              "downtime": 0,
+              "uptime": 0.68
+            },
+            {
+              "date": "2015-06-23",
+              "availability": 75.36,
+              "reliability": 75.36,
+              "unknown": 0,
+              "downtime": 0,
+              "uptime": 0.75
+            }
+          ]
+        },
+        {
+          "name": "GROUP-Y",
+          "type": "SERVICEGROUP",
+          "results": [
+            {
+              "date": "2015-06-22",
+              "availability": 68.14,
+              "reliability": 68.14,
+              "unknown": 0,
+              "downtime": 0,
+              "uptime": 0.68
+            },
+            {
+              "date": "2015-06-23",
+              "availability": 75.36,
+              "reliability": 75.36,
+              "unknown": 0,
+              "downtime": 0,
+              "uptime": 0.75
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+### Example Request 2: monthly granularity
+
+#### Request
+
+##### Method
+`HTTP GET`
+
+##### Path
+
+```
+/api/v5/results/Report_A/groups?start_time=2015-06-20T12:00:00Z&end_time=2015-06-26T23:00:00Z&granularity=monthly
+```
+##### Headers
+
+```
+x-api-key: "tenant_key_value"
+Accept: "application/json"
+```
+
+#### Response
+
+##### Code
+
+```
+Status: 200 OK
+```
+
+##### Body
+
+```json
+{
+  "results": [
+    {
+      "name": "PROJECT_A",
+      "type": "PROJECT",
+      "groups": [
+        {
+          "name": "GROUP-A",
+          "type": "SERVICEGROUP",
+          "results": [
+            {
+              "date": "2015-06",
+              "availability": 70,
+              "reliability": 70,
+              "unknown": 0,
+              "downtime": 0,
+              "uptime": 0.7
+            }
+          ]
+        },
+        {
+          "name": "GROUP-B",
+          "type": "SERVICEGROUP",
+          "results": [
+            {
+              "date": "2015-06",
+              "availability": 70,
+              "reliability": 70,
+              "unknown": 0,
+              "downtime": 0,
+              "uptime": 0.7
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "PROJECT_B",
+      "type": "PROJECT",
+      "groups": [
+        {
+          "name": "GROUP-X",
+          "type": "SERVICEGROUP",
+          "results": [
+            {
+              "date": "2015-06",
+              "availability": 70,
+              "reliability": 70,
+              "unknown": 0,
+              "downtime": 0,
+              "uptime": 0.7
+            }
+          ]
+        },
+        {
+          "name": "GROUP-Y",
+          "type": "SERVICEGROUP",
+          "results": [
+            {
+              "date": "2015-06",
+              "availability": 80,
+              "reliability": 80,
+              "unknown": 0,
+              "downtime": 0,
+              "uptime": 0.8
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+### Example Request 3: Custom granularity
+This request returns availability/reliability score numbers for the whole custom period defined between `start-time` and `end-time`. 
+This means that for each item the user will receive one availability and reliability result concerning the whole period (instead of multiple daily or monthly results)
+
+#### Request
+
+##### Method
+`HTTP GET`
+
+##### Path
+
+```
+/api/v5/results/Report_A/groups?start_time=2015-06-20T12:00:00Z&end_time=2015-06-26T23:00:00Z&granularity=custom
+```
+##### Headers
+
+```
+x-api-key: "tenant_key_value"
+Accept: "application/json"
+```
+
+#### Response
+
+##### Code
+
+```
+Status: 200 OK
+```
+
+##### Body
+
+```json
+{
+  "results": [
+    {
+      "name": "PROJECT_A",
+      "type": "PROJECT",
+      "groups": [
+        {
+          "name": "GROUP-A",
+          "type": "SERVICEGROUP",
+          "results": [
+            {
+              "date": "2015-06",
+              "availability": 70,
+              "reliability": 70,
+              "unknown": 0,
+              "downtime": 0,
+              "uptime": 0.7
+            }
+          ]
+        },
+        {
+          "name": "GROUP-B",
+          "type": "SERVICEGROUP",
+          "results": [
+            {
+              "date": "2015-06",
+              "availability": 70,
+              "reliability": 70,
+              "unknown": 0,
+              "downtime": 0,
+              "uptime": 0.7
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "PROJECT_B",
+      "type": "PROJECT",
+      "groups": [
+        {
+          "name": "GROUP-X",
+          "type": "SERVICEGROUP",
+          "results": [
+            {
+              "date": "2015-06",
+              "availability": 90,
+              "reliability": 90,
+              "unknown": 0,
+              "downtime": 0,
+              "uptime": 0.9
+            }
+          ]
+        },
+        {
+          "name": "GROUP-Y",
+          "type": "SERVICEGROUP",
+          "results": [
+            {
+              "date": "2015-06",
+              "availability": 33,
+              "reliability": 33,
+              "unknown": 0,
+              "downtime": 0,
+              "uptime": 0.33
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+## Get results for specific group {#4}
+
+The following method can be used to obtain a tenant's Availability and Reliability result metrics for specific group. The api authenticates the tenant using the api-key within the x-api-key header (or using an admin key along with `x-tenant-id` param). User can specify time granularity (`monthly`, `daily` or `custom`) for retrieved results 
+
+### Input
+
+```
+HTTP GET /api/v5/results/{report-name}/groups/{group-name}?[start-time]&[end-time]&[granularity]
+```
+
+#### Query Parameters
+
+| Type            | Description                                                                                     | Required | Default value |
+| --------------- | ----------------------------------------------------------------------------------------------- | -------- | ------------- |
+| `[start-time]`  | UTC time in W3C format                                                                          | YES      |
+| `[end-time]`    | UTC time in W3C format                                                                          | YES      |
+| `[granularity]` | Granularity of time that will be used to present data. Possible values are `monthly`,  `daily` or `custom` | NO       | `daily`       |
+
+#### Path Parameters
+
+| Name            | Description                                                                                           | Required | Default value |
+| --------------- | ----------------------------------------------------------------------------------------------------- | -------- | ------------- |
+| `{report-name}` | Name of the report that contains the results | YES      |
+| `{group-name}`  | Name of the specific group to target | YES      |
+
+
+### Example Request 1: default daily granularity
+
+#### Request
+
+##### Method
+`HTTP GET`
+
+##### Path
+
+```
+/api/v5/results/Report_A/groups/GROUP-A?start_time=2015-06-20T12:00:00Z&end_time=2015-06-26T23:00:00Z 
+```
+or 
+```
+/api/v3/results/Report_A/groups/GROUP-A?start_time=2015-06-20T12:00:00Z&end_time=2015-06-26T23:00:00Z&granularity=daily`
+```
+
+##### Headers
+
+```
+x-api-key: "tenant_key_value"
+Accept: "application/json"
+```
+
+#### Response
+
+##### Code
+
+```
+Status: 200 OK
+```
+
+##### Body
+
+```json
+{
+  "results": [
+    {
+      "name": "PROJECT_A",
+      "type": "PROJECT",
+      "groups": [
+        {
+          "name": "GROUP-A",
+          "type": "SERVICEGROUP",
+          "results": [
+            {
+              "date": "2015-06-22",
+              "availability": 68.14,
+              "reliability": 68.14,
+              "unknown": 0,
+              "downtime": 0,
+              "uptime": 0.68
+            },
+            {
+              "date": "2015-06-23",
+              "availability": 75.36,
+              "reliability": 75.36,
+              "unknown": 0,
+              "downtime": 0,
+              "uptime": 0.75
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+### Example Request 2: monthly granularity
+
+#### Request
+
+##### Method
+`HTTP GET`
+
+##### Path
+
+```
+/api/v5/results/Report_A/groups/GROUP-A?start_time=2015-06-20T12:00:00Z&end_time=2015-06-26T23:00:00Z&granularity=monthly
+```
+##### Headers
+
+```
+x-api-key: "tenant_key_value"
+Accept: "application/json"
+```
+
+#### Response
+
+##### Code
+
+```
+Status: 200 OK
+```
+
+##### Body
+
+```json
+{
+  "results": [
+    {
+      "name": "PROJECT_A",
+      "type": "PROJECT",
+      "groups": [
+        {
+          "name": "GROUP-A",
+          "type": "SERVICEGROUP",
+          "results": [
+            {
+              "date": "2015-06",
+              "availability": 70,
+              "reliability": 70,
+              "unknown": 0,
+              "downtime": 0,
+              "uptime": 0.7
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+### Example Request 3: Custom granularity
+This request returns availability/reliability score numbers for the whole custom period defined between `start-time` and `end-time`. 
+This means that for each item the user will receive one availability and reliability result concerning the whole period (instead of multiple daily or monthly results)
+
+#### Request
+
+##### Method
+`HTTP GET`
+
+##### Path
+
+```
+/api/v5/results/Report_A/groups/GROUP-A?start_time=2015-06-20T12:00:00Z&end_time=2015-06-26T23:00:00Z&granularity=custom
+```
+##### Headers
+
+```
+x-api-key: "tenant_key_value"
+Accept: "application/json"
+```
+
+#### Response
+
+##### Code
+
+```
+Status: 200 OK
+```
+
+##### Body
+
+```json
+{
+  "results": [
+    {
+      "name": "PROJECT_A",
+      "type": "PROJECT",
+      "groups": [
+        {
+          "name": "GROUP-A",
+          "type": "SERVICEGROUP",
+          "results": [
+            {
+              "date": "2015-06",
+              "availability": 70,
+              "reliability": 70,
+              "unknown": 0,
+              "downtime": 0,
+              "uptime": 0.7
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```

--- a/website/static/openapi/argo-web-api.yml
+++ b/website/static/openapi/argo-web-api.yml
@@ -11104,9 +11104,6 @@ paths:
             application/json:
               schema:
                 type: string
-
-
-
   /v4/status/groups:
     get:
       tags:
@@ -12195,6 +12192,535 @@ paths:
             application/json:
               schema:
                 type: string
+
+
+  /v5/results/{report-name}/supergroups:
+    get:
+      tags:
+      - v5
+      summary: List availability & reliability results for supergroups
+      description: this method retrieves the availability and reliability results for top level supergroups such as projects
+      operationId: v5.get_supergroups
+      parameters:
+      - name: x-api-key
+        in: header
+        description: the x-api-key
+        required: true
+        schema:
+          type: string
+          default: SecretKey123
+      - name: report-name
+        in: path
+        description: report the probes belong to
+        required: true
+        schema:
+          type: string
+          default: Default
+      - name: start-time
+        in: query
+        description: start date of query in zulu format
+        required: false
+        schema:
+          type: string
+          default: 2006-01-01T00:04:05Z
+      - name: end-time
+        in: query
+        description: end date of query in zulu format
+        required: false
+        schema:
+          type: string
+          default: 2006-01-03T15:04:05Z
+      responses:
+        "200":
+          description: Successful retrieval of latest availability/reliability results
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SupergroupAR'
+              examples:
+                daily a/r results:
+                  value:
+                    results: 
+                      - name: PROJECT-A
+                        type: PROJECT
+                        results:
+                         - date: '2022-10-12'
+                           availability: 100
+                           reliability: 100
+                         - date: '2022-10-13'
+                           availability: 80
+                           reliability: 80
+                      - name: PROJECT-B
+                        type: PROJECT
+                        results:
+                         - date: '2022-10-12'
+                           availability: 100
+                           reliability: 100
+                         - date: '2022-10-13'
+                           availability: 80
+                           reliability: 80
+                monthly a/r results:
+                  value:
+                    results: 
+                      - name: PROJECT-A
+                        type: PROJECT
+                        results:
+                         - date: '2022-10'
+                           availability: 100
+                           reliability: 100
+                      - name: PROJECT-B
+                        type: PROJECT
+                        results:
+                         - date: '2022-10'
+                           availability: 100
+                           reliability: 100
+        "400":
+          description: Item not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status_error'
+        "401":
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                  code:
+                    type: string
+                  details:
+                    type: string
+        "406":
+          description: Content Not acceptable
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status_error'
+        "422":
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status_error'
+        "500":
+          description: internal server error
+          content:
+            application/json:
+              schema:
+                type: string                
+
+
+  /v5/results/{report-name}/supergroups/{supergroup-name}:
+    get:
+      tags:
+      - v5
+      summary: List availability & reliability results for a specific supergroup
+      description: this method retrieves the availability and reliability results for a specific top level supergroup
+      operationId: v5.get_supergroup
+      parameters:
+      - name: x-api-key
+        in: header
+        description: the x-api-key
+        required: true
+        schema:
+          type: string
+          default: SecretKey123
+      - name: report-name
+        in: path
+        description: report the results belong to
+        required: true
+        schema:
+          type: string
+          default: Default
+      - name: supergroup-name
+        in: path
+        description: name of the specific supergroup to target
+        required: true
+        schema:
+          type: string
+          default: Default
+      - name: start-time
+        in: query
+        description: start date of query in zulu format
+        required: false
+        schema:
+          type: string
+          default: 2006-01-01T00:04:05Z
+      - name: end-time
+        in: query
+        description: end date of query in zulu format
+        required: false
+        schema:
+          type: string
+          default: 2006-01-03T15:04:05Z
+      responses:
+        "200":
+          description: Successful retrieval of latest availability/reliability results
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SupergroupAR'
+              examples:
+                daily a/r results:
+                  value:
+                    results: 
+                      - name: PROJECT-A
+                        type: PROJECT
+                        results:
+                         - date: '2022-10-12'
+                           availability: 100
+                           reliability: 100
+                         - date: '2022-10-13'
+                           availability: 80
+                           reliability: 80
+                monthly a/r results:
+                  value:
+                    results: 
+                      - name: PROJECT-A
+                        type: PROJECT
+                        results:
+                         - date: '2022-10'
+                           availability: 100
+                           reliability: 100
+                      
+             
+
+        "400":
+          description: Item not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status_error'
+        "401":
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                  code:
+                    type: string
+                  details:
+                    type: string
+        "406":
+          description: Content Not acceptable
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status_error'
+        "422":
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status_error'
+        "500":
+          description: internal server error
+          content:
+            application/json:
+              schema:
+                type: string                
+
+  /v5/results/{report-name}/groups:
+    get:
+      tags:
+      - v5
+      summary: List availability & reliability results for a specific group
+      description: this method retrieves the availability and reliability results for a specific group such as a specific SERVICEGROUP.
+      operationId: v5.get_groups
+      parameters:
+      - name: x-api-key
+        in: header
+        description: the x-api-key
+        required: true
+        schema:
+          type: string
+          default: SecretKey123
+      - name: report-name
+        in: path
+        description: report the results belong to
+        required: true
+        schema:
+          type: string
+          default: Default
+      - name: start-time
+        in: query
+        description: start date of query in zulu format
+        required: false
+        schema:
+          type: string
+          default: 2006-01-01T00:04:05Z
+      - name: end-time
+        in: query
+        description: end date of query in zulu format
+        required: false
+        schema:
+          type: string
+          default: 2006-01-03T15:04:05Z
+      responses:
+        "200":
+          description: Successful retrieval of latest availability/reliability results
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GroupAR'
+              examples:
+                daily a/r results:
+                  value:
+                    results: 
+                      - name: PROJECT-B
+                        type: PROJECT
+                        groups:
+                          - name: SERVICEGROUP-Y
+                            type: SERVICEGROUP
+                            results:
+                              - date: '2022-10-12'
+                                availability: 100
+                                reliability: 100
+                                unknown: 0
+                                uptime: 1
+                                downtime: 0
+                              - date: '2022-10-13'
+                                availability: 90
+                                reliability: 90
+                                unknown: 0
+                                uptime: 0.9
+                monthly a/r results:
+                  value:
+                    results: 
+                      - name: PROJECT-B
+                        type: PROJECT
+                        groups:
+                          - name: SERVICEGROUP-Y
+                            type: SERVICEGROUP
+                            results:
+                              - date: '2022-10'
+                                availability: 100
+                                reliability: 100
+                                unknown: 0
+                                uptime: 1
+                                downtime: 0
+        "400":
+          description: Item not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status_error'
+        "401":
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                  code:
+                    type: string
+                  details:
+                    type: string
+        "406":
+          description: Content Not acceptable
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status_error'
+        "422":
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status_error'
+        "500":
+          description: internal server error
+          content:
+            application/json:
+              schema:
+                type: string                
+
+
+  /v5/results/{report-name}/groups/{group-name}:
+    get:
+      tags:
+      - v5
+      summary: List availability & reliability results for a specific group
+      description: this method retrieves the availability and reliability results for a specific group such as a specific SERVICEGROUP.
+      operationId: v5.get_group
+      parameters:
+      - name: x-api-key
+        in: header
+        description: the x-api-key
+        required: true
+        schema:
+          type: string
+          default: SecretKey123
+      - name: report-name
+        in: path
+        description: report the results belong to
+        required: true
+        schema:
+          type: string
+          default: Default
+      - name: group-name
+        in: path
+        description: name of the specific group to target
+        required: true
+        schema:
+          type: string
+          default: Default
+      - name: start-time
+        in: query
+        description: start date of query in zulu format
+        required: false
+        schema:
+          type: string
+          default: 2006-01-01T00:04:05Z
+      - name: end-time
+        in: query
+        description: end date of query in zulu format
+        required: false
+        schema:
+          type: string
+          default: 2006-01-03T15:04:05Z
+      responses:
+        "200":
+          description: Successful retrieval of latest availability/reliability results
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GroupAR'
+              examples:
+                daily a/r results:
+                  value:
+                    results: 
+                      - name: PROJECT-A
+                        type: PROJECT
+                        groups:
+                          - name: SERVICEGROUP-A
+                            type: SERVICEGROUP
+                            results:
+                              - date: '2022-10-12'
+                                availability: 100
+                                reliability: 100
+                                unknown: 0
+                                uptime: 1
+                                downtime: 0
+                              - date: '2022-10-13'
+                                availability: 80
+                                reliability: 80
+                                unknown: 0
+                                uptime: 0.8
+                                downtime: 0
+                      - name: PROJECT-B
+                        type: PROJECT
+                        groups:
+                          - name: SERVICEGROUP-X
+                            type: SERVICEGROUP
+                            results:
+                              - date: '2022-10-12'
+                                availability: 100
+                                reliability: 100
+                                unknown: 0
+                                uptime: 1
+                                downtime: 0
+                              - date: '2022-10-13'
+                                availability: 80
+                                reliability: 80
+                                unknown: 0
+                                uptime: 0.8
+                          - name: SERVICEGROUP-Y
+                            type: SERVICEGROUP
+                            results:
+                              - date: '2022-10-12'
+                                availability: 100
+                                reliability: 100
+                                unknown: 0
+                                uptime: 1
+                                downtime: 0
+                              - date: '2022-10-13'
+                                availability: 90
+                                reliability: 90
+                                unknown: 0
+                                uptime: 0.9
+                monthly a/r results:
+                  value:
+                    results: 
+                      - name: PROJECT-A
+                        type: PROJECT
+                        groups:
+                          - name: SERVICEGROUP-A
+                            type: SERVICEGROUP
+                            results:
+                              - date: '2022-10'
+                                availability: 100
+                                reliability: 100
+                                unknown: 0
+                                uptime: 1
+                                downtime: 0
+                      - name: PROJECT-B
+                        type: PROJECT
+                        groups:
+                          - name: SERVICEGROUP-X
+                            type: SERVICEGROUP
+                            results:
+                              - date: '2022-10'
+                                availability: 99
+                                reliability: 99
+                                unknown: 0
+                                uptime: 0.99
+                                downtime: 0
+                          - name: SERVICEGROUP-Y
+                            type: SERVICEGROUP
+                            results:
+                              - date: '2022-10'
+                                availability: 100
+                                reliability: 100
+                                unknown: 0
+                                uptime: 1
+                                downtime: 0
+        "400":
+          description: Item not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status_error'
+        "401":
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                  code:
+                    type: string
+                  details:
+                    type: string
+        "406":
+          description: Content Not acceptable
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status_error'
+        "422":
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status_error'
+        "500":
+          description: internal server error
+          content:
+            application/json:
+              schema:
+                type: string                
+
                 
 components:
   schemas:
@@ -12412,6 +12938,58 @@ components:
                       type: number
                     downtime:
                       type: number
+    
+    SupergroupAR:
+      type: object
+      properties:
+        results: 
+          type: array
+          items:
+            type: object
+            properties:
+              name: 
+                type: string
+              type:
+                type: string
+              results:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    availability: 
+                      type: number
+                    reliability:
+                      type: number
+
+    GroupAR:
+      type: object
+      properties:
+        results: 
+          type: array
+          items:
+            type: object
+            properties:
+              name: 
+                type: string
+              type:
+                type: string
+              results:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    availability: 
+                      type: number
+                    reliability:
+                      type: number
+                    uptime:
+                      type: number
+                    downtime:
+                      type: number
+                    unknown:
+                      type: number
+
+      
     FactorsResponse:
       type: object
       properties:


### PR DESCRIPTION
…nd groups

# Goal
Provide a more robust and predictable way to retrieve a/r results per report for supergroups and groups

# Implementation
Added the following `/api/v5/` calls: 

```
HTTP GET /api/v5/results/{report-name}/supergroups?start-time&end-time&granularity
HTTP GET /api/v5/results/{report-name}/supergroups/{supergroup-name}?start-time&end-time&granularity
HTTP GET /api/v5/results/{report-name}/groups?start-time&end-time&granularity
HTTP GET /api/v5/results/{report-name}/groups/{supergroup-name}?start-time&end-time&granularity
```

Notice that the url params are changed to dashes: `start-time` and `end-time`

Results are also provided directly using numbers with 2 decimal rounding

example response for get supergroups:
```json
{
  "results": [
    {
      "name": "PROJECT_A",
      "type": "PROJECT",
      "results": [
        {
          "date": "2015-06-22",
          "availability": 68.14,
          "reliability": 68.14
        },
        {
          "date": "2015-06-23",
          "availability": 75.36,
          "reliability": 75.36
        }
      ]
    },
    {
      "name": "PROJECT_B",
      "type": "PROJECT",
      "results": [
        {
          "date": "2015-06-22",
          "availability": 33.13,
          "reliability": 55.13
        },
        {
          "date": "2015-06-23",
          "availability": 23.36,
          "reliability": 88.36
        }
      ]
    }
  ]
}
```

example response of get groups:

```json
{
  "results": [
    {
      "name": "PROJECT_A",
      "type": "PROJECT",
      "groups": [
        {
          "name": "GROUP-A",
          "type": "SERVICEGROUP",
          "results": [
            {
              "date": "2015-06-22",
              "availability": 68.14,
              "reliability": 68.14,
              "unknown": 0,
              "downtime": 0,
              "uptime": 0.68
            },
            {
              "date": "2015-06-23",
              "availability": 75.36,
              "reliability": 75.36,
              "unknown": 0,
              "downtime": 0,
              "uptime": 0.75
            }
          ]
        },
        {
          "name": "GROUP-B",
          "type": "SERVICEGROUP",
          "results": [
            {
              "date": "2015-06-22",
              "availability": 68.14,
              "reliability": 68.14,
              "unknown": 0,
              "downtime": 0,
              "uptime": 0.68
            },
            {
              "date": "2015-06-23",
              "availability": 75.36,
              "reliability": 75.36,
              "unknown": 0,
              "downtime": 0,
              "uptime": 0.75
            }
          ]
        }
      ]
    },
    {
      "name": "PROJECT_B",
      "type": "PROJECT",
      "groups": [
        {
          "name": "GROUP-X",
          "type": "SERVICEGROUP",
          "results": [
            {
              "date": "2015-06-22",
              "availability": 68.14,
              "reliability": 68.14,
              "unknown": 0,
              "downtime": 0,
              "uptime": 0.68
            },
            {
              "date": "2015-06-23",
              "availability": 75.36,
              "reliability": 75.36,
              "unknown": 0,
              "downtime": 0,
              "uptime": 0.75
            }
          ]
        },
        {
          "name": "GROUP-Y",
          "type": "SERVICEGROUP",
          "results": [
            {
              "date": "2015-06-22",
              "availability": 68.14,
              "reliability": 68.14,
              "unknown": 0,
              "downtime": 0,
              "uptime": 0.68
            },
            {
              "date": "2015-06-23",
              "availability": 75.36,
              "reliability": 75.36,
              "unknown": 0,
              "downtime": 0,
              "uptime": 0.75
            }
          ]
        }
      ]
    }
  ]
}
```