### PR TITLE
ARGO-5788 Provide monitoring capability metrics according to spec

### DIFF
--- a/app/topology/controller.go
+++ b/app/topology/controller.go
@@ -1263,6 +1263,8 @@ func ListEndpointsByReport(r *http.Request, cfg config.Config) (int, http.Header
 		fEndpoint.GroupType = append(fEndpoint.GroupType, egroupType)
 	}
 
+	fmt.Println("$$$$$", groupType, egroupType)
+
 	results, _, err := getGroupEndpointResults(cfg.MongoClient, tenantDbConfig, dt, fGroup, fEndpoint)
 	if err != nil {
 		code = http.StatusInternalServerError

--- a/docker/files/init_mongo.js
+++ b/docker/files/init_mongo.js
@@ -710,6 +710,14 @@ db.roles.insertMany([
     roles: ['super_admin', 'admin', 'editor']
   },
   {
+    resource: 'v4.nodes.monitoring.metrics',
+    roles: [ 'super_admin', 'admin', 'editor', 'viewer' ]
+  },
+  {
+    resource: 'v4.nodes.monitoring.metrics.item',
+    roles: [ 'super_admin', 'admin', 'editor', 'viewer' ]
+  },
+  {
     resource: 'v4.nodes.summary',
     roles: [ 'super_admin', 'admin', 'editor', 'viewer' ]
   },
@@ -2479,7 +2487,7 @@ const base_endpoints = [
       report: 'cf010255-cda3-49d8-92d1-926c2c6cf9eb',
       supergroup: 'ESHOP',
       service: 'webportal',
-      name: 'hostname1.eshop.foo',
+      name: 'hostname1.eshop.foo_f4dd6e5e-fa7e-420c-9f65-b0d42524eed2',
       availability: 100,
       reliability: 100,
       up: 1,
@@ -2556,7 +2564,7 @@ const base_endpoints = [
       report: 'c7a6b0d4-4885-46da-9dd1-1f91d0e9142e',
       supergroup: 'ESHOP',
       service: 'webportal',
-      name: 'hostname1.eshop.foo',
+      name: 'hostname1.eshop.foo_f4dd6e5e-fa7e-420c-9f65-b0d42524eed2',
       availability: 100,
       reliability: 100,
       up: 1,

--- a/v4/nodes/handlers.go
+++ b/v4/nodes/handlers.go
@@ -16,6 +16,124 @@ import (
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
+// GetMetrics lists availability, reliability, uptime for a specific group
+func GetMetrics(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
+
+	//STANDARD DECLARATIONS START
+	code := http.StatusOK
+	h := http.Header{}
+	output := []byte("")
+	err := error(nil)
+	charset := "utf-8"
+	//STANDARD DECLARATIONS END
+
+	// Set Content-Type response Header value
+	contentType := r.Header.Get("Accept")
+	h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+
+	// Parse the request into the input
+	urlValues := r.URL.Query()
+	vars := mux.Vars(r)
+
+	item := vars["item"]
+
+	// Grab Tenant DB configuration from context
+	tenantDbConfig := gcontext.Get(r, "tenant_conf").(config.MongoConfig)
+
+	// get node report id
+	nodeReport := NodeReport{}
+
+	report := reports.MongoInterface{}
+	nrCol := cfg.MongoClient.Database(tenantDbConfig.Db).Collection(nodeReportColName)
+	rCol := cfg.MongoClient.Database(tenantDbConfig.Db).Collection(reportsColName)
+
+	err = nrCol.FindOne(context.TODO(), bson.M{"_id": "node-report"}).Decode(&nodeReport)
+
+	if err != nil {
+		code = http.StatusNotFound
+		message := "Node report not set"
+		output, err := createErrorMessage(message, code, contentType)
+		h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+		return code, h, output, err
+	}
+
+	err = rCol.FindOne(context.TODO(), bson.M{"id": nodeReport.ReportId}).Decode(&report)
+
+	if err != nil {
+		code = http.StatusNotFound
+		message := "The report with the id " + nodeReport.ReportId + " does not exist"
+		output, err := createErrorMessage(message, code, contentType)
+		h.Set("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+		return code, h, output, err
+	}
+
+	input :=
+		basicQuery{
+			Name:        item,
+			Granularity: urlValues.Get("granularity"),
+			Format:      contentType,
+			Report:      report,
+			Vars:        vars,
+			StartDate:   urlValues.Get("start-date"),
+			EndDate:     urlValues.Get("end-date"),
+		}
+	errs := input.ValidateV2()
+	if len(errs) > 0 {
+		out := respond.BadRequestSimple
+		out.Errors = errs
+		output = out.MarshalTo(contentType)
+		code = 400
+		return code, h, output, err
+	}
+
+	resultsGroups := []GroupInterface{}
+
+	filter := bson.M{
+		"date":   bson.M{"$gte": input.StartTimeInt, "$lte": input.EndTimeInt},
+		"report": report.ID,
+	}
+	var query []primitive.M
+
+	if input.Name != "" {
+		filter["name"] = input.Name
+	}
+
+	// Prepare the group results
+	// Select the granularity of the search daily/monthly
+
+	if input.Granularity == "daily" {
+		customForm[0] = "20060102"
+		customForm[1] = "2006-01-02"
+		query = DailyEndpoint(filter)
+
+	} else if input.Granularity == "monthly" {
+		customForm[0] = "200601"
+		customForm[1] = "2006-01"
+		query = MonthlyGroup(filter)
+
+	}
+
+	arCol := cfg.MongoClient.Database(tenantDbConfig.Db).Collection(groupColName)
+	cursor, err := arCol.Aggregate(context.TODO(), query)
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	defer cursor.Close(context.TODO())
+	cursor.All(context.TODO(), &resultsGroups)
+
+	output, err = createMetricsView(resultsGroups)
+
+	if err != nil {
+		code = http.StatusInternalServerError
+		return code, h, output, err
+	}
+
+	return code, h, output, err
+}
+
 // GetSummary lists availability, reliability and uptime for a specific group
 func GetSummary(r *http.Request, cfg config.Config) (int, http.Header, []byte, error) {
 

--- a/v4/nodes/models.go
+++ b/v4/nodes/models.go
@@ -1,6 +1,9 @@
 package nodes
 
 import (
+	"encoding/json"
+	"math"
+
 	"github.com/ARGOeu/argo-web-api/app/reports"
 )
 
@@ -15,6 +18,12 @@ func init() {
 const zuluForm = "2006-01-02T15:04:05Z"
 const ymdForm = "20060102"
 const dtForm = "2006-01-02"
+
+type RoundedFloat float64
+
+func (rf RoundedFloat) MarshalJSON() ([]byte, error) {
+	return json.Marshal(math.Round(float64(rf)*100) / 100)
+}
 
 type basicQuery struct {
 	Name         string                 `bson:"name"`
@@ -69,6 +78,13 @@ type NodeReport struct {
 	ReportId string `bson:"report_id"`
 }
 
+type Metrics struct {
+	Date         string       `json:"date,omitempty"`
+	Availability RoundedFloat `json:"availability"`
+	Reliability  RoundedFloat `json:"reliability"`
+	Uptime       RoundedFloat `json:"uptime,omitempty"`
+}
+
 type Summary struct {
 	Date         string `json:"date,omitempty"`
 	Availability string `json:"availability"`
@@ -96,12 +112,12 @@ type StatusResult struct {
 	AffectedByThresholdRule bool   `json:"affected_by_threshold_rule,omitempty"`
 }
 
-type Results[T Availability | Uptime | Summary] struct {
+type Results[T Availability | Uptime | Summary | Metrics] struct {
 	Name    string `json:"name"`
 	Results []T    `json:"results"`
 }
 
-type Data[T Availability | Uptime | Summary] struct {
+type Data[T Availability | Uptime | Summary | Metrics] struct {
 	Data []Results[T] `json:"data"`
 }
 

--- a/v4/nodes/routing.go
+++ b/v4/nodes/routing.go
@@ -103,6 +103,18 @@ var arRoutes = []respond.AppRoutes{
 		SubrouterHandler: GetStatus,
 	},
 	{
+		Name:             "v4.nodes.monitoring.metrics",
+		Verb:             "GET",
+		Path:             "/nodes/{node_name}/capabilities/monitoring/metrics",
+		SubrouterHandler: GetMetrics,
+	},
+	{
+		Name:             "v4.nodes.monitoring.metrics.item",
+		Verb:             "GET",
+		Path:             "/nodes/{node_name}/capabilities/monitoring/metrics/{item}",
+		SubrouterHandler: GetMetrics,
+	},
+	{
 		Name:             "v4.nodes.status.item",
 		Verb:             "GET",
 		Path:             "/nodes/{node_name}/capabilities/status/{item}",
@@ -142,6 +154,18 @@ var arRoutes = []respond.AppRoutes{
 		Name:             "v4.nodes.uptime.item.options",
 		Verb:             "OPTIONS",
 		Path:             "/nodes/{node_name}/capabilities/uptime/{item}",
+		SubrouterHandler: Options,
+	},
+	{
+		Name:             "v4.nodes.monitoring.metrics.options",
+		Verb:             "OPTIONS",
+		Path:             "/nodes/{node_name}/capabilities/monitoring/metrics",
+		SubrouterHandler: Options,
+	},
+	{
+		Name:             "v4.nodes.monitoring.metrics.item.options",
+		Verb:             "OPTIONS",
+		Path:             "/nodes/{node_name}/capabilities/monitoring/metrics_item",
 		SubrouterHandler: Options,
 	},
 }

--- a/v4/nodes/validations.go
+++ b/v4/nodes/validations.go
@@ -118,3 +118,110 @@ func (query *basicQuery) Validate() []ErrorResponse {
 
 	return errs
 }
+
+func (query *basicQuery) ValidateV2() []ErrorResponse {
+	errs := []ErrorResponse{}
+	query.Granularity = strings.ToLower(query.Granularity)
+	if query.Granularity == "" {
+		query.Granularity = "daily"
+	} else if query.Granularity != "daily" && query.Granularity != "monthly" && query.Granularity != "custom" {
+		errs = append(errs, ErrorResponse{
+			Message: "Wrong Granularity",
+			Code:    "400",
+			Details: fmt.Sprintf("%s is not accepted as granularity parameter, please provide either daily, monthly or custom", query.Granularity),
+		})
+	}
+
+	if query.Date != "" {
+		ts, tserr := time.Parse(dtForm, query.Date)
+		if tserr != nil {
+			errs = append(errs, ErrorResponse{
+				Message: "date parsing error",
+				Code:    "400",
+				Details: fmt.Sprintf("Error parsing date string %s please use YYYY-MM-DD format like %s", query.StartTime, dtForm),
+			})
+			return errs
+		}
+		query.StartTime = time.Date(ts.Year(), ts.Month(), ts.Day(), 0, 0, 0, 0, time.UTC).Format(time.RFC3339)
+		query.EndTime = time.Date(ts.Year(), ts.Month(), ts.Day(), 23, 59, 59, 0, time.UTC).Format(time.RFC3339)
+	}
+
+	if query.StartDate != "" || query.EndDate != "" {
+		if !(query.StartDate != "" && query.EndDate != "") {
+			errs = append(errs, ErrorResponse{
+				Message: "date parsing error",
+				Code:    "400",
+				Details: "You should speficy both start-date and end-date",
+			})
+			return errs
+		}
+		sd, tserr := time.Parse(dtForm, query.StartDate)
+		if tserr != nil {
+			errs = append(errs, ErrorResponse{
+				Message: "date parsing error",
+				Code:    "400",
+				Details: fmt.Sprintf("Error parsing start-date string %s please use YYYY-MM-DD format like %s", query.StartTime, dtForm),
+			})
+		}
+		ed, tserr := time.Parse(dtForm, query.EndDate)
+		if ed.Before(sd) {
+			errs = append(errs, ErrorResponse{
+				Message: "date parsing error",
+				Code:    "400",
+				Details: "start-date should be a date before end-date",
+			})
+			return errs
+		}
+		if tserr != nil {
+			errs = append(errs, ErrorResponse{
+				Message: "date parsing error",
+				Code:    "400",
+				Details: fmt.Sprintf("Error parsing end-date string %s please use YYYY-MM-DD format like %s", query.StartTime, dtForm),
+			})
+		}
+
+		query.StartTime = time.Date(sd.Year(), sd.Month(), sd.Day(), 0, 0, 0, 0, time.UTC).Format(time.RFC3339)
+		query.EndTime = time.Date(ed.Year(), ed.Month(), ed.Day(), 23, 59, 59, 0, time.UTC).Format(time.RFC3339)
+	}
+
+	if query.StartTime == "" || query.EndTime == "" {
+		now := time.Now().UTC()
+		query.StartTime = time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC).Format(time.RFC3339)
+		query.EndTime = time.Date(now.Year(), now.Month(), now.Day(), 23, 59, 59, 0, time.UTC).Format(time.RFC3339)
+
+	}
+	if query.StartTime != "" && query.EndTime != "" {
+		ts, tserr := time.Parse(zuluForm, query.StartTime)
+		if tserr != nil {
+			errs = append(errs, ErrorResponse{
+				Message: "start-time parsing error",
+				Code:    "400",
+				Details: fmt.Sprintf("Error parsing date string %s please use zulu format like %s", query.StartTime, zuluForm),
+			})
+			return errs
+		}
+		query.StartTimeInt, _ = strconv.Atoi(ts.Format(ymdForm))
+
+		te, teerr := time.Parse(zuluForm, query.EndTime)
+		if teerr != nil {
+			errs = append(errs, ErrorResponse{
+				Message: "end-time parsing error",
+				Code:    "400",
+				Details: fmt.Sprintf("Error parsing date string %s please use zulu format like %s", query.EndTime, zuluForm),
+			})
+			return errs
+		}
+		query.EndTimeInt, _ = strconv.Atoi(te.Format(ymdForm))
+
+		if te.Before(ts) {
+			errs = append(errs, ErrorResponse{
+				Message: "time parsing error",
+				Code:    "400",
+				Details: "start-time should be a timestamp before end-time",
+			})
+			return errs
+		}
+	}
+
+	return errs
+}

--- a/v4/nodes/views.go
+++ b/v4/nodes/views.go
@@ -60,6 +60,41 @@ func createSummaryView(results []GroupInterface) ([]byte, error) {
 
 }
 
+func createMetricsView(results []GroupInterface) ([]byte, error) {
+
+	docRoot := Data[Metrics]{
+		Data: []Results[Metrics]{},
+	}
+
+	prevEndpoint := ""
+
+	for i := 0; i < len(results); i++ {
+		row := results[i]
+		timestamp, _ := time.Parse(customForm[0], fmt.Sprint(row.Date))
+
+		if prevEndpoint != row.Name {
+			prevEndpoint = row.Name
+			docRoot.Data = append(docRoot.Data, Results[Metrics]{
+				Name:    row.Name,
+				Results: []Metrics{},
+			})
+		}
+
+		currIdx := len(docRoot.Data) - 1
+		prepDate := timestamp.Format(customForm[1])
+
+		docRoot.Data[currIdx].Results = append(docRoot.Data[currIdx].Results,
+			Metrics{
+				Date:         prepDate,
+				Availability: RoundedFloat(row.Availability),
+				Reliability:  RoundedFloat(row.Availability),
+				Uptime:       RoundedFloat(row.Up),
+			})
+	}
+	return json.MarshalIndent(docRoot, " ", "  ")
+
+}
+
 func createAvailabilityView(results []GroupInterface) ([]byte, error) {
 
 	docRoot := Data[Availability]{

--- a/website/docs/apiv4/v4nodes.md
+++ b/website/docs/apiv4/v4nodes.md
@@ -27,10 +27,207 @@ _Note_: The following calls implement the node capabilities
 
 | Name                                                                          | Description                                                                                                                                                                                                                              | Shortcut          |
 | ----------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
+| GET: Monitoric capability metric results for the node's services | This method retrieves by default the latest daily availability and uptime for a node's service | [Description](#1AA) |
 | GET: Summary results for the node's services | This method retrieves by default the latest daily availability and uptime for a node's service | [Description](#1A) |
 | GET: Availability results for the node's services | This method retrieves by default the latest daily availability for a node's service | [Description](#1) |
 | GET: Uptime results for the node's services | This method retrieves by default the latest daily availability for a node's service | [Description](#2) |
 | GET: Status results for the node's services | This method retrieves by default the latest daily availability for a node's service | [Description](#3) |
+
+
+
+
+## [GET]: Monitoric capability metric results for the node's services {#1AA}
+
+The following methods can be used to obtain availability and uptime results for a node's services. The api authenticates the tenant using the api-key within the x-api-key header. User can specify time granularity (`monthly`, `daily`) for retrieved results and also format using the `Accept` header. 
+
+### Input
+
+```
+/nodes/{node_name}/capabilities/monitoring/metrics?[start-date]&[end-date]&[granularity]
+/nodes/{node_name}/capabilities/monitoring/metrics/{service-name}?[start-date]&[end-date]&[granularity]
+```
+
+#### Query Parameters
+
+| Type            | Description                                                                                     | Required | Default value |
+| --------------- | ----------------------------------------------------------------------------------------------- | -------- | ------------- |
+| `[start-date]`  | UTC date in YYYY-MM-DD format                                                                   | NO       |               |
+| `[start-date]`  | UTC date in YYYY-MM-DD format                                                                   | NO       |               |
+| `[granularity]` | Granularity of time that will be used to present data. Possible values are `monthly`,  `daily`  | NO       | `daily`       |
+
+- If a user doesn't specify any query parameter the api returns the latest daily availability results.
+- If a user specifies the date parameter the api retuerns the daily availability results for that date
+- A user can specify the period of availability results by using start_date and end_date instead of start_time and end_time
+
+#### Path Parameters
+
+| Name            | Description                                                                                           | Required | Default value |
+| --------------- | ----------------------------------------------------------------------------------------------------- | -------- | ------------- |
+| `{service-name}`| Target a specific service. If omitted you get a result list for all the services                | NO       |               |
+| `{node_name}` | Name of the node | YES      |
+
+
+### Example Request 1: Get default daily metrics for all services of NODE_A
+
+```
+/api/v4/nodes/NODE_A/capabilities/monitoring/metrics`
+```
+
+##### Headers
+
+```
+x-api-key: "tenant_key_value"
+Accept: "application/json"
+```
+
+#### Response
+
+##### Code
+
+```
+Status: 200 OK
+```
+
+##### Body
+
+```json
+{
+  "data": [
+    {
+      "name": "SERVICE001",
+      "results": [
+        {
+          "date": "2015-06-26",
+          "availability": 100,
+          "reliability": 100,
+          "uptime": 1
+        }
+      ]
+    },
+    {
+      "name": "SERVICE002",
+      "results": [
+        {
+          "date": "2015-06-26",
+          "availability": 100,
+          "reliability": 100,
+          "uptime": 1
+        }
+      ]
+    }
+  ]
+}
+```
+
+
+### Example Request 2: daily metrics for a specific service over a period
+
+#### Request
+
+##### Method
+`HTTP GET`
+
+##### Path
+
+```
+/api/v4/nodes/NODE_A/capabilities/monitoring/metrics/SERVICE001?start-date=2015-06-20Z&end-date=2015-06-22T&granularity=daily`
+```
+
+
+##### Headers
+
+```
+x-api-key: "tenant_key_value"
+Accept: "application/json"
+```
+
+#### Response
+
+##### Code
+
+```
+Status: 200 OK
+```
+
+##### Body
+
+```json
+{
+   "data": [
+     {
+       "name": "SERVICE001",
+       "results": [
+         {
+           "date": "2015-06-20",
+           "availability": 100,
+           "reliability": 100,
+           "uptime": 1
+         },
+         {
+           "date": "2015-06-21",
+           "availability": 100,
+           "reliability": 100,
+           "uptime": 1
+         },
+         {
+           "date": "2015-06-22",
+           "availability": 100,
+           "reliability": 100,
+           "uptime": 1
+         }
+       ]
+     }
+   ]
+ }
+```
+
+### Example Request 3: monthly granularity
+
+#### Request
+
+##### Method
+`HTTP GET`
+
+##### Path
+
+```
+/api/v4/nodes/NODE_A/capabilities/monitoring/metrics/SERVICE001?start-date=2015-07-01&end-date=2015-07-31&granularity=monthly
+```
+##### Headers
+
+```
+x-api-key: "tenant_key_value"
+Accept: "application/json"
+```
+
+#### Response
+
+##### Code
+
+```
+Status: 200 OK
+```
+
+##### Body
+
+```json
+{
+  "data": [
+    {
+      "name": "SERVICE001",
+      "results": [
+        {
+          "date": "2015-06",
+          "availability": 100,
+          "reliability": 100,
+          "uptime": 1
+        }
+      ]
+    }
+  ]
+}  
+```
+
 
 
 ## [GET]: Availability results for the node's services {#1A}

--- a/website/static/openapi/argo-web-api.yml
+++ b/website/static/openapi/argo-web-api.yml
@@ -11325,7 +11325,235 @@ paths:
             application/json:
               schema:
                 type: string
-  
+
+  /v4/nodes/{node-name}/capabilities/monitoring/metrics:
+    get:
+      tags:
+      - Node Capabilities (v4)
+      summary: List service metrics such as availability, reliability etc.
+      description: List service metrics such as availability, reliability etc.
+      operationId: nodeMetrics
+      parameters:
+      - name: x-api-key
+        in: header
+        description: the x-api-key
+        required: true
+        schema:
+          type: string
+          default: SecretKey123
+      - name: node-name
+        in: path
+        description: name of the node
+        required: true
+        schema:
+          type: string
+      - name: start-date
+        in: query
+        description: start date of query in YYYY-MM-DD
+        schema:
+          type: string
+          default: 2006-01-01
+      - name: end-date
+        in: query
+        description: end date of query in YYYY-MM-DD
+        schema:
+          type: string
+          default: 2006-01-03
+      - name: granularity
+        in: query
+        description: specify daily or monthly granularity
+        schema:
+          type: string
+          default: daily
+      responses:
+        "200":
+          description: Successful retrieval of metric results for all nodes services
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        results:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              date:
+                                type: string
+                                format: date
+                                example: "2015-06-22"
+                              availability:
+                                type: number
+                                example: 100
+                              reliability:
+                                type: number
+                                example: 100
+                              uptime:
+                                type: number
+                                example: 1
+
+        "400":
+          description: Item not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status_error'
+        "401":
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                  code:
+                    type: string
+                  details:
+                    type: string
+        "406":
+          description: Content Not acceptable
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status_error'
+        "422":
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status_error'
+        "500":
+          description: internal server error
+          content:
+            application/json:
+              schema:
+                type: string
+
+  /v4/nodes/{node-name}/capabilities/monitoring/metrics/{service-name}:
+    get:
+      tags:
+      - Node Capabilities (v4)
+      summary: List service metrics such as availability, reliability etc.
+      description: List service metrics such as availability, reliability etc.
+      operationId: nodeMetrics.item
+      parameters:
+      - name: x-api-key
+        in: header
+        description: the x-api-key
+        required: true
+        schema:
+          type: string
+          default: SecretKey123
+      - name: node-name
+        in: path
+        description: name of the node
+        required: true
+        schema:
+          type: string
+      - name: service-name
+        in: path
+        description: name of the service
+        required: true
+        schema:
+          type: string
+      - name: start-date
+        in: query
+        description: start date of query in YYYY-MM-DD
+        schema:
+          type: string
+          default: 2006-01-01
+      - name: end-date
+        in: query
+        description: end date of query in YYYY-MM-DD
+        schema:
+          type: string
+          default: 2006-01-03
+      - name: granularity
+        in: query
+        description: specify daily or monthly granularity
+        schema:
+          type: string
+          default: daily
+      responses:
+        "200":
+          description: Successful retrieval of metric results for specific service
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        results:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              date:
+                                type: string
+                                format: date
+                                example: "2015-06-22"
+                              availability:
+                                type: number
+                                example: 100
+                              reliability:
+                                type: number
+                                example: 100
+                              uptime:
+                                type: number
+                                example: 1
+
+        "400":
+          description: Item not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status_error'
+        "401":
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                  code:
+                    type: string
+                  details:
+                    type: string
+        "406":
+          description: Content Not acceptable
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status_error'
+        "422":
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status_error'
+        "500":
+          description: internal server error
+          content:
+            application/json:
+              schema:
+                type: string
+
 
   /v4/nodes/{node_name}/capabilities/summary/{service_name}:
     get:


### PR DESCRIPTION
# Goal 
Provide monitoring capability metrics according to spec: https://argoeu.github.io/argo-monitoring/openapi/explore.html#/metrics/listMetrics

# Implementation

## Monitoring capability metrics for all nodes services or a specific service

Requests:

```
HTTP GET /api/v4/nodes/{node-name}/capabilities/monitoring/metrics?start-date=YYYY-MM-DD&end-date=YYYY-MM-DD&granularity=daily|monthly
```
```
HTTP GET /api/v4/nodes/{node-name}/capabilities/monitoring/metrics/{service-name}?start-date=YYYY-MM-DD&end-date=YYYY-MM-DD&granularity=daily|monthly
```

Response:

```
{
    "data": [
        {
            "name": "Service-A",
            "results": [
                {
                    "date": "2025-04-14",
                    "availability": 100,
                    "reliability": 100,
                    "uptime": 1
                }
            ]
        },
        {
            "name": "Service-B",
            "results": [
                {
                    "date": "2025-04-14",
                    "availability": 100,
                    "reliability": 100,
                    "uptime": 1
                }
            ]
        },
        {
            "name": "Service-C",
            "results": [
                {
                    "date": "2025-04-14",
                    "availability": 100,
                    "reliability": 100,
                    "uptime": 1
                }
            ]
        }
    ]
}
```